### PR TITLE
chore: Add GitHub labels documentation and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# CODEOWNERS - https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# These owners will be automatically requested for review when someone opens
+# a pull request that modifies code that they own.
+
+# Default owner for everything in the repository
+* @davidmigloz
+
+# Packages
+/packages/anthropic_sdk_dart/    @davidmigloz
+/packages/chromadb/              @davidmigloz
+/packages/googleai_dart/         @davidmigloz
+/packages/mistralai_dart/        @davidmigloz
+/packages/ollama_dart/           @davidmigloz
+/packages/openai_dart/           @davidmigloz
+/packages/openai_realtime_dart/  @davidmigloz
+/packages/tavily_dart/           @davidmigloz
+/packages/vertex_ai/             @davidmigloz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,3 +98,29 @@ This repository uses [Conventional Commits](https://www.conventionalcommits.org/
 melos version    # Bump versions based on conventional commits, update changelogs
 melos publish    # Publish packages to pub.dev
 ```
+
+## GitHub
+
+### Labels
+
+When creating issues or pull requests, you **must** always set the following labels:
+
+- **`p:{package}`** (required) - The package(s) affected (e.g., `p:openai_dart`, `p:googleai_dart`)
+- **`t:{type}`** (required) - The type of issue/PR (e.g., `t:bug`, `t:feature`, `t:enhancement`)
+- **`f:{flag}`** (optional) - Additional flags (e.g., `f:help-wanted`, `f:good-first-issue`)
+
+To list all available labels:
+
+```bash
+gh label list --repo davidmigloz/ai_clients_dart
+```
+
+### Assignees
+
+Issues and pull requests should be assigned to the code owner of the affected code. Code owners are defined in `.github/CODEOWNERS`.
+
+To find the code owner for a path:
+
+```bash
+cat .github/CODEOWNERS
+```


### PR DESCRIPTION
## Summary
- Document required labels (`p:`, `t:`) and optional flags (`f:`) for issues/PRs in AGENTS.md
- Add `.github/CODEOWNERS` file for automatic review requests
- Add assignee guidelines referencing code owners

## Changes
- **AGENTS.md**: Added `## GitHub` section with labels and assignees documentation
- **.github/CODEOWNERS**: New file defining @davidmigloz as owner for all packages

## Related
This PR documents the GitHub labels created for the repository:
- `p:` (purple) - Package labels
- `t:` (teal) - Type labels  
- `f:` (orange) - Flag labels