### PR TITLE
docs: Add multipart upload patterns to OpenAPI toolkit

### DIFF
--- a/.claude/shared/openapi-toolkit/references/REVIEW_CHECKLIST-core.md
+++ b/.claude/shared/openapi-toolkit/references/REVIEW_CHECKLIST-core.md
@@ -47,6 +47,14 @@ For resources with streaming methods:
 - [ ] `sendStreamingRequest()` handles HTTP errors before streaming
 - [ ] Abort monitoring tested (if applicable)
 
+### Multipart Upload Resources
+For resources with file uploads using `MultipartRequest`:
+- [ ] Has `_applyAuthentication()` helper method
+- [ ] Calls `_applyAuthentication(request)` before `httpClient.send()`
+- [ ] Removes `content-type` header (multipart sets its own boundary)
+- [ ] Handles HTTP errors with proper exception mapping
+- [ ] Imports `AuthProvider` and credential types
+
 ---
 
 ## Cross-Reference Verification

--- a/docs/spec-core.md
+++ b/docs/spec-core.md
@@ -139,6 +139,23 @@ Streaming responses (SSE) cannot pass through the full interceptor chain since `
 
 This is an acceptable tradeoff for real-time streaming while maintaining security.
 
+### Multipart Uploads
+
+Like streaming, multipart form uploads use `httpClient.send()` directly, bypassing the interceptor chain.
+
+**Pattern**: Resources with multipart uploads must:
+1. Include an `_applyAuthentication(http.BaseRequest request)` helper
+2. Call it before `httpClient.send(request)`
+3. Handle HTTP errors manually with proper exception mapping
+
+```dart
+// CRITICAL: Apply auth before sending multipart requests
+await _applyAuthentication(request);
+final response = await httpClient.send(request);
+```
+
+**Common mistake**: Forgetting to apply auth to multipart/streaming requests results in `401 Unauthorized`.
+
 ### Request Cancellation
 
 Requests can be canceled via `abortTrigger` parameter:


### PR DESCRIPTION
## Summary

Document authentication patterns for multipart uploads that bypass the interceptor chain (similar to streaming requests):

- Add `_applyAuthentication()` helper pattern for multipart requests
- Add multipart upload section to `implementation-patterns-core.md`
- Add multipart upload section to `spec-core.md`
- Add multipart resource checklist items to `REVIEW_CHECKLIST-core.md`

This documents patterns discovered while implementing the Files API in `anthropic_sdk_dart`.

## Test plan

- [x] Documentation only, no code changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
