### PR TITLE
feat(open_responses_dart): Add SummaryTextContent for reasoning models

### DIFF
--- a/packages/open_responses_dart/lib/src/models/content/output_content.dart
+++ b/packages/open_responses_dart/lib/src/models/content/output_content.dart
@@ -16,6 +16,7 @@ sealed class OutputContent {
     return switch (type) {
       'output_text' => OutputTextContent.fromJson(json),
       'reasoning_text' => ReasoningTextContent.fromJson(json),
+      'summary_text' => SummaryTextContent.fromJson(json),
       'refusal' => RefusalContent.fromJson(json),
       _ => throw FormatException('Unknown OutputContent type: $type'),
     };
@@ -160,4 +161,35 @@ class RefusalContent extends OutputContent {
 
   @override
   String toString() => 'RefusalContent(refusal: $refusal)';
+}
+
+/// Summary text content from reasoning models.
+@immutable
+class SummaryTextContent extends OutputContent {
+  /// The summary text from the reasoning output.
+  final String text;
+
+  /// Creates a [SummaryTextContent].
+  const SummaryTextContent({required this.text});
+
+  /// Creates a [SummaryTextContent] from JSON.
+  factory SummaryTextContent.fromJson(Map<String, dynamic> json) {
+    return SummaryTextContent(text: json['text'] as String);
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {'type': 'summary_text', 'text': text};
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SummaryTextContent &&
+          runtimeType == other.runtimeType &&
+          text == other.text;
+
+  @override
+  int get hashCode => text.hashCode;
+
+  @override
+  String toString() => 'SummaryTextContent(text: $text)';
 }

--- a/packages/open_responses_dart/lib/src/models/items/item.dart
+++ b/packages/open_responses_dart/lib/src/models/items/item.dart
@@ -216,7 +216,9 @@ sealed class FunctionCallOutput {
     }
     if (json is List) {
       return FunctionCallOutputContent(
-        json.map((e) => InputContent.fromJson(e as Map<String, dynamic>)).toList(),
+        json
+            .map((e) => InputContent.fromJson(e as Map<String, dynamic>))
+            .toList(),
       );
     }
     throw FormatException('Invalid FunctionCallOutput format: $json');

--- a/packages/open_responses_dart/test/unit/models/function_call_output_test.dart
+++ b/packages/open_responses_dart/test/unit/models/function_call_output_test.dart
@@ -79,15 +79,9 @@ void main() {
     });
 
     test('equality works correctly', () {
-      const a = FunctionCallOutputContent([
-        InputTextContent(text: 'Hello'),
-      ]);
-      const b = FunctionCallOutputContent([
-        InputTextContent(text: 'Hello'),
-      ]);
-      const c = FunctionCallOutputContent([
-        InputTextContent(text: 'World'),
-      ]);
+      const a = FunctionCallOutputContent([InputTextContent(text: 'Hello')]);
+      const b = FunctionCallOutputContent([InputTextContent(text: 'Hello')]);
+      const c = FunctionCallOutputContent([InputTextContent(text: 'World')]);
       const d = FunctionCallOutputContent([]);
 
       expect(a, equals(b));
@@ -96,12 +90,8 @@ void main() {
     });
 
     test('hashCode is consistent with equality', () {
-      const a = FunctionCallOutputContent([
-        InputTextContent(text: 'Hello'),
-      ]);
-      const b = FunctionCallOutputContent([
-        InputTextContent(text: 'Hello'),
-      ]);
+      const a = FunctionCallOutputContent([InputTextContent(text: 'Hello')]);
+      const b = FunctionCallOutputContent([InputTextContent(text: 'Hello')]);
 
       expect(a.hashCode, equals(b.hashCode));
     });

--- a/packages/open_responses_dart/test/unit/models/metadata_test.dart
+++ b/packages/open_responses_dart/test/unit/models/metadata_test.dart
@@ -29,10 +29,7 @@ void main() {
         FunctionCallStatus.fromJson('some_new_status'),
         FunctionCallStatus.unknown,
       );
-      expect(
-        FunctionCallStatus.fromJson(''),
-        FunctionCallStatus.unknown,
-      );
+      expect(FunctionCallStatus.fromJson(''), FunctionCallStatus.unknown);
     });
 
     test('toJson returns correct value', () {
@@ -53,14 +50,16 @@ void main() {
 
   group('StreamOptions', () {
     test('fromJson parses includeObfuscation true', () {
-      final options =
-          StreamOptions.fromJson(const {'include_obfuscation': true});
+      final options = StreamOptions.fromJson(const {
+        'include_obfuscation': true,
+      });
       expect(options.includeObfuscation, true);
     });
 
     test('fromJson parses includeObfuscation false', () {
-      final options =
-          StreamOptions.fromJson(const {'include_obfuscation': false});
+      final options = StreamOptions.fromJson(const {
+        'include_obfuscation': false,
+      });
       expect(options.includeObfuscation, false);
     });
 

--- a/packages/open_responses_dart/test/unit/models/tool_choice_test.dart
+++ b/packages/open_responses_dart/test/unit/models/tool_choice_test.dart
@@ -251,9 +251,7 @@ void main() {
 
       test('toJson returns correct map with mode', () {
         const choice = ToolChoiceAllowedTools(
-          tools: [
-            SpecificFunctionChoice(name: 'func1'),
-          ],
+          tools: [SpecificFunctionChoice(name: 'func1')],
           mode: ToolChoiceMode.required,
         );
         expect(choice.toJson(), {
@@ -333,10 +331,7 @@ void main() {
     });
 
     test('fromJson throws on invalid format', () {
-      expect(
-        () => ToolChoice.fromJson(123),
-        throwsA(isA<FormatException>()),
-      );
+      expect(() => ToolChoice.fromJson(123), throwsA(isA<FormatException>()));
     });
 
     test('fromJson throws on unknown object type', () {


### PR DESCRIPTION
## Summary
- Add `SummaryTextContent` class for handling summary text output from reasoning models (e.g., OpenAI o1)
- Minor code formatting improvements in tests

## Test plan
- [x] Static analysis passes
- [x] Unit tests pass (172 tests)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/23">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
