### PR TITLE
fix(openapi-toolkit): Improve beta endpoint detection and documentation

### DIFF
--- a/.claude/shared/openapi-toolkit/README.md
+++ b/.claude/shared/openapi-toolkit/README.md
@@ -93,12 +93,15 @@ Create these in your extension skill's `config/` directory:
   "resources_dir": "lib/src/resources",
   "tests_dir": "test/unit/models",
   "examples_dir": "example",
-  "skip_files": ["copy_with_sentinel.dart"],
+  "skip_files": ["copy_with_sentinel.dart", "equality_helpers.dart"],
   "internal_barrel_files": [],
   "pr_title_prefix": "feat(your_package_dart)",
   "changelog_title": "Your Package Changelog"
 }
 ```
+
+**Field descriptions:**
+- `skip_files`: List of filenames to exclude from export verification. Use this for internal utility files that shouldn't be publicly exported (e.g., `copy_with_sentinel.dart`, `equality_helpers.dart`, `common.dart`). When `verify_exports.py` flags internal files as unexported, add them here rather than exporting them.
 
 ### `specs.json` - API Specifications
 
@@ -224,6 +227,28 @@ python3 .claude/shared/openapi-toolkit/scripts/analyze_changes.py \
 
 **Note:** The script auto-locates the old spec from `specs_dir` and the new spec from `output_dir` in specs.json. You can still provide explicit paths if needed.
 
+#### If No Changes Found
+
+If the analysis shows all zeros (no new/modified/removed endpoints or schemas):
+
+1. The spec is unchanged - no implementation work needed
+2. Still run verification (Step 3-4) to ensure the package is in sync
+3. If verification passes, the package is up-to-date
+
+**Example output when no changes:**
+```
+==================================================
+Analysis Summary
+==================================================
+  New Endpoints: 0
+  Modified Endpoints: 0
+  Removed Endpoints: 0
+  New Schemas: 0
+  Modified Schemas: 0
+  Removed Schemas: 0
+  Breaking Changes: 0
+```
+
 ### 3. Check Coverage (CRITICAL - from PACKAGE ROOT)
 **Always run coverage check.** This catches APIs that exist in the spec but were never implemented. **Spec is auto-located** if not provided:
 
@@ -250,6 +275,21 @@ python3 ../../.claude/shared/openapi-toolkit/scripts/verify_exports.py \
 python3 ../../.claude/shared/openapi-toolkit/scripts/verify_coverage.py \
   --config-dir .claude/skills/openapi-{shortname}/config
 ```
+
+**Success output:**
+- Coverage: `✓ Full API coverage achieved!`
+- Exports: `✓ All model files are exported.`
+
+### When Complete
+
+The package is fully up-to-date when all of the following are true:
+
+1. `analyze_changes.py` shows no changes (or all changes have been implemented)
+2. `verify_coverage.py` shows 100% coverage
+3. `verify_exports.py` shows all model files exported
+4. `verify_model_properties.py` shows all critical models complete
+
+At this point, no further implementation work is needed.
 
 ## Script Usage
 

--- a/.claude/shared/openapi-toolkit/scripts/fetch_spec.py
+++ b/.claude/shared/openapi-toolkit/scripts/fetch_spec.py
@@ -22,7 +22,7 @@ import argparse
 import json
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from urllib.request import urlopen, Request
 from urllib.error import URLError, HTTPError
@@ -177,7 +177,7 @@ def save_spec_metadata(specs_dir: Path, spec_name: str, spec: dict, url: str) ->
     metadata["specs"][spec_name] = {
         "title": info.get("title", "Unknown"),
         "current_version": current_version,
-        "last_fetched": datetime.utcnow().isoformat() + "Z",
+        "last_fetched": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "source_url": url,
         "version_history": history
     }

--- a/.claude/shared/openapi-toolkit/scripts/verify_coverage.py
+++ b/.claude/shared/openapi-toolkit/scripts/verify_coverage.py
@@ -34,7 +34,9 @@ class EndpointInfo:
     @property
     def resource_name(self) -> str:
         """Extract resource name from path (e.g., /v1/responses -> responses, /api/v2/chat -> chat)."""
-        parts = self.path.strip('/').split('/')
+        # Strip query parameters first (e.g., /v1/files?beta=true -> /v1/files)
+        path_without_query = self.path.split('?')[0]
+        parts = path_without_query.strip('/').split('/')
         idx = 0
         # Skip leading "api" prefix if present (e.g., /api/..., /api/v2/...)
         if idx < len(parts) and parts[idx] == 'api':

--- a/packages/anthropic_sdk_dart/.claude/skills/openapi-anthropic/SKILL.md
+++ b/packages/anthropic_sdk_dart/.claude/skills/openapi-anthropic/SKILL.md
@@ -62,6 +62,13 @@ python3 ../../.claude/shared/openapi-toolkit/scripts/verify_coverage.py \
   --config-dir .claude/skills/openapi-anthropic/config
 ```
 
+## Troubleshooting
+
+- **No changes detected**: Analysis shows all zeros - package is up-to-date, no action needed
+- **Unexported files warning**: Add internal utility files to `skip_files` in `config/package.json`
+- **Coverage < 100%**: Missing APIs need implementation before other updates
+- **API key error**: Export `ANTHROPIC_API_KEY` environment variable
+
 ## Package-Specific References
 
 - [Package Guide](references/package-guide.md)

--- a/packages/chromadb/.claude/skills/openapi-chromadb/SKILL.md
+++ b/packages/chromadb/.claude/skills/openapi-chromadb/SKILL.md
@@ -61,6 +61,12 @@ python3 ../../.claude/shared/openapi-toolkit/scripts/verify_coverage.py \
   --config-dir .claude/skills/openapi-chromadb/config
 ```
 
+## Troubleshooting
+
+- **No changes detected**: Analysis shows all zeros - package is up-to-date, no action needed
+- **Unexported files warning**: Add internal utility files to `skip_files` in `config/package.json`
+- **Coverage < 100%**: Missing APIs need implementation before other updates
+
 ## Package-Specific References
 
 - [Package Guide](references/package-guide.md)

--- a/packages/mistralai_dart/.claude/skills/openapi-mistral/SKILL.md
+++ b/packages/mistralai_dart/.claude/skills/openapi-mistral/SKILL.md
@@ -62,6 +62,13 @@ python3 ../../.claude/shared/openapi-toolkit/scripts/verify_coverage.py \
   --config-dir .claude/skills/openapi-mistral/config
 ```
 
+## Troubleshooting
+
+- **No changes detected**: Analysis shows all zeros - package is up-to-date, no action needed
+- **Unexported files warning**: Add internal utility files to `skip_files` in `config/package.json`
+- **Coverage < 100%**: Missing APIs need implementation before other updates
+- **API key error**: Export `MISTRAL_API_KEY` environment variable
+
 ## Package-Specific References
 
 - [Package Guide](references/package-guide.md)

--- a/packages/ollama_dart/.claude/skills/openapi-ollama/SKILL.md
+++ b/packages/ollama_dart/.claude/skills/openapi-ollama/SKILL.md
@@ -106,6 +106,12 @@ if any expected properties are missing from the implementation.
 This serves as a regression prevention mechanism: if a future OpenAPI spec update
 inadvertently removes a property that should exist, the verification will catch it.
 
+## Troubleshooting
+
+- **No changes detected**: Analysis shows all zeros - package is up-to-date, no action needed
+- **Unexported files warning**: Add internal utility files to `skip_files` in `config/package.json`
+- **Coverage < 100%**: Missing APIs need implementation before other updates
+
 ## Package-Specific References
 
 - [Package Guide](references/package-guide.md)

--- a/packages/openai_dart/.claude/skills/openapi-openai/SKILL.md
+++ b/packages/openai_dart/.claude/skills/openapi-openai/SKILL.md
@@ -132,6 +132,13 @@ python3 ../../.claude/shared/openapi-toolkit/scripts/verify_coverage.py \
   --config-dir .claude/skills/openapi-openai/config
 ```
 
+**Expected success output:**
+- Coverage: `✓ Full API coverage achieved!`
+- Exports: `✓ All model files are exported.`
+- Properties: `✓ All critical models have complete properties.`
+
+If all checks pass and no spec changes were found, the package is up-to-date.
+
 ## Configuration Files
 
 - `config/specs.json` - Spec URLs and output paths


### PR DESCRIPTION
## Summary

- Fix beta endpoint detection in `verify_coverage.py` by stripping query parameters from paths before resource extraction
- Use timezone-aware datetime in `fetch_spec.py` to avoid deprecation warning
- Improve documentation across the toolkit

## Changes

### Beta Endpoint Fix

Paths with query parameters (e.g., `/v1/files?beta=true`) were being incorrectly extracted as separate resources (`files?beta=true` instead of `files`). This caused beta endpoints to be flagged as unimplemented even when the base resource was implemented.

**Before:** anthropic_sdk_dart showed 85.1% coverage (beta endpoints counted separately)
**After:** anthropic_sdk_dart shows 97.9% coverage (beta endpoints correctly grouped)

### Documentation Improvements

- Document `skip_files` field usage in README.md
- Add "when complete" success criteria section to README.md  
- Add troubleshooting sections to all package SKILL.md files

## Test plan

- [x] Verified anthropic_sdk_dart coverage increased from 85.1% to 97.9%
- [x] Verified openai_dart still shows 100% coverage (no regression)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
