### PR TITLE
Improve release skill based on real-world feedback

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -42,8 +42,16 @@ Perform all applicable checks before proceeding. Fail fast with an actionable er
    In `--plan` and `--dry-run` modes, skip this check.
 4. **CLI availability**: `dart` and `gh` must be on PATH.
 5. **Auth preflight** (skip in `--plan` mode):
-   - `gh auth status` — must show authenticated. If not, tell user to run `gh auth login`.
-   - `dart pub token list` — must show a token for `pub.dev`. If not, tell user to run `dart pub token add https://pub.dev`.
+   - **GitHub**: `gh auth status` — must show authenticated. If not, tell user to run `gh auth login`.
+   - **pub.dev**: There are two authentication mechanisms:
+     - **OAuth session** (from `dart pub login`) — this is the primary and recommended method. It does NOT appear in `dart pub token list`.
+     - **Token-based** (from `dart pub token add`) — these appear in `dart pub token list` but are less common.
+   - **Do not assume unauthenticated just because `dart pub token list` is empty.** An active OAuth session is invisible to that command.
+   - **Reliable verification**: Run `dart pub publish --dry-run` in any package directory as the auth smoke test. If it succeeds (exit code 0, no auth errors), authentication is working regardless of the mechanism.
+     ```bash
+     cd packages/{any_pkg} && dart pub publish --dry-run 2>&1
+     ```
+   - If the dry-run fails with an authentication error, tell the user to run `dart pub login` (OAuth, recommended) or `dart pub token add https://pub.dev` (token-based, alternative).
 
 ---
 
@@ -70,6 +78,18 @@ Read the `workspace` list from the root `pubspec.yaml` (the source of truth). Ea
 3. **No previous tag** (first release): use all commits touching `packages/{pkg}/`.
 
 4. **No commits since tag**: skip this package — no release needed.
+
+5. **Detect unreleased version bumps**: After checking commits, compare the `version:` field in `packages/{pkg}/pubspec.yaml` against the version extracted from the latest tag:
+   ```bash
+   # Extract version from latest tag (e.g., "foo_dart-v1.0.0" → "1.0.0")
+   tag_version=$(echo "$latest_tag" | sed "s/^${pkg}-v//")
+   # Read pubspec version
+   pubspec_version=$(grep '^version:' packages/${pkg}/pubspec.yaml | awk '{print $2}')
+   ```
+   - If `pubspec_version` > `tag_version`, this package has a **pre-applied version bump** — someone manually set the version in the pubspec but never published it. Flag this package for release even if Step 4 found "no commits since tag" would normally skip it.
+   - If `pubspec_version` == `tag_version` and there are no new commits, skip as normal.
+
+   > **Caution**: The git tag is the definitive indicator of whether a version has been published, not the pubspec. A pubspec may show `version: 1.0.0` while no `{pkg}-v1.0.0` tag exists — this means 1.0.0 was never actually released. Always check tags to determine published state.
 
 ---
 
@@ -117,6 +137,14 @@ Take the **highest** bump across all commits that trigger a release for each pac
 ### Handle build metadata
 
 If the current version has `+N` build metadata (e.g., `0.3.0+1`), strip the `+N` before bumping. The new version will not have build metadata.
+
+### Pre-applied version bumps
+
+If Step 2.5 detected that a package's pubspec version is ahead of its latest tag version:
+
+1. **Pubspec version >= computed bump version**: Use the pubspec version as-is. The version was intentionally set (e.g., a 1.0.0 rewrite) and should be respected.
+2. **Computed bump would be higher than pubspec version**: Warn the user and ask which version to use. This is unusual and may indicate a mistake (e.g., someone set a patch bump manually but breaking changes were added later).
+3. **Changelog scope**: In either case, include **all commits since the last tag** in the changelog, not just commits since the pubspec was changed. The tag marks the last published state, so all changes since then are unreleased.
 
 ---
 
@@ -180,6 +208,17 @@ For each released package, **prepend** a new section to `packages/{pkg}/CHANGELO
 8. **Breaking note**: Only include `> Note: This release has breaking changes.` if there are breaking changes
 9. **AI summary**: Write 1-3 sentences summarizing the main changes in plain English. Place it between the breaking note (if any) and the entry list.
 
+### Pre-existing changelog sections
+
+Before writing a new changelog section, check if `## {new_version}` already exists in `CHANGELOG.md`:
+
+1. **Detection**: Match `^## {new_version}` (exact version, at start of line) in the file.
+2. **If the section already exists**:
+   1. **Review the existing content for quality**: Pre-existing sections may be draft notes, rough bullet points, or incomplete text from a PR. Read the content carefully and ensure it is polished, well-structured, and presentable as a published changelog. Fix grammar, formatting, missing links, or unclear descriptions. Ensure it follows the same formatting conventions as the rest of the changelog (bold type prefixes, issue/commit links, ordering rules defined above).
+   2. **Append** a `### Commits` subsection at the end of the existing section with the auto-generated commit entries (using the standard formatting rules above). This preserves the hand-written narrative while adding the structured commit log.
+   3. If the existing section lacks a breaking change note but the commits include breaking changes, add the `> Note: This release has breaking changes.` line at the top of the section (after the `## {version}` heading).
+3. **If the section does not exist**: Proceed with normal prepend behavior as described above.
+
 ---
 
 ## Step 6: Update pubspec.yaml Versions
@@ -233,6 +272,33 @@ If any package **fails** to publish:
 4. Only packages that were **successfully published** proceed to the commit/tag steps
 
 > **Warning**: Published packages cannot be unpublished from pub.dev. If a partial failure occurs, the already-published packages will be live on pub.dev but the repo won't yet have the corresponding commit/tags. The operator **must** continue with Steps 9-11 for the successfully published packages to bring the repo into a consistent state. Do not abandon the process after a partial publish.
+
+---
+
+## Step 8b: Reconciliation Checkpoint
+
+**Only in full release mode.** Perform this checkpoint after all publish attempts (Step 8) and before committing (Step 9).
+
+1. **Display a checklist** of all packages from the release plan with their publish status:
+   ```
+   | Package | Planned Version | Status |
+   |---------|-----------------|--------|
+   | foo_dart | 1.0.0 | Published |
+   | bar_dart | 2.1.0 | Published |
+   | baz_dart | 0.5.0 | FAILED |
+   | qux_dart | 1.3.0 | Skipped (user request) |
+   ```
+
+2. **Verify completeness**: Every package from the release plan must be accounted for with one of these statuses:
+   - **Published** — successfully published to pub.dev
+   - **Failed** — publish attempted but failed (files reverted per Step 8)
+   - **Skipped** — user explicitly chose to skip during Step 4
+
+3. **Flag any unaccounted packages**: If any planned package is missing from the checklist (neither published, failed, nor skipped), this is an error. The package was likely overlooked. Stop and resolve before proceeding.
+
+4. **Require user confirmation** before proceeding to Step 9.
+
+> **Why this checkpoint exists**: Discovering a missed package after committing and tagging (Steps 9-10) requires messy fixups — amending commits, re-tagging, force-pushing. Catching omissions here is far cheaper. Take 30 seconds to verify completeness now to avoid 30 minutes of cleanup later.
 
 ---
 
@@ -348,3 +414,87 @@ EOF
 8. **Partial publish failure** → report status, revert unpublished packages, only commit/tag published ones
 9. **Cross-package commits** → file-path detection handles correctly (same commit may appear in multiple packages)
 10. **Aggregate tag collision** → append counter suffix (`.1`, `.2`, etc.)
+
+---
+
+## Resuming an Interrupted Release
+
+If the release process is interrupted (e.g., context window exhausted, network failure, user abort), use the following guidance to determine current state and resume safely.
+
+### Determine current state
+
+Run these commands to assess where the release stopped:
+
+```bash
+# 1. Check for uncommitted release changes (pubspec.yaml, CHANGELOG.md edits)
+git status --porcelain
+
+# 2. Check for a release commit on HEAD
+git log -1 --oneline  # look for "chore(release): publish packages"
+
+# 3. Check for per-package tags on HEAD
+git tag --points-at HEAD
+
+# 4. Check if tags have been pushed
+git fetch origin --tags
+git log -1 --oneline origin/main  # compare with local HEAD
+
+# 5. Check for a GitHub release
+gh release list --limit 5
+
+# 6. Check pub.dev for published versions
+# For each package in the release plan:
+dart pub global activate pana  # if needed
+curl -s https://pub.dev/api/packages/{pkg} | grep '"version"' | head -1
+```
+
+### Progress checkpoints
+
+To enable safe resumption, write a progress file after each major step:
+
+```bash
+cat > /tmp/release-progress.md <<'EOF'
+# Release Progress — {date}
+
+## Plan
+| Package | Target Version | Status |
+|---------|----------------|--------|
+| foo_dart | 1.0.0 | published |
+| bar_dart | 2.1.0 | changelog written, not published |
+| baz_dart | 0.5.0 | pending |
+
+## Completed Steps
+- [x] Step 1: Environment validated
+- [x] Step 2-3: Changes detected, bumps computed
+- [x] Step 4: Plan confirmed
+- [x] Step 5: Changelogs written (all packages)
+- [x] Step 6: pubspec.yaml updated (all packages)
+- [x] Step 7: Dry-run passed
+- [x] Step 8: Published foo_dart
+- [ ] Step 8: Publish bar_dart, baz_dart
+- [ ] Step 8b: Reconciliation
+- [ ] Step 9: Commit
+- [ ] Step 10: Tags
+- [ ] Step 11: GitHub release
+
+## Last Updated
+{timestamp}
+EOF
+```
+
+Update this file after completing each step. A new session can read it to resume.
+
+### Recovery table
+
+| Interrupted After | State | Recovery Procedure |
+|---|---|---|
+| **Step 4** (plan confirmed) | No files modified yet. | Start fresh from Step 5. |
+| **Steps 5-6** (changelogs/pubspec written) | Working tree has uncommitted changes. | Verify the changes with `git diff`. Resume from Step 7 (dry-run publish). |
+| **Step 7** (dry-run passed) | Working tree has uncommitted changes, dry-run validated. | Resume from Step 8 (publish). |
+| **Step 8** (some packages published) | Some packages live on pub.dev, uncommitted changes in tree. | **Critical**: Check which packages are published (`curl -s https://pub.dev/api/packages/{pkg}`). For unpublished packages, revert their files (`git checkout HEAD -- packages/{pkg}/pubspec.yaml packages/{pkg}/CHANGELOG.md`). Resume from Step 8b with only the published packages. |
+| **Step 8b** (reconciliation done) | All publishes complete, user confirmed, uncommitted changes. | Resume from Step 9 (commit). |
+| **Step 9** (committed) | Release commit exists locally, not pushed. | Resume from Step 10 (create tags). |
+| **Step 10** (tags created) | Commit and tags exist locally, not pushed. | Resume from the push command in Step 10 (`git push origin main --tags`). Then proceed to Step 11. |
+| **Step 11** (GitHub release) | Everything done except GitHub release. | Check `gh release list`. If the release doesn't exist, create it per Step 11. If it exists but is incomplete, use `gh release edit` to update the body. |
+
+> **Critical rule**: If **any** packages have been published to pub.dev (Step 8), you **must** complete Steps 9-11 for those packages. Published packages without corresponding tags and commits leave the repository in an inconsistent state. Never abandon the process after a partial publish.


### PR DESCRIPTION
## Summary

- Fix auth preflight check to use `dart pub publish --dry-run` instead of `dart pub token list`, which misses OAuth sessions
- Add Step 2.5 to detect unreleased version bumps (pubspec version ahead of latest tag) so packages aren't incorrectly skipped
- Handle pre-existing changelog sections by reviewing quality and appending a `### Commits` subsection
- Add Step 8b reconciliation checkpoint to verify all planned packages are accounted for before committing/tagging
- Add "Resuming an Interrupted Release" section with state detection, progress checkpoints, and recovery table

## Test plan

- [x] Run `/release --plan` to verify the skill parses correctly end-to-end
- [x] Verify formatting consistency across all new sections
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
