### PR TITLE
ci: optimize test workflow to only test changed packages

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -117,7 +117,7 @@ jobs:
       - name: Run unit tests
         run: |
           echo "Testing packages/${{ matrix.package }}"
-          output=$(dart test "packages/${{ matrix.package }}/test" --exclude-tags integration 2>&1) && true
+          output=$(dart test "packages/${{ matrix.package }}/test" --exclude-tags integration --reporter failures-only 2>&1) && true
           exit_code=$?
           echo "$output"
           if [ $exit_code -ne 0 ]; then
@@ -163,7 +163,7 @@ jobs:
           for pkg in packages/*/; do
             if [ -d "$pkg/test" ]; then
               echo "::group::Testing $pkg"
-              output=$(dart test "$pkg/test" --exclude-tags integration 2>&1) && true
+              output=$(dart test "$pkg/test" --exclude-tags integration --reporter failures-only 2>&1) && true
               pkg_exit=$?
               echo "$output"
               if [ $pkg_exit -ne 0 ]; then


### PR DESCRIPTION
## Summary
- On PRs, detect which packages have changed files and run tests only for those packages in a **parallel matrix**, instead of testing all 10 packages sequentially
- Root-level changes (`pubspec.yaml`, `analysis_options.yaml`, etc.) still trigger all packages
- Push to `main` continues to run full sequential regression of all packages
- A `test-result` aggregator job provides a stable status check name for branch protection rules

## Test plan
- [ ] Open this PR (touches only `.github/` files) → verify `detect-changes` outputs `[]` and `test-result` passes
- [ ] Open a PR touching one package → verify only that package runs in the matrix
- [ ] Open a PR changing `pubspec.yaml` → verify all packages run
- [ ] Merge to `main` → verify `test-all` runs all packages sequentially

## Note
If branch protection uses required status checks, update the required check name from `Test` to `Test result`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
