### PR TITLE
fix(openai_dart): handle unknown streaming event types gracefully

### DIFF
--- a/packages/openai_dart/lib/src/models/responses/streaming/response_stream_event.dart
+++ b/packages/openai_dart/lib/src/models/responses/streaming/response_stream_event.dart
@@ -1,5 +1,6 @@
 import 'package:meta/meta.dart';
 
+import '../common/equality_helpers.dart';
 import '../content/annotation.dart';
 import '../content/logprob.dart';
 import '../content/output_content.dart';
@@ -3479,10 +3480,12 @@ class UnknownEvent extends ResponseStreamEvent {
       other is UnknownEvent &&
           runtimeType == other.runtimeType &&
           type == other.type &&
-          sequenceNumber == other.sequenceNumber;
+          sequenceNumber == other.sequenceNumber &&
+          mapsDeepEqual(rawJson, other.rawJson);
 
   @override
-  int get hashCode => Object.hash(type, sequenceNumber);
+  int get hashCode =>
+      Object.hash(type, sequenceNumber, mapDeepHashCode(rawJson));
 
   @override
   String toString() => 'UnknownEvent(type: $type)';

--- a/packages/openai_dart/test/integration/responses_test.dart
+++ b/packages/openai_dart/test/integration/responses_test.dart
@@ -315,50 +315,6 @@ void main() {
         expect(finalAccumulator.responseId, isNotNull);
       },
     );
-
-    test(
-      'handles keepalive events during long-running image generation stream',
-      timeout: const Timeout(Duration(minutes: 5)),
-      () async {
-        if (apiKey == null) {
-          markTestSkipped('API key not available');
-          return;
-        }
-
-        final stream = client!.responses.createStream(
-          CreateResponseRequest(
-            model: 'gpt-4o',
-            input: const ResponseInput.text(
-              'Generate a simple image of a red circle on white background.',
-            ),
-            tools: [
-              ResponseTool.imageGeneration(quality: 'low', size: '1024x1024'),
-            ],
-          ),
-        );
-
-        final events = <ResponseStreamEvent>[];
-        await stream.forEach(events.add);
-
-        // Stream should complete without throwing FormatException on keepalive
-        expect(events, isNotEmpty);
-        expect(events.last.isFinal, isTrue);
-
-        // Check if any keepalive/unknown events were received
-        final unknownEvents = events.whereType<UnknownEvent>().toList();
-        print(
-          'Received ${events.length} events, '
-          '${unknownEvents.length} unknown '
-          '(${unknownEvents.map((e) => e.type).toSet()})',
-        );
-
-        // Verify image generation events are present
-        expect(
-          events.whereType<ResponseImageGenerationCallInProgressEvent>(),
-          isNotEmpty,
-        );
-      },
-    );
   });
 
   // ==========================================================================
@@ -1000,6 +956,50 @@ void main() {
   // ==========================================================================
 
   group('Optional Tests', skip: 'Expensive/slow tests - run manually', () {
+    test(
+      'handles keepalive events during long-running image generation stream',
+      timeout: const Timeout(Duration(minutes: 5)),
+      () async {
+        if (apiKey == null) {
+          markTestSkipped('API key not available');
+          return;
+        }
+
+        final stream = client!.responses.createStream(
+          CreateResponseRequest(
+            model: 'gpt-4o',
+            input: const ResponseInput.text(
+              'Generate a simple image of a red circle on white background.',
+            ),
+            tools: [
+              ResponseTool.imageGeneration(quality: 'low', size: '1024x1024'),
+            ],
+          ),
+        );
+
+        final events = <ResponseStreamEvent>[];
+        await stream.forEach(events.add);
+
+        // Stream should complete without throwing FormatException on keepalive
+        expect(events, isNotEmpty);
+        expect(events.last.isFinal, isTrue);
+
+        // Check if any keepalive/unknown events were received
+        final unknownEvents = events.whereType<UnknownEvent>().toList();
+        print(
+          'Received ${events.length} events, '
+          '${unknownEvents.length} unknown '
+          '(${unknownEvents.map((e) => e.type).toSet()})',
+        );
+
+        // Verify image generation events are present
+        expect(
+          events.whereType<ResponseImageGenerationCallInProgressEvent>(),
+          isNotEmpty,
+        );
+      },
+    );
+
     test(
       'processes image input (vision)',
       timeout: const Timeout(Duration(minutes: 3)),

--- a/packages/openai_dart/test/unit/models/responses_test.dart
+++ b/packages/openai_dart/test/unit/models/responses_test.dart
@@ -2039,6 +2039,25 @@ void main() {
       expect(event.toJson(), equals(json));
     });
 
+    test('UnknownEvent equality includes rawJson', () {
+      const a = UnknownEvent(
+        type: 'keepalive',
+        rawJson: {'type': 'keepalive', 'data': 'A'},
+      );
+      const b = UnknownEvent(
+        type: 'keepalive',
+        rawJson: {'type': 'keepalive', 'data': 'A'},
+      );
+      const c = UnknownEvent(
+        type: 'keepalive',
+        rawJson: {'type': 'keepalive', 'data': 'B'},
+      );
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
+
     test('accumulator handles UnknownEvent gracefully', () {
       final accumulator = ResponseStreamAccumulator()
         // Should not throw


### PR DESCRIPTION
## Summary

- `ResponseStreamEvent.fromJson()` threw `FormatException` on unrecognized event types like `keepalive` that OpenAI emits during long-running streaming operations (e.g. image generation)
- Added `UnknownEvent` subclass as a catch-all for unrecognized event types instead of throwing, preserving the raw JSON for inspection
- This is future-proof against any new undocumented event types OpenAI may add

Closes #71

## Test plan

- [x] Unit test: `keepalive` event deserializes as `UnknownEvent`
- [x] Unit test: arbitrary unknown event types deserialize without throwing
- [x] Unit test: `UnknownEvent` roundtrips through `toJson`
- [x] Unit test: `ResponseStreamAccumulator` handles `UnknownEvent` gracefully
- [x] Integration test: streaming image generation completes without `FormatException`
- [x] All 887 existing unit tests pass
- [x] Analyzer reports no errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/72" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
