### PR TITLE
fix(skills): fix release skill working directory and delimiter issues

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -57,7 +57,7 @@ Perform all applicable checks before proceeding. Fail fast with an actionable er
 
 ## Step 2: Detect Changes Per Package
 
-> **IMPORTANT — Working directory**: All `git` and shell commands throughout this skill assume the **repository root** as the working directory. The Bash tool does not persist `cd` between calls, so **always use absolute paths or prefix commands with `cd /path/to/repo &&`** when running shell commands. Never rely on a previous `cd` having set the working directory. This applies to every step, not just this one.
+> **IMPORTANT — Working directory**: All `git` and shell commands throughout this skill assume the **repository root** as the working directory. The Bash tool does not persist `cd` between calls, so **always use absolute paths or prefix commands with a quoted repo path, for example `REPO_ROOT="/path/to/repo"` then `cd "$REPO_ROOT" && ...`, when running shell commands**. Never rely on a previous `cd` having set the working directory. This applies to every step, not just this one.
 
 ### Discover packages
 
@@ -75,7 +75,7 @@ Read the `workspace` list from the root `pubspec.yaml` (the source of truth). Ea
    ```bash
    git log --format="%H|||%s|||%b|||END" {tag}..HEAD -- packages/{pkg}/
    ```
-   Use `|||` as field delimiter and `|||END` as record terminator. **Parse by splitting on `|||END` first** (to get individual commit records), then split each record on `|||` (to get hash, subject, body). Avoid using ASCII control characters (`%x1f`, `%x1e`) as delimiters — they can be silently stripped or mangled by shell processing, leading to empty results.
+   Use `|||` as field delimiter and `|||END` as record terminator. **Parse by splitting on `|||END` first** (to get individual commit records), then discard any empty records from the result (the final terminator produces a trailing empty element). After filtering, split each remaining record on `|||` **into at most three parts** (hash, subject, body) so any additional `|||` sequences in the subject or body remain inside the body field. Do not blindly split on every occurrence of `|||`. Avoid using ASCII control characters (`%x1f`, `%x1e`) as delimiters — they can be silently stripped or mangled by shell processing, leading to empty results.
 
 3. **No previous tag** (first release): use all commits touching `packages/{pkg}/`.
 


### PR DESCRIPTION
## Summary

- Fix release skill's commit detection silently returning empty results due to two issues:
  - Added explicit instruction that all shell commands must run from the repository root (the Bash tool does not persist `cd` between calls)
  - Replaced ASCII control character delimiters (`%x1f`, `%x1e`) with plain-text `|||`/`|||END` delimiters that are not stripped by shell processing

## Test plan

- [x] Verified the delimiter change works by running `git log --format="%H|||%s|||%b|||END"` and confirming output is parseable
- [x] Run `/release --plan` to confirm packages with changes are correctly detected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
