### PR TITLE
chore: add .pubignore to exclude .agents/ and specs/ from publishing

### DIFF
--- a/packages/anthropic_sdk_dart/.pubignore
+++ b/packages/anthropic_sdk_dart/.pubignore
@@ -1,2 +1,3 @@
 .agents/
+.claude/
 specs/

--- a/packages/chromadb/.pubignore
+++ b/packages/chromadb/.pubignore
@@ -1,2 +1,3 @@
 .agents/
+.claude/
 specs/

--- a/packages/googleai_dart/.pubignore
+++ b/packages/googleai_dart/.pubignore
@@ -1,2 +1,3 @@
 .agents/
+.claude/
 specs/

--- a/packages/mistralai_dart/.pubignore
+++ b/packages/mistralai_dart/.pubignore
@@ -1,2 +1,3 @@
 .agents/
+.claude/
 specs/

--- a/packages/ollama_dart/.pubignore
+++ b/packages/ollama_dart/.pubignore
@@ -1,2 +1,3 @@
 .agents/
+.claude/
 specs/

--- a/packages/open_responses/.pubignore
+++ b/packages/open_responses/.pubignore
@@ -1,2 +1,3 @@
 .agents/
+.claude/
 specs/

--- a/packages/openai_dart/.pubignore
+++ b/packages/openai_dart/.pubignore
@@ -1,2 +1,3 @@
 .agents/
+.claude/
 specs/


### PR DESCRIPTION
## Summary

- Adds `.pubignore` files to 7 packages (`anthropic_sdk_dart`, `chromadb`, `googleai_dart`, `mistralai_dart`, `ollama_dart`, `openai_dart`, `open_responses`) to exclude `.agents/` and `specs/` directories from pub.dev publishing
- These directories contain internal tooling configurations and OpenAPI specs that package consumers don't need

## Test plan

- [x] Verify `dart pub publish --dry-run` still passes for affected packages
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
