### PR TITLE
feat(openai_dart): update model references to gpt-realtime-1.5 and gpt-audio-1.5

### DIFF
--- a/packages/openai_dart/MIGRATION.md
+++ b/packages/openai_dart/MIGRATION.md
@@ -701,7 +701,7 @@ import 'package:openai_dart/openai_dart_realtime.dart' as realtime;
 
 // Connect to a realtime session
 final session = await client.realtime.connect(
-  model: 'gpt-4o-realtime-preview',
+  model: 'gpt-realtime-1.5',
   config: realtime.SessionUpdateConfig(
     voice: 'alloy',
     instructions: 'You are a helpful assistant.',

--- a/packages/openai_dart/lib/src/client/openai_client.dart
+++ b/packages/openai_dart/lib/src/client/openai_client.dart
@@ -629,7 +629,7 @@ class OpenAIClient {
   ///
   /// ```dart
   /// final session = await client.realtime.connect(
-  ///   model: 'gpt-4o-realtime-preview',
+  ///   model: 'gpt-realtime-1.5',
   /// );
   ///
   /// session.events.listen((event) {
@@ -661,7 +661,7 @@ class OpenAIClient {
   /// // Create a session with ephemeral key
   /// final session = await client.realtimeSessions.create(
   ///   RealtimeSessionCreateRequest(
-  ///     model: 'gpt-4o-realtime-preview',
+  ///     model: 'gpt-realtime-1.5',
   ///     voice: RealtimeVoice.alloy,
   ///   ),
   /// );

--- a/packages/openai_dart/lib/src/models/chat/chat_audio_config.dart
+++ b/packages/openai_dart/lib/src/models/chat/chat_audio_config.dart
@@ -13,7 +13,7 @@ import 'package:meta/meta.dart';
 ///
 /// ```dart
 /// final request = ChatCompletionCreateRequest(
-///   model: 'gpt-4o-audio-preview',
+///   model: 'gpt-audio-1.5',
 ///   messages: [...],
 ///   modalities: [ChatModality.text, ChatModality.audio],
 ///   audio: ChatAudioConfig(
@@ -54,7 +54,7 @@ enum ChatModality {
 
 /// Voice options for chat audio output.
 ///
-/// These voices are available for the `gpt-4o-audio-preview` model
+/// These voices are available for the `gpt-audio-1.5` model
 /// when generating audio responses.
 enum ChatAudioVoice {
   /// Alloy voice.
@@ -157,14 +157,14 @@ enum ChatAudioFormat {
 
 /// Configuration for audio output in chat completions.
 ///
-/// Used with `gpt-4o-audio-preview` to configure how audio responses
+/// Used with `gpt-audio-1.5` to configure how audio responses
 /// are generated.
 ///
 /// ## Example
 ///
 /// ```dart
 /// final request = ChatCompletionCreateRequest(
-///   model: 'gpt-4o-audio-preview',
+///   model: 'gpt-audio-1.5',
 ///   messages: [ChatMessage.user('Tell me a story.')],
 ///   modalities: [ChatModality.text, ChatModality.audio],
 ///   audio: ChatAudioConfig(

--- a/packages/openai_dart/lib/src/models/chat/chat_completion_request.dart
+++ b/packages/openai_dart/lib/src/models/chat/chat_completion_request.dart
@@ -320,7 +320,7 @@ class ChatCompletionCreateRequest {
   /// Output modalities to request.
   ///
   /// Use `[ChatModality.text, ChatModality.audio]` to request both text
-  /// and audio output from audio-capable models like `gpt-4o-audio-preview`.
+  /// and audio output from audio-capable models like `gpt-audio-1.5`.
   final List<ChatModality>? modalities;
 
   /// Audio output configuration.

--- a/packages/openai_dart/lib/src/models/realtime/realtime_call.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_call.dart
@@ -18,7 +18,7 @@ import 'realtime_session_create.dart';
 ///   RealtimeCallCreateRequest(
 ///     sdp: sdpOffer,
 ///     session: RealtimeSessionCreateRequest(
-///       model: 'gpt-4o-realtime-preview',
+///       model: 'gpt-realtime-1.5',
 ///       voice: RealtimeVoice.alloy,
 ///     ),
 ///   ),

--- a/packages/openai_dart/lib/src/models/realtime/realtime_client_secret.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_client_secret.dart
@@ -62,7 +62,7 @@ class ExpiresAfter {
 ///   RealtimeClientSecretCreateRequest(
 ///     expiresAfter: ExpiresAfter(anchor: 'created_at', seconds: 3600),
 ///     session: RealtimeSessionCreateRequest(
-///       model: 'gpt-4o-realtime-preview',
+///       model: 'gpt-realtime-1.5',
 ///       voice: RealtimeVoice.alloy,
 ///     ),
 ///   ),

--- a/packages/openai_dart/lib/src/models/realtime/realtime_session_create.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_session_create.dart
@@ -97,7 +97,7 @@ class NoiseReductionConfig {
 /// ```dart
 /// final response = await client.realtimeSessions.create(
 ///   RealtimeSessionCreateRequest(
-///     model: 'gpt-4o-realtime-preview',
+///     model: 'gpt-realtime-1.5',
 ///     voice: RealtimeVoice.alloy,
 ///     instructions: 'You are a helpful assistant.',
 ///   ),
@@ -181,7 +181,7 @@ class RealtimeSessionCreateRequest {
   /// for realtime sessions. Only needed for certain endpoints like client secrets.
   final String? type;
 
-  /// The model to use (required for HTTP, e.g., 'gpt-4o-realtime-preview').
+  /// The model to use (required for HTTP, e.g., 'gpt-realtime-1.5').
   final String model;
 
   /// The modalities enabled (e.g., ["text", "audio"]).

--- a/packages/openai_dart/lib/src/resources/realtime_resource.dart
+++ b/packages/openai_dart/lib/src/resources/realtime_resource.dart
@@ -19,7 +19,7 @@ import 'realtime/websocket_connector.dart';
 /// ```dart
 /// // Connect to realtime session
 /// final session = await client.realtime.connect(
-///   model: 'gpt-4o-realtime-preview',
+///   model: 'gpt-realtime-1.5',
 /// );
 ///
 /// // Listen for events
@@ -49,7 +49,7 @@ class RealtimeResource extends ResourceBase {
   ///
   /// ## Parameters
   ///
-  /// - [model] - The model to use (e.g., 'gpt-4o-realtime-preview').
+  /// - [model] - The model to use (e.g., 'gpt-realtime-1.5').
   /// - [config] - Optional session configuration.
   ///
   /// ## Returns
@@ -67,7 +67,7 @@ class RealtimeResource extends ResourceBase {
   ///
   /// ```dart
   /// final session = await client.realtime.connect(
-  ///   model: 'gpt-4o-realtime-preview',
+  ///   model: 'gpt-realtime-1.5',
   ///   config: SessionUpdateConfig(
   ///     voice: 'alloy',
   ///     instructions: 'You are a helpful assistant.',

--- a/packages/openai_dart/lib/src/resources/realtime_sessions_resource.dart
+++ b/packages/openai_dart/lib/src/resources/realtime_sessions_resource.dart
@@ -18,7 +18,7 @@ import 'base_resource.dart';
 /// // Create a realtime session with ephemeral key
 /// final session = await client.realtimeSessions.create(
 ///   RealtimeSessionCreateRequest(
-///     model: 'gpt-4o-realtime-preview',
+///     model: 'gpt-realtime-1.5',
 ///     voice: RealtimeVoice.alloy,
 ///   ),
 /// );
@@ -74,7 +74,7 @@ class RealtimeSessionsResource extends ResourceBase {
   /// ```dart
   /// final session = await client.realtimeSessions.create(
   ///   RealtimeSessionCreateRequest(
-  ///     model: 'gpt-4o-realtime-preview',
+  ///     model: 'gpt-realtime-1.5',
   ///     voice: RealtimeVoice.alloy,
   ///     instructions: 'You are a helpful assistant.',
   ///     turnDetection: TurnDetection(
@@ -175,7 +175,7 @@ class RealtimeSessionsResource extends ResourceBase {
   ///   RealtimeClientSecretCreateRequest(
   ///     expiresAfter: ExpiresAfter(anchor: 'created_at', seconds: 3600),
   ///     session: RealtimeSessionCreateRequest(
-  ///       model: 'gpt-4o-realtime-preview',
+  ///       model: 'gpt-realtime-1.5',
   ///       voice: RealtimeVoice.shimmer,
   ///     ),
   ///   ),
@@ -245,7 +245,7 @@ class RealtimeCallsResource extends ResourceBase {
   ///   RealtimeCallCreateRequest(
   ///     sdp: myPeerConnection.localDescription.sdp,
   ///     session: RealtimeSessionCreateRequest(
-  ///       model: 'gpt-4o-realtime-preview',
+  ///       model: 'gpt-realtime-1.5',
   ///       voice: RealtimeVoice.alloy,
   ///     ),
   ///   ),

--- a/packages/openai_dart/specs/spec_metadata.json
+++ b/packages/openai_dart/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "2.3.0",
-      "last_fetched": "2026-03-06T18:18:15.969811Z",
+      "last_fetched": "2026-03-09T19:32:36.261056Z",
       "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai%2Fopenai-9c802d45a9bf2a896b5fd22ac22bba185e8a145bd40ed242df9bb87a05e954eb.yml",
       "title": "OpenAI API",
       "version_history": []

--- a/packages/openai_dart/test/integration/realtime_test.dart
+++ b/packages/openai_dart/test/integration/realtime_test.dart
@@ -45,7 +45,7 @@ void main() {
 
         final response = await client!.realtimeSessions.create(
           const realtime.RealtimeSessionCreateRequest(
-            model: 'gpt-4o-realtime-preview',
+            model: 'gpt-realtime-1.5',
           ),
         );
 
@@ -72,7 +72,7 @@ void main() {
 
         final response = await client!.realtimeSessions.create(
           const realtime.RealtimeSessionCreateRequest(
-            model: 'gpt-4o-realtime-preview',
+            model: 'gpt-realtime-1.5',
             modalities: ['text', 'audio'],
             voice: realtime.RealtimeVoice.alloy,
             instructions: 'You are a helpful assistant.',
@@ -141,7 +141,7 @@ void main() {
             ),
             session: realtime.RealtimeSessionCreateRequest(
               type: 'realtime', // Required discriminator for client secrets
-              model: 'gpt-4o-realtime-preview',
+              model: 'gpt-realtime-1.5',
             ),
           ),
         );
@@ -171,7 +171,7 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-4o-realtime-preview',
+          model: 'gpt-realtime-1.5',
         );
 
         expect(connection.isClosed, isFalse);
@@ -191,7 +191,7 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-4o-realtime-preview',
+          model: 'gpt-realtime-1.5',
         );
 
         try {
@@ -220,7 +220,7 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-4o-realtime-preview',
+          model: 'gpt-realtime-1.5',
         );
 
         // Wait for session created
@@ -245,7 +245,7 @@ void main() {
 
         for (var i = 0; i < 2; i++) {
           final connection = await client!.realtime.connect(
-            model: 'gpt-4o-realtime-preview',
+            model: 'gpt-realtime-1.5',
           );
 
           await waitForEvent<realtime.SessionCreatedEvent>(connection);
@@ -275,7 +275,7 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-4o-realtime-preview',
+          model: 'gpt-realtime-1.5',
         );
 
         try {
@@ -317,7 +317,7 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-4o-realtime-preview',
+          model: 'gpt-realtime-1.5',
           config: const realtime.SessionUpdateConfig(
             voice: realtime.RealtimeVoice.echo,
             modalities: ['text', 'audio'],
@@ -361,7 +361,7 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-4o-realtime-preview',
+          model: 'gpt-realtime-1.5',
           config: const realtime.SessionUpdateConfig(modalities: ['text']),
         );
 
@@ -421,7 +421,7 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-4o-realtime-preview',
+          model: 'gpt-realtime-1.5',
           config: const realtime.SessionUpdateConfig(
             modalities: ['text'],
             tools: [
@@ -529,7 +529,7 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-4o-realtime-preview',
+          model: 'gpt-realtime-1.5',
           config: const realtime.SessionUpdateConfig(modalities: ['text']),
         );
 
@@ -577,7 +577,7 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-4o-realtime-preview',
+          model: 'gpt-realtime-1.5',
           config: const realtime.SessionUpdateConfig(modalities: ['text']),
         );
 
@@ -627,7 +627,7 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-4o-realtime-preview',
+          model: 'gpt-realtime-1.5',
           config: const realtime.SessionUpdateConfig(modalities: ['text']),
         );
 
@@ -686,7 +686,7 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-4o-realtime-preview',
+          model: 'gpt-realtime-1.5',
         );
 
         try {
@@ -736,7 +736,7 @@ void main() {
         final audioBytes = await audioFile.readAsBytes();
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-4o-realtime-preview',
+          model: 'gpt-realtime-1.5',
           config: const realtime.SessionUpdateConfig(
             modalities: ['text', 'audio'],
             inputAudioFormat: realtime.RealtimeAudioFormat.pcm16,
@@ -817,7 +817,7 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-4o-realtime-preview',
+          model: 'gpt-realtime-1.5',
           config: const realtime.SessionUpdateConfig(
             modalities: ['text', 'audio'],
             inputAudioFormat: realtime.RealtimeAudioFormat.pcm16,

--- a/packages/openai_dart/test/unit/models/chat_completion_test.dart
+++ b/packages/openai_dart/test/unit/models/chat_completion_test.dart
@@ -351,7 +351,7 @@ void main() {
 
     test('supports modalities for audio output', () {
       final request = ChatCompletionCreateRequest(
-        model: 'gpt-4o-audio-preview',
+        model: 'gpt-audio-1.5',
         messages: [ChatMessage.user('Tell me a story.')],
         modalities: const [ChatModality.text, ChatModality.audio],
         audio: const ChatAudioConfig(

--- a/packages/openai_dart/test/unit/models/realtime_test.dart
+++ b/packages/openai_dart/test/unit/models/realtime_test.dart
@@ -132,7 +132,7 @@ void main() {
       final json = {
         'id': 'sess_abc123',
         'object': 'realtime.session',
-        'model': 'gpt-4o-realtime-preview',
+        'model': 'gpt-realtime-1.5',
         'modalities': ['text', 'audio'],
         'instructions': 'You are a helpful assistant.',
         'voice': 'alloy',
@@ -152,7 +152,7 @@ void main() {
       final session = RealtimeSession.fromJson(json);
 
       expect(session.id, 'sess_abc123');
-      expect(session.model, 'gpt-4o-realtime-preview');
+      expect(session.model, 'gpt-realtime-1.5');
       expect(session.modalities, ['text', 'audio']);
       expect(session.voice, RealtimeVoice.alloy);
       expect(session.inputAudioFormat, RealtimeAudioFormat.pcm16);
@@ -168,7 +168,7 @@ void main() {
       final json = {
         'id': 'sess_abc123',
         'object': 'realtime.session',
-        'model': 'gpt-4o-realtime-preview',
+        'model': 'gpt-realtime-1.5',
         'max_response_output_tokens': 4096,
       };
 
@@ -182,7 +182,7 @@ void main() {
       const session = RealtimeSession(
         id: 'sess_abc123',
         object: 'realtime.session',
-        model: 'gpt-4o-realtime-preview',
+        model: 'gpt-realtime-1.5',
         voice: RealtimeVoice.shimmer,
         inputAudioFormat: RealtimeAudioFormat.g711Ulaw,
         toolChoice: RealtimeToolChoiceRequired(),

--- a/packages/openai_dart/test/unit/resources/realtime_url_test.dart
+++ b/packages/openai_dart/test/unit/resources/realtime_url_test.dart
@@ -15,16 +15,13 @@ void main() {
       // Test that buildUrl works correctly for the realtime endpoint
       final httpUrl = builder.buildUrl(
         '/realtime',
-        queryParams: {'model': 'gpt-4o-realtime-preview'},
+        queryParams: {'model': 'gpt-realtime-1.5'},
       );
 
       expect(httpUrl.scheme, equals('https'));
       expect(httpUrl.host, equals('api.openai.com'));
       expect(httpUrl.path, equals('/v1/realtime'));
-      expect(
-        httpUrl.queryParameters['model'],
-        equals('gpt-4o-realtime-preview'),
-      );
+      expect(httpUrl.queryParameters['model'], equals('gpt-realtime-1.5'));
 
       // Verify scheme conversion
       final wsUrl = httpUrl.replace(
@@ -33,7 +30,7 @@ void main() {
       expect(wsUrl.scheme, equals('wss'));
       expect(wsUrl.host, equals('api.openai.com'));
       expect(wsUrl.path, equals('/v1/realtime'));
-      expect(wsUrl.queryParameters['model'], equals('gpt-4o-realtime-preview'));
+      expect(wsUrl.queryParameters['model'], equals('gpt-realtime-1.5'));
     });
 
     test('buildUrl handles HTTP base URL (converts to WS)', () {
@@ -46,7 +43,7 @@ void main() {
 
       final httpUrl = builder.buildUrl(
         '/realtime',
-        queryParams: {'model': 'gpt-4o-realtime-preview'},
+        queryParams: {'model': 'gpt-realtime-1.5'},
       );
 
       // Verify scheme conversion for HTTP -> WS
@@ -70,7 +67,7 @@ void main() {
 
       final httpUrl = builder.buildUrl(
         '/realtime',
-        queryParams: {'model': 'gpt-4o-realtime-preview'},
+        queryParams: {'model': 'gpt-realtime-1.5'},
       );
 
       expect(httpUrl.scheme, equals('https'));
@@ -78,10 +75,7 @@ void main() {
       expect(httpUrl.path, equals('/openai/deployments/my-deploy/realtime'));
       // Both base URL params and request params should be present
       expect(httpUrl.queryParameters['api-version'], equals('2024-10-01'));
-      expect(
-        httpUrl.queryParameters['model'],
-        equals('gpt-4o-realtime-preview'),
-      );
+      expect(httpUrl.queryParameters['model'], equals('gpt-realtime-1.5'));
 
       // Verify scheme conversion
       final wsUrl = httpUrl.replace(


### PR DESCRIPTION
## Summary

Update all model references in the `openai_dart` package from the deprecated preview model names to the new recommended ones:

- `gpt-4o-realtime-preview` → `gpt-realtime-1.5`
- `gpt-4o-audio-preview` → `gpt-audio-1.5`

## Changes

- Updated doc comments, code examples, and migration guide references
- Updated unit and integration test fixtures
- Bumped spec metadata timestamp