### PR TITLE
chore(anthropic_sdk_dart): update OpenAPI spec and migrate deprecated model IDs

### DIFF
--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/specs.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/specs.json
@@ -27,9 +27,9 @@
       "fetch_mode": "remote",
       "local_file": "openapi.yaml",
       "name": "Anthropic API",
-      "pinned_hash": "dfe504526eed07979685a729ac9afd45e59cc2879291714b9f4674f2ef1247c7",
+      "pinned_hash": "f4d4f18820ecfbe244fb1bbc2232939afca73dfcb21ce23bc296571ee7320e3a",
       "requires_auth": false,
-      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic%2Fanthropic-dfe504526eed07979685a729ac9afd45e59cc2879291714b9f4674f2ef1247c7.yml"
+      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic%2Fanthropic-f4d4f18820ecfbe244fb1bbc2232939afca73dfcb21ce23bc296571ee7320e3a.yml"
     }
   },
   "specs_dir": "packages/anthropic_sdk_dart/specs"

--- a/packages/anthropic_sdk_dart/example/abort_example.dart
+++ b/packages/anthropic_sdk_dart/example/abort_example.dart
@@ -27,7 +27,7 @@ void main() async {
     // Start a request that would take some time
     final requestFuture = client.messages.create(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 4096,
         messages: [
           InputMessage.user(
@@ -66,7 +66,7 @@ void main() async {
     try {
       final response = await client.messages.create(
         MessageCreateRequest(
-          model: 'claude-sonnet-4-20250514',
+          model: 'claude-sonnet-4-6',
           maxTokens: 100,
           messages: [InputMessage.user('Say hello in 5 different languages.')],
         ),
@@ -84,7 +84,7 @@ void main() async {
 
     final stream = client.messages.createStream(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 1024,
         messages: [InputMessage.user('Write a poem about the ocean.')],
       ),
@@ -119,7 +119,7 @@ void main() async {
     try {
       await client.messages.create(
         MessageCreateRequest(
-          model: 'claude-sonnet-4-20250514',
+          model: 'claude-sonnet-4-6',
           maxTokens: 100,
           messages: [InputMessage.user('Hello')],
         ),

--- a/packages/anthropic_sdk_dart/example/anthropic_sdk_dart_example.dart
+++ b/packages/anthropic_sdk_dart/example/anthropic_sdk_dart_example.dart
@@ -20,7 +20,7 @@ void main() async {
     print('=== Basic Message ===');
     final response = await client.messages.create(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 1024,
         messages: [InputMessage.user('What is the capital of France?')],
       ),
@@ -37,7 +37,7 @@ void main() async {
     print('\n=== Multi-turn Conversation ===');
     final conversation = await client.messages.create(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 1024,
         messages: [
           InputMessage.user('My name is Alice.'),
@@ -52,7 +52,7 @@ void main() async {
     print('\n=== System Prompt ===');
     final pirate = await client.messages.create(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 1024,
         system: SystemPrompt.text(
           'You are a friendly pirate. Respond in pirate speak.',
@@ -67,7 +67,7 @@ void main() async {
     stdout.write('Streaming response: ');
     final stream = client.messages.createStream(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 256,
         messages: [InputMessage.user('Count from 1 to 5 slowly.')],
       ),

--- a/packages/anthropic_sdk_dart/example/batch_example.dart
+++ b/packages/anthropic_sdk_dart/example/batch_example.dart
@@ -26,7 +26,7 @@ void main() async {
           BatchRequestItem(
             customId: 'request-1',
             params: MessageCreateRequest(
-              model: 'claude-sonnet-4-20250514',
+              model: 'claude-sonnet-4-6',
               maxTokens: 100,
               messages: [InputMessage.user('What is 2 + 2?')],
             ),
@@ -34,7 +34,7 @@ void main() async {
           BatchRequestItem(
             customId: 'request-2',
             params: MessageCreateRequest(
-              model: 'claude-sonnet-4-20250514',
+              model: 'claude-sonnet-4-6',
               maxTokens: 100,
               messages: [InputMessage.user('What is the capital of France?')],
             ),
@@ -42,7 +42,7 @@ void main() async {
           BatchRequestItem(
             customId: 'request-3',
             params: MessageCreateRequest(
-              model: 'claude-sonnet-4-20250514',
+              model: 'claude-sonnet-4-6',
               maxTokens: 100,
               messages: [InputMessage.user('Write a haiku about coding.')],
             ),

--- a/packages/anthropic_sdk_dart/example/computer_use_example.dart
+++ b/packages/anthropic_sdk_dart/example/computer_use_example.dart
@@ -36,7 +36,7 @@ final tools = [
 
 final response = await client.messages.create(
   MessageCreateRequest(
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     maxTokens: 4096,
     tools: tools,
     messages: [

--- a/packages/anthropic_sdk_dart/example/document_example.dart
+++ b/packages/anthropic_sdk_dart/example/document_example.dart
@@ -30,7 +30,7 @@ void main() async {
 
       final response = await client.messages.create(
         MessageCreateRequest(
-          model: 'claude-sonnet-4-20250514',
+          model: 'claude-sonnet-4-6',
           maxTokens: 4096,
           messages: [
             InputMessage.userBlocks([
@@ -66,7 +66,7 @@ To extract structured data from a document, you would use:
 
 final response = await client.messages.create(
   MessageCreateRequest(
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     maxTokens: 4096,
     messages: [
       InputMessage.userBlocks([
@@ -95,7 +95,7 @@ To compare multiple documents:
 
 final response = await client.messages.create(
   MessageCreateRequest(
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     maxTokens: 8192,
     messages: [
       InputMessage.userBlocks([
@@ -140,7 +140,7 @@ final messages = [
 
 final response = await client.messages.create(
   MessageCreateRequest(
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     maxTokens: 2048,
     messages: messages,
   ),

--- a/packages/anthropic_sdk_dart/example/error_handling_example.dart
+++ b/packages/anthropic_sdk_dart/example/error_handling_example.dart
@@ -23,7 +23,7 @@ void main() async {
     try {
       await invalidClient.messages.create(
         MessageCreateRequest(
-          model: 'claude-sonnet-4-20250514',
+          model: 'claude-sonnet-4-6',
           maxTokens: 100,
           messages: [InputMessage.user('Hello')],
         ),
@@ -39,7 +39,7 @@ void main() async {
     try {
       await client.messages.create(
         MessageCreateRequest(
-          model: 'claude-sonnet-4-20250514',
+          model: 'claude-sonnet-4-6',
           maxTokens: -1, // Invalid: must be positive
           messages: [InputMessage.user('Hello')],
         ),
@@ -54,7 +54,7 @@ void main() async {
       // This would happen with too many requests
       await client.messages.create(
         MessageCreateRequest(
-          model: 'claude-sonnet-4-20250514',
+          model: 'claude-sonnet-4-6',
           maxTokens: 100,
           messages: [InputMessage.user('Hello')],
         ),
@@ -70,7 +70,7 @@ void main() async {
     try {
       await client.messages.create(
         MessageCreateRequest(
-          model: 'claude-sonnet-4-20250514',
+          model: 'claude-sonnet-4-6',
           maxTokens: 100,
           messages: [InputMessage.user('Hello')],
         ),

--- a/packages/anthropic_sdk_dart/example/mcp_example.dart
+++ b/packages/anthropic_sdk_dart/example/mcp_example.dart
@@ -39,7 +39,7 @@ final tools = [
 
 final response = await client.messages.create(
   MessageCreateRequest(
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     maxTokens: 4096,
     tools: tools,
     messages: [

--- a/packages/anthropic_sdk_dart/example/message_batches_example.dart
+++ b/packages/anthropic_sdk_dart/example/message_batches_example.dart
@@ -28,7 +28,7 @@ void main() async {
           BatchRequestItem(
             customId: 'greeting-1',
             params: MessageCreateRequest(
-              model: 'claude-sonnet-4-20250514',
+              model: 'claude-sonnet-4-6',
               maxTokens: 50,
               messages: [InputMessage.user('Say hello!')],
             ),
@@ -36,7 +36,7 @@ void main() async {
           BatchRequestItem(
             customId: 'greeting-2',
             params: MessageCreateRequest(
-              model: 'claude-sonnet-4-20250514',
+              model: 'claude-sonnet-4-6',
               maxTokens: 50,
               messages: [InputMessage.user('Say goodbye!')],
             ),

--- a/packages/anthropic_sdk_dart/example/messages_example.dart
+++ b/packages/anthropic_sdk_dart/example/messages_example.dart
@@ -20,7 +20,7 @@ void main() async {
     print('=== Simple Message ===');
     final simpleResponse = await client.messages.create(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 1024,
         messages: [InputMessage.user('What is the capital of France?')],
       ),
@@ -35,7 +35,7 @@ void main() async {
     print('\n=== With System Prompt ===');
     final systemResponse = await client.messages.create(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 1024,
         system: SystemPrompt.text(
           'You are a helpful assistant that speaks like a pirate. '
@@ -50,7 +50,7 @@ void main() async {
     print('\n=== Multi-turn Conversation ===');
     final conversationResponse = await client.messages.create(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 1024,
         messages: [
           InputMessage.user('My name is Alice.'),
@@ -65,7 +65,7 @@ void main() async {
     print('\n=== Content Blocks ===');
     final contentBlockResponse = await client.messages.create(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 1024,
         messages: [
           InputMessage.userBlocks([
@@ -83,7 +83,7 @@ void main() async {
     print('\n=== Stop Sequences ===');
     final stopResponse = await client.messages.create(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 1024,
         stopSequences: const ['END'],
         messages: [InputMessage.user('Count from 1 to 10, say END after 5')],
@@ -96,7 +96,7 @@ void main() async {
     print('\n=== Temperature and Metadata ===');
     final tempResponse = await client.messages.create(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 1024,
         temperature: 0.0, // Deterministic
         metadata: const Metadata(userId: 'example-user-123'),

--- a/packages/anthropic_sdk_dart/example/models_example.dart
+++ b/packages/anthropic_sdk_dart/example/models_example.dart
@@ -30,7 +30,7 @@ void main() async {
 
     // Example 2: Retrieve a specific model
     print('\n=== Retrieve Model ===');
-    const modelId = 'claude-sonnet-4-20250514';
+    const modelId = 'claude-sonnet-4-6';
     final model = await client.models.retrieve(modelId);
 
     print('Model details:');

--- a/packages/anthropic_sdk_dart/example/streaming_example.dart
+++ b/packages/anthropic_sdk_dart/example/streaming_example.dart
@@ -22,7 +22,7 @@ void main() async {
     print('=== Basic Streaming ===');
     final stream = client.messages.createStream(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 1024,
         messages: [InputMessage.user('Write a haiku about programming')],
       ),
@@ -66,7 +66,7 @@ void main() async {
     final textBuffer = StringBuffer();
     final accStream = client.messages.createStream(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 1024,
         messages: [
           InputMessage.user('What is the meaning of life in one sentence?'),
@@ -87,7 +87,7 @@ void main() async {
     print('\n=== Multi-turn Streaming ===');
     final conversationStream = client.messages.createStream(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 1024,
         messages: [
           InputMessage.user('Hello!'),
@@ -113,7 +113,7 @@ void main() async {
 
     final usageStream = client.messages.createStream(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 1024,
         messages: [InputMessage.user('Say "Hello, World!"')],
       ),
@@ -139,7 +139,7 @@ void main() async {
     final fullText = await client.messages
         .createStream(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 1024,
             messages: [InputMessage.user('What is 2+2?')],
           ),
@@ -152,7 +152,7 @@ void main() async {
     await client.messages
         .createStream(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 1024,
             messages: [InputMessage.user('Say hello!')],
           ),
@@ -164,7 +164,7 @@ void main() async {
     print('\n=== Message Stream Accumulator ===');
     final accumulatorStream = client.messages.createStream(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 1024,
         messages: [InputMessage.user('Tell me a fun fact.')],
       ),

--- a/packages/anthropic_sdk_dart/example/thinking_example.dart
+++ b/packages/anthropic_sdk_dart/example/thinking_example.dart
@@ -22,7 +22,7 @@ void main() async {
     print('=== Extended Thinking ===');
     final thinkingResponse = await client.messages.create(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 16000,
         thinking: const ThinkingEnabled(budgetTokens: 10000),
         messages: [
@@ -58,7 +58,7 @@ void main() async {
     print('\n=== Streaming with Thinking ===');
     final thinkingStream = client.messages.createStream(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 16000,
         thinking: const ThinkingEnabled(budgetTokens: 5000),
         messages: [InputMessage.user('What is 15% of 240? Show your work.')],
@@ -102,7 +102,7 @@ void main() async {
     print('\n=== Complex Reasoning ===');
     final complexResponse = await client.messages.create(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 16000,
         thinking: const ThinkingEnabled(budgetTokens: 8000),
         messages: [

--- a/packages/anthropic_sdk_dart/example/token_counting_example.dart
+++ b/packages/anthropic_sdk_dart/example/token_counting_example.dart
@@ -19,7 +19,7 @@ void main() async {
     print('=== Simple Token Count ===');
     final simpleCount = await client.messages.countTokens(
       TokenCountRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         messages: [InputMessage.user('Hello, how are you today?')],
       ),
     );
@@ -30,7 +30,7 @@ void main() async {
     print('\n=== With System Prompt ===');
     final systemCount = await client.messages.countTokens(
       TokenCountRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         system: SystemPrompt.text(
           'You are a helpful assistant that specializes in explaining '
           'complex topics in simple terms.',
@@ -45,7 +45,7 @@ void main() async {
     print('\n=== Multi-turn Conversation ===');
     final conversationCount = await client.messages.countTokens(
       TokenCountRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         messages: [
           InputMessage.user('What is machine learning?'),
           InputMessage.assistant(
@@ -71,14 +71,14 @@ void main() async {
 
     final shortMessage = await client.messages.countTokens(
       TokenCountRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         messages: [InputMessage.user('Hi!')],
       ),
     );
 
     final longMessage = await client.messages.countTokens(
       TokenCountRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         messages: [
           InputMessage.user(
             'Please provide a comprehensive analysis of the impact of '
@@ -129,7 +129,7 @@ void main() async {
 
     final toolsCount = await client.messages.countTokens(
       TokenCountRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         tools: [ToolDefinition.custom(weatherTool)],
         messages: [InputMessage.user("What's the weather in New York?")],
       ),

--- a/packages/anthropic_sdk_dart/example/tool_calling_example.dart
+++ b/packages/anthropic_sdk_dart/example/tool_calling_example.dart
@@ -39,7 +39,7 @@ void main() async {
     print('Asking Claude about the weather...');
     final response = await client.messages.create(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 1024,
         tools: [ToolDefinition.custom(weatherTool)],
         messages: [InputMessage.user('What is the weather in San Francisco?')],
@@ -59,7 +59,7 @@ void main() async {
         // Send tool result back to Claude
         final finalResponse = await client.messages.create(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 1024,
             tools: [ToolDefinition.custom(weatherTool)],
             messages: [

--- a/packages/anthropic_sdk_dart/example/vision_example.dart
+++ b/packages/anthropic_sdk_dart/example/vision_example.dart
@@ -23,7 +23,7 @@ void main() async {
     print('=== Image from URL ===');
     final urlResponse = await client.messages.create(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 1024,
         messages: [
           InputMessage.userBlocks([
@@ -50,7 +50,7 @@ void main() async {
 
     final base64Response = await client.messages.create(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 1024,
         messages: [
           InputMessage.userBlocks([
@@ -71,7 +71,7 @@ void main() async {
     print('\n=== Multiple Images ===');
     final multiResponse = await client.messages.create(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 1024,
         messages: [
           InputMessage.userBlocks([
@@ -101,7 +101,7 @@ void main() async {
     print('\n=== Detailed Image Analysis ===');
     final detailResponse = await client.messages.create(
       MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         maxTokens: 2048,
         messages: [
           InputMessage.userBlocks([
@@ -134,7 +134,7 @@ void main() async {
       final imageBytes = await localImageFile.readAsBytes();
       final localResponse = await client.messages.create(
         MessageCreateRequest(
-          model: 'claude-sonnet-4-20250514',
+          model: 'claude-sonnet-4-6',
           maxTokens: 1024,
           messages: [
             InputMessage.userBlocks([

--- a/packages/anthropic_sdk_dart/example/web_search_example.dart
+++ b/packages/anthropic_sdk_dart/example/web_search_example.dart
@@ -41,7 +41,7 @@ final tools = [
 
 final response = await client.messages.create(
   MessageCreateRequest(
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-sonnet-4-6',
     maxTokens: 4096,
     tools: tools,
     messages: [

--- a/packages/anthropic_sdk_dart/llms.txt
+++ b/packages/anthropic_sdk_dart/llms.txt
@@ -10,26 +10,26 @@
 
 ## Examples
 
-- [messages_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/messages_example.dart) (~833 tokens): Basic message creation.
+- [messages_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/messages_example.dart) (~821 tokens): Basic message creation.
 - [streaming_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/streaming_example.dart) (~1.3k tokens): Streaming responses.
-- [tool_calling_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/tool_calling_example.dart) (~781 tokens): Tool calling with schemas.
-- [thinking_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/thinking_example.dart) (~943 tokens): Extended thinking.
+- [tool_calling_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/tool_calling_example.dart) (~777 tokens): Tool calling with schemas.
+- [thinking_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/thinking_example.dart) (~937 tokens): Extended thinking.
 - [vision_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/vision_example.dart) (~1.2k tokens): Image and document inputs.
 - [token_counting_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/token_counting_example.dart) (~1.1k tokens): Token counting.
-- [message_batches_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/message_batches_example.dart) (~863 tokens): Batch processing.
-- [models_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/models_example.dart) (~473 tokens): Model listing.
+- [message_batches_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/message_batches_example.dart) (~859 tokens): Batch processing.
+- [models_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/models_example.dart) (~471 tokens): Model listing.
 - [files_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/files_example.dart) (~842 tokens): File management (beta).
 - [skills_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/skills_example.dart) (~1k tokens): Skills management (beta).
-- [error_handling_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/error_handling_example.dart) (~640 tokens): Exception handling patterns.
-- [web_search_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/web_search_example.dart) (~795 tokens): Web search tool.
-- [advisor_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/advisor_example.dart) (~941 tokens): Advisor tool (beta).
-- [computer_use_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/computer_use_example.dart) (~868 tokens): Computer use tool.
-- [document_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/document_example.dart) (~945 tokens): Document inputs with citations.
-- [mcp_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/mcp_example.dart) (~906 tokens): MCP tool integration.
-- [anthropic_sdk_dart_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/anthropic_sdk_dart_example.dart) (~678 tokens): Quick-start overview.
+- [error_handling_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/error_handling_example.dart) (~632 tokens): Exception handling patterns.
+- [web_search_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/web_search_example.dart) (~793 tokens): Web search tool.
+- [advisor_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/advisor_example.dart) (~967 tokens): Advisor tool (beta).
+- [computer_use_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/computer_use_example.dart) (~866 tokens): Computer use tool.
+- [document_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/document_example.dart) (~937 tokens): Document inputs with citations.
+- [mcp_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/mcp_example.dart) (~904 tokens): MCP tool integration.
+- [anthropic_sdk_dart_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/anthropic_sdk_dart_example.dart) (~670 tokens): Quick-start overview.
 
 ## Optional
 
 - [Package directory](https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/anthropic_sdk_dart): Source tree, pubspec, and package-local files.
 
-**Total: ~30.2k tokens**
+**Total: ~30.1k tokens**

--- a/packages/anthropic_sdk_dart/specs/openapi.yaml
+++ b/packages/anthropic_sdk_dart/specs/openapi.yaml
@@ -22216,22 +22216,30 @@
           },
           {
             "const": "claude-opus-4-0",
+            "deprecated": true,
             "description": "Powerful model for complex tasks",
+            "x-stainless-deprecation-message": "Will reach end-of-life on June 15th, 2026. Please migrate to a newer model. Visit https://docs.anthropic.com/en/docs/resources/model-deprecations for more information.",
             "x-stainless-nominal": false
           },
           {
             "const": "claude-opus-4-20250514",
+            "deprecated": true,
             "description": "Powerful model for complex tasks",
+            "x-stainless-deprecation-message": "Will reach end-of-life on June 15th, 2026. Please migrate to a newer model. Visit https://docs.anthropic.com/en/docs/resources/model-deprecations for more information.",
             "x-stainless-nominal": false
           },
           {
             "const": "claude-sonnet-4-0",
+            "deprecated": true,
             "description": "High-performance model with extended thinking",
+            "x-stainless-deprecation-message": "Will reach end-of-life on June 15th, 2026. Please migrate to a newer model. Visit https://docs.anthropic.com/en/docs/resources/model-deprecations for more information.",
             "x-stainless-nominal": false
           },
           {
             "const": "claude-sonnet-4-20250514",
+            "deprecated": true,
             "description": "High-performance model with extended thinking",
+            "x-stainless-deprecation-message": "Will reach end-of-life on June 15th, 2026. Please migrate to a newer model. Visit https://docs.anthropic.com/en/docs/resources/model-deprecations for more information.",
             "x-stainless-nominal": false
           },
           {

--- a/packages/anthropic_sdk_dart/specs/spec_metadata.json
+++ b/packages/anthropic_sdk_dart/specs/spec_metadata.json
@@ -2,8 +2,8 @@
   "specs": {
     "main": {
       "current_version": "unknown",
-      "last_fetched": "2026-04-13T20:39:24.894396Z",
-      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic%2Fanthropic-dfe504526eed07979685a729ac9afd45e59cc2879291714b9f4674f2ef1247c7.yml",
+      "last_fetched": "2026-04-16T07:18:58.355996Z",
+      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic%2Fanthropic-f4d4f18820ecfbe244fb1bbc2232939afca73dfcb21ce23bc296571ee7320e3a.yml",
       "title": "Anthropic API + advisor-tool",
       "version_history": [
         {

--- a/packages/anthropic_sdk_dart/test/integration/server_tools_integration_test.dart
+++ b/packages/anthropic_sdk_dart/test/integration/server_tools_integration_test.dart
@@ -39,7 +39,7 @@ void main() {
 
         final response = await client!.messages.create(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 1024,
             tools: [ToolDefinition.builtIn(BuiltInTool.webSearch())],
             messages: [
@@ -78,7 +78,7 @@ void main() {
 
         final stream = client!.messages.createStream(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 1024,
             tools: [ToolDefinition.builtIn(BuiltInTool.webSearch())],
             messages: [

--- a/packages/anthropic_sdk_dart/test/integration/thinking_integration_test.dart
+++ b/packages/anthropic_sdk_dart/test/integration/thinking_integration_test.dart
@@ -38,7 +38,7 @@ void main() {
 
         final response = await client!.messages.create(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 16000,
             thinking: const ThinkingEnabled(budgetTokens: 5000),
             messages: [
@@ -85,7 +85,7 @@ void main() {
 
         final stream = client!.messages.createStream(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 16000,
             thinking: const ThinkingEnabled(budgetTokens: 3000),
             messages: [
@@ -142,7 +142,7 @@ void main() {
 
         final response = await client!.messages.create(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 16000,
             thinking: const ThinkingEnabled(budgetTokens: 8000),
             messages: [
@@ -182,7 +182,7 @@ void main() {
 
         final response = await client!.messages.create(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 16000,
             thinking: const ThinkingEnabled(budgetTokens: 3000),
             messages: [InputMessage.user('What is 2 + 2? Think about it.')],

--- a/packages/anthropic_sdk_dart/test/integration/tools_integration_test.dart
+++ b/packages/anthropic_sdk_dart/test/integration/tools_integration_test.dart
@@ -53,7 +53,7 @@ void main() {
         // Send a message that should trigger tool use
         final response = await client!.messages.create(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 1024,
             tools: [ToolDefinition.custom(calculatorTool)],
             messages: [
@@ -104,7 +104,7 @@ void main() {
         // First turn - ask about weather
         final response1 = await client!.messages.create(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 1024,
             tools: [ToolDefinition.custom(weatherTool)],
             messages: [InputMessage.user('What is the weather in Paris?')],
@@ -123,7 +123,7 @@ void main() {
         // Second turn - provide tool result
         final response2 = await client!.messages.create(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 1024,
             tools: [ToolDefinition.custom(weatherTool)],
             messages: [
@@ -167,7 +167,7 @@ void main() {
         // With auto, model decides whether to use tools
         final response = await client!.messages.create(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 1024,
             tools: [ToolDefinition.custom(tool)],
             toolChoice: ToolChoice.auto(),
@@ -205,7 +205,7 @@ void main() {
         // Force use of specific tool
         final response = await client!.messages.create(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 1024,
             tools: [ToolDefinition.custom(tool)],
             toolChoice: ToolChoice.tool('random_number'),
@@ -244,7 +244,7 @@ void main() {
 
         final stream = client!.messages.createStream(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 1024,
             tools: [ToolDefinition.custom(tool)],
             messages: [

--- a/packages/anthropic_sdk_dart/test/integration/vision_integration_test.dart
+++ b/packages/anthropic_sdk_dart/test/integration/vision_integration_test.dart
@@ -40,7 +40,7 @@ void main() {
 
         final response = await client!.messages.create(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 1024,
             messages: [
               InputMessage.userBlocks([
@@ -94,7 +94,7 @@ void main() {
 
         final response = await client!.messages.create(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 1024,
             messages: [
               InputMessage.userBlocks([
@@ -129,7 +129,7 @@ void main() {
 
         final response = await client!.messages.create(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 1024,
             messages: [
               InputMessage.userBlocks([
@@ -176,7 +176,7 @@ void main() {
 
         final response = await client!.messages.create(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 2048,
             messages: [
               InputMessage.userBlocks([
@@ -216,7 +216,7 @@ void main() {
 
         final stream = client!.messages.createStream(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 1024,
             messages: [
               InputMessage.userBlocks([

--- a/packages/anthropic_sdk_dart/test/mocks/mock_http_client.dart
+++ b/packages/anthropic_sdk_dart/test/mocks/mock_http_client.dart
@@ -138,7 +138,7 @@ class MockResponses {
   /// Creates a successful message response.
   static Map<String, dynamic> message({
     String id = 'msg_test123',
-    String model = 'claude-sonnet-4-20250514',
+    String model = 'claude-sonnet-4-6',
     String text = 'Hello! How can I help you?',
     String stopReason = 'end_turn',
     int inputTokens = 10,
@@ -161,7 +161,7 @@ class MockResponses {
   /// Creates streaming events for a message.
   static List<Map<String, dynamic>> streamingEvents({
     String id = 'msg_test123',
-    String model = 'claude-sonnet-4-20250514',
+    String model = 'claude-sonnet-4-6',
     String text = 'Hello!',
     int inputTokens = 10,
     int outputTokens = 5,
@@ -208,7 +208,7 @@ class MockResponses {
           models ??
           [
             {
-              'id': 'claude-sonnet-4-20250514',
+              'id': 'claude-sonnet-4-6',
               'type': 'model',
               'display_name': 'Claude Sonnet 4',
               'created_at': '2025-05-14T00:00:00Z',
@@ -221,7 +221,7 @@ class MockResponses {
             },
           ],
       'has_more': false,
-      'first_id': 'claude-sonnet-4-20250514',
+      'first_id': 'claude-sonnet-4-6',
       'last_id': 'claude-3-5-haiku-20241022',
     };
   }

--- a/packages/anthropic_sdk_dart/test/unit/client/anthropic_client_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/client/anthropic_client_test.dart
@@ -118,7 +118,7 @@ void main() {
       await expectLater(
         client.messages.create(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 100,
             messages: [InputMessage.user('Hi')],
           ),

--- a/packages/anthropic_sdk_dart/test/unit/extensions/stream_extensions_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/extensions/stream_extensions_test.dart
@@ -18,7 +18,7 @@ const Map<String, Object> _messageStartJson = {
     'type': 'message',
     'role': 'assistant',
     'content': <dynamic>[],
-    'model': 'claude-sonnet-4-20250514',
+    'model': 'claude-sonnet-4-6',
     'usage': {'input_tokens': 10, 'output_tokens': 0},
   },
 };

--- a/packages/anthropic_sdk_dart/test/unit/models/message_batch_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/message_batch_test.dart
@@ -254,7 +254,7 @@ void main() {
             'id': 'msg_123',
             'type': 'message',
             'role': 'assistant',
-            'model': 'claude-sonnet-4-20250514',
+            'model': 'claude-sonnet-4-6',
             'content': [
               {'type': 'text', 'text': 'Hello!'},
             ],
@@ -326,7 +326,7 @@ void main() {
           'id': 'msg_123',
           'type': 'message',
           'role': 'assistant',
-          'model': 'claude-sonnet-4-20250514',
+          'model': 'claude-sonnet-4-6',
           'content': [
             {'type': 'text', 'text': 'Hello!'},
           ],

--- a/packages/anthropic_sdk_dart/test/unit/models/message_stream_accumulator_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/message_stream_accumulator_test.dart
@@ -10,7 +10,7 @@ MessageStreamEvent _event(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _messageStartJson({
   String id = 'msg_123',
-  String model = 'claude-sonnet-4-20250514',
+  String model = 'claude-sonnet-4-6',
   int inputTokens = 100,
   int outputTokens = 0,
   Map<String, dynamic>? usageExtra,

--- a/packages/anthropic_sdk_dart/test/unit/models/message_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/message_test.dart
@@ -8,7 +8,7 @@ void main() {
         'id': 'msg_123',
         'type': 'message',
         'role': 'assistant',
-        'model': 'claude-sonnet-4-20250514',
+        'model': 'claude-sonnet-4-6',
         'content': [
           {'type': 'text', 'text': 'Hello, world!'},
         ],
@@ -30,7 +30,7 @@ void main() {
       expect(message.id, 'msg_123');
       expect(message.type, 'message');
       expect(message.role, MessageRole.assistant);
-      expect(message.model, 'claude-sonnet-4-20250514');
+      expect(message.model, 'claude-sonnet-4-6');
       expect(message.content, hasLength(1));
       expect(message.content.first, isA<TextBlock>());
       expect((message.content.first as TextBlock).text, 'Hello, world!');
@@ -48,7 +48,7 @@ void main() {
         'id': 'msg_456',
         'type': 'message',
         'role': 'assistant',
-        'model': 'claude-sonnet-4-20250514',
+        'model': 'claude-sonnet-4-6',
         'content': [
           {'type': 'text', 'text': 'Let me check the weather.'},
           {
@@ -81,7 +81,7 @@ void main() {
         'id': 'msg_think',
         'type': 'message',
         'role': 'assistant',
-        'model': 'claude-sonnet-4-20250514',
+        'model': 'claude-sonnet-4-6',
         'content': [
           {
             'type': 'thinking',
@@ -111,7 +111,7 @@ void main() {
         'id': 'msg_refusal',
         'type': 'message',
         'role': 'assistant',
-        'model': 'claude-sonnet-4-20250514',
+        'model': 'claude-sonnet-4-6',
         'content': [
           {'type': 'text', 'text': ''},
         ],
@@ -139,7 +139,7 @@ void main() {
         'id': 'msg_normal',
         'type': 'message',
         'role': 'assistant',
-        'model': 'claude-sonnet-4-20250514',
+        'model': 'claude-sonnet-4-6',
         'content': [
           {'type': 'text', 'text': 'Hello!'},
         ],
@@ -178,7 +178,7 @@ void main() {
         id: 'msg_test',
         role: MessageRole.assistant,
         content: [TextBlock(text: 'Test response')],
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         stopReason: StopReason.endTurn,
         usage: Usage(inputTokens: 5, outputTokens: 3),
       );
@@ -187,7 +187,7 @@ void main() {
 
       expect(json['id'], 'msg_test');
       expect(json['role'], 'assistant');
-      expect(json['model'], 'claude-sonnet-4-20250514');
+      expect(json['model'], 'claude-sonnet-4-6');
       expect(json['stop_reason'], 'end_turn');
       expect(json['content'], hasLength(1));
       expect(
@@ -201,7 +201,7 @@ void main() {
         id: 'msg_test',
         role: MessageRole.assistant,
         content: [TextBlock(text: 'Refused')],
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         stopReason: StopReason.refusal,
         stopDetails: RefusalStopDetails(
           category: RefusalCategory.bio,
@@ -225,7 +225,7 @@ void main() {
         id: 'msg_test',
         role: MessageRole.assistant,
         content: [TextBlock(text: 'Test')],
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         stopReason: StopReason.endTurn,
         usage: Usage(inputTokens: 5, outputTokens: 3),
       );
@@ -239,7 +239,7 @@ void main() {
         id: 'msg_orig',
         role: MessageRole.assistant,
         content: [TextBlock(text: 'Original')],
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         stopReason: StopReason.endTurn,
         usage: Usage(inputTokens: 10, outputTokens: 5),
       );
@@ -252,7 +252,7 @@ void main() {
       expect(modified.id, 'msg_copy');
       expect((modified.content.first as TextBlock).text, 'Modified');
       expect(modified.role, MessageRole.assistant); // Unchanged
-      expect(modified.model, 'claude-sonnet-4-20250514'); // Unchanged
+      expect(modified.model, 'claude-sonnet-4-6'); // Unchanged
     });
   });
 
@@ -265,7 +265,7 @@ void main() {
           TextBlock(text: 'Hello, '),
           TextBlock(text: 'world!'),
         ],
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         stopReason: StopReason.endTurn,
         usage: Usage(inputTokens: 5, outputTokens: 3),
       );
@@ -282,7 +282,7 @@ void main() {
           ToolUseBlock(id: 'tu_1', name: 'tool1', input: {}),
           ToolUseBlock(id: 'tu_2', name: 'tool2', input: {}),
         ],
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         stopReason: StopReason.toolUse,
         usage: Usage(inputTokens: 10, outputTokens: 20),
       );
@@ -300,7 +300,7 @@ void main() {
           TextBlock(text: 'Response'),
           ThinkingBlock(thinking: 'Thinking 2...', signature: 'sig2'),
         ],
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         stopReason: StopReason.endTurn,
         usage: Usage(inputTokens: 10, outputTokens: 20),
       );
@@ -315,7 +315,7 @@ void main() {
         id: 'msg_1',
         role: MessageRole.assistant,
         content: [TextBlock(text: 'Done')],
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         stopReason: StopReason.endTurn,
         usage: Usage(inputTokens: 5, outputTokens: 3),
       );
@@ -330,7 +330,7 @@ void main() {
         id: 'msg_1',
         role: MessageRole.assistant,
         content: [TextBlock(text: 'Truncated...')],
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         stopReason: StopReason.maxTokens,
         usage: Usage(inputTokens: 5, outputTokens: 100),
       );

--- a/packages/anthropic_sdk_dart/test/unit/models/models_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/models_test.dart
@@ -115,7 +115,7 @@ void main() {
   group('ModelInfo', () {
     test('fromJson deserializes with all fields', () {
       final json = {
-        'id': 'claude-sonnet-4-20250514',
+        'id': 'claude-sonnet-4-6',
         'type': 'model',
         'display_name': 'Claude Sonnet 4',
         'created_at': '2025-05-14T00:00:00Z',
@@ -123,7 +123,7 @@ void main() {
 
       final model = ModelInfo.fromJson(json);
 
-      expect(model.id, 'claude-sonnet-4-20250514');
+      expect(model.id, 'claude-sonnet-4-6');
       expect(model.type, 'model');
       expect(model.displayName, 'Claude Sonnet 4');
       expect(model.createdAt, DateTime.utc(2025, 5, 14));
@@ -288,25 +288,25 @@ void main() {
       final json = {
         'data': [
           {
-            'id': 'claude-sonnet-4-20250514',
+            'id': 'claude-sonnet-4-6',
             'type': 'model',
             'display_name': 'Claude Sonnet 4',
             'created_at': '2025-05-14T00:00:00Z',
           },
         ],
         'has_more': true,
-        'first_id': 'claude-sonnet-4-20250514',
-        'last_id': 'claude-sonnet-4-20250514',
+        'first_id': 'claude-sonnet-4-6',
+        'last_id': 'claude-sonnet-4-6',
       };
 
       final response = ModelListResponse.fromJson(json);
 
       expect(response.data, hasLength(1));
-      expect(response.data.first.id, 'claude-sonnet-4-20250514');
+      expect(response.data.first.id, 'claude-sonnet-4-6');
       expect(response.data.first.displayName, 'Claude Sonnet 4');
       expect(response.hasMore, isTrue);
-      expect(response.firstId, 'claude-sonnet-4-20250514');
-      expect(response.lastId, 'claude-sonnet-4-20250514');
+      expect(response.firstId, 'claude-sonnet-4-6');
+      expect(response.lastId, 'claude-sonnet-4-6');
     });
 
     test('fromJson deserializes with required fields only', () {
@@ -324,7 +324,7 @@ void main() {
       final json = {
         'data': [
           {
-            'id': 'claude-sonnet-4-20250514',
+            'id': 'claude-sonnet-4-6',
             'type': 'model',
             'display_name': 'Claude Sonnet 4',
             'created_at': '2025-05-14T00:00:00Z',
@@ -343,17 +343,17 @@ void main() {
           },
         ],
         'has_more': true,
-        'first_id': 'claude-sonnet-4-20250514',
+        'first_id': 'claude-sonnet-4-6',
         'last_id': 'claude-3-haiku-20240307',
       };
 
       final response = ModelListResponse.fromJson(json);
 
       expect(response.data, hasLength(3));
-      expect(response.data[0].id, 'claude-sonnet-4-20250514');
+      expect(response.data[0].id, 'claude-sonnet-4-6');
       expect(response.data[1].id, 'claude-3-5-haiku-20241022');
       expect(response.data[2].id, 'claude-3-haiku-20240307');
-      expect(response.firstId, 'claude-sonnet-4-20250514');
+      expect(response.firstId, 'claude-sonnet-4-6');
       expect(response.lastId, 'claude-3-haiku-20240307');
     });
 
@@ -361,14 +361,14 @@ void main() {
       final response = ModelListResponse(
         data: [
           ModelInfo(
-            id: 'claude-sonnet-4-20250514',
+            id: 'claude-sonnet-4-6',
             displayName: 'Claude Sonnet 4',
             createdAt: DateTime.utc(2025, 5, 14),
           ),
         ],
         hasMore: false,
-        firstId: 'claude-sonnet-4-20250514',
-        lastId: 'claude-sonnet-4-20250514',
+        firstId: 'claude-sonnet-4-6',
+        lastId: 'claude-sonnet-4-6',
       );
 
       final json = response.toJson();
@@ -377,11 +377,11 @@ void main() {
       final dataList = json['data'] as List<dynamic>;
       expect(
         (dataList.first as Map<String, dynamic>)['id'],
-        'claude-sonnet-4-20250514',
+        'claude-sonnet-4-6',
       );
       expect(json['has_more'], false);
-      expect(json['first_id'], 'claude-sonnet-4-20250514');
-      expect(json['last_id'], 'claude-sonnet-4-20250514');
+      expect(json['first_id'], 'claude-sonnet-4-6');
+      expect(json['last_id'], 'claude-sonnet-4-6');
     });
 
     test('toJson excludes null optional fields', () {

--- a/packages/anthropic_sdk_dart/test/unit/models/streaming_events_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/streaming_events_test.dart
@@ -12,7 +12,7 @@ void main() {
           'id': 'msg_123',
           'type': 'message',
           'role': 'assistant',
-          'model': 'claude-sonnet-4-20250514',
+          'model': 'claude-sonnet-4-6',
           'content': <Map<String, dynamic>>[],
           'stop_reason': null,
           'stop_sequence': null,
@@ -25,7 +25,7 @@ void main() {
       expect(event, isA<MessageStartEvent>());
       final messageStart = event as MessageStartEvent;
       expect(messageStart.message.id, 'msg_123');
-      expect(messageStart.message.model, 'claude-sonnet-4-20250514');
+      expect(messageStart.message.model, 'claude-sonnet-4-6');
     });
 
     test('parses content_block_start event with text block', () {
@@ -431,7 +431,7 @@ void main() {
             'id': 'msg_123',
             'type': 'message',
             'role': 'assistant',
-            'model': 'claude-sonnet-4-20250514',
+            'model': 'claude-sonnet-4-6',
             'content': <Map<String, dynamic>>[],
             'stop_reason': null,
             'stop_sequence': null,
@@ -489,7 +489,7 @@ void main() {
             'id': 'msg_456',
             'type': 'message',
             'role': 'assistant',
-            'model': 'claude-sonnet-4-20250514',
+            'model': 'claude-sonnet-4-6',
             'content': <Map<String, dynamic>>[],
             'stop_reason': null,
             'stop_sequence': null,

--- a/packages/anthropic_sdk_dart/test/unit/models/token_count_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/token_count_test.dart
@@ -5,7 +5,7 @@ void main() {
   group('TokenCountRequest', () {
     test('fromJson deserializes with all fields', () {
       final json = {
-        'model': 'claude-sonnet-4-20250514',
+        'model': 'claude-sonnet-4-6',
         'messages': [
           {'role': 'user', 'content': 'Hello, Claude'},
         ],
@@ -42,7 +42,7 @@ void main() {
 
       final request = TokenCountRequest.fromJson(json);
 
-      expect(request.model, 'claude-sonnet-4-20250514');
+      expect(request.model, 'claude-sonnet-4-6');
       expect(request.messages, hasLength(1));
       expect(request.system, isNotNull);
       expect(request.toolChoice, isNotNull);
@@ -57,7 +57,7 @@ void main() {
 
     test('fromJson deserializes with required fields only', () {
       final json = {
-        'model': 'claude-sonnet-4-20250514',
+        'model': 'claude-sonnet-4-6',
         'messages': [
           {'role': 'user', 'content': 'Hello, Claude'},
         ],
@@ -65,7 +65,7 @@ void main() {
 
       final request = TokenCountRequest.fromJson(json);
 
-      expect(request.model, 'claude-sonnet-4-20250514');
+      expect(request.model, 'claude-sonnet-4-6');
       expect(request.messages, hasLength(1));
       expect(request.system, isNull);
       expect(request.toolChoice, isNull);
@@ -76,7 +76,7 @@ void main() {
 
     test('fromJson deserializes system as string', () {
       final json = {
-        'model': 'claude-sonnet-4-20250514',
+        'model': 'claude-sonnet-4-6',
         'messages': [
           {'role': 'user', 'content': 'Hello'},
         ],
@@ -92,7 +92,7 @@ void main() {
 
     test('fromJson deserializes system as array of blocks', () {
       final json = {
-        'model': 'claude-sonnet-4-20250514',
+        'model': 'claude-sonnet-4-6',
         'messages': [
           {'role': 'user', 'content': 'Hello'},
         ],
@@ -108,21 +108,21 @@ void main() {
 
     test('toJson serializes correctly', () {
       final request = TokenCountRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         messages: [InputMessage.user('Hello')],
         system: SystemPrompt.text('Be helpful'),
       );
 
       final json = request.toJson();
 
-      expect(json['model'], 'claude-sonnet-4-20250514');
+      expect(json['model'], 'claude-sonnet-4-6');
       expect(json['messages'], hasLength(1));
       expect(json['system'], 'Be helpful');
     });
 
     test('toJson serializes cache_control with TTL', () {
       final request = TokenCountRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         messages: [InputMessage.user('Hello')],
         cacheControl: const CacheControlEphemeral(ttl: CacheTtl.ttl5m),
       );
@@ -137,7 +137,7 @@ void main() {
 
     test('toJson serializes cache_control without TTL', () {
       final request = TokenCountRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         messages: [InputMessage.user('Hello')],
         cacheControl: const CacheControlEphemeral(),
       );
@@ -152,7 +152,7 @@ void main() {
 
     test('toJson excludes null optional fields', () {
       final request = TokenCountRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         messages: [InputMessage.user('Hello')],
       );
 
@@ -167,7 +167,7 @@ void main() {
 
     test('fromJson parses thinking config', () {
       final json = {
-        'model': 'claude-sonnet-4-20250514',
+        'model': 'claude-sonnet-4-6',
         'messages': [
           {'role': 'user', 'content': 'Hello'},
         ],
@@ -185,7 +185,7 @@ void main() {
   group('TokenCountRequest.fromMessageCreateRequest', () {
     test('copies shared fields', () {
       final request = MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         messages: [InputMessage.user('Hello')],
         maxTokens: 1024,
         system: SystemPrompt.text('Be helpful'),
@@ -220,7 +220,7 @@ void main() {
 
     test('omits fields not in TokenCountRequest', () {
       final request = MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         messages: [InputMessage.user('Hello')],
         maxTokens: 1024,
         metadata: const Metadata(userId: 'user-123'),
@@ -246,14 +246,14 @@ void main() {
 
     test('handles minimal request', () {
       final request = MessageCreateRequest(
-        model: 'claude-sonnet-4-20250514',
+        model: 'claude-sonnet-4-6',
         messages: [InputMessage.user('Hi')],
         maxTokens: 100,
       );
 
       final tokenRequest = TokenCountRequest.fromMessageCreateRequest(request);
 
-      expect(tokenRequest.model, 'claude-sonnet-4-20250514');
+      expect(tokenRequest.model, 'claude-sonnet-4-6');
       expect(tokenRequest.messages, hasLength(1));
       expect(tokenRequest.system, isNull);
     });

--- a/packages/anthropic_sdk_dart/test/unit/resources/messages_resource_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/resources/messages_resource_test.dart
@@ -30,7 +30,7 @@ void main() {
 
       final response = await client.messages.create(
         MessageCreateRequest(
-          model: 'claude-sonnet-4-20250514',
+          model: 'claude-sonnet-4-6',
           maxTokens: 1024,
           messages: [InputMessage.user('Hello!')],
         ),
@@ -57,7 +57,7 @@ void main() {
 
       await client.messages.create(
         MessageCreateRequest(
-          model: 'claude-sonnet-4-20250514',
+          model: 'claude-sonnet-4-6',
           maxTokens: 256,
           messages: [InputMessage.user('Hello!')],
         ),
@@ -80,7 +80,7 @@ void main() {
 
         final stream = client.messages.createStream(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 256,
             messages: [InputMessage.user('Hello!')],
           ),
@@ -107,7 +107,7 @@ void main() {
 
         await client.messages.countTokens(
           TokenCountRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             messages: [InputMessage.user('Count my tokens!')],
           ),
           betas: const ['fast-mode-2026-02-07'],
@@ -123,7 +123,7 @@ void main() {
         'id': 'msg_tools',
         'type': 'message',
         'role': 'assistant',
-        'model': 'claude-sonnet-4-20250514',
+        'model': 'claude-sonnet-4-6',
         'content': [
           {'type': 'text', 'text': 'Let me check the weather.'},
           {
@@ -140,7 +140,7 @@ void main() {
 
       final response = await client.messages.create(
         MessageCreateRequest(
-          model: 'claude-sonnet-4-20250514',
+          model: 'claude-sonnet-4-6',
           maxTokens: 1024,
           messages: [InputMessage.user('What is the weather in SF?')],
         ),
@@ -162,7 +162,7 @@ void main() {
 
       final response = await client.messages.countTokens(
         TokenCountRequest(
-          model: 'claude-sonnet-4-20250514',
+          model: 'claude-sonnet-4-6',
           messages: [InputMessage.user('Count my tokens!')],
         ),
       );
@@ -199,7 +199,7 @@ void main() {
       expect(
         () => client.messages.create(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 1024,
             messages: [InputMessage.user('Hello')],
           ),
@@ -218,7 +218,7 @@ void main() {
       expect(
         () => client.messages.create(
           MessageCreateRequest(
-            model: 'claude-sonnet-4-20250514',
+            model: 'claude-sonnet-4-6',
             maxTokens: 1024,
             messages: [InputMessage.user('Hello')],
           ),
@@ -235,21 +235,21 @@ void main() {
       final response = await client.models.list();
 
       expect(response.data, hasLength(2));
-      expect(response.data.first.id, 'claude-sonnet-4-20250514');
+      expect(response.data.first.id, 'claude-sonnet-4-6');
       expect(response.data.first.displayName, 'Claude Sonnet 4');
     });
 
     test('retrieve returns single model', () async {
       mockHttpClient.queueJsonResponse({
-        'id': 'claude-sonnet-4-20250514',
+        'id': 'claude-sonnet-4-6',
         'type': 'model',
         'display_name': 'Claude Sonnet 4',
         'created_at': '2025-05-14T00:00:00Z',
       });
 
-      final response = await client.models.retrieve('claude-sonnet-4-20250514');
+      final response = await client.models.retrieve('claude-sonnet-4-6');
 
-      expect(response.id, 'claude-sonnet-4-20250514');
+      expect(response.id, 'claude-sonnet-4-6');
       expect(response.displayName, 'Claude Sonnet 4');
     });
   });
@@ -269,7 +269,7 @@ void main() {
             BatchRequestItem(
               customId: 'req_1',
               params: MessageCreateRequest(
-                model: 'claude-sonnet-4-20250514',
+                model: 'claude-sonnet-4-6',
                 maxTokens: 100,
                 messages: [InputMessage.user('Hello')],
               ),

--- a/packages/anthropic_sdk_dart/test/unit/resources/streaming_resource_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/resources/streaming_resource_test.dart
@@ -34,7 +34,7 @@ void main() {
       final events = await client.messages
           .createStream(
             MessageCreateRequest(
-              model: 'claude-sonnet-4-20250514',
+              model: 'claude-sonnet-4-6',
               maxTokens: 256,
               messages: [InputMessage.user('Hi!')],
             ),
@@ -63,7 +63,7 @@ void main() {
         await client.messages
             .createStream(
               MessageCreateRequest(
-                model: 'claude-sonnet-4-20250514',
+                model: 'claude-sonnet-4-6',
                 maxTokens: 256,
                 messages: [InputMessage.user('Hi!')],
               ),
@@ -108,7 +108,7 @@ void main() {
         client.messages
             .createStream(
               MessageCreateRequest(
-                model: 'claude-sonnet-4-20250514',
+                model: 'claude-sonnet-4-6',
                 maxTokens: 256,
                 messages: [InputMessage.user('Hi!')],
               ),


### PR DESCRIPTION
## Summary
- Update Anthropic OpenAPI spec to latest version with deprecation markers on Claude 4.0 model identifiers reaching end-of-life on June 15, 2026
- Migrate all examples and tests from deprecated `claude-sonnet-4-20250514` to `claude-sonnet-4-6`

## Details

The spec update adds deprecation markers to four model IDs: `claude-opus-4-0`, `claude-opus-4-20250514`, `claude-sonnet-4-0`, and `claude-sonnet-4-20250514`. No new endpoints, schemas, or API surface changes. The `model` field in this package is a plain `String`, so the deprecation markers don't require any Dart-side annotations.

All 31 Dart files in `example/` and `test/` that referenced `claude-sonnet-4-20250514` have been updated to use `claude-sonnet-4-6`. Historical documents (`MIGRATION.md`, `CHANGELOG.md`) are left unchanged since they document the v1-to-v2 migration at that point in time.

## References

- [Model deprecations](https://docs.anthropic.com/en/docs/resources/model-deprecations) — official Anthropic deprecation schedule; lists the four affected model IDs and their June 15, 2026 end-of-life date

## Test Plan
- [x] Unit tests pass (`dart test test/unit/` — 611 passed)
- [x] `dart analyze --fatal-infos` — no issues
- [x] `dart format --set-exit-if-changed .` — 0 files changed
- [x] Toolkit verify passes (pre-existing warnings only, no new issues)
- [x] `pinned_hash` in `specs.json` updated to match promoted spec
- [x] `llms.txt` regenerated