### PR TITLE
feat(anthropic_sdk_dart): fix verify gaps and add MCP content blocks

### DIFF
--- a/packages/anthropic_sdk_dart/README.md
+++ b/packages/anthropic_sdk_dart/README.md
@@ -45,6 +45,7 @@ Dart client for the **[Anthropic API](https://docs.anthropic.com/en/api)** to bu
 
 - Message batches for large-scale offline processing
 - Model discovery, files (beta), and skills (beta)
+- Managed agents with sessions, vaults, and streaming events (beta)
 
 ## Quickstart
 
@@ -497,6 +498,61 @@ Future<void> main() async {
 
 </details>
 
+### How do I use managed agents?
+
+<details>
+<summary><b>Show example</b></summary>
+
+Use `client.agents`, `client.sessions`, and `client.vaults` for the Managed Agents beta API. Create an agent configuration, start sessions to interact with Claude, and use vaults to securely store credentials.
+
+```dart
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+
+Future<void> main() async {
+  final client = AnthropicClient.fromEnvironment();
+
+  try {
+    // Create an agent
+    final agent = await client.agents.create(
+      const CreateAgentParams(
+        name: 'My Agent',
+        model: ModelParamsId(id: 'claude-sonnet-4-6'),
+      ),
+    );
+
+    // Start a session and send a message
+    final session = await client.sessions.create(
+      CreateSessionParams(
+        agent: AgentParamsId(id: agent.id),
+        environmentId: 'default',
+      ),
+    );
+
+    final eventsResource = client.sessions.events(session.id);
+    await eventsResource.send(
+      const SendSessionEventsParams(
+        events: [
+          UserMessageEventParams(
+            content: [{'type': 'text', 'text': 'Hello, agent!'}],
+          ),
+        ],
+      ),
+    );
+
+    final events = await eventsResource.list();
+    for (final event in events.data) {
+      print('Event: ${event.runtimeType}');
+    }
+  } finally {
+    client.close();
+  }
+}
+```
+
+→ [Full example](example/managed_agents_example.dart)
+
+</details>
+
 ## Error Handling
 
 <details>
@@ -556,6 +612,7 @@ See the [example/](example/) directory for complete examples:
 | [`files_example.dart`](example/files_example.dart) | File management (beta) |
 | [`skills_example.dart`](example/skills_example.dart) | Skills management (beta) |
 | [`mcp_example.dart`](example/mcp_example.dart) | MCP tool integration |
+| [`managed_agents_example.dart`](example/managed_agents_example.dart) | Managed agents: agents, sessions, vaults (beta) |
 | [`models_example.dart`](example/models_example.dart) | Model listing |
 | [`error_handling_example.dart`](example/error_handling_example.dart) | Exception handling patterns |
 | [`anthropic_sdk_dart_example.dart`](example/anthropic_sdk_dart_example.dart) | Quick-start overview |
@@ -569,6 +626,9 @@ See the [example/](example/) directory for complete examples:
 | Models | ✅ Full |
 | Files (Beta) | ✅ Full |
 | Skills (Beta) | ✅ Full |
+| Agents (Beta) | ✅ Full |
+| Sessions (Beta) | ✅ Full |
+| Vaults (Beta) | ✅ Full |
 
 ## Official Documentation
 

--- a/packages/anthropic_sdk_dart/example/managed_agents_example.dart
+++ b/packages/anthropic_sdk_dart/example/managed_agents_example.dart
@@ -1,0 +1,118 @@
+// ignore_for_file: avoid_print
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+
+/// Managed Agents API example (Beta).
+///
+/// This example demonstrates:
+/// - Creating and managing agents
+/// - Starting sessions and sending messages
+/// - Polling session events
+/// - Managing vaults and credentials
+///
+/// Note: The Managed Agents API is a beta feature.
+void main() async {
+  final client = AnthropicClient(
+    config: const AnthropicConfig(
+      authProvider: ApiKeyProvider(String.fromEnvironment('ANTHROPIC_API_KEY')),
+    ),
+  );
+
+  try {
+    // =========================================================================
+    // 1. Agents — create, list, retrieve
+    // =========================================================================
+    print('=== Agents ===');
+
+    // Create an agent with a model and system prompt
+    final agent = await client.agents.create(
+      const CreateAgentParams(
+        name: 'Helper Agent',
+        model: ModelParamsId(id: 'claude-sonnet-4-6'),
+        system: 'You are a helpful assistant.',
+      ),
+    );
+    print('Created agent: ${agent.id} (v${agent.version})');
+
+    // List agents
+    final agents = await client.agents.list(limit: 5);
+    print('Total agents: ${agents.data.length}');
+
+    // Retrieve a specific agent
+    final retrieved = await client.agents.retrieve(agent.id);
+    print('Retrieved: ${retrieved.name}');
+
+    // =========================================================================
+    // 2. Sessions — create, send messages, poll events
+    // =========================================================================
+    print('\n=== Sessions ===');
+
+    // Create a session from the agent
+    final session = await client.sessions.create(
+      CreateSessionParams(
+        agent: AgentParamsId(id: agent.id),
+        environmentId: 'default',
+      ),
+    );
+    print('Created session: ${session.id} (status: ${session.status.value})');
+
+    // Send a user message
+    final eventsResource = client.sessions.events(session.id);
+    await eventsResource.send(
+      const SendSessionEventsParams(
+        events: [
+          UserMessageEventParams(
+            content: [
+              {'type': 'text', 'text': 'What is 2 + 2?'},
+            ],
+          ),
+        ],
+      ),
+    );
+    print('Sent message to session');
+
+    // Poll for events
+    final events = await eventsResource.list();
+    for (final event in events.data) {
+      print('Event: ${event.runtimeType}');
+    }
+
+    // List sessions
+    final sessions = await client.sessions.list(agentId: agent.id, limit: 5);
+    print('Total sessions: ${sessions.data.length}');
+
+    // =========================================================================
+    // 3. Vaults — create, list credentials
+    // =========================================================================
+    print('\n=== Vaults ===');
+
+    // Create a vault
+    final vault = await client.vaults.create(
+      const CreateVaultParams(displayName: 'My Vault'),
+    );
+    print('Created vault: ${vault.id}');
+
+    // List vaults
+    final vaults = await client.vaults.list(limit: 5);
+    print('Total vaults: ${vaults.data.length}');
+
+    // List credentials in the vault
+    final credentials = await client.vaults.credentials(vault.id).list();
+    print('Credentials in vault: ${credentials.data.length}');
+
+    // =========================================================================
+    // 4. Cleanup
+    // =========================================================================
+    print('\n=== Cleanup ===');
+
+    await client.sessions.delete(session.id);
+    print('Deleted session');
+
+    await client.agents.archive(agent.id);
+    print('Archived agent');
+
+    await client.vaults.delete(vault.id);
+    print('Deleted vault');
+  } finally {
+    client.close();
+  }
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/content/content_block.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/content_block.dart
@@ -1513,6 +1513,11 @@ class AdvisorResult extends AdvisorToolResultContent {
   @override
   int get hashCode => text.hashCode;
 
+  /// Creates a copy with replaced values.
+  AdvisorResult copyWith({String? text}) {
+    return AdvisorResult(text: text ?? this.text);
+  }
+
   @override
   String toString() => 'AdvisorResult(text: ${text.length} chars)';
 }
@@ -1554,6 +1559,13 @@ class AdvisorRedactedResult extends AdvisorToolResultContent {
 
   @override
   int get hashCode => encryptedContent.hashCode;
+
+  /// Creates a copy with replaced values.
+  AdvisorRedactedResult copyWith({String? encryptedContent}) {
+    return AdvisorRedactedResult(
+      encryptedContent: encryptedContent ?? this.encryptedContent,
+    );
+  }
 
   @override
   String toString() =>

--- a/packages/anthropic_sdk_dart/lib/src/models/content/content_block.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/content_block.dart
@@ -33,6 +33,8 @@ sealed class ContentBlock {
       'tool_search_tool_result' => ToolSearchToolResultBlock.fromJson(json),
       'container_upload' => ContainerUploadBlock.fromJson(json),
       'compaction' => CompactionBlock.fromJson(json),
+      'mcp_tool_use' => MCPToolUseBlock.fromJson(json),
+      'mcp_tool_result' => MCPToolResultBlock.fromJson(json),
       'advisor_tool_result' => AdvisorToolResultBlock.fromJson(json),
       _ => UnknownContentBlock.fromJson(json),
     };
@@ -1348,6 +1350,242 @@ class WebSearchResultLocationCitation extends Citation {
       'WebSearchResultLocationCitation(citedText: [${citedText.length} chars], '
       'encryptedIndex: [${encryptedIndex.length} chars], '
       'title: $title, url: $url)';
+}
+
+// ============================================================================
+// MCP Tool Content Blocks
+// ============================================================================
+
+/// MCP tool use block in a response.
+///
+/// Represents a model-initiated tool call to an MCP server tool.
+@immutable
+class MCPToolUseBlock extends ContentBlock {
+  /// Unique identifier for this tool use.
+  final String id;
+
+  /// Name of the MCP tool being used.
+  final String name;
+
+  /// Name of the MCP server providing the tool.
+  final String serverName;
+
+  /// Input parameters for the tool.
+  final Map<String, dynamic> input;
+
+  /// Creates an [MCPToolUseBlock].
+  const MCPToolUseBlock({
+    required this.id,
+    required this.name,
+    required this.serverName,
+    required this.input,
+  });
+
+  /// Creates an [MCPToolUseBlock] from JSON.
+  factory MCPToolUseBlock.fromJson(Map<String, dynamic> json) {
+    return MCPToolUseBlock(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      serverName: json['server_name'] as String,
+      input: json['input'] as Map<String, dynamic>,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'mcp_tool_use',
+    'id': id,
+    'name': name,
+    'server_name': serverName,
+    'input': input,
+  };
+
+  /// Creates a copy with replaced values.
+  MCPToolUseBlock copyWith({
+    String? id,
+    String? name,
+    String? serverName,
+    Map<String, dynamic>? input,
+  }) {
+    return MCPToolUseBlock(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      serverName: serverName ?? this.serverName,
+      input: input ?? this.input,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MCPToolUseBlock &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          name == other.name &&
+          serverName == other.serverName &&
+          mapsEqual(input, other.input);
+
+  @override
+  int get hashCode => Object.hash(id, name, serverName, mapHash(input));
+
+  @override
+  String toString() =>
+      'MCPToolUseBlock(id: $id, name: $name, '
+      'serverName: $serverName, input: $input)';
+}
+
+/// Content of an MCP tool result — either a plain string or a list of
+/// text blocks.
+sealed class MCPToolResultContent {
+  const MCPToolResultContent();
+
+  /// Creates from a plain string.
+  factory MCPToolResultContent.text(String text) = MCPToolResultStringContent;
+
+  /// Creates from a list of text blocks.
+  factory MCPToolResultContent.blocks(List<TextBlock> blocks) =
+      MCPToolResultBlocksContent;
+
+  /// Creates an [MCPToolResultContent] from JSON.
+  factory MCPToolResultContent.fromJson(Object json) {
+    if (json is String) return MCPToolResultStringContent(json);
+    if (json is List) {
+      return MCPToolResultBlocksContent(
+        json
+            .map((e) => TextBlock.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+    }
+    throw FormatException(
+      'Expected String or List for MCPToolResultContent, '
+      'got ${json.runtimeType}',
+    );
+  }
+
+  /// Converts to JSON.
+  Object toJson();
+}
+
+/// Plain string content for an MCP tool result.
+@immutable
+class MCPToolResultStringContent extends MCPToolResultContent {
+  /// The text content.
+  final String text;
+
+  /// Creates an [MCPToolResultStringContent].
+  const MCPToolResultStringContent(this.text);
+
+  @override
+  Object toJson() => text;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MCPToolResultStringContent &&
+          runtimeType == other.runtimeType &&
+          text == other.text;
+
+  @override
+  int get hashCode => text.hashCode;
+
+  @override
+  String toString() => 'MCPToolResultStringContent(${text.length} chars)';
+}
+
+/// List of text blocks content for an MCP tool result.
+@immutable
+class MCPToolResultBlocksContent extends MCPToolResultContent {
+  /// The text blocks.
+  final List<TextBlock> blocks;
+
+  /// Creates an [MCPToolResultBlocksContent].
+  const MCPToolResultBlocksContent(this.blocks);
+
+  @override
+  Object toJson() => blocks.map((b) => b.toJson()).toList();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MCPToolResultBlocksContent &&
+          runtimeType == other.runtimeType &&
+          listsEqual(blocks, other.blocks);
+
+  @override
+  int get hashCode => listHash(blocks);
+
+  @override
+  String toString() =>
+      'MCPToolResultBlocksContent(${blocks.length} blocks)';
+}
+
+/// MCP tool result block in a response.
+///
+/// Contains the result of an MCP tool call.
+@immutable
+class MCPToolResultBlock extends ContentBlock {
+  /// The content of the tool result.
+  final MCPToolResultContent content;
+
+  /// Whether this result represents an error.
+  final bool isError;
+
+  /// The ID of the tool use this result corresponds to.
+  final String toolUseId;
+
+  /// Creates an [MCPToolResultBlock].
+  const MCPToolResultBlock({
+    required this.content,
+    this.isError = false,
+    required this.toolUseId,
+  });
+
+  /// Creates an [MCPToolResultBlock] from JSON.
+  factory MCPToolResultBlock.fromJson(Map<String, dynamic> json) {
+    return MCPToolResultBlock(
+      content: MCPToolResultContent.fromJson(json['content'] as Object),
+      isError: json['is_error'] as bool? ?? false,
+      toolUseId: json['tool_use_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'mcp_tool_result',
+    'content': content.toJson(),
+    'is_error': isError,
+    'tool_use_id': toolUseId,
+  };
+
+  /// Creates a copy with replaced values.
+  MCPToolResultBlock copyWith({
+    MCPToolResultContent? content,
+    bool? isError,
+    String? toolUseId,
+  }) {
+    return MCPToolResultBlock(
+      content: content ?? this.content,
+      isError: isError ?? this.isError,
+      toolUseId: toolUseId ?? this.toolUseId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MCPToolResultBlock &&
+          runtimeType == other.runtimeType &&
+          content == other.content &&
+          isError == other.isError &&
+          toolUseId == other.toolUseId;
+
+  @override
+  int get hashCode => Object.hash(content, isError, toolUseId);
+
+  @override
+  String toString() =>
+      'MCPToolResultBlock(content: $content, '
+      'isError: $isError, toolUseId: $toolUseId)';
 }
 
 // ============================================================================

--- a/packages/anthropic_sdk_dart/lib/src/models/content/content_block.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/content_block.dart
@@ -1451,9 +1451,7 @@ sealed class MCPToolResultContent {
     if (json is String) return MCPToolResultStringContent(json);
     if (json is List) {
       return MCPToolResultBlocksContent(
-        json
-            .map((e) => TextBlock.fromJson(e as Map<String, dynamic>))
-            .toList(),
+        json.map((e) => TextBlock.fromJson(e as Map<String, dynamic>)).toList(),
       );
     }
     throw FormatException(
@@ -1515,8 +1513,7 @@ class MCPToolResultBlocksContent extends MCPToolResultContent {
   int get hashCode => listHash(blocks);
 
   @override
-  String toString() =>
-      'MCPToolResultBlocksContent(${blocks.length} blocks)';
+  String toString() => 'MCPToolResultBlocksContent(${blocks.length} blocks)';
 }
 
 /// MCP tool result block in a response.

--- a/packages/anthropic_sdk_dart/lib/src/models/content/input_content_block.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/input_content_block.dart
@@ -94,6 +94,23 @@ sealed class InputContentBlock {
     CacheControlEphemeral? cacheControl,
   }) = CompactionInputBlock;
 
+  /// Creates an MCP tool use block (for assistant messages).
+  factory InputContentBlock.mcpToolUse({
+    required String id,
+    required String name,
+    required String serverName,
+    required Map<String, dynamic> input,
+    CacheControlEphemeral? cacheControl,
+  }) = MCPToolUseInputBlock;
+
+  /// Creates an MCP tool result block (for user messages).
+  factory InputContentBlock.mcpToolResult({
+    required String toolUseId,
+    MCPToolResultContent? content,
+    bool? isError,
+    CacheControlEphemeral? cacheControl,
+  }) = MCPToolResultInputBlock;
+
   /// Creates an advisor tool result block (for multi-turn conversations).
   factory InputContentBlock.advisorToolResult({
     required String toolUseId,
@@ -131,6 +148,8 @@ sealed class InputContentBlock {
       'container_upload' => ContainerUploadInputBlock.fromJson(json),
       'compaction' => CompactionInputBlock.fromJson(json),
       'tool_reference' => ToolReferenceInputBlock.fromJson(json),
+      'mcp_tool_use' => MCPToolUseInputBlock.fromJson(json),
+      'mcp_tool_result' => MCPToolResultInputBlock.fromJson(json),
       'advisor_tool_result' => AdvisorToolResultInputBlock.fromJson(json),
       _ => UnknownInputContentBlock.fromJson(json),
     };
@@ -1447,6 +1466,190 @@ class AdvisorToolResultInputBlock extends InputContentBlock {
   String toString() =>
       'AdvisorToolResultInputBlock(toolUseId: $toolUseId, '
       'content: $content, cacheControl: $cacheControl)';
+}
+
+/// MCP tool use block for assistant messages in input.
+///
+/// Used when round-tripping an assistant message containing an MCP tool call.
+@immutable
+class MCPToolUseInputBlock extends InputContentBlock {
+  /// Unique identifier for this tool use.
+  final String id;
+
+  /// Name of the MCP tool being used.
+  final String name;
+
+  /// Name of the MCP server providing the tool.
+  final String serverName;
+
+  /// Input parameters for the tool.
+  final Map<String, dynamic> input;
+
+  /// Cache control for this block.
+  final CacheControlEphemeral? cacheControl;
+
+  /// Creates an [MCPToolUseInputBlock].
+  const MCPToolUseInputBlock({
+    required this.id,
+    required this.name,
+    required this.serverName,
+    required this.input,
+    this.cacheControl,
+  });
+
+  /// Creates an [MCPToolUseInputBlock] from JSON.
+  factory MCPToolUseInputBlock.fromJson(Map<String, dynamic> json) {
+    return MCPToolUseInputBlock(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      serverName: json['server_name'] as String,
+      input: (json['input'] as Map).cast<String, dynamic>(),
+      cacheControl: json['cache_control'] != null
+          ? CacheControlEphemeral.fromJson(
+              json['cache_control'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'mcp_tool_use',
+    'id': id,
+    'name': name,
+    'server_name': serverName,
+    'input': input,
+    if (cacheControl != null) 'cache_control': cacheControl!.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  MCPToolUseInputBlock copyWith({
+    String? id,
+    String? name,
+    String? serverName,
+    Map<String, dynamic>? input,
+    Object? cacheControl = unsetCopyWithValue,
+  }) {
+    return MCPToolUseInputBlock(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      serverName: serverName ?? this.serverName,
+      input: input ?? this.input,
+      cacheControl: cacheControl == unsetCopyWithValue
+          ? this.cacheControl
+          : cacheControl as CacheControlEphemeral?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MCPToolUseInputBlock &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          name == other.name &&
+          serverName == other.serverName &&
+          mapsEqual(input, other.input) &&
+          cacheControl == other.cacheControl;
+
+  @override
+  int get hashCode =>
+      Object.hash(id, name, serverName, mapHash(input), cacheControl);
+
+  @override
+  String toString() =>
+      'MCPToolUseInputBlock(id: $id, name: $name, '
+      'serverName: $serverName, input: $input, '
+      'cacheControl: $cacheControl)';
+}
+
+/// MCP tool result block for input messages.
+///
+/// Used when round-tripping a user message containing an MCP tool result.
+@immutable
+class MCPToolResultInputBlock extends InputContentBlock {
+  /// The ID of the tool use this result corresponds to.
+  final String toolUseId;
+
+  /// The content of the tool result.
+  final MCPToolResultContent? content;
+
+  /// Whether this result represents an error.
+  final bool? isError;
+
+  /// Cache control for this block.
+  final CacheControlEphemeral? cacheControl;
+
+  /// Creates an [MCPToolResultInputBlock].
+  const MCPToolResultInputBlock({
+    required this.toolUseId,
+    this.content,
+    this.isError,
+    this.cacheControl,
+  });
+
+  /// Creates an [MCPToolResultInputBlock] from JSON.
+  factory MCPToolResultInputBlock.fromJson(Map<String, dynamic> json) {
+    return MCPToolResultInputBlock(
+      toolUseId: json['tool_use_id'] as String,
+      content: json['content'] != null
+          ? MCPToolResultContent.fromJson(json['content'] as Object)
+          : null,
+      isError: json['is_error'] as bool?,
+      cacheControl: json['cache_control'] != null
+          ? CacheControlEphemeral.fromJson(
+              json['cache_control'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'mcp_tool_result',
+    'tool_use_id': toolUseId,
+    if (content != null) 'content': content!.toJson(),
+    if (isError != null) 'is_error': isError,
+    if (cacheControl != null) 'cache_control': cacheControl!.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  MCPToolResultInputBlock copyWith({
+    String? toolUseId,
+    Object? content = unsetCopyWithValue,
+    Object? isError = unsetCopyWithValue,
+    Object? cacheControl = unsetCopyWithValue,
+  }) {
+    return MCPToolResultInputBlock(
+      toolUseId: toolUseId ?? this.toolUseId,
+      content: content == unsetCopyWithValue
+          ? this.content
+          : content as MCPToolResultContent?,
+      isError: isError == unsetCopyWithValue ? this.isError : isError as bool?,
+      cacheControl: cacheControl == unsetCopyWithValue
+          ? this.cacheControl
+          : cacheControl as CacheControlEphemeral?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MCPToolResultInputBlock &&
+          runtimeType == other.runtimeType &&
+          toolUseId == other.toolUseId &&
+          content == other.content &&
+          isError == other.isError &&
+          cacheControl == other.cacheControl;
+
+  @override
+  int get hashCode => Object.hash(toolUseId, content, isError, cacheControl);
+
+  @override
+  String toString() =>
+      'MCPToolResultInputBlock(toolUseId: $toolUseId, '
+      'content: $content, isError: $isError, '
+      'cacheControl: $cacheControl)';
 }
 
 /// Forward-compatible fallback for unknown input content block types.

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/credentials/credential_auth.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/credentials/credential_auth.dart
@@ -1329,32 +1329,41 @@ sealed class TokenEndpointAuthUpdateParam {
 /// Updated HTTP Basic authentication parameters for the token endpoint.
 @immutable
 class TokenEndpointAuthBasicUpdateParam extends TokenEndpointAuthUpdateParam {
+  /// The type discriminator. Always `client_secret_basic`.
+  final String type;
+
   /// Updated OAuth client secret.
   final String? clientSecret;
 
   /// Creates a [TokenEndpointAuthBasicUpdateParam].
-  const TokenEndpointAuthBasicUpdateParam({this.clientSecret});
+  const TokenEndpointAuthBasicUpdateParam({
+    this.type = 'client_secret_basic',
+    this.clientSecret,
+  });
 
   /// Creates a [TokenEndpointAuthBasicUpdateParam] from JSON.
   factory TokenEndpointAuthBasicUpdateParam.fromJson(
     Map<String, dynamic> json,
   ) {
     return TokenEndpointAuthBasicUpdateParam(
+      type: json['type'] as String? ?? 'client_secret_basic',
       clientSecret: json['client_secret'] as String?,
     );
   }
 
   @override
   Map<String, dynamic> toJson() => {
-    'type': 'client_secret_basic',
+    'type': type,
     if (clientSecret != null) 'client_secret': clientSecret,
   };
 
   /// Creates a copy with replaced values.
   TokenEndpointAuthBasicUpdateParam copyWith({
+    String? type,
     Object? clientSecret = unsetCopyWithValue,
   }) {
     return TokenEndpointAuthBasicUpdateParam(
+      type: type ?? this.type,
       clientSecret: clientSecret == unsetCopyWithValue
           ? this.clientSecret
           : clientSecret as String?,
@@ -1366,43 +1375,57 @@ class TokenEndpointAuthBasicUpdateParam extends TokenEndpointAuthUpdateParam {
       identical(this, other) ||
       other is TokenEndpointAuthBasicUpdateParam &&
           runtimeType == other.runtimeType &&
+          type == other.type &&
           clientSecret == other.clientSecret;
 
   @override
-  int get hashCode => clientSecret.hashCode;
+  int get hashCode => Object.hash(type, clientSecret);
 
   @override
   String toString() =>
-      'TokenEndpointAuthBasicUpdateParam(clientSecret: $clientSecret)';
+      'TokenEndpointAuthBasicUpdateParam('
+      'type: $type, '
+      'clientSecret: $clientSecret)';
 }
 
 /// Updated POST body authentication parameters for the token endpoint.
 @immutable
 class TokenEndpointAuthPostUpdateParam extends TokenEndpointAuthUpdateParam {
+  /// The type discriminator. Always `client_secret_post`.
+  final String type;
+
   /// Updated OAuth client secret.
   final String? clientSecret;
 
   /// Creates a [TokenEndpointAuthPostUpdateParam].
-  const TokenEndpointAuthPostUpdateParam({this.clientSecret});
+  const TokenEndpointAuthPostUpdateParam({
+    this.type = 'client_secret_post',
+    this.clientSecret,
+  });
 
   /// Creates a [TokenEndpointAuthPostUpdateParam] from JSON.
-  factory TokenEndpointAuthPostUpdateParam.fromJson(Map<String, dynamic> json) {
+  factory TokenEndpointAuthPostUpdateParam.fromJson(
+    Map<String, dynamic> json,
+  ) {
     return TokenEndpointAuthPostUpdateParam(
+      type: json['type'] as String? ?? 'client_secret_post',
       clientSecret: json['client_secret'] as String?,
     );
   }
 
   @override
   Map<String, dynamic> toJson() => {
-    'type': 'client_secret_post',
+    'type': type,
     if (clientSecret != null) 'client_secret': clientSecret,
   };
 
   /// Creates a copy with replaced values.
   TokenEndpointAuthPostUpdateParam copyWith({
+    String? type,
     Object? clientSecret = unsetCopyWithValue,
   }) {
     return TokenEndpointAuthPostUpdateParam(
+      type: type ?? this.type,
       clientSecret: clientSecret == unsetCopyWithValue
           ? this.clientSecret
           : clientSecret as String?,
@@ -1414,14 +1437,17 @@ class TokenEndpointAuthPostUpdateParam extends TokenEndpointAuthUpdateParam {
       identical(this, other) ||
       other is TokenEndpointAuthPostUpdateParam &&
           runtimeType == other.runtimeType &&
+          type == other.type &&
           clientSecret == other.clientSecret;
 
   @override
-  int get hashCode => clientSecret.hashCode;
+  int get hashCode => Object.hash(type, clientSecret);
 
   @override
   String toString() =>
-      'TokenEndpointAuthPostUpdateParam(clientSecret: $clientSecret)';
+      'TokenEndpointAuthPostUpdateParam('
+      'type: $type, '
+      'clientSecret: $clientSecret)';
 }
 
 /// Unrecognized token endpoint auth update type (preserves raw JSON).

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/credentials/credential_auth.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/credentials/credential_auth.dart
@@ -1404,9 +1404,7 @@ class TokenEndpointAuthPostUpdateParam extends TokenEndpointAuthUpdateParam {
   });
 
   /// Creates a [TokenEndpointAuthPostUpdateParam] from JSON.
-  factory TokenEndpointAuthPostUpdateParam.fromJson(
-    Map<String, dynamic> json,
-  ) {
+  factory TokenEndpointAuthPostUpdateParam.fromJson(Map<String, dynamic> json) {
     return TokenEndpointAuthPostUpdateParam(
       type: json['type'] as String? ?? 'client_secret_post',
       clientSecret: json['client_secret'] as String?,

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/errors/managed_agent_error.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/errors/managed_agent_error.dart
@@ -481,12 +481,21 @@ class UnknownManagedAgentError {
   }
 
   /// Converts to JSON.
-  Map<String, dynamic> toJson() => {
-    if (rawJson != null) ...rawJson!,
-    'type': type,
-    'message': message,
-    'retry_status': retryStatus.toJson(),
-  };
+  ///
+  /// When [rawJson] is present, it is used as the base to preserve unknown
+  /// fields. Only lossless scalar fields (`type`, `message`) are overwritten.
+  /// The `retry_status` from [rawJson] is kept verbatim because the parsed
+  /// [RetryStatus] subclasses may not round-trip all fields (e.g. `retry_at`).
+  Map<String, dynamic> toJson() {
+    if (rawJson != null) {
+      return {...rawJson!, 'type': type, 'message': message};
+    }
+    return {
+      'type': type,
+      'message': message,
+      'retry_status': retryStatus.toJson(),
+    };
+  }
 
   /// Creates a copy with replaced values.
   UnknownManagedAgentError copyWith({

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/errors/managed_agent_error.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/errors/managed_agent_error.dart
@@ -445,36 +445,60 @@ class ModelRequestFailedError {
       'retryStatus: $retryStatus)';
 }
 
-/// An unknown managed agent error (preserves raw JSON).
+/// An unknown managed agent error (preserves raw JSON for forward compatibility).
 @immutable
 class UnknownManagedAgentError {
+  /// The type discriminator. Always `unknown_error`.
+  final String type;
+
   /// Human-readable error description.
   final String message;
 
-  /// The raw JSON data.
+  /// What the client should do next.
+  final RetryStatus retryStatus;
+
+  /// The raw JSON data (preserves unknown future fields).
   final Map<String, dynamic>? rawJson;
 
   /// Creates an [UnknownManagedAgentError].
-  const UnknownManagedAgentError({required this.message, this.rawJson});
+  const UnknownManagedAgentError({
+    this.type = 'unknown_error',
+    required this.message,
+    required this.retryStatus,
+    this.rawJson,
+  });
 
   /// Creates an [UnknownManagedAgentError] from JSON.
   factory UnknownManagedAgentError.fromJson(Map<String, dynamic> json) {
     return UnknownManagedAgentError(
+      type: json['type'] as String? ?? 'unknown_error',
       message: json['message'] as String,
+      retryStatus: RetryStatus.fromJson(
+        json['retry_status'] as Map<String, dynamic>,
+      ),
       rawJson: json,
     );
   }
 
   /// Converts to JSON.
-  Map<String, dynamic> toJson() => rawJson ?? {'message': message};
+  Map<String, dynamic> toJson() => {
+    if (rawJson != null) ...rawJson!,
+    'type': type,
+    'message': message,
+    'retry_status': retryStatus.toJson(),
+  };
 
   /// Creates a copy with replaced values.
   UnknownManagedAgentError copyWith({
+    String? type,
     String? message,
+    RetryStatus? retryStatus,
     Object? rawJson = unsetCopyWithValue,
   }) {
     return UnknownManagedAgentError(
+      type: type ?? this.type,
       message: message ?? this.message,
+      retryStatus: retryStatus ?? this.retryStatus,
       rawJson: rawJson == unsetCopyWithValue
           ? this.rawJson
           : rawJson as Map<String, dynamic>?,
@@ -486,13 +510,20 @@ class UnknownManagedAgentError {
       identical(this, other) ||
       other is UnknownManagedAgentError &&
           runtimeType == other.runtimeType &&
+          type == other.type &&
           message == other.message &&
+          retryStatus == other.retryStatus &&
           mapsDeepEqual(rawJson, other.rawJson);
 
   @override
-  int get hashCode => Object.hash(message, mapDeepHashCode(rawJson));
+  int get hashCode =>
+      Object.hash(type, message, retryStatus, mapDeepHashCode(rawJson));
 
   @override
   String toString() =>
-      'UnknownManagedAgentError(message: $message, rawJson: $rawJson)';
+      'UnknownManagedAgentError('
+      'type: $type, '
+      'message: $message, '
+      'retryStatus: $retryStatus, '
+      'rawJson: $rawJson)';
 }

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/errors/managed_agent_error.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/errors/managed_agent_error.dart
@@ -483,17 +483,29 @@ class UnknownManagedAgentError {
   /// Converts to JSON.
   ///
   /// When [rawJson] is present, it is used as the base to preserve unknown
-  /// fields. Only lossless scalar fields (`type`, `message`) are overwritten.
-  /// The `retry_status` from [rawJson] is kept verbatim because the parsed
-  /// [RetryStatus] subclasses may not round-trip all fields (e.g. `retry_at`).
+  /// fields. Lossless scalar fields (`type`, `message`) are overwritten, and
+  /// `retry_status` is merged so the current [retryStatus] state is reflected
+  /// while preserving any extra unknown fields from the original payload
+  /// (e.g. `retry_at`).
   Map<String, dynamic> toJson() {
+    final retryStatusJson = retryStatus.toJson();
     if (rawJson != null) {
-      return {...rawJson!, 'type': type, 'message': message};
+      final rawRetryStatus = rawJson!['retry_status'];
+      final mergedRetryStatus =
+          rawRetryStatus is Map<String, dynamic>
+              ? {...rawRetryStatus, ...retryStatusJson}
+              : retryStatusJson;
+      return {
+        ...rawJson!,
+        'type': type,
+        'message': message,
+        'retry_status': mergedRetryStatus,
+      };
     }
     return {
       'type': type,
       'message': message,
-      'retry_status': retryStatus.toJson(),
+      'retry_status': retryStatusJson,
     };
   }
 

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/errors/managed_agent_error.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/errors/managed_agent_error.dart
@@ -491,10 +491,9 @@ class UnknownManagedAgentError {
     final retryStatusJson = retryStatus.toJson();
     if (rawJson != null) {
       final rawRetryStatus = rawJson!['retry_status'];
-      final mergedRetryStatus =
-          rawRetryStatus is Map<String, dynamic>
-              ? {...rawRetryStatus, ...retryStatusJson}
-              : retryStatusJson;
+      final mergedRetryStatus = rawRetryStatus is Map<String, dynamic>
+          ? {...rawRetryStatus, ...retryStatusJson}
+          : retryStatusJson;
       return {
         ...rawJson!,
         'type': type,
@@ -502,11 +501,7 @@ class UnknownManagedAgentError {
         'retry_status': mergedRetryStatus,
       };
     }
-    return {
-      'type': type,
-      'message': message,
-      'retry_status': retryStatusJson,
-    };
+    return {'type': type, 'message': message, 'retry_status': retryStatusJson};
   }
 
   /// Creates a copy with replaced values.

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/errors/managed_agent_error.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/errors/managed_agent_error.dart
@@ -461,12 +461,12 @@ class UnknownManagedAgentError {
   final Map<String, dynamic>? rawJson;
 
   /// Creates an [UnknownManagedAgentError].
-  const UnknownManagedAgentError({
+  UnknownManagedAgentError({
     this.type = 'unknown_error',
     required this.message,
     required this.retryStatus,
-    this.rawJson,
-  });
+    Map<String, dynamic>? rawJson,
+  }) : rawJson = rawJson != null ? Map.unmodifiable(rawJson) : null;
 
   /// Creates an [UnknownManagedAgentError] from JSON.
   factory UnknownManagedAgentError.fromJson(Map<String, dynamic> json) {

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/session.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/session.dart
@@ -60,25 +60,25 @@ class Session {
   final SessionAgent agent;
 
   /// ID of the environment defining the container configuration.
-  final String? environmentId;
+  final String environmentId;
 
   /// Human-readable session title.
   final String? title;
 
   /// Arbitrary key-value metadata attached to the session.
-  final Map<String, String>? metadata;
+  final Map<String, String> metadata;
 
   /// Resources mounted into the session.
-  final List<SessionResource>? resources;
+  final List<SessionResource> resources;
 
   /// Vault IDs attached to the session.
-  final List<String>? vaultIds;
+  final List<String> vaultIds;
 
   /// Timing statistics for the session.
-  final SessionStats? stats;
+  final SessionStats stats;
 
   /// Cumulative token usage for the session.
-  final SessionUsage? usage;
+  final SessionUsage usage;
 
   /// When the session was created.
   final DateTime createdAt;
@@ -95,16 +95,16 @@ class Session {
     this.type = 'session',
     required this.status,
     required this.agent,
-    this.environmentId,
-    this.title,
-    this.metadata,
-    this.resources,
-    this.vaultIds,
-    this.stats,
-    this.usage,
+    required this.environmentId,
+    required this.title,
+    required this.metadata,
+    required this.resources,
+    required this.vaultIds,
+    required this.stats,
+    required this.usage,
     required this.createdAt,
     required this.updatedAt,
-    this.archivedAt,
+    required this.archivedAt,
   });
 
   /// Creates a [Session] from JSON.
@@ -114,21 +114,17 @@ class Session {
       type: json['type'] as String? ?? 'session',
       status: SessionStatus.fromJson(json['status'] as String),
       agent: SessionAgent.fromJson(json['agent'] as Map<String, dynamic>),
-      environmentId: json['environment_id'] as String?,
+      environmentId: json['environment_id'] as String,
       title: json['title'] as String?,
-      metadata: (json['metadata'] as Map<String, dynamic>?)?.map(
+      metadata: (json['metadata'] as Map<String, dynamic>).map(
         (k, v) => MapEntry(k, v as String),
       ),
-      resources: (json['resources'] as List?)
-          ?.map((e) => SessionResource.fromJson(e as Map<String, dynamic>))
+      resources: (json['resources'] as List)
+          .map((e) => SessionResource.fromJson(e as Map<String, dynamic>))
           .toList(),
-      vaultIds: (json['vault_ids'] as List?)?.map((e) => e as String).toList(),
-      stats: json['stats'] != null
-          ? SessionStats.fromJson(json['stats'] as Map<String, dynamic>)
-          : null,
-      usage: json['usage'] != null
-          ? SessionUsage.fromJson(json['usage'] as Map<String, dynamic>)
-          : null,
+      vaultIds: (json['vault_ids'] as List).map((e) => e as String).toList(),
+      stats: SessionStats.fromJson(json['stats'] as Map<String, dynamic>),
+      usage: SessionUsage.fromJson(json['usage'] as Map<String, dynamic>),
       createdAt: DateTime.parse(json['created_at'] as String),
       updatedAt: DateTime.parse(json['updated_at'] as String),
       archivedAt: json['archived_at'] != null
@@ -143,14 +139,13 @@ class Session {
     'type': type,
     'status': status.toJson(),
     'agent': agent.toJson(),
-    if (environmentId != null) 'environment_id': environmentId,
+    'environment_id': environmentId,
     'title': title,
-    if (metadata != null) 'metadata': metadata,
-    if (resources != null)
-      'resources': resources!.map((e) => e.toJson()).toList(),
-    if (vaultIds != null) 'vault_ids': vaultIds,
-    if (stats != null) 'stats': stats!.toJson(),
-    if (usage != null) 'usage': usage!.toJson(),
+    'metadata': metadata,
+    'resources': resources.map((e) => e.toJson()).toList(),
+    'vault_ids': vaultIds,
+    'stats': stats.toJson(),
+    'usage': usage.toJson(),
     'created_at': createdAt.toUtc().toIso8601String(),
     'updated_at': updatedAt.toUtc().toIso8601String(),
     'archived_at': archivedAt?.toUtc().toIso8601String(),
@@ -162,13 +157,13 @@ class Session {
     String? type,
     SessionStatus? status,
     SessionAgent? agent,
-    Object? environmentId = unsetCopyWithValue,
+    String? environmentId,
     Object? title = unsetCopyWithValue,
-    Object? metadata = unsetCopyWithValue,
-    Object? resources = unsetCopyWithValue,
-    Object? vaultIds = unsetCopyWithValue,
-    Object? stats = unsetCopyWithValue,
-    Object? usage = unsetCopyWithValue,
+    Map<String, String>? metadata,
+    List<SessionResource>? resources,
+    List<String>? vaultIds,
+    SessionStats? stats,
+    SessionUsage? usage,
     DateTime? createdAt,
     DateTime? updatedAt,
     Object? archivedAt = unsetCopyWithValue,
@@ -178,21 +173,13 @@ class Session {
       type: type ?? this.type,
       status: status ?? this.status,
       agent: agent ?? this.agent,
-      environmentId: environmentId == unsetCopyWithValue
-          ? this.environmentId
-          : environmentId as String?,
+      environmentId: environmentId ?? this.environmentId,
       title: title == unsetCopyWithValue ? this.title : title as String?,
-      metadata: metadata == unsetCopyWithValue
-          ? this.metadata
-          : metadata as Map<String, String>?,
-      resources: resources == unsetCopyWithValue
-          ? this.resources
-          : resources as List<SessionResource>?,
-      vaultIds: vaultIds == unsetCopyWithValue
-          ? this.vaultIds
-          : vaultIds as List<String>?,
-      stats: stats == unsetCopyWithValue ? this.stats : stats as SessionStats?,
-      usage: usage == unsetCopyWithValue ? this.usage : usage as SessionUsage?,
+      metadata: metadata ?? this.metadata,
+      resources: resources ?? this.resources,
+      vaultIds: vaultIds ?? this.vaultIds,
+      stats: stats ?? this.stats,
+      usage: usage ?? this.usage,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
       archivedAt: archivedAt == unsetCopyWithValue

--- a/packages/anthropic_sdk_dart/llms.txt
+++ b/packages/anthropic_sdk_dart/llms.txt
@@ -4,7 +4,7 @@
 
 ## Docs
 
-- [README](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/README.md) (~4k tokens): Primary package documentation with installation, configuration, and usage examples.
+- [README](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/README.md) (~4.4k tokens): Primary package documentation with installation, configuration, and usage examples.
 - [CHANGELOG](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/CHANGELOG.md) (~6.9k tokens): Release history and version-by-version changes.
 - [MIGRATION](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/MIGRATION.md) (~4.1k tokens): Upgrade notes and breaking-change guidance.
 
@@ -20,6 +20,7 @@
 - [models_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/models_example.dart) (~471 tokens): Model listing.
 - [files_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/files_example.dart) (~842 tokens): File management (beta).
 - [skills_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/skills_example.dart) (~1k tokens): Skills management (beta).
+- [managed_agents_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/managed_agents_example.dart) (~775 tokens): Managed agents: agents, sessions, vaults (beta).
 - [error_handling_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/error_handling_example.dart) (~632 tokens): Exception handling patterns.
 - [web_search_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/web_search_example.dart) (~793 tokens): Web search tool.
 - [advisor_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/advisor_example.dart) (~967 tokens): Advisor tool (beta).
@@ -32,4 +33,4 @@
 
 - [Package directory](https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/anthropic_sdk_dart): Source tree, pubspec, and package-local files.
 
-**Total: ~30.1k tokens**
+**Total: ~31.3k tokens**

--- a/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
@@ -864,5 +864,41 @@ void main() {
       expect(a.hashCode, equals(b.hashCode));
       expect(a, isNot(equals(c)));
     });
+
+    group('AdvisorResult copyWith', () {
+      test('creates modified copy', () {
+        const original = AdvisorResult(text: 'original advice');
+        final modified = original.copyWith(text: 'new advice');
+
+        expect(modified.text, 'new advice');
+        expect(original.text, 'original advice');
+      });
+
+      test('returns equal copy when no args', () {
+        const original = AdvisorResult(text: 'advice');
+        final copy = original.copyWith();
+
+        expect(copy, equals(original));
+        expect(copy.hashCode, equals(original.hashCode));
+      });
+    });
+
+    group('AdvisorRedactedResult copyWith', () {
+      test('creates modified copy', () {
+        const original = AdvisorRedactedResult(encryptedContent: 'enc1');
+        final modified = original.copyWith(encryptedContent: 'enc2');
+
+        expect(modified.encryptedContent, 'enc2');
+        expect(original.encryptedContent, 'enc1');
+      });
+
+      test('returns equal copy when no args', () {
+        const original = AdvisorRedactedResult(encryptedContent: 'enc');
+        final copy = original.copyWith();
+
+        expect(copy, equals(original));
+        expect(copy.hashCode, equals(original.hashCode));
+      });
+    });
   });
 }

--- a/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
@@ -240,6 +240,158 @@ void main() {
       });
     });
 
+    group('MCPToolUseBlock', () {
+      test('fromJson parses all fields', () {
+        final json = {
+          'type': 'mcp_tool_use',
+          'id': 'tu_mcp_1',
+          'name': 'read_file',
+          'server_name': 'filesystem',
+          'input': {'path': '/tmp/test.txt'},
+        };
+
+        final block = ContentBlock.fromJson(json);
+        expect(block, isA<MCPToolUseBlock>());
+        final mcp = block as MCPToolUseBlock;
+        expect(mcp.id, 'tu_mcp_1');
+        expect(mcp.name, 'read_file');
+        expect(mcp.serverName, 'filesystem');
+        expect(mcp.input, {'path': '/tmp/test.txt'});
+      });
+
+      test('toJson round-trips correctly', () {
+        const block = MCPToolUseBlock(
+          id: 'tu_1',
+          name: 'query',
+          serverName: 'db-server',
+          input: {'sql': 'SELECT 1'},
+        );
+
+        final json = block.toJson();
+        expect(json['type'], 'mcp_tool_use');
+        expect(json['server_name'], 'db-server');
+
+        final restored = MCPToolUseBlock.fromJson(json);
+        expect(restored, equals(block));
+      });
+
+      test('copyWith creates modified copy', () {
+        const block = MCPToolUseBlock(
+          id: 'tu_1',
+          name: 'tool_a',
+          serverName: 'server_a',
+          input: {'key': 'value'},
+        );
+
+        final modified = block.copyWith(name: 'tool_b');
+        expect(modified.name, 'tool_b');
+        expect(modified.id, 'tu_1');
+      });
+
+      test('equality uses content-based map comparison', () {
+        const a = MCPToolUseBlock(
+          id: 'tu_1',
+          name: 'tool',
+          serverName: 'srv',
+          input: {'k': 'v'},
+        );
+        const b = MCPToolUseBlock(
+          id: 'tu_1',
+          name: 'tool',
+          serverName: 'srv',
+          input: {'k': 'v'},
+        );
+
+        expect(a, equals(b));
+        expect(a.hashCode, equals(b.hashCode));
+      });
+    });
+
+    group('MCPToolResultBlock', () {
+      test('fromJson with string content', () {
+        final json = {
+          'type': 'mcp_tool_result',
+          'content': 'file contents here',
+          'is_error': false,
+          'tool_use_id': 'tu_mcp_1',
+        };
+
+        final block = ContentBlock.fromJson(json);
+        expect(block, isA<MCPToolResultBlock>());
+        final result = block as MCPToolResultBlock;
+        expect(result.content, isA<MCPToolResultStringContent>());
+        expect(
+          (result.content as MCPToolResultStringContent).text,
+          'file contents here',
+        );
+        expect(result.isError, false);
+        expect(result.toolUseId, 'tu_mcp_1');
+      });
+
+      test('fromJson with list content', () {
+        final json = {
+          'type': 'mcp_tool_result',
+          'content': [
+            {'type': 'text', 'text': 'block one'},
+            {'type': 'text', 'text': 'block two'},
+          ],
+          'is_error': false,
+          'tool_use_id': 'tu_mcp_2',
+        };
+
+        final block = MCPToolResultBlock.fromJson(json);
+        expect(block.content, isA<MCPToolResultBlocksContent>());
+        final blocks =
+            (block.content as MCPToolResultBlocksContent).blocks;
+        expect(blocks, hasLength(2));
+        expect(blocks[0].text, 'block one');
+        expect(blocks[1].text, 'block two');
+      });
+
+      test('isError defaults to false', () {
+        final json = {
+          'type': 'mcp_tool_result',
+          'content': 'ok',
+          'tool_use_id': 'tu_1',
+        };
+
+        final block = MCPToolResultBlock.fromJson(json);
+        expect(block.isError, false);
+      });
+
+      test('toJson round-trips string content', () {
+        final block = MCPToolResultBlock(
+          content: MCPToolResultContent.text('result'),
+          toolUseId: 'tu_1',
+        );
+
+        final json = block.toJson();
+        expect(json['type'], 'mcp_tool_result');
+        expect(json['content'], 'result');
+        expect(json['is_error'], false);
+
+        final restored = MCPToolResultBlock.fromJson(json);
+        expect(restored, equals(block));
+      });
+
+      test('toJson round-trips list content', () {
+        final block = MCPToolResultBlock(
+          content: MCPToolResultContent.blocks([
+            const TextBlock(text: 'hello'),
+          ]),
+          isError: true,
+          toolUseId: 'tu_1',
+        );
+
+        final json = block.toJson();
+        expect(json['is_error'], true);
+        expect(json['content'], isList);
+
+        final restored = MCPToolResultBlock.fromJson(json);
+        expect(restored, equals(block));
+      });
+    });
+
     group('Additional tool result blocks', () {
       test('parses web fetch tool result block', () {
         final json = {
@@ -429,6 +581,104 @@ void main() {
         final parsed = InputContentBlock.fromJson(json);
         expect(parsed, isA<CompactionInputBlock>());
         expect((parsed as CompactionInputBlock).content, 'Compacted summary');
+      });
+    });
+
+    group('MCPToolUseInputBlock', () {
+      test('fromJson parses all fields', () {
+        final json = {
+          'type': 'mcp_tool_use',
+          'id': 'tu_mcp_1',
+          'name': 'read_file',
+          'server_name': 'filesystem',
+          'input': {'path': '/tmp/test.txt'},
+          'cache_control': {'type': 'ephemeral'},
+        };
+
+        final block = InputContentBlock.fromJson(json);
+        expect(block, isA<MCPToolUseInputBlock>());
+        final mcp = block as MCPToolUseInputBlock;
+        expect(mcp.id, 'tu_mcp_1');
+        expect(mcp.serverName, 'filesystem');
+        expect(mcp.cacheControl, isNotNull);
+      });
+
+      test('toJson round-trips correctly', () {
+        const block = MCPToolUseInputBlock(
+          id: 'tu_1',
+          name: 'tool',
+          serverName: 'server',
+          input: {'k': 'v'},
+        );
+
+        final json = block.toJson();
+        expect(json['type'], 'mcp_tool_use');
+        expect(json['server_name'], 'server');
+        expect(json.containsKey('cache_control'), false);
+
+        final restored = MCPToolUseInputBlock.fromJson(json);
+        expect(restored, equals(block));
+      });
+
+      test('factory constructor works', () {
+        final block = InputContentBlock.mcpToolUse(
+          id: 'tu_1',
+          name: 'query',
+          serverName: 'db',
+          input: const {'sql': 'SELECT 1'},
+        );
+        expect(block, isA<MCPToolUseInputBlock>());
+      });
+    });
+
+    group('MCPToolResultInputBlock', () {
+      test('fromJson with all optional fields', () {
+        final json = {
+          'type': 'mcp_tool_result',
+          'tool_use_id': 'tu_mcp_1',
+          'content': 'result text',
+          'is_error': true,
+          'cache_control': {'type': 'ephemeral'},
+        };
+
+        final block = InputContentBlock.fromJson(json);
+        expect(block, isA<MCPToolResultInputBlock>());
+        final mcp = block as MCPToolResultInputBlock;
+        expect(mcp.toolUseId, 'tu_mcp_1');
+        expect(mcp.content, isA<MCPToolResultStringContent>());
+        expect(mcp.isError, true);
+        expect(mcp.cacheControl, isNotNull);
+      });
+
+      test('fromJson with minimal fields', () {
+        final json = {
+          'type': 'mcp_tool_result',
+          'tool_use_id': 'tu_mcp_1',
+        };
+
+        final block = MCPToolResultInputBlock.fromJson(json);
+        expect(block.toolUseId, 'tu_mcp_1');
+        expect(block.content, isNull);
+        expect(block.isError, isNull);
+      });
+
+      test('toJson omits null fields', () {
+        const block = MCPToolResultInputBlock(toolUseId: 'tu_1');
+        final json = block.toJson();
+
+        expect(json['type'], 'mcp_tool_result');
+        expect(json['tool_use_id'], 'tu_1');
+        expect(json.containsKey('content'), false);
+        expect(json.containsKey('is_error'), false);
+        expect(json.containsKey('cache_control'), false);
+      });
+
+      test('factory constructor works', () {
+        final block = InputContentBlock.mcpToolResult(
+          toolUseId: 'tu_1',
+          content: MCPToolResultContent.text('ok'),
+        );
+        expect(block, isA<MCPToolResultInputBlock>());
       });
     });
 

--- a/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
@@ -341,8 +341,7 @@ void main() {
 
         final block = MCPToolResultBlock.fromJson(json);
         expect(block.content, isA<MCPToolResultBlocksContent>());
-        final blocks =
-            (block.content as MCPToolResultBlocksContent).blocks;
+        final blocks = (block.content as MCPToolResultBlocksContent).blocks;
         expect(blocks, hasLength(2));
         expect(blocks[0].text, 'block one');
         expect(blocks[1].text, 'block two');
@@ -651,10 +650,7 @@ void main() {
       });
 
       test('fromJson with minimal fields', () {
-        final json = {
-          'type': 'mcp_tool_result',
-          'tool_use_id': 'tu_mcp_1',
-        };
+        final json = {'type': 'mcp_tool_result', 'tool_use_id': 'tu_mcp_1'};
 
         final block = MCPToolResultInputBlock.fromJson(json);
         expect(block.toolUseId, 'tu_mcp_1');

--- a/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
@@ -846,6 +846,29 @@ void main() {
       expect(retryStatus['retry_at'], '2026-04-01T00:01:00Z');
     });
 
+    test('toJson reflects copyWith retryStatus while preserving retry_at', () {
+      final json = {
+        'type': 'unknown_error',
+        'message': 'Retrying',
+        'retry_status': {
+          'type': 'retrying',
+          'retry_at': '2026-04-01T00:01:00Z',
+        },
+      };
+
+      final error = UnknownManagedAgentError.fromJson(json);
+      final modified = error.copyWith(
+        retryStatus: const RetryStatusTerminal(),
+      );
+      final output = modified.toJson();
+
+      // The merged retry_status should reflect the new type from copyWith
+      // while preserving retry_at from the original rawJson.
+      final retryStatus = output['retry_status'] as Map<String, dynamic>;
+      expect(retryStatus['type'], 'terminal');
+      expect(retryStatus['retry_at'], '2026-04-01T00:01:00Z');
+    });
+
     test('toJson preserves unknown fields from rawJson', () {
       final json = {
         'type': 'unknown_error',

--- a/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
@@ -51,8 +51,24 @@ class ManagedAgentsFixtures {
         'skills': <Map<String, dynamic>>[],
         'tools': <Map<String, dynamic>>[],
       },
+      'environment_id': 'env_test123',
+      'title': null,
+      'metadata': <String, String>{},
+      'resources': <Map<String, dynamic>>[],
+      'vault_ids': <String>[],
+      'stats': {
+        'active_seconds': 0,
+        'duration_seconds': 0,
+      },
+      'usage': {
+        'input_tokens': 0,
+        'output_tokens': 0,
+        'cache_read_input_tokens': 0,
+        'cache_creation_input_tokens': 0,
+      },
       'created_at': '2026-04-01T00:00:00Z',
       'updated_at': '2026-04-01T00:00:00Z',
+      'archived_at': null,
     };
   }
 

--- a/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
@@ -775,4 +775,81 @@ void main() {
       expect(request.method, 'POST');
     });
   });
+
+  group('UnknownManagedAgentError', () {
+    test('fromJson parses type, message, and retryStatus', () {
+      final json = {
+        'type': 'unknown_error',
+        'message': 'Something went wrong',
+        'retry_status': {'type': 'retrying', 'retry_at': '2026-04-01T00:01:00Z'},
+      };
+
+      final error = UnknownManagedAgentError.fromJson(json);
+
+      expect(error.type, 'unknown_error');
+      expect(error.message, 'Something went wrong');
+      expect(error.retryStatus, isA<RetryStatusRetrying>());
+      expect(error.rawJson, json);
+    });
+
+    test('toJson round-trips correctly', () {
+      final json = {
+        'type': 'unknown_error',
+        'message': 'Something went wrong',
+        'retry_status': {'type': 'retrying', 'retry_at': '2026-04-01T00:01:00Z'},
+      };
+
+      final error = UnknownManagedAgentError.fromJson(json);
+      final output = error.toJson();
+
+      expect(output['type'], 'unknown_error');
+      expect(output['message'], 'Something went wrong');
+      expect(output['retry_status'], isA<Map>());
+    });
+
+    test('toJson preserves unknown fields from rawJson', () {
+      final json = {
+        'type': 'unknown_error',
+        'message': 'Error',
+        'retry_status': {'type': 'terminal'},
+        'extra_field': 'preserved',
+      };
+
+      final error = UnknownManagedAgentError.fromJson(json);
+      final output = error.toJson();
+
+      expect(output['extra_field'], 'preserved');
+    });
+
+    test('copyWith creates modified copy', () {
+      final error = UnknownManagedAgentError(
+        message: 'original',
+        retryStatus: const RetryStatusTerminal(),
+      );
+      final modified = error.copyWith(message: 'updated');
+
+      expect(modified.message, 'updated');
+      expect(modified.retryStatus, isA<RetryStatusTerminal>());
+      expect(error.message, 'original');
+    });
+
+    test('equality includes type and retryStatus', () {
+      final a = UnknownManagedAgentError(
+        message: 'error',
+        retryStatus: const RetryStatusTerminal(),
+      );
+      final b = UnknownManagedAgentError(
+        message: 'error',
+        retryStatus: const RetryStatusTerminal(),
+      );
+      final c = UnknownManagedAgentError(
+        message: 'different',
+        retryStatus: const RetryStatusTerminal(),
+      );
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
+  });
 }

--- a/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
@@ -882,9 +882,9 @@ void main() {
     });
 
     test('copyWith creates modified copy', () {
-      const error = UnknownManagedAgentError(
+      final error = UnknownManagedAgentError(
         message: 'original',
-        retryStatus: RetryStatusTerminal(),
+        retryStatus: const RetryStatusTerminal(),
       );
       final modified = error.copyWith(message: 'updated');
 
@@ -894,17 +894,17 @@ void main() {
     });
 
     test('equality includes type and retryStatus', () {
-      const a = UnknownManagedAgentError(
+      final a = UnknownManagedAgentError(
         message: 'error',
-        retryStatus: RetryStatusTerminal(),
+        retryStatus: const RetryStatusTerminal(),
       );
-      const b = UnknownManagedAgentError(
+      final b = UnknownManagedAgentError(
         message: 'error',
-        retryStatus: RetryStatusTerminal(),
+        retryStatus: const RetryStatusTerminal(),
       );
-      const c = UnknownManagedAgentError(
+      final c = UnknownManagedAgentError(
         message: 'different',
-        retryStatus: RetryStatusTerminal(),
+        retryStatus: const RetryStatusTerminal(),
       );
 
       expect(a, equals(b));

--- a/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
@@ -826,6 +826,26 @@ void main() {
       expect(output['retry_status'], isA<Map<String, dynamic>>());
     });
 
+    test('toJson preserves retry_status fields like retry_at', () {
+      final json = {
+        'type': 'unknown_error',
+        'message': 'Retrying',
+        'retry_status': {
+          'type': 'retrying',
+          'retry_at': '2026-04-01T00:01:00Z',
+        },
+      };
+
+      final error = UnknownManagedAgentError.fromJson(json);
+      final output = error.toJson();
+
+      // retry_status must preserve retry_at — the parsed RetryStatusRetrying
+      // only stores 'type', so rawJson is used verbatim.
+      final retryStatus = output['retry_status'] as Map<String, dynamic>;
+      expect(retryStatus['type'], 'retrying');
+      expect(retryStatus['retry_at'], '2026-04-01T00:01:00Z');
+    });
+
     test('toJson preserves unknown fields from rawJson', () {
       final json = {
         'type': 'unknown_error',

--- a/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
@@ -804,7 +804,7 @@ void main() {
 
       expect(output['type'], 'unknown_error');
       expect(output['message'], 'Something went wrong');
-      expect(output['retry_status'], isA<Map>());
+      expect(output['retry_status'], isA<Map<String, dynamic>>());
     });
 
     test('toJson preserves unknown fields from rawJson', () {
@@ -822,9 +822,9 @@ void main() {
     });
 
     test('copyWith creates modified copy', () {
-      final error = UnknownManagedAgentError(
+      const error = UnknownManagedAgentError(
         message: 'original',
-        retryStatus: const RetryStatusTerminal(),
+        retryStatus: RetryStatusTerminal(),
       );
       final modified = error.copyWith(message: 'updated');
 
@@ -834,17 +834,17 @@ void main() {
     });
 
     test('equality includes type and retryStatus', () {
-      final a = UnknownManagedAgentError(
+      const a = UnknownManagedAgentError(
         message: 'error',
-        retryStatus: const RetryStatusTerminal(),
+        retryStatus: RetryStatusTerminal(),
       );
-      final b = UnknownManagedAgentError(
+      const b = UnknownManagedAgentError(
         message: 'error',
-        retryStatus: const RetryStatusTerminal(),
+        retryStatus: RetryStatusTerminal(),
       );
-      final c = UnknownManagedAgentError(
+      const c = UnknownManagedAgentError(
         message: 'different',
-        retryStatus: const RetryStatusTerminal(),
+        retryStatus: RetryStatusTerminal(),
       );
 
       expect(a, equals(b));

--- a/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
@@ -56,10 +56,7 @@ class ManagedAgentsFixtures {
       'metadata': <String, String>{},
       'resources': <Map<String, dynamic>>[],
       'vault_ids': <String>[],
-      'stats': {
-        'active_seconds': 0,
-        'duration_seconds': 0,
-      },
+      'stats': {'active_seconds': 0, 'duration_seconds': 0},
       'usage': {
         'input_tokens': 0,
         'output_tokens': 0,
@@ -797,7 +794,10 @@ void main() {
       final json = {
         'type': 'unknown_error',
         'message': 'Something went wrong',
-        'retry_status': {'type': 'retrying', 'retry_at': '2026-04-01T00:01:00Z'},
+        'retry_status': {
+          'type': 'retrying',
+          'retry_at': '2026-04-01T00:01:00Z',
+        },
       };
 
       final error = UnknownManagedAgentError.fromJson(json);
@@ -812,7 +812,10 @@ void main() {
       final json = {
         'type': 'unknown_error',
         'message': 'Something went wrong',
-        'retry_status': {'type': 'retrying', 'retry_at': '2026-04-01T00:01:00Z'},
+        'retry_status': {
+          'type': 'retrying',
+          'retry_at': '2026-04-01T00:01:00Z',
+        },
       };
 
       final error = UnknownManagedAgentError.fromJson(json);

--- a/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
@@ -857,9 +857,7 @@ void main() {
       };
 
       final error = UnknownManagedAgentError.fromJson(json);
-      final modified = error.copyWith(
-        retryStatus: const RetryStatusTerminal(),
-      );
+      final modified = error.copyWith(retryStatus: const RetryStatusTerminal());
       final output = modified.toJson();
 
       // The merged retry_status should reflect the new type from copyWith


### PR DESCRIPTION
## Summary
- Fix pre-existing verify errors: missing `copyWith` on advisor result blocks, missing fields on `UnknownManagedAgentError` and token endpoint auth update params, incorrect nullability on 6 `Session` fields
- Add `MCPToolUseBlock` and `MCPToolResultBlock` response types with matching input block pairs for multi-turn round-tripping
- Add managed agents documentation (README, example, llms.txt)

## Details

Addresses 30 of the 72 issues reported by `verify --checks all --scope all`. The remaining 42 are confirmed false positives or intentional design choices:
- `CacheCreationUsage` fields already exist (verify tool bug)
- `Session.title` and `SpanModelRequestEndEvent.isError` are correctly nullable (spec says `required + nullable: true`)
- `ContentBlock` "BetaResponse*" warnings are naming mismatches (Dart uses simplified names like `TextBlock` instead of `BetaResponseTextBlock`)
- Consistency warnings on `AgentTool`/`StreamSessionEvents` reflect intentional type differences across sealed variants

### MCP content blocks

New `mcp_tool_use` and `mcp_tool_result` content block types from the spec:

```dart
// Response blocks
final mcpUse = MCPToolUseBlock(
  id: 'tu_1', name: 'read_file', serverName: 'filesystem',
  input: {'path': '/tmp/test.txt'},
);

// Content is a union: String or List<TextBlock>
final mcpResult = MCPToolResultBlock(
  content: MCPToolResultContent.text('file contents'),
  toolUseId: 'tu_1',
);

// Input blocks for multi-turn round-tripping
final inputUse = InputContentBlock.mcpToolUse(
  id: 'tu_1', name: 'read_file', serverName: 'filesystem',
  input: {'path': '/tmp/test.txt'},
);
```

### Session field nullability

Six `Session` fields changed from nullable to required non-nullable per the `BetaManagedAgentsSession` spec: `environmentId`, `metadata`, `resources`, `vaultIds`, `stats`, `usage`. The `title` and `archivedAt` fields stay nullable (`spec: nullable: true`) but are now `required` in the constructor.

## References

- [Anthropic API docs](https://docs.anthropic.com/en/api) — managed agents beta API

## Test Plan
- [x] Unit tests pass (`dart test test/unit/` — 636 passed)
- [x] `dart analyze --fatal-infos` — no issues
- [x] `dart format --set-exit-if-changed .` — 0 files changed
- [x] Toolkit verify: 15 errors → all confirmed false positives; 27 warnings → all intentional design
- [x] New MCP block tests: fromJson, toJson round-trip, copyWith, dispatch, equality/hashCode
- [x] Session fixture updated with all newly-required fields
- [x] `llms.txt` regenerated
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
