### PR TITLE
feat(googleai_dart): update OpenAPI spec with new types and fields

### DIFF
--- a/packages/googleai_dart/.agents/skills/openapi-googleai/config/manifest.json
+++ b/packages/googleai_dart/.agents/skills/openapi-googleai/config/manifest.json
@@ -544,7 +544,8 @@
           "mcp_server_tool_call": "#/components/schemas/McpServerToolCallDelta",
           "mcp_server_tool_result": "#/components/schemas/McpServerToolResultDelta",
           "file_search_call": "#/components/schemas/FileSearchCallDelta",
-          "file_search_result": "#/components/schemas/FileSearchResultDelta"
+          "file_search_result": "#/components/schemas/FileSearchResultDelta",
+          "text_annotation": "#/components/schemas/TextAnnotationDelta"
         }
       }
     },
@@ -1045,6 +1046,14 @@
         "acknowledged"
       ]
     },
+    "TextAnnotationDelta": {
+      "spec": "interactions",
+      "schema": "TextAnnotationDelta",
+      "dart_class": "TextAnnotationDelta",
+      "file": "lib/src/models/interactions/deltas/text_annotation_delta.dart",
+      "kind": "sealed_variant",
+      "parent": "InteractionDelta"
+    },
     "ThoughtSummary": {
       "spec": "interactions",
       "schema": "ThoughtSummary",
@@ -1086,9 +1095,25 @@
           "url_context": "#/components/schemas/UrlContext",
           "computer_use": "#/components/schemas/ComputerUse",
           "mcp_server": "#/components/schemas/McpServer",
-          "file_search": "#/components/schemas/FileSearch"
+          "file_search": "#/components/schemas/FileSearch",
+          "retrieval": "#/components/schemas/Retrieval"
         }
       }
+    },
+    "interactions:Retrieval": {
+      "spec": "interactions",
+      "schema": "Retrieval",
+      "dart_class": "RetrievalTool",
+      "file": "lib/src/models/interactions/tools/retrieval_tool.dart",
+      "kind": "sealed_variant",
+      "parent": "InteractionTool"
+    },
+    "interactions:VertexAISearchConfig": {
+      "spec": "interactions",
+      "schema": "VertexAISearchConfig",
+      "dart_class": "VertexAISearchConfig",
+      "file": "lib/src/models/interactions/tools/vertex_ai_search_config.dart",
+      "kind": "object"
     },
     "ToolChoiceConfig": {
       "spec": "interactions",
@@ -1276,6 +1301,13 @@
       "file": "lib/src/models/common/grounding_chunk_custom_metadata.dart",
       "schema": "GroundingChunkCustomMetadata"
     },
+    "RetrievedContext": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "RetrievedContext",
+      "file": "lib/src/models/metadata/retrieved_context.dart",
+      "schema": "RetrievedContext"
+    },
     "GroundingChunkStringList": {
       "spec": "main",
       "kind": "object",
@@ -1339,10 +1371,14 @@
     },
     "ToolType": {
       "spec": "main",
-      "kind": "enum",
+      "kind": "skip",
       "dart_class": "ToolType",
       "file": "lib/src/models/tools/tool_type.dart",
-      "schema": "ToolType"
+      "schema": "ToolType",
+      "note": "Removed from spec; kept for Part.toolCall()/toolResponse() convenience APIs",
+      "tags": [
+        "acknowledged"
+      ]
     },
     "ToolCall": {
       "spec": "main",

--- a/packages/googleai_dart/lib/googleai_dart.dart
+++ b/packages/googleai_dart/lib/googleai_dart.dart
@@ -147,6 +147,7 @@ export 'src/models/interactions/tool_choice.dart';
 export 'src/models/interactions/tool_choice_type.dart';
 export 'src/models/interactions/tool_result.dart';
 export 'src/models/interactions/tools/tools.dart';
+export 'src/models/interactions/tools/vertex_ai_search_config.dart';
 export 'src/models/interactions/turn.dart';
 export 'src/models/interactions/turn_content.dart';
 export 'src/models/interactions/usage.dart';

--- a/packages/googleai_dart/lib/src/models/interactions/content/audio_content.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/content/audio_content.dart
@@ -14,14 +14,28 @@ class AudioContent extends InteractionContent {
   /// The MIME type of the audio.
   final String? mimeType;
 
+  /// The number of audio channels.
+  final int? channels;
+
+  /// The sample rate of the audio.
+  final int? rate;
+
   /// Creates an [AudioContent] instance.
-  const AudioContent({this.data, this.uri, this.mimeType});
+  const AudioContent({
+    this.data,
+    this.uri,
+    this.mimeType,
+    this.channels,
+    this.rate,
+  });
 
   /// Creates an [AudioContent] from JSON.
   factory AudioContent.fromJson(Map<String, dynamic> json) => AudioContent(
     data: json['data'] as String?,
     uri: json['uri'] as String?,
     mimeType: json['mime_type'] as String?,
+    channels: json['channels'] as int?,
+    rate: json['rate'] as int?,
   );
 
   @override
@@ -30,6 +44,8 @@ class AudioContent extends InteractionContent {
     if (data != null) 'data': data,
     if (uri != null) 'uri': uri,
     if (mimeType != null) 'mime_type': mimeType,
+    if (channels != null) 'channels': channels,
+    if (rate != null) 'rate': rate,
   };
 
   /// Creates a copy with replaced values.
@@ -37,6 +53,8 @@ class AudioContent extends InteractionContent {
     Object? data = unsetCopyWithValue,
     Object? uri = unsetCopyWithValue,
     Object? mimeType = unsetCopyWithValue,
+    Object? channels = unsetCopyWithValue,
+    Object? rate = unsetCopyWithValue,
   }) {
     return AudioContent(
       data: data == unsetCopyWithValue ? this.data : data as String?,
@@ -44,6 +62,10 @@ class AudioContent extends InteractionContent {
       mimeType: mimeType == unsetCopyWithValue
           ? this.mimeType
           : mimeType as String?,
+      channels: channels == unsetCopyWithValue
+          ? this.channels
+          : channels as int?,
+      rate: rate == unsetCopyWithValue ? this.rate : rate as int?,
     );
   }
 }

--- a/packages/googleai_dart/lib/src/models/interactions/deltas/audio_delta.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/deltas/audio_delta.dart
@@ -14,14 +14,28 @@ class AudioDelta extends InteractionDelta {
   /// The MIME type of the audio.
   final String? mimeType;
 
+  /// The number of audio channels.
+  final int? channels;
+
+  /// The sample rate of the audio.
+  final int? rate;
+
   /// Creates an [AudioDelta] instance.
-  const AudioDelta({this.data, this.uri, this.mimeType});
+  const AudioDelta({
+    this.data,
+    this.uri,
+    this.mimeType,
+    this.channels,
+    this.rate,
+  });
 
   /// Creates an [AudioDelta] from JSON.
   factory AudioDelta.fromJson(Map<String, dynamic> json) => AudioDelta(
     data: json['data'] as String?,
     uri: json['uri'] as String?,
     mimeType: json['mime_type'] as String?,
+    channels: json['channels'] as int?,
+    rate: json['rate'] as int?,
   );
 
   @override
@@ -30,5 +44,7 @@ class AudioDelta extends InteractionDelta {
     if (data != null) 'data': data,
     if (uri != null) 'uri': uri,
     if (mimeType != null) 'mime_type': mimeType,
+    if (channels != null) 'channels': channels,
+    if (rate != null) 'rate': rate,
   };
 }

--- a/packages/googleai_dart/lib/src/models/interactions/deltas/deltas.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/deltas/deltas.dart
@@ -1,3 +1,4 @@
+import '../../copy_with_sentinel.dart';
 import '../content/content.dart';
 import '../media_resolution.dart';
 import '../tool_result.dart';
@@ -17,6 +18,7 @@ part 'google_search_result_delta.dart';
 part 'image_delta.dart';
 part 'mcp_server_tool_call_delta.dart';
 part 'mcp_server_tool_result_delta.dart';
+part 'text_annotation_delta.dart';
 part 'text_delta.dart';
 part 'thought_signature_delta.dart';
 part 'thought_summary_delta.dart';
@@ -58,6 +60,7 @@ sealed class InteractionDelta {
       'mcp_server_tool_result' => McpServerToolResultDelta.fromJson(json),
       'file_search_call' => FileSearchCallDelta.fromJson(json),
       'file_search_result' => FileSearchResultDelta.fromJson(json),
+      'text_annotation' => TextAnnotationDelta.fromJson(json),
       _ => throw ArgumentError('Unknown delta type: $type'),
     };
   }

--- a/packages/googleai_dart/lib/src/models/interactions/deltas/text_annotation_delta.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/deltas/text_annotation_delta.dart
@@ -1,0 +1,37 @@
+part of 'deltas.dart';
+
+/// A text annotation delta update containing citation information.
+class TextAnnotationDelta extends InteractionDelta {
+  @override
+  String get type => 'text_annotation';
+
+  /// Citation information for model-generated content.
+  final List<Annotation>? annotations;
+
+  /// Creates a [TextAnnotationDelta] instance.
+  const TextAnnotationDelta({this.annotations});
+
+  /// Creates a [TextAnnotationDelta] from JSON.
+  factory TextAnnotationDelta.fromJson(Map<String, dynamic> json) =>
+      TextAnnotationDelta(
+        annotations: (json['annotations'] as List<dynamic>?)
+            ?.map((e) => Annotation.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (annotations != null)
+      'annotations': annotations!.map((e) => e.toJson()).toList(),
+  };
+
+  /// Creates a copy with replaced values.
+  TextAnnotationDelta copyWith({Object? annotations = unsetCopyWithValue}) {
+    return TextAnnotationDelta(
+      annotations: annotations == unsetCopyWithValue
+          ? this.annotations
+          : annotations as List<Annotation>?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/deltas/text_delta.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/deltas/text_delta.dart
@@ -8,25 +8,16 @@ class TextDelta extends InteractionDelta {
   /// The text content.
   final String? text;
 
-  /// Citation information for model-generated content.
-  final List<Annotation>? annotations;
-
   /// Creates a [TextDelta] instance.
-  const TextDelta({this.text, this.annotations});
+  const TextDelta({this.text});
 
   /// Creates a [TextDelta] from JSON.
-  factory TextDelta.fromJson(Map<String, dynamic> json) => TextDelta(
-    text: json['text'] as String?,
-    annotations: (json['annotations'] as List<dynamic>?)
-        ?.map((e) => Annotation.fromJson(e as Map<String, dynamic>))
-        .toList(),
-  );
+  factory TextDelta.fromJson(Map<String, dynamic> json) =>
+      TextDelta(text: json['text'] as String?);
 
   @override
   Map<String, dynamic> toJson() => {
     'type': type,
     if (text != null) 'text': text,
-    if (annotations != null)
-      'annotations': annotations!.map((e) => e.toJson()).toList(),
   };
 }

--- a/packages/googleai_dart/lib/src/models/interactions/interaction.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/interaction.dart
@@ -168,7 +168,8 @@ class Interaction {
           .toList(),
     if (responseMimeType != null) 'response_mime_type': responseMimeType,
     if (agentConfig != null) 'agent_config': agentConfig!.toJson(),
-    if (serviceTier != null) 'service_tier': serviceTierToString(serviceTier!),
+    if (serviceTier != null && serviceTier != ServiceTier.unspecified)
+      'service_tier': serviceTierToString(serviceTier!),
   };
 
   /// Creates a copy with replaced values.
@@ -337,7 +338,8 @@ class CreateModelInteractionParams {
     if (previousInteractionId != null)
       'previous_interaction_id': previousInteractionId,
     if (background != null) 'background': background,
-    if (serviceTier != null) 'service_tier': serviceTierToString(serviceTier!),
+    if (serviceTier != null && serviceTier != ServiceTier.unspecified)
+      'service_tier': serviceTierToString(serviceTier!),
   };
 }
 
@@ -396,6 +398,7 @@ class CreateAgentInteractionParams {
     if (previousInteractionId != null)
       'previous_interaction_id': previousInteractionId,
     if (background != null) 'background': background,
-    if (serviceTier != null) 'service_tier': serviceTierToString(serviceTier!),
+    if (serviceTier != null && serviceTier != ServiceTier.unspecified)
+      'service_tier': serviceTierToString(serviceTier!),
   };
 }

--- a/packages/googleai_dart/lib/src/models/interactions/interaction.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/interaction.dart
@@ -71,6 +71,9 @@ class Interaction {
   /// Configuration for the agent.
   final AgentConfig? agentConfig;
 
+  /// The service tier for the interaction.
+  final String? serviceTier;
+
   /// Creates an [Interaction] instance.
   const Interaction({
     required this.id,
@@ -91,6 +94,7 @@ class Interaction {
     this.responseModalities,
     this.responseMimeType,
     this.agentConfig,
+    this.serviceTier,
   });
 
   /// Creates an [Interaction] from JSON.
@@ -133,6 +137,7 @@ class Interaction {
     agentConfig: json['agent_config'] != null
         ? AgentConfig.fromJson(json['agent_config'] as Map<String, dynamic>)
         : null,
+    serviceTier: json['service_tier'] as String?,
   );
 
   /// Converts to JSON.
@@ -160,6 +165,7 @@ class Interaction {
           .toList(),
     if (responseMimeType != null) 'response_mime_type': responseMimeType,
     if (agentConfig != null) 'agent_config': agentConfig!.toJson(),
+    if (serviceTier != null) 'service_tier': serviceTier,
   };
 
   /// Creates a copy with replaced values.
@@ -182,6 +188,7 @@ class Interaction {
     Object? responseModalities = unsetCopyWithValue,
     Object? responseMimeType = unsetCopyWithValue,
     Object? agentConfig = unsetCopyWithValue,
+    Object? serviceTier = unsetCopyWithValue,
   }) {
     return Interaction(
       id: id == unsetCopyWithValue ? this.id : id! as String,
@@ -228,6 +235,9 @@ class Interaction {
       agentConfig: agentConfig == unsetCopyWithValue
           ? this.agentConfig
           : agentConfig as AgentConfig?,
+      serviceTier: serviceTier == unsetCopyWithValue
+          ? this.serviceTier
+          : serviceTier as String?,
     );
   }
 }
@@ -264,6 +274,9 @@ class CreateModelInteractionParams {
   /// Whether to run the model interaction in the background.
   final bool? background;
 
+  /// The service tier for the interaction.
+  final String? serviceTier;
+
   /// Creates a [CreateModelInteractionParams] instance.
   const CreateModelInteractionParams({
     required this.model,
@@ -275,6 +288,7 @@ class CreateModelInteractionParams {
     this.responseMimeType,
     this.previousInteractionId,
     this.background,
+    this.serviceTier,
   });
 
   /// Creates from JSON.
@@ -299,6 +313,7 @@ class CreateModelInteractionParams {
         responseMimeType: json['response_mime_type'] as String?,
         previousInteractionId: json['previous_interaction_id'] as String?,
         background: json['background'] as bool?,
+        serviceTier: json['service_tier'] as String?,
       );
 
   /// Converts to JSON.
@@ -317,6 +332,7 @@ class CreateModelInteractionParams {
     if (previousInteractionId != null)
       'previous_interaction_id': previousInteractionId,
     if (background != null) 'background': background,
+    if (serviceTier != null) 'service_tier': serviceTier,
   };
 }
 
@@ -337,6 +353,9 @@ class CreateAgentInteractionParams {
   /// Whether to run the agent interaction in the background.
   final bool? background;
 
+  /// The service tier for the interaction.
+  final String? serviceTier;
+
   /// Creates a [CreateAgentInteractionParams] instance.
   const CreateAgentInteractionParams({
     required this.agent,
@@ -344,6 +363,7 @@ class CreateAgentInteractionParams {
     this.agentConfig,
     this.previousInteractionId,
     this.background,
+    this.serviceTier,
   });
 
   /// Creates from JSON.
@@ -358,6 +378,7 @@ class CreateAgentInteractionParams {
             : null,
         previousInteractionId: json['previous_interaction_id'] as String?,
         background: json['background'] as bool?,
+        serviceTier: json['service_tier'] as String?,
       );
 
   /// Converts to JSON.
@@ -368,5 +389,6 @@ class CreateAgentInteractionParams {
     if (previousInteractionId != null)
       'previous_interaction_id': previousInteractionId,
     if (background != null) 'background': background,
+    if (serviceTier != null) 'service_tier': serviceTier,
   };
 }

--- a/packages/googleai_dart/lib/src/models/interactions/interaction.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/interaction.dart
@@ -1,3 +1,4 @@
+import '../common/service_tier.dart';
 import '../copy_with_sentinel.dart';
 import 'agent_config.dart';
 import 'content/content.dart';
@@ -72,7 +73,7 @@ class Interaction {
   final AgentConfig? agentConfig;
 
   /// The service tier for the interaction.
-  final String? serviceTier;
+  final ServiceTier? serviceTier;
 
   /// Creates an [Interaction] instance.
   const Interaction({
@@ -137,7 +138,9 @@ class Interaction {
     agentConfig: json['agent_config'] != null
         ? AgentConfig.fromJson(json['agent_config'] as Map<String, dynamic>)
         : null,
-    serviceTier: json['service_tier'] as String?,
+    serviceTier: json['service_tier'] != null
+        ? serviceTierFromString(json['service_tier'] as String?)
+        : null,
   );
 
   /// Converts to JSON.
@@ -165,7 +168,7 @@ class Interaction {
           .toList(),
     if (responseMimeType != null) 'response_mime_type': responseMimeType,
     if (agentConfig != null) 'agent_config': agentConfig!.toJson(),
-    if (serviceTier != null) 'service_tier': serviceTier,
+    if (serviceTier != null) 'service_tier': serviceTierToString(serviceTier!),
   };
 
   /// Creates a copy with replaced values.
@@ -237,7 +240,7 @@ class Interaction {
           : agentConfig as AgentConfig?,
       serviceTier: serviceTier == unsetCopyWithValue
           ? this.serviceTier
-          : serviceTier as String?,
+          : serviceTier as ServiceTier?,
     );
   }
 }
@@ -275,7 +278,7 @@ class CreateModelInteractionParams {
   final bool? background;
 
   /// The service tier for the interaction.
-  final String? serviceTier;
+  final ServiceTier? serviceTier;
 
   /// Creates a [CreateModelInteractionParams] instance.
   const CreateModelInteractionParams({
@@ -313,7 +316,9 @@ class CreateModelInteractionParams {
         responseMimeType: json['response_mime_type'] as String?,
         previousInteractionId: json['previous_interaction_id'] as String?,
         background: json['background'] as bool?,
-        serviceTier: json['service_tier'] as String?,
+        serviceTier: json['service_tier'] != null
+            ? serviceTierFromString(json['service_tier'] as String?)
+            : null,
       );
 
   /// Converts to JSON.
@@ -332,7 +337,7 @@ class CreateModelInteractionParams {
     if (previousInteractionId != null)
       'previous_interaction_id': previousInteractionId,
     if (background != null) 'background': background,
-    if (serviceTier != null) 'service_tier': serviceTier,
+    if (serviceTier != null) 'service_tier': serviceTierToString(serviceTier!),
   };
 }
 
@@ -354,7 +359,7 @@ class CreateAgentInteractionParams {
   final bool? background;
 
   /// The service tier for the interaction.
-  final String? serviceTier;
+  final ServiceTier? serviceTier;
 
   /// Creates a [CreateAgentInteractionParams] instance.
   const CreateAgentInteractionParams({
@@ -378,7 +383,9 @@ class CreateAgentInteractionParams {
             : null,
         previousInteractionId: json['previous_interaction_id'] as String?,
         background: json['background'] as bool?,
-        serviceTier: json['service_tier'] as String?,
+        serviceTier: json['service_tier'] != null
+            ? serviceTierFromString(json['service_tier'] as String?)
+            : null,
       );
 
   /// Converts to JSON.
@@ -389,6 +396,6 @@ class CreateAgentInteractionParams {
     if (previousInteractionId != null)
       'previous_interaction_id': previousInteractionId,
     if (background != null) 'background': background,
-    if (serviceTier != null) 'service_tier': serviceTier,
+    if (serviceTier != null) 'service_tier': serviceTierToString(serviceTier!),
   };
 }

--- a/packages/googleai_dart/lib/src/models/interactions/response_modality.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/response_modality.dart
@@ -9,11 +9,11 @@ enum InteractionResponseModality {
   /// Audio response modality.
   audio,
 
-  /// Document response modality.
-  document,
-
   /// Video response modality.
   video,
+
+  /// Document response modality.
+  document,
 }
 
 /// Converts a string to [InteractionResponseModality].
@@ -24,8 +24,8 @@ InteractionResponseModality interactionResponseModalityFromString(
     'text' => InteractionResponseModality.text,
     'image' => InteractionResponseModality.image,
     'audio' => InteractionResponseModality.audio,
-    'document' => InteractionResponseModality.document,
     'video' => InteractionResponseModality.video,
+    'document' => InteractionResponseModality.document,
     _ => InteractionResponseModality.text,
   };
 }
@@ -38,7 +38,7 @@ String interactionResponseModalityToString(
     InteractionResponseModality.text => 'text',
     InteractionResponseModality.image => 'image',
     InteractionResponseModality.audio => 'audio',
-    InteractionResponseModality.document => 'document',
     InteractionResponseModality.video => 'video',
+    InteractionResponseModality.document => 'document',
   };
 }

--- a/packages/googleai_dart/lib/src/models/interactions/response_modality.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/response_modality.dart
@@ -8,6 +8,12 @@ enum InteractionResponseModality {
 
   /// Audio response modality.
   audio,
+
+  /// Document response modality.
+  document,
+
+  /// Video response modality.
+  video,
 }
 
 /// Converts a string to [InteractionResponseModality].
@@ -18,6 +24,8 @@ InteractionResponseModality interactionResponseModalityFromString(
     'text' => InteractionResponseModality.text,
     'image' => InteractionResponseModality.image,
     'audio' => InteractionResponseModality.audio,
+    'document' => InteractionResponseModality.document,
+    'video' => InteractionResponseModality.video,
     _ => InteractionResponseModality.text,
   };
 }
@@ -30,5 +38,7 @@ String interactionResponseModalityToString(
     InteractionResponseModality.text => 'text',
     InteractionResponseModality.image => 'image',
     InteractionResponseModality.audio => 'audio',
+    InteractionResponseModality.document => 'document',
+    InteractionResponseModality.video => 'video',
   };
 }

--- a/packages/googleai_dart/lib/src/models/interactions/tools/retrieval_tool.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/tools/retrieval_tool.dart
@@ -1,0 +1,49 @@
+part of 'tools.dart';
+
+/// A tool that enables file retrieval capabilities.
+class RetrievalTool extends InteractionTool {
+  @override
+  String get type => 'retrieval';
+
+  /// The types of file retrieval to enable.
+  final List<String>? retrievalTypes;
+
+  /// Configuration for Vertex AI Search.
+  final VertexAISearchConfig? vertexAiSearchConfig;
+
+  /// Creates a [RetrievalTool] instance.
+  const RetrievalTool({this.retrievalTypes, this.vertexAiSearchConfig});
+
+  /// Creates a [RetrievalTool] from JSON.
+  factory RetrievalTool.fromJson(Map<String, dynamic> json) => RetrievalTool(
+    retrievalTypes: (json['retrieval_types'] as List<dynamic>?)?.cast<String>(),
+    vertexAiSearchConfig: json['vertex_ai_search_config'] != null
+        ? VertexAISearchConfig.fromJson(
+            json['vertex_ai_search_config'] as Map<String, dynamic>,
+          )
+        : null,
+  );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (retrievalTypes != null) 'retrieval_types': retrievalTypes,
+    if (vertexAiSearchConfig != null)
+      'vertex_ai_search_config': vertexAiSearchConfig!.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  RetrievalTool copyWith({
+    Object? retrievalTypes = unsetCopyWithValue,
+    Object? vertexAiSearchConfig = unsetCopyWithValue,
+  }) {
+    return RetrievalTool(
+      retrievalTypes: retrievalTypes == unsetCopyWithValue
+          ? this.retrievalTypes
+          : retrievalTypes as List<String>?,
+      vertexAiSearchConfig: vertexAiSearchConfig == unsetCopyWithValue
+          ? this.vertexAiSearchConfig
+          : vertexAiSearchConfig as VertexAISearchConfig?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/tools/tools.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/tools/tools.dart
@@ -1,4 +1,6 @@
+import '../../copy_with_sentinel.dart';
 import '../allowed_tools.dart';
+import 'vertex_ai_search_config.dart';
 
 part 'code_execution_tool.dart';
 part 'computer_use_tool.dart';
@@ -7,6 +9,7 @@ part 'function_tool.dart';
 part 'google_maps_tool.dart';
 part 'google_search_tool.dart';
 part 'mcp_server_tool.dart';
+part 'retrieval_tool.dart';
 part 'url_context_tool.dart';
 
 /// A tool that can be used by the model.
@@ -30,6 +33,7 @@ sealed class InteractionTool {
       'computer_use' => ComputerUseTool.fromJson(json),
       'mcp_server' => McpServerTool.fromJson(json),
       'file_search' => FileSearchTool.fromJson(json),
+      'retrieval' => RetrievalTool.fromJson(json),
       _ => throw ArgumentError('Unknown tool type: $type'),
     };
   }

--- a/packages/googleai_dart/lib/src/models/interactions/tools/vertex_ai_search_config.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/tools/vertex_ai_search_config.dart
@@ -1,0 +1,39 @@
+import '../../copy_with_sentinel.dart';
+
+/// Configuration for Vertex AI Search.
+class VertexAISearchConfig {
+  /// Optional. Vertex AI Search datastores.
+  final List<String>? datastores;
+
+  /// Optional. Vertex AI Search engine.
+  final String? engine;
+
+  /// Creates a [VertexAISearchConfig] instance.
+  const VertexAISearchConfig({this.datastores, this.engine});
+
+  /// Creates a [VertexAISearchConfig] from JSON.
+  factory VertexAISearchConfig.fromJson(Map<String, dynamic> json) =>
+      VertexAISearchConfig(
+        datastores: (json['datastores'] as List<dynamic>?)?.cast<String>(),
+        engine: json['engine'] as String?,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (datastores != null) 'datastores': datastores,
+    if (engine != null) 'engine': engine,
+  };
+
+  /// Creates a copy with replaced values.
+  VertexAISearchConfig copyWith({
+    Object? datastores = unsetCopyWithValue,
+    Object? engine = unsetCopyWithValue,
+  }) {
+    return VertexAISearchConfig(
+      datastores: datastores == unsetCopyWithValue
+          ? this.datastores
+          : datastores as List<String>?,
+      engine: engine == unsetCopyWithValue ? this.engine : engine as String?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/metadata/retrieved_context.dart
+++ b/packages/googleai_dart/lib/src/models/metadata/retrieved_context.dart
@@ -17,6 +17,9 @@ class RetrievedContext {
   /// Example: `fileSearchStores/123`
   final String? fileSearchStore;
 
+  /// Optional. Page number of the retrieved context, if applicable.
+  final int? pageNumber;
+
   /// Optional. Custom metadata associated with the retrieved context.
   final List<GroundingChunkCustomMetadata>? customMetadata;
 
@@ -26,6 +29,7 @@ class RetrievedContext {
     this.title,
     this.text,
     this.fileSearchStore,
+    this.pageNumber,
     this.customMetadata,
   });
 
@@ -36,6 +40,7 @@ class RetrievedContext {
         title: json['title'] as String?,
         text: json['text'] as String?,
         fileSearchStore: json['fileSearchStore'] as String?,
+        pageNumber: json['pageNumber'] as int?,
         customMetadata: (json['customMetadata'] as List?)
             ?.map(
               (e) => GroundingChunkCustomMetadata.fromJson(
@@ -51,6 +56,7 @@ class RetrievedContext {
     if (title != null) 'title': title,
     if (text != null) 'text': text,
     if (fileSearchStore != null) 'fileSearchStore': fileSearchStore,
+    if (pageNumber != null) 'pageNumber': pageNumber,
     if (customMetadata != null)
       'customMetadata': customMetadata!.map((e) => e.toJson()).toList(),
   };
@@ -61,6 +67,7 @@ class RetrievedContext {
     Object? title = unsetCopyWithValue,
     Object? text = unsetCopyWithValue,
     Object? fileSearchStore = unsetCopyWithValue,
+    Object? pageNumber = unsetCopyWithValue,
     Object? customMetadata = unsetCopyWithValue,
   }) {
     return RetrievedContext(
@@ -70,6 +77,9 @@ class RetrievedContext {
       fileSearchStore: fileSearchStore == unsetCopyWithValue
           ? this.fileSearchStore
           : fileSearchStore as String?,
+      pageNumber: pageNumber == unsetCopyWithValue
+          ? this.pageNumber
+          : pageNumber as int?,
       customMetadata: customMetadata == unsetCopyWithValue
           ? this.customMetadata
           : customMetadata as List<GroundingChunkCustomMetadata>?,
@@ -78,5 +88,5 @@ class RetrievedContext {
 
   @override
   String toString() =>
-      'RetrievedContext(uri: $uri, title: $title, text: $text, fileSearchStore: $fileSearchStore, customMetadata: $customMetadata)';
+      'RetrievedContext(uri: $uri, title: $title, text: $text, fileSearchStore: $fileSearchStore, pageNumber: $pageNumber, customMetadata: $customMetadata)';
 }

--- a/packages/googleai_dart/specs/openapi-interactions.json
+++ b/packages/googleai_dart/specs/openapi-interactions.json
@@ -75,6 +75,11 @@
           }
         ],
         "properties": {
+          "channels": {
+            "description": "The number of audio channels.",
+            "format": "int32",
+            "type": "integer"
+          },
           "data": {
             "description": "The audio content.",
             "format": "byte",
@@ -90,7 +95,8 @@
               "audio/ogg",
               "audio/flac",
               "audio/mpeg",
-              "audio/m4a"
+              "audio/m4a",
+              "audio/l16"
             ],
             "type": "string",
             "x-google-enum-descriptions": [
@@ -101,8 +107,14 @@
               "OGG audio format",
               "FLAC audio format",
               "MPEG audio format",
-              "M4A audio format"
+              "M4A audio format",
+              "L16 audio format"
             ]
+          },
+          "rate": {
+            "description": "The sample rate of the audio.",
+            "format": "int32",
+            "type": "integer"
           },
           "type": {
             "const": "audio"
@@ -119,6 +131,11 @@
       },
       "AudioDelta": {
         "properties": {
+          "channels": {
+            "description": "The number of audio channels.",
+            "format": "int32",
+            "type": "integer"
+          },
           "data": {
             "format": "byte",
             "type": "string"
@@ -132,7 +149,8 @@
               "audio/ogg",
               "audio/flac",
               "audio/mpeg",
-              "audio/m4a"
+              "audio/m4a",
+              "audio/l16"
             ],
             "type": "string",
             "x-google-enum-descriptions": [
@@ -143,8 +161,14 @@
               "OGG audio format",
               "FLAC audio format",
               "MPEG audio format",
-              "M4A audio format"
+              "M4A audio format",
+              "L16 audio format"
             ]
+          },
+          "rate": {
+            "description": "The sample rate of the audio.",
+            "format": "int32",
+            "type": "integer"
           },
           "type": {
             "const": "audio"
@@ -567,6 +591,9 @@
           },
           {
             "$ref": "#/components/schemas/GoogleMapsResultDelta"
+          },
+          {
+            "$ref": "#/components/schemas/TextAnnotationDelta"
           }
         ],
         "type": "object"
@@ -711,6 +738,20 @@
             "readOnly": true,
             "type": "string"
           },
+          "service_tier": {
+            "description": "The service tier for the interaction.",
+            "enum": [
+              "flex",
+              "standard",
+              "priority"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Flex service tier.",
+              "Standard service tier.",
+              "Priority service tier."
+            ]
+          },
           "status": {
             "description": "Required. Output only. The status of the interaction.",
             "enum": [
@@ -831,6 +872,20 @@
             "description": "Output only. The role of the interaction.",
             "readOnly": true,
             "type": "string"
+          },
+          "service_tier": {
+            "description": "The service tier for the interaction.",
+            "enum": [
+              "flex",
+              "standard",
+              "priority"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Flex service tier.",
+              "Standard service tier.",
+              "Priority service tier."
+            ]
           },
           "status": {
             "description": "Required. Output only. The status of the interaction.",
@@ -1795,12 +1850,14 @@
             "items": {
               "enum": [
                 "web_search",
-                "image_search"
+                "image_search",
+                "enterprise_web_search"
               ],
               "type": "string",
               "x-google-enum-descriptions": [
                 "Setting this field enables web search. Only text results are returned.",
-                "Setting this field enables image search. Image bytes are returned."
+                "Setting this field enables image search. Image bytes are returned.",
+                "Setting this field enables enterprise web search."
               ]
             },
             "type": "array"
@@ -1875,12 +1932,14 @@
             "description": "The type of search grounding enabled.",
             "enum": [
               "web_search",
-              "image_search"
+              "image_search",
+              "enterprise_web_search"
             ],
             "type": "string",
             "x-google-enum-descriptions": [
               "Setting this field enables web search. Only text results are returned.",
-              "Setting this field enables image search. Image bytes are returned."
+              "Setting this field enables image search. Image bytes are returned.",
+              "Setting this field enables enterprise web search."
             ]
           },
           "signature": {
@@ -2098,7 +2157,6 @@
               "image/webp",
               "image/heic",
               "image/heif",
-              "image/jpg",
               "image/gif",
               "image/bmp",
               "image/tiff"
@@ -2110,7 +2168,6 @@
               "WebP image format",
               "HEIC image format",
               "HEIF image format",
-              "JPG image format",
               "GIF image format",
               "BMP image format",
               "TIFF image format"
@@ -2146,7 +2203,6 @@
               "image/webp",
               "image/heic",
               "image/heif",
-              "image/jpg",
               "image/gif",
               "image/bmp",
               "image/tiff"
@@ -2158,7 +2214,6 @@
               "WebP image format",
               "HEIC image format",
               "HEIF image format",
-              "JPG image format",
               "GIF image format",
               "BMP image format",
               "TIFF image format"
@@ -2283,6 +2338,20 @@
             "description": "Output only. The role of the interaction.",
             "readOnly": true,
             "type": "string"
+          },
+          "service_tier": {
+            "description": "The service tier for the interaction.",
+            "enum": [
+              "flex",
+              "standard",
+              "priority"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Flex service tier.",
+              "Standard service tier.",
+              "Priority service tier."
+            ]
           },
           "status": {
             "description": "Required. Output only. The status of the interaction.",
@@ -2815,6 +2884,11 @@
             "type": "string"
           },
           {
+            "const": "gemini-2.5-computer-use-preview-10-2025",
+            "description": "An agentic capability model designed for direct interface interaction, allowing Gemini to perceive and navigate digital environments.",
+            "x-stainless-nominal": false
+          },
+          {
             "const": "gemini-2.5-flash",
             "description": "Our first hybrid reasoning model which supports a 1M token context window and has thinking budgets.",
             "x-stainless-nominal": false
@@ -2882,6 +2956,21 @@
           {
             "const": "gemini-3.1-flash-image-preview",
             "description": "Pro-level visual intelligence with Flash-speed efficiency and reality-grounded generation capabilities.",
+            "x-stainless-nominal": false
+          },
+          {
+            "const": "gemini-3.1-flash-lite-preview",
+            "description": "Our most cost-efficient model, optimized for high-volume agentic tasks, translation, and simple data processing.",
+            "x-stainless-nominal": false
+          },
+          {
+            "const": "lyria-3-clip-preview",
+            "description": "Our low-latency, music generation model optimized for high-fidelity audio clips and precise rhythmic control.",
+            "x-stainless-nominal": false
+          },
+          {
+            "const": "lyria-3-pro-preview",
+            "description": "Our advanced, full-song generative model with deep compositional understanding, optimized for precise structural control and complex transitions across diverse musical styles.",
             "x-stainless-nominal": false
           }
         ],
@@ -2957,14 +3046,47 @@
         "enum": [
           "text",
           "image",
-          "audio"
+          "audio",
+          "video",
+          "document"
         ],
         "type": "string",
         "x-google-enum-descriptions": [
           "Indicates the model should return text.",
           "Indicates the model should return images.",
-          "Indicates the model should return audio."
+          "Indicates the model should return audio.",
+          "Indicates the model should return video.",
+          "Indicates the model should return documents."
         ]
+      },
+      "Retrieval": {
+        "description": "A tool that can be used by the model to retrieve files.",
+        "properties": {
+          "retrieval_types": {
+            "description": "The types of file retrieval to enable.",
+            "items": {
+              "enum": [
+                "vertex_ai_search"
+              ],
+              "type": "string",
+              "x-google-enum-descriptions": [
+                ""
+              ]
+            },
+            "type": "array"
+          },
+          "type": {
+            "const": "retrieval"
+          },
+          "vertex_ai_search_config": {
+            "$ref": "#/components/schemas/VertexAISearchConfig",
+            "description": "Used to specify configuration for VertexAISearch."
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
       },
       "ReviewSnippet": {
         "description": "Encapsulates a snippet of a user review that answers a question about\nthe features of a specific place in Google Maps.",
@@ -3000,6 +3122,24 @@
             "type": "string"
           }
         },
+        "type": "object"
+      },
+      "TextAnnotationDelta": {
+        "properties": {
+          "annotations": {
+            "description": "Citation information for model-generated content.",
+            "items": {
+              "$ref": "#/components/schemas/Annotation"
+            },
+            "type": "array"
+          },
+          "type": {
+            "const": "text_annotation"
+          }
+        },
+        "required": [
+          "type"
+        ],
         "type": "object"
       },
       "TextContent": {
@@ -3039,13 +3179,6 @@
       },
       "TextDelta": {
         "properties": {
-          "annotations": {
-            "description": "Citation information for model-generated content.",
-            "items": {
-              "$ref": "#/components/schemas/Annotation"
-            },
-            "type": "array"
-          },
           "text": {
             "type": "string"
           },
@@ -3200,6 +3333,9 @@
           },
           {
             "$ref": "#/components/schemas/GoogleMaps"
+          },
+          {
+            "$ref": "#/components/schemas/Retrieval"
           }
         ],
         "type": "object"
@@ -3590,6 +3726,23 @@
             "description": "Number of tokens present in tool-use prompt(s).",
             "format": "int32",
             "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "VertexAISearchConfig": {
+        "description": "Used to specify configuration for VertexAISearch.",
+        "properties": {
+          "datastores": {
+            "description": "Optional. Used to specify Vertex AI Search datastores.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "engine": {
+            "description": "Optional. Used to specify Vertex AI Search engine.",
+            "type": "string"
           }
         },
         "type": "object"

--- a/packages/googleai_dart/specs/openapi.json
+++ b/packages/googleai_dart/specs/openapi.json
@@ -3598,7 +3598,7 @@
         "type": "object"
       },
       "McpServer": {
-        "description": "A MCPServer is a server that can be called by the model to perform actions.\nIt is a server that implements the MCP protocol.\nNext ID: 5",
+        "description": "A MCPServer is a server that can be called by the model to perform actions.\nIt is a server that implements the MCP protocol.\nNext ID: 6",
         "properties": {
           "name": {
             "description": "The name of the MCPServer.",
@@ -4289,6 +4289,11 @@
             "description": "Optional. Name of the `FileSearchStore` containing the document.\nExample: `fileSearchStores/123`",
             "type": "string"
           },
+          "pageNumber": {
+            "description": "Optional. Page number of the retrieved context, if applicable.",
+            "format": "int32",
+            "type": "integer"
+          },
           "text": {
             "description": "Optional. Text of the chunk.",
             "type": "string"
@@ -4871,7 +4876,7 @@
         "type": "object"
       },
       "Tool": {
-        "description": "Tool details that the model may use to generate response.\n\nA `Tool` is a piece of code that enables the system to interact with\nexternal systems to perform an action, or set of actions, outside of\nknowledge and scope of the model.\n\nNext ID: 15",
+        "description": "Tool details that the model may use to generate response.\n\nA `Tool` is a piece of code that enables the system to interact with\nexternal systems to perform an action, or set of actions, outside of\nknowledge and scope of the model.\n\nNext ID: 16",
         "properties": {
           "codeExecution": {
             "allOf": [
@@ -5027,25 +5032,6 @@
           "toolType"
         ],
         "type": "object"
-      },
-      "ToolType": {
-        "enum": [
-          "TOOL_TYPE_UNSPECIFIED",
-          "GOOGLE_SEARCH_WEB",
-          "GOOGLE_SEARCH_IMAGE",
-          "URL_CONTEXT",
-          "GOOGLE_MAPS",
-          "FILE_SEARCH"
-        ],
-        "type": "string",
-        "x-google-enum-descriptions": [
-          "Unspecified tool type.",
-          "Google search tool, maps to Tool.google_search.search_types.web_search.",
-          "Image search tool, maps to Tool.google_search.search_types.image_search.",
-          "URL context tool, maps to Tool.url_context.",
-          "Google maps tool, maps to Tool.google_maps.",
-          "File search tool, maps to Tool.file_search."
-        ]
       },
       "TopCandidates": {
         "description": "Candidates with top log probabilities at each decoding step.",
@@ -5651,9 +5637,9 @@
   },
   "info": {
     "description": "The Gemini API allows developers to build generative AI applications using Gemini models. Gemini is our most capable model, built from the ground up to be multimodal. It can generalize and seamlessly understand, operate across, and combine different types of information including language, images, audio, video, and code. You can use the Gemini API for use cases like reasoning across text and images, content generation, dialogue agents, summarization and classification systems, and more.",
-    "title": "Generative Language API",
+    "title": "Gemini API",
     "version": "v1beta",
-    "x-google-revision": "20260407"
+    "x-google-revision": "20260414"
   },
   "openapi": "3.0.3",
   "paths": {

--- a/packages/googleai_dart/specs/spec_metadata.json
+++ b/packages/googleai_dart/specs/spec_metadata.json
@@ -2,16 +2,16 @@
   "specs": {
     "interactions": {
       "current_version": "v1beta",
-      "last_fetched": "2026-04-08T21:16:59.110157Z",
+      "last_fetched": "2026-04-16T07:20:15.891003Z",
       "source_url": "https://ai.google.dev/static/api/interactions.openapi.json",
       "title": "Gemini API",
       "version_history": []
     },
     "main": {
       "current_version": "v1beta",
-      "last_fetched": "2026-04-08T21:16:58.466587Z",
+      "last_fetched": "2026-04-16T07:20:15.299652Z",
       "source_url": "https://generativelanguage.googleapis.com/$discovery/OPENAPI3_0?version=v1beta",
-      "title": "Generative Language API",
+      "title": "Gemini API",
       "version_history": []
     }
   }

--- a/packages/googleai_dart/test/unit/models/interactions/content_test.dart
+++ b/packages/googleai_dart/test/unit/models/interactions/content_test.dart
@@ -219,6 +219,30 @@ void main() {
         expect((content as AudioContent).data, 'base64audio');
         expect(content.mimeType, 'audio/mp3');
       });
+
+      test('deserializes channels and rate from JSON', () {
+        final json = {
+          'type': 'audio',
+          'data': 'base64audio',
+          'mime_type': 'audio/l16',
+          'channels': 2,
+          'rate': 24000,
+        };
+        final content = InteractionContent.fromJson(json) as AudioContent;
+        expect(content.channels, 2);
+        expect(content.rate, 24000);
+
+        final toJson = content.toJson();
+        expect(toJson['channels'], 2);
+        expect(toJson['rate'], 24000);
+      });
+
+      test('copyWith preserves channels and rate', () {
+        const content = AudioContent(data: 'data', channels: 1, rate: 16000);
+        final copy = content.copyWith(rate: 24000);
+        expect(copy.channels, 1);
+        expect(copy.rate, 24000);
+      });
     });
 
     group('DocumentContent', () {

--- a/packages/googleai_dart/test/unit/models/interactions/delta_test.dart
+++ b/packages/googleai_dart/test/unit/models/interactions/delta_test.dart
@@ -1,0 +1,110 @@
+import 'package:googleai_dart/googleai_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('InteractionDelta', () {
+    group('TextAnnotationDelta', () {
+      test('deserializes from JSON', () {
+        final json = {
+          'type': 'text_annotation',
+          'annotations': [
+            {
+              'type': 'url_citation',
+              'url': 'https://example.com',
+              'title': 'Example',
+              'start_index': 0,
+              'end_index': 10,
+            },
+          ],
+        };
+        final delta = InteractionDelta.fromJson(json);
+        expect(delta, isA<TextAnnotationDelta>());
+        final tad = delta as TextAnnotationDelta;
+        expect(tad.type, 'text_annotation');
+        expect(tad.annotations, hasLength(1));
+        expect(tad.annotations![0], isA<UrlCitation>());
+      });
+
+      test('handles partial JSON (delta start)', () {
+        final json = {'type': 'text_annotation'};
+        final delta = InteractionDelta.fromJson(json);
+        expect(delta, isA<TextAnnotationDelta>());
+        expect((delta as TextAnnotationDelta).annotations, isNull);
+      });
+
+      test('roundtrip serialization', () {
+        const original = TextAnnotationDelta(
+          annotations: [
+            UrlCitation(
+              url: 'https://example.com',
+              title: 'Test',
+              startIndex: 0,
+              endIndex: 5,
+            ),
+          ],
+        );
+        final json = original.toJson();
+        expect(json['type'], 'text_annotation');
+        final restored = InteractionDelta.fromJson(json) as TextAnnotationDelta;
+        expect(restored.annotations, hasLength(1));
+        expect(
+          (restored.annotations![0] as UrlCitation).url,
+          'https://example.com',
+        );
+      });
+    });
+
+    group('AudioDelta', () {
+      test('deserializes channels and rate', () {
+        final json = {
+          'type': 'audio',
+          'data': 'audiodata',
+          'channels': 2,
+          'rate': 24000,
+        };
+        final delta = InteractionDelta.fromJson(json) as AudioDelta;
+        expect(delta.channels, 2);
+        expect(delta.rate, 24000);
+
+        final toJson = delta.toJson();
+        expect(toJson['channels'], 2);
+        expect(toJson['rate'], 24000);
+      });
+    });
+
+    group('TextDelta', () {
+      test('does not have annotations field', () {
+        final json = {'type': 'text', 'text': 'hello'};
+        final delta = InteractionDelta.fromJson(json) as TextDelta;
+        expect(delta.text, 'hello');
+
+        final toJson = delta.toJson();
+        expect(toJson.containsKey('annotations'), false);
+      });
+    });
+  });
+
+  group('InteractionResponseModality', () {
+    test('parses document value', () {
+      expect(
+        interactionResponseModalityFromString('document'),
+        InteractionResponseModality.document,
+      );
+    });
+
+    test('parses video value', () {
+      expect(
+        interactionResponseModalityFromString('video'),
+        InteractionResponseModality.video,
+      );
+    });
+
+    test('roundtrip all values', () {
+      for (final value in InteractionResponseModality.values) {
+        final str = interactionResponseModalityToString(value);
+        final parsed = interactionResponseModalityFromString(str);
+        expect(parsed, value);
+      }
+    });
+  });
+}

--- a/packages/googleai_dart/test/unit/models/interactions/interaction_test.dart
+++ b/packages/googleai_dart/test/unit/models/interactions/interaction_test.dart
@@ -11,6 +11,7 @@ void main() {
           'status': 'completed',
           'created': '2024-01-15T10:30:00Z',
           'updated': '2024-01-15T10:31:00Z',
+          'service_tier': 'standard',
           'usage': {
             'total_input_tokens': 100,
             'total_output_tokens': 50,
@@ -28,6 +29,7 @@ void main() {
         expect(interaction.status, InteractionStatus.completed);
         expect(interaction.created, DateTime.parse('2024-01-15T10:30:00Z'));
         expect(interaction.updated, DateTime.parse('2024-01-15T10:31:00Z'));
+        expect(interaction.serviceTier, 'standard');
         expect(interaction.usage, isNotNull);
         expect(interaction.usage!.totalInputTokens, 100);
         expect(interaction.outputs, isNotNull);
@@ -382,6 +384,16 @@ void main() {
   });
 
   group('CreateModelInteractionParams tools type safety', () {
+    test('parses serviceTier correctly', () {
+      final json = {'model': 'gemini-2.0-flash', 'service_tier': 'priority'};
+      final params = CreateModelInteractionParams.fromJson(json);
+
+      expect(params.serviceTier, 'priority');
+
+      final toJson = params.toJson();
+      expect(toJson['service_tier'], 'priority');
+    });
+
     test('parses GoogleSearchTool correctly', () {
       final json = {
         'model': 'gemini-2.0-flash',
@@ -459,6 +471,39 @@ void main() {
       expect(params.tools![0], isA<GoogleSearchTool>());
       expect(params.tools![1], isA<CodeExecutionTool>());
       expect(params.tools![2], isA<FunctionTool>());
+    });
+
+    test('parses RetrievalTool correctly', () {
+      final json = {
+        'model': 'gemini-2.0-flash',
+        'tools': [
+          {
+            'type': 'retrieval',
+            'retrieval_types': ['vertex_ai_search'],
+            'vertex_ai_search_config': {
+              'datastores': ['ds-1', 'ds-2'],
+              'engine': 'engine-1',
+            },
+          },
+        ],
+      };
+      final params = CreateModelInteractionParams.fromJson(json);
+
+      expect(params.tools, hasLength(1));
+      expect(params.tools!.first, isA<RetrievalTool>());
+      final tool = params.tools!.first as RetrievalTool;
+      expect(tool.retrievalTypes, ['vertex_ai_search']);
+      expect(tool.vertexAiSearchConfig, isNotNull);
+      expect(tool.vertexAiSearchConfig!.datastores, ['ds-1', 'ds-2']);
+      expect(tool.vertexAiSearchConfig!.engine, 'engine-1');
+
+      // Round-trip
+      final toolJson = tool.toJson();
+      expect(toolJson['type'], 'retrieval');
+      expect(toolJson['retrieval_types'], ['vertex_ai_search']);
+      final restored = RetrievalTool.fromJson(toolJson);
+      expect(restored.retrievalTypes, tool.retrievalTypes);
+      expect(restored.vertexAiSearchConfig!.engine, 'engine-1');
     });
 
     test('handles null tools', () {

--- a/packages/googleai_dart/test/unit/models/interactions/interaction_test.dart
+++ b/packages/googleai_dart/test/unit/models/interactions/interaction_test.dart
@@ -29,7 +29,7 @@ void main() {
         expect(interaction.status, InteractionStatus.completed);
         expect(interaction.created, DateTime.parse('2024-01-15T10:30:00Z'));
         expect(interaction.updated, DateTime.parse('2024-01-15T10:31:00Z'));
-        expect(interaction.serviceTier, 'standard');
+        expect(interaction.serviceTier, ServiceTier.standard);
         expect(interaction.usage, isNotNull);
         expect(interaction.usage!.totalInputTokens, 100);
         expect(interaction.outputs, isNotNull);
@@ -388,7 +388,7 @@ void main() {
       final json = {'model': 'gemini-2.0-flash', 'service_tier': 'priority'};
       final params = CreateModelInteractionParams.fromJson(json);
 
-      expect(params.serviceTier, 'priority');
+      expect(params.serviceTier, ServiceTier.priority);
 
       final toJson = params.toJson();
       expect(toJson['service_tier'], 'priority');


### PR DESCRIPTION
## Summary
- Update main and interactions OpenAPI specs to latest upstream versions
- Add `pageNumber` to `RetrievedContext`, `channels`/`rate` to audio types, `serviceTier` to interaction params
- Add new types: `TextAnnotationDelta`, `RetrievalTool`, `VertexAISearchConfig`
- Add `document` and `video` response modalities
- Move `annotations` from `TextDelta` to new `TextAnnotationDelta` (breaking change in interactions API)

## Details

### Main spec
- **RetrievedContext**: new optional `pageNumber` (int?) field for page-level attribution
- **ToolType**: enum removed from upstream spec; kept in code for `Part.toolCall()`/`Part.toolResponse()` convenience APIs, manifest updated to `skip` with `acknowledged` tag

### Interactions spec
- **AudioContent / AudioDelta**: new `channels` (int?) and `rate` (int?) fields for audio stream configuration
- **TextDelta**: `annotations` field removed (moved to dedicated `TextAnnotationDelta`)
- **TextAnnotationDelta**: new sealed variant of `InteractionDelta` with `type: "text_annotation"` — carries citation annotations as a separate delta event
- **InteractionResponseModality**: two new enum values: `document` and `video`
- **Interaction / CreateModelInteractionParams / CreateAgentInteractionParams**: new `serviceTier` (String?) field for flex/standard/priority tier selection
- **RetrievalTool**: new sealed variant of `InteractionTool` with `retrievalTypes` and `vertexAiSearchConfig` for Vertex AI Search retrieval
- **VertexAISearchConfig**: new standalone class with `datastores` (List<String>?) and `engine` (String?) for configuring Vertex AI Search

## Test Plan
- [x] `dart analyze --fatal-infos` — no issues
- [x] `dart format` — all files formatted
- [x] Unit tests pass (1389 tests)
- [x] Toolkit verify (main spec) — 0 errors
- [x] Toolkit verify (interactions spec) — 0 errors
- [x] New tests added for `TextAnnotationDelta`, `RetrievalTool`, `VertexAISearchConfig`
- [x] Existing tests updated for `serviceTier`, `channels`/`rate`, response modalities
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
