### PR TITLE
feat(openai_dart): update OpenAPI spec and add file input detail

### DIFF
--- a/packages/openai_dart/.agents/skills/openapi-openai/config/manifest.json
+++ b/packages/openai_dart/.agents/skills/openapi-openai/config/manifest.json
@@ -580,7 +580,7 @@
       "file": null,
       "schema": "ResponseProperties",
       "tags": ["acknowledged"],
-      "note": "Spec helper schema; properties inlined on CreateResponseRequest and Response. max_output_tokens moved to inline."
+      "note": "Spec helper schema; properties inlined on CreateResponse and Response. max_output_tokens moved to inline."
     },
     "ToolChoice": {
       "spec": "main",

--- a/packages/openai_dart/.agents/skills/openapi-openai/config/manifest.json
+++ b/packages/openai_dart/.agents/skills/openapi-openai/config/manifest.json
@@ -573,6 +573,15 @@
       "tags": ["acknowledged"],
       "note": "Shares discriminator value 'json_schema' with ResponseFormatJsonSchema. Both handled by JsonSchemaResponseFormat. TextResponseFormatJsonSchema has flat properties while ResponseFormatJsonSchema nests under json_schema key."
     },
+    "ResponseProperties": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "file": null,
+      "schema": "ResponseProperties",
+      "tags": ["acknowledged"],
+      "note": "Spec helper schema; properties inlined on CreateResponseRequest and Response. max_output_tokens moved to inline."
+    },
     "ToolChoice": {
       "spec": "main",
       "kind": "sealed_parent",
@@ -1030,20 +1039,20 @@
     "FileDetailEnum": {
       "spec": "main",
       "kind": "skip",
-      "dart_class": null,
-      "file": null,
+      "dart_class": "FileInputDetail",
+      "file": "lib/src/models/responses/content/input_content.dart",
       "schema": "FileDetailEnum",
       "tags": ["acknowledged"],
-      "note": "Removed from spec and Dart. Was FileInputDetail enum."
+      "note": "Identical to FileInputDetail; single Dart enum serves both schemas."
     },
     "FileInputDetail": {
       "spec": "main",
       "kind": "skip",
-      "dart_class": null,
-      "file": null,
+      "dart_class": "FileInputDetail",
+      "file": "lib/src/models/responses/content/input_content.dart",
       "schema": "FileInputDetail",
       "tags": ["acknowledged"],
-      "note": "Removed from spec and Dart."
+      "note": "Enum co-located in input_content.dart with InputFileContent."
     },
     "FunctionToolCallOutputResource": {
       "spec": "main",
@@ -1079,7 +1088,7 @@
       "file": "lib/src/models/responses/content/input_content.dart",
       "schema": "InputFileContent",
       "tags": ["acknowledged"],
-      "note": "detail property removed per spec change."
+      "note": "Manual class with detail property. Serves both InputFileContent and InputFileContentParam roles."
     },
     "InputFileContentParam": {
       "spec": "main",

--- a/packages/openai_dart/.agents/skills/openapi-openai/config/specs.json
+++ b/packages/openai_dart/.agents/skills/openapi-openai/config/specs.json
@@ -28,7 +28,7 @@
       "local_file": "openapi.json",
       "name": "OpenAI API",
       "requires_auth": false,
-      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai%2Fopenai-a6eca1bd01e0c434af356fe5275c206057216a4e626d1051d294c27016cd6d05.yml"
+      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai%2Fopenai-7c540cce6eb30401259f4831ea9803b6d88501605d13734f98212cbb3b199e10.yml"
     }
   },
   "specs_dir": "packages/openai_dart/specs"

--- a/packages/openai_dart/lib/src/models/responses/content/input_content.dart
+++ b/packages/openai_dart/lib/src/models/responses/content/input_content.dart
@@ -355,23 +355,27 @@ class InputVideoContent extends InputContent {
 /// Controls how the model processes file content. Use `low` for the default
 /// rendering behavior, or `high` to render the file at higher quality.
 enum FileInputDetail {
+  /// Unknown detail level (fallback for unrecognized values).
+  unknown('unknown'),
+
   /// High detail: more thorough processing.
   high('high'),
 
   /// Low detail: default processing.
   low('low');
 
-  const FileInputDetail(this.value);
-
   /// The JSON value for this detail level.
   final String value;
 
-  /// Creates a [FileInputDetail] from JSON.
-  static FileInputDetail fromJson(String value) => switch (value) {
-    'high' => FileInputDetail.high,
-    'low' => FileInputDetail.low,
-    _ => throw FormatException('Unknown FileInputDetail: $value'),
-  };
+  const FileInputDetail(this.value);
+
+  /// Creates a [FileInputDetail] from a JSON value.
+  factory FileInputDetail.fromJson(String json) {
+    return FileInputDetail.values.firstWhere(
+      (e) => e.value == json,
+      orElse: () => FileInputDetail.unknown,
+    );
+  }
 
   /// Converts to JSON.
   String toJson() => value;

--- a/packages/openai_dart/lib/src/models/responses/content/input_content.dart
+++ b/packages/openai_dart/lib/src/models/responses/content/input_content.dart
@@ -38,12 +38,18 @@ sealed class InputContent {
       InputImageContent.file;
 
   /// Creates an [InputFileContent] from a URL.
-  const factory InputContent.fileUrl(String url, {String? filename}) =
-      InputFileContent.url;
+  const factory InputContent.fileUrl(
+    String url, {
+    String? filename,
+    FileInputDetail? detail,
+  }) = InputFileContent.url;
 
   /// Creates an [InputFileContent] from a file ID.
-  const factory InputContent.fileId(String id, {String? filename}) =
-      InputFileContent.file;
+  const factory InputContent.fileId(
+    String id, {
+    String? filename,
+    FileInputDetail? detail,
+  }) = InputFileContent.file;
 
   /// Creates an [InputFileContent] from base64-encoded data.
   ///
@@ -55,6 +61,7 @@ sealed class InputContent {
     String data, {
     required String mediaType,
     String? filename,
+    FileInputDetail? detail,
   }) = InputFileContent.data;
 
   /// Creates an [InputContent] from JSON.
@@ -228,22 +235,26 @@ class InputFileContent extends InputContent {
   /// The filename.
   final String? filename;
 
+  /// Optional detail level for file processing.
+  final FileInputDetail? detail;
+
   /// Creates an [InputFileContent].
   const InputFileContent({
     this.fileUrl,
     this.fileId,
     this.fileData,
     this.filename,
+    this.detail,
   });
 
   /// Creates an [InputFileContent] from a URL.
-  const InputFileContent.url(String url, {this.filename})
+  const InputFileContent.url(String url, {this.filename, this.detail})
     : fileUrl = url,
       fileId = null,
       fileData = null;
 
   /// Creates an [InputFileContent] from a file ID.
-  const InputFileContent.file(String id, {this.filename})
+  const InputFileContent.file(String id, {this.filename, this.detail})
     : fileUrl = null,
       fileId = id,
       fileData = null;
@@ -258,6 +269,7 @@ class InputFileContent extends InputContent {
     String data, {
     required String mediaType,
     this.filename,
+    this.detail,
   }) : fileUrl = null,
        fileId = null,
        fileData = 'data:$mediaType;base64,$data';
@@ -269,6 +281,9 @@ class InputFileContent extends InputContent {
       fileId: json['file_id'] as String?,
       fileData: json['file_data'] as String?,
       filename: json['filename'] as String?,
+      detail: json['detail'] != null
+          ? FileInputDetail.fromJson(json['detail'] as String)
+          : null,
     );
   }
 
@@ -279,6 +294,7 @@ class InputFileContent extends InputContent {
     if (fileId != null) 'file_id': fileId,
     if (fileData != null) 'file_data': fileData,
     if (filename != null) 'filename': filename,
+    if (detail != null) 'detail': detail!.toJson(),
   };
 
   @override
@@ -289,14 +305,15 @@ class InputFileContent extends InputContent {
           fileUrl == other.fileUrl &&
           fileId == other.fileId &&
           fileData == other.fileData &&
-          filename == other.filename;
+          filename == other.filename &&
+          detail == other.detail;
 
   @override
-  int get hashCode => Object.hash(fileUrl, fileId, fileData, filename);
+  int get hashCode => Object.hash(fileUrl, fileId, fileData, filename, detail);
 
   @override
   String toString() =>
-      'InputFileContent(fileUrl: $fileUrl, fileId: $fileId, fileData: $fileData, filename: $filename)';
+      'InputFileContent(fileUrl: $fileUrl, fileId: $fileId, fileData: $fileData, filename: $filename, detail: $detail)';
 }
 
 /// Video content via URL.
@@ -331,4 +348,31 @@ class InputVideoContent extends InputContent {
 
   @override
   String toString() => 'InputVideoContent(videoUrl: $videoUrl)';
+}
+
+/// Detail level for file inputs.
+///
+/// Controls how the model processes file content. Use `low` for the default
+/// rendering behavior, or `high` to render the file at higher quality.
+enum FileInputDetail {
+  /// High detail: more thorough processing.
+  high('high'),
+
+  /// Low detail: default processing.
+  low('low');
+
+  const FileInputDetail(this.value);
+
+  /// The JSON value for this detail level.
+  final String value;
+
+  /// Creates a [FileInputDetail] from JSON.
+  static FileInputDetail fromJson(String value) => switch (value) {
+    'high' => FileInputDetail.high,
+    'low' => FileInputDetail.low,
+    _ => throw FormatException('Unknown FileInputDetail: $value'),
+  };
+
+  /// Converts to JSON.
+  String toJson() => value;
 }

--- a/packages/openai_dart/specs/openapi.json
+++ b/packages/openai_dart/specs/openapi.json
@@ -9830,6 +9830,18 @@
                   }
                 ]
               },
+              "max_output_tokens": {
+                "anyOf": [
+                  {
+                    "description": "An upper bound for the number of tokens that can be generated for a response, including visible output tokens and [reasoning tokens](https://platform.openai.com/docs/guides/reasoning).\n",
+                    "minimum": 16,
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "parallel_tool_calls": {
                 "anyOf": [
                   {
@@ -14144,6 +14156,13 @@
         "title": "File citation",
         "type": "object"
       },
+      "FileDetailEnum": {
+        "enum": [
+          "low",
+          "high"
+        ],
+        "type": "string"
+      },
       "FileExpirationAfter": {
         "description": "The expiration policy for a file. By default, files with `purpose=batch` expire after 30 days and all other files are persisted until they are manually deleted.",
         "properties": {
@@ -14168,6 +14187,13 @@
         ],
         "title": "File expiration policy",
         "type": "object"
+      },
+      "FileInputDetail": {
+        "enum": [
+          "low",
+          "high"
+        ],
+        "type": "string"
       },
       "FilePath": {
         "description": "A path to a file.\n",
@@ -17887,6 +17913,10 @@
       "InputFileContent": {
         "description": "A file input to the model.",
         "properties": {
+          "detail": {
+            "$ref": "#/components/schemas/FileInputDetail",
+            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          },
           "file_data": {
             "description": "The content of the file to be sent to the model.\n",
             "type": "string"
@@ -17929,11 +17959,15 @@
       "InputFileContentParam": {
         "description": "A file input to the model.",
         "properties": {
+          "detail": {
+            "$ref": "#/components/schemas/FileDetailEnum",
+            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+          },
           "file_data": {
             "anyOf": [
               {
                 "description": "The base64-encoded data of the file to be sent to the model.",
-                "maxLength": 33554432,
+                "maxLength": 73400320,
                 "type": "string"
               },
               {
@@ -31051,6 +31085,17 @@
                   }
                 ]
               },
+              "max_output_tokens": {
+                "anyOf": [
+                  {
+                    "description": "An upper bound for the number of tokens that can be generated for a response, including visible output tokens and [reasoning tokens](https://platform.openai.com/docs/guides/reasoning).\n",
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "object": {
                 "description": "The object type of this resource - always set to `response`.\n",
                 "enum": [
@@ -32999,17 +33044,6 @@
                 "default": false,
                 "description": "Whether to run the model response in the background.\n[Learn more](https://platform.openai.com/docs/guides/background).\n",
                 "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "max_output_tokens": {
-            "anyOf": [
-              {
-                "description": "An upper bound for the number of tokens that can be generated for a response, including visible output tokens and [reasoning tokens](https://platform.openai.com/docs/guides/reasoning).\n",
-                "type": "integer"
               },
               {
                 "type": "null"

--- a/packages/openai_dart/specs/spec_metadata.json
+++ b/packages/openai_dart/specs/spec_metadata.json
@@ -2,8 +2,8 @@
   "specs": {
     "main": {
       "current_version": "2.3.0",
-      "last_fetched": "2026-04-08T21:18:01.788107Z",
-      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai%2Fopenai-a6eca1bd01e0c434af356fe5275c206057216a4e626d1051d294c27016cd6d05.yml",
+      "last_fetched": "2026-04-16T09:40:55.880616Z",
+      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai%2Fopenai-7c540cce6eb30401259f4831ea9803b6d88501605d13734f98212cbb3b199e10.yml",
       "title": "OpenAI API",
       "version_history": []
     }

--- a/packages/openai_dart/test/unit/models/responses_test.dart
+++ b/packages/openai_dart/test/unit/models/responses_test.dart
@@ -2590,8 +2590,8 @@ void main() {
       expect(FileInputDetail.low.toJson(), 'low');
     });
 
-    test('fromJson throws on unknown value', () {
-      expect(() => FileInputDetail.fromJson('auto'), throwsFormatException);
+    test('fromJson returns unknown for unrecognized value', () {
+      expect(FileInputDetail.fromJson('auto'), FileInputDetail.unknown);
     });
   });
 

--- a/packages/openai_dart/test/unit/models/responses_test.dart
+++ b/packages/openai_dart/test/unit/models/responses_test.dart
@@ -1012,6 +1012,71 @@ void main() {
         equals('data:application/pdf;base64,base64data=='),
       );
     });
+
+    test('creates file content from URL with detail', () {
+      const content = InputContent.fileUrl(
+        'https://example.com/file.pdf',
+        detail: FileInputDetail.high,
+      );
+
+      expect(content, isA<InputFileContent>());
+      const file = content as InputFileContent;
+      expect(file.fileUrl, equals('https://example.com/file.pdf'));
+      expect(file.detail, equals(FileInputDetail.high));
+    });
+
+    test('creates file content from file ID with detail', () {
+      const content = InputContent.fileId(
+        'file_456',
+        detail: FileInputDetail.low,
+      );
+
+      expect(content, isA<InputFileContent>());
+      const file = content as InputFileContent;
+      expect(file.fileId, equals('file_456'));
+      expect(file.detail, equals(FileInputDetail.low));
+    });
+
+    test('creates file content from base64 data with detail', () {
+      const content = InputContent.fileData(
+        'base64data==',
+        mediaType: 'application/pdf',
+        detail: FileInputDetail.high,
+      );
+
+      expect(content, isA<InputFileContent>());
+      const file = content as InputFileContent;
+      expect(file.fileData, equals('data:application/pdf;base64,base64data=='));
+      expect(file.detail, equals(FileInputDetail.high));
+    });
+
+    test('InputFileContent round-trip with detail', () {
+      const content = InputFileContent(
+        fileUrl: 'https://example.com/file.pdf',
+        filename: 'test.pdf',
+        detail: FileInputDetail.high,
+      );
+      final json = content.toJson();
+
+      expect(json['type'], equals('input_file'));
+      expect(json['file_url'], equals('https://example.com/file.pdf'));
+      expect(json['filename'], equals('test.pdf'));
+      expect(json['detail'], equals('high'));
+
+      final restored = InputFileContent.fromJson(json);
+      expect(restored, equals(content));
+    });
+
+    test('InputFileContent round-trip without detail', () {
+      const content = InputFileContent(fileId: 'file_123');
+      final json = content.toJson();
+
+      expect(json.containsKey('detail'), isFalse);
+
+      final restored = InputFileContent.fromJson(json);
+      expect(restored, equals(content));
+      expect(restored.detail, isNull);
+    });
   });
 
   group('AssistantTextContent', () {
@@ -2508,6 +2573,25 @@ void main() {
 
     test('toJson returns original', () {
       expect(ImageDetail.original.toJson(), 'original');
+    });
+  });
+
+  group('FileInputDetail', () {
+    test('fromJson parses high', () {
+      expect(FileInputDetail.fromJson('high'), FileInputDetail.high);
+    });
+
+    test('fromJson parses low', () {
+      expect(FileInputDetail.fromJson('low'), FileInputDetail.low);
+    });
+
+    test('toJson returns correct values', () {
+      expect(FileInputDetail.high.toJson(), 'high');
+      expect(FileInputDetail.low.toJson(), 'low');
+    });
+
+    test('fromJson throws on unknown value', () {
+      expect(() => FileInputDetail.fromJson('auto'), throwsFormatException);
     });
   });
 


### PR DESCRIPTION
## Summary
- Update OpenAI OpenAPI spec to latest version (hash `7c540cce`)
- Add `FileInputDetail` enum and `detail` property to `InputFileContent` for controlling file processing quality (`high`/`low`)

## Details

The latest OpenAI spec re-introduces the `detail` field on `InputFileContent` (and `InputFileContentParam`), which controls how thoroughly the model processes file inputs. This was temporarily removed in a prior spec update and is now restored.

The new `FileInputDetail` enum follows the same pattern as the existing `ImageDetail` enum. It supports two values:
- `high` — more thorough file processing
- `low` — default processing (server-side default when omitted)

Usage:
```dart
// File URL with high detail
final content = InputContent.fileUrl(
  'https://example.com/report.pdf',
  detail: FileInputDetail.high,
);

// File ID with low detail
final content = InputContent.fileId(
  'file_abc123',
  detail: FileInputDetail.low,
);

// Base64 data with detail
final content = InputContent.fileData(
  base64EncodedData,
  mediaType: 'application/pdf',
  detail: FileInputDetail.high,
);
```

The spec also moved `max_output_tokens` from the shared `ResponseProperties` schema to inline properties on `CreateResponse` and `Response`. This is a spec-level refactoring only — the field still exists on both Dart classes, so no code changes were needed. A manifest entry was added to acknowledge the schema.

## Test Plan

- [x] Unit tests pass (`dart test test/unit/` — 1174 pass)
- [x] `FileInputDetail` enum tests (fromJson, toJson, unknown value)
- [x] `detail` parameter tests on all three file content factories
- [x] JSON round-trip serialization with and without `detail`
- [x] `dart analyze` clean (no issues)
- [x] `dart format` clean
- [x] Toolkit `verify --checks all --scope all` passes (0 errors, 0 warnings)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
