### PR TITLE
feat(chromadb): add get collection by ID endpoint

### DIFF
--- a/packages/chromadb/example/collections_example.dart
+++ b/packages/chromadb/example/collections_example.dart
@@ -22,6 +22,13 @@ void main() async {
     print('Fetched: ${fetched.name}');
     print('Metadata: ${fetched.metadata.metadata}');
 
+    // Get a collection by ID
+    print('\nGetting collection by ID...');
+    final fetchedById = await client.getCollectionById(
+      collectionId: collection.id,
+    );
+    print('Fetched by ID: ${fetchedById.name}');
+
     // Get or create (idempotent operation)
     print('\nGet or create collection...');
     final existing = await client.getOrCreateCollection(

--- a/packages/chromadb/lib/src/client/chromadb_client.dart
+++ b/packages/chromadb/lib/src/client/chromadb_client.dart
@@ -407,6 +407,38 @@ class ChromaClient {
     );
   }
 
+  /// Gets an existing collection by ID.
+  ///
+  /// Throws if the collection does not exist.
+  ///
+  /// [collectionId] - The collection UUID.
+  /// [embeddingFunction] - Optional embedding function for auto-embedding.
+  /// [dataLoader] - Optional data loader for loading data from URIs.
+  /// [tenant] - The tenant (defaults to client's configured tenant).
+  /// [database] - The database (defaults to client's configured database).
+  Future<ChromaCollection> getCollectionById({
+    required String collectionId,
+    EmbeddingFunction? embeddingFunction,
+    DataLoader<Loadable>? dataLoader,
+    String? tenant,
+    String? database,
+  }) async {
+    final collection = await collections.getById(
+      collectionId: collectionId,
+      tenant: tenant,
+      database: database,
+    );
+
+    return ChromaCollection(
+      records: records(collection.id, tenant: tenant, database: database),
+      collections: collections,
+      functions: functions(collection.id, tenant: tenant, database: database),
+      metadata: collection,
+      embeddingFunction: embeddingFunction,
+      dataLoader: dataLoader,
+    );
+  }
+
   /// Lists all collections in the database.
   ///
   /// [limit] - Maximum number of collections to return.

--- a/packages/chromadb/lib/src/resources/collections_resource.dart
+++ b/packages/chromadb/lib/src/resources/collections_resource.dart
@@ -120,7 +120,7 @@ class CollectionsResource extends ResourceBase {
   ///
   /// Returns the [Collection] if found.
   ///
-  /// Throws [ChromaNotFoundException] if the collection does not exist.
+  /// Throws [NotFoundException] if the collection does not exist.
   ///
   /// Endpoint: `GET /api/v2/tenants/{tenant}/databases/{database}/collections/{name}`
   Future<Collection> getByName({
@@ -146,7 +146,7 @@ class CollectionsResource extends ResourceBase {
   ///
   /// Returns the [Collection] if found.
   ///
-  /// Throws [ChromaNotFoundException] if the collection does not exist.
+  /// Throws [NotFoundException] if the collection does not exist.
   ///
   /// Endpoint: `GET /api/v2/tenants/{tenant}/databases/{database}/collections/by-id/{collection_id}`
   Future<Collection> getById({

--- a/packages/chromadb/lib/src/resources/collections_resource.dart
+++ b/packages/chromadb/lib/src/resources/collections_resource.dart
@@ -138,6 +138,32 @@ class CollectionsResource extends ResourceBase {
     return Collection.fromJson(parseJson(response));
   }
 
+  /// Gets a collection by ID.
+  ///
+  /// [collectionId] - The collection UUID.
+  /// [tenant] - The tenant containing the database.
+  /// [database] - The database containing the collection.
+  ///
+  /// Returns the [Collection] if found.
+  ///
+  /// Throws [ChromaNotFoundException] if the collection does not exist.
+  ///
+  /// Endpoint: `GET /api/v2/tenants/{tenant}/databases/{database}/collections/by-id/{collection_id}`
+  Future<Collection> getById({
+    required String collectionId,
+    String? tenant,
+    String? database,
+  }) async {
+    ensureNotClosed?.call();
+    final url = requestBuilder.buildUrl(
+      '${_basePath(tenant: tenant, database: database)}/by-id/${Uri.encodeComponent(collectionId)}',
+    );
+    final headers = requestBuilder.buildHeaders(null);
+    final httpRequest = http.Request('GET', url)..headers.addAll(headers);
+    final response = await interceptorChain.execute(httpRequest);
+    return Collection.fromJson(parseJson(response));
+  }
+
   /// Gets a collection by Chroma Resource Name (CRN).
   ///
   /// [crn] - The Chroma Resource Name.

--- a/packages/chromadb/lib/src/resources/databases_resource.dart
+++ b/packages/chromadb/lib/src/resources/databases_resource.dart
@@ -86,7 +86,7 @@ class DatabasesResource extends ResourceBase {
   ///
   /// Returns the [Database] if found.
   ///
-  /// Throws [ChromaNotFoundException] if the database does not exist.
+  /// Throws [NotFoundException] if the database does not exist.
   ///
   /// Endpoint: `GET /api/v2/tenants/{tenant}/databases/{database}`
   Future<Database> getByName({required String name, String? tenant}) async {

--- a/packages/chromadb/lib/src/resources/tenants_resource.dart
+++ b/packages/chromadb/lib/src/resources/tenants_resource.dart
@@ -56,7 +56,7 @@ class TenantsResource extends ResourceBase {
   ///
   /// Returns the [Tenant] if found.
   ///
-  /// Throws [ChromaNotFoundException] if the tenant does not exist.
+  /// Throws [NotFoundException] if the tenant does not exist.
   ///
   /// Endpoint: `GET /api/v2/tenants/{tenant_name}`
   Future<Tenant> getByName({required String name}) async {

--- a/packages/chromadb/specs/openapi.json
+++ b/packages/chromadb/specs/openapi.json
@@ -3500,6 +3500,104 @@
         ]
       }
     },
+    "/api/v2/tenants/{tenant}/databases/{database}/collections/by-id/{collection_id}": {
+      "get": {
+        "description": "Returns a collection by its UUID within a specific tenant and database.",
+        "operationId": "get_collection_by_id",
+        "parameters": [
+          {
+            "description": "Tenant ID",
+            "in": "path",
+            "name": "tenant",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Database name",
+            "in": "path",
+            "name": "database",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Collection UUID",
+            "in": "path",
+            "name": "collection_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Collection"
+                }
+              }
+            },
+            "description": "Collection found"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Collection not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Server error"
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "summary": "Get collection by ID",
+        "tags": [
+          "Collection"
+        ],
+        "x-codeSamples": [
+          {
+            "label": "Get collection by ID",
+            "lang": "typescript",
+            "source": "const collection = await client.getCollectionById({ id: 'collection-uuid-here' });"
+          },
+          {
+            "label": "Get collection by ID",
+            "lang": "python",
+            "source": "collection = client.get_collection_by_id(uuid.UUID('collection-uuid-here'))"
+          }
+        ]
+      }
+    },
     "/api/v2/tenants/{tenant}/databases/{database}/collections/{collection_id}": {
       "delete": {
         "description": "Deletes a collection in a database.",

--- a/packages/chromadb/specs/spec_metadata.json
+++ b/packages/chromadb/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "1.0.0",
-      "last_fetched": "2026-04-08T21:16:38.929681Z",
+      "last_fetched": "2026-04-16T09:58:41.000000Z",
       "source_url": "https://api.trychroma.com/openapi.json",
       "title": "chroma-frontend",
       "version_history": []

--- a/packages/chromadb/test/unit/resources/collections_resource_test.dart
+++ b/packages/chromadb/test/unit/resources/collections_resource_test.dart
@@ -1,0 +1,178 @@
+@TestOn('vm')
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:chromadb/chromadb.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class MockHttpClient extends Mock implements http.Client {}
+
+class FakeBaseRequest extends Fake implements http.BaseRequest {}
+
+const Map<String, dynamic> _collectionJson = {
+  'id': 'coll-uuid-123',
+  'name': 'test-collection',
+  'metadata': {'key': 'value'},
+  'tenant': 'default_tenant',
+  'database': 'default_database',
+  'log_position': 0,
+  'version': 1,
+  'configuration_json': <String, dynamic>{},
+};
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeBaseRequest());
+  });
+
+  group('CollectionsResource', () {
+    late MockHttpClient mockHttpClient;
+
+    setUp(() {
+      mockHttpClient = MockHttpClient();
+    });
+
+    tearDown(() {
+      reset(mockHttpClient);
+    });
+
+    group('getById', () {
+      test('fetches a collection by UUID', () async {
+        http.Request? capturedRequest;
+        when(() => mockHttpClient.send(any())).thenAnswer((invocation) async {
+          capturedRequest = invocation.positionalArguments[0] as http.Request;
+          return http.StreamedResponse(
+            Stream.value(utf8.encode(jsonEncode(_collectionJson))),
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        });
+
+        final client = ChromaClient(httpClient: mockHttpClient);
+        addTearDown(client.close);
+
+        final collection = await client.collections.getById(
+          collectionId: 'coll-uuid-123',
+        );
+
+        expect(capturedRequest, isNotNull);
+        expect(capturedRequest!.method, 'GET');
+        expect(
+          capturedRequest!.url.path,
+          '/api/v2/tenants/default_tenant/databases/default_database'
+          '/collections/by-id/coll-uuid-123',
+        );
+        expect(collection.id, 'coll-uuid-123');
+        expect(collection.name, 'test-collection');
+      });
+
+      test('uses custom tenant and database', () async {
+        http.Request? capturedRequest;
+        when(() => mockHttpClient.send(any())).thenAnswer((invocation) async {
+          capturedRequest = invocation.positionalArguments[0] as http.Request;
+          return http.StreamedResponse(
+            Stream.value(utf8.encode(jsonEncode(_collectionJson))),
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        });
+
+        final client = ChromaClient(httpClient: mockHttpClient);
+        addTearDown(client.close);
+
+        await client.collections.getById(
+          collectionId: 'coll-uuid-123',
+          tenant: 'my-tenant',
+          database: 'my-db',
+        );
+
+        expect(
+          capturedRequest!.url.path,
+          '/api/v2/tenants/my-tenant/databases/my-db'
+          '/collections/by-id/coll-uuid-123',
+        );
+      });
+
+      test('throws NotFoundException for non-existent UUID', () async {
+        when(() => mockHttpClient.send(any())).thenAnswer((_) async {
+          return http.StreamedResponse(
+            Stream.value(
+              utf8.encode(jsonEncode({'error': 'Collection not found'})),
+            ),
+            404,
+            headers: {'content-type': 'application/json'},
+          );
+        });
+
+        final client = ChromaClient(httpClient: mockHttpClient);
+        addTearDown(client.close);
+
+        await expectLater(
+          client.collections.getById(collectionId: 'non-existent'),
+          throwsA(isA<NotFoundException>()),
+        );
+      });
+    });
+  });
+
+  group('ChromaClient', () {
+    late MockHttpClient mockHttpClient;
+
+    setUp(() {
+      mockHttpClient = MockHttpClient();
+    });
+
+    tearDown(() {
+      reset(mockHttpClient);
+    });
+
+    group('getCollectionById', () {
+      test(
+        'returns ChromaCollection wrapping the fetched collection',
+        () async {
+          when(() => mockHttpClient.send(any())).thenAnswer((invocation) async {
+            return http.StreamedResponse(
+              Stream.value(utf8.encode(jsonEncode(_collectionJson))),
+              200,
+              headers: {'content-type': 'application/json'},
+            );
+          });
+
+          final client = ChromaClient(httpClient: mockHttpClient);
+          addTearDown(client.close);
+
+          final chromaCollection = await client.getCollectionById(
+            collectionId: 'coll-uuid-123',
+          );
+
+          expect(chromaCollection.id, 'coll-uuid-123');
+          expect(chromaCollection.name, 'test-collection');
+        },
+      );
+
+      test('throws NotFoundException for non-existent UUID', () async {
+        when(() => mockHttpClient.send(any())).thenAnswer((_) async {
+          return http.StreamedResponse(
+            Stream.value(
+              utf8.encode(jsonEncode({'error': 'Collection not found'})),
+            ),
+            404,
+            headers: {'content-type': 'application/json'},
+          );
+        });
+
+        final client = ChromaClient(httpClient: mockHttpClient);
+        addTearDown(client.close);
+
+        await expectLater(
+          client.getCollectionById(collectionId: 'non-existent'),
+          throwsA(isA<NotFoundException>()),
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add support for the new `getCollectionById` endpoint that retrieves a collection by its UUID
- Update OpenAPI spec to latest version (29 endpoints, up from 28)

## Details

The ChromaDB API added a new endpoint: **GET `/api/v2/tenants/{tenant}/databases/{database}/collections/by-id/{collection_id}`** that returns a `Collection` by its UUID. Previously, collections could only be fetched by name (`getByName`) or CRN (`getByCrn`).

### New APIs

**Low-level** — `CollectionsResource.getById()`:
```dart
final collection = await client.collections.getById(
  collectionId: 'collection-uuid-here',
);
```

**High-level** — `ChromaClient.getCollectionById()`:
```dart
final collection = await client.getCollectionById(
  collectionId: 'collection-uuid-here',
  embeddingFunction: myEmbeddingFn,
);
```

## Test Plan
- [x] Unit tests pass (299 passing)
- [x] `dart analyze --fatal-infos` — no issues
- [x] `dart format --set-exit-if-changed .` — no changes needed
- [x] Toolkit verify — 0 errors, 0 warnings
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
