### PR TITLE
chore(ollama_dart,open_responses): update OpenAPI spec metadata

### DIFF
--- a/packages/ollama_dart/specs/spec_metadata.json
+++ b/packages/ollama_dart/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "0.1.0",
-      "last_fetched": "2026-04-08T21:17:25.078041Z",
+      "last_fetched": "2026-04-16T09:46:56.281077Z",
       "source_url": "https://raw.githubusercontent.com/ollama/ollama/refs/heads/main/docs/openapi.yaml",
       "title": "Ollama API",
       "version_history": []

--- a/packages/open_responses/specs/spec_metadata.json
+++ b/packages/open_responses/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "2.3.0",
-      "last_fetched": "2026-04-08T21:17:39.123015Z",
+      "last_fetched": "2026-04-16T09:41:29.251899Z",
       "source_url": "https://www.openresponses.org/openapi/openapi.json",
       "title": "OpenAI API",
       "version_history": []


### PR DESCRIPTION
## Summary
- Update `last_fetched` timestamps in spec metadata for `ollama_dart` and `open_responses` after re-fetching upstream OpenAPI specs with no changes detected

## Test Plan
- [x] No code changes — only metadata timestamp updates
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
