### PR TITLE
feat(anthropic_sdk_dart): add Claude Opus 4.7 and refresh OpenAPI spec

### DIFF
--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
@@ -2763,6 +2763,75 @@
       "dart_class": "UserToolConfirmationResult",
       "file": "lib/src/models/managed_agents/events/session_event.dart",
       "schema": "BetaManagedAgentsUserToolConfirmationResult"
+    },
+    "BetaCreateMessageParams": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "MessageCreateRequest",
+      "file": "lib/src/models/messages/message_create_request.dart",
+      "schema": "BetaCreateMessageParams",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Beta variant of CreateMessageParams; MessageCreateRequest covers the shared surface. Beta-only fields (context_management, mcp_servers, output_format) are not yet implemented."
+    },
+    "OutputConfig": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "OutputConfig",
+      "file": "lib/src/models/beta/config/output_config.dart",
+      "schema": "OutputConfig"
+    },
+    "BetaOutputConfig": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "OutputConfig",
+      "file": "lib/src/models/beta/config/output_config.dart",
+      "schema": "BetaOutputConfig",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Beta variant of OutputConfig; same Dart class covers both surfaces."
+    },
+    "TokenTaskBudget": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "TokenTaskBudget",
+      "file": "lib/src/models/beta/config/token_task_budget.dart",
+      "schema": "BetaTokenTaskBudget"
+    },
+    "EffortLevel": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "EffortLevel",
+      "file": "lib/src/models/beta/config/output_config.dart",
+      "schema": "EffortLevel",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "EffortLevel enum uses strict fromJson (FormatException on unknown values) matching the convention of ServiceTier/Speed enums in this package."
+    },
+    "BetaEffortLevel": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "EffortLevel",
+      "file": "lib/src/models/beta/config/output_config.dart",
+      "schema": "BetaEffortLevel",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Beta variant of EffortLevel enum; same Dart enum covers both surfaces."
+    },
+    "BetaEffortCapability": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "EffortCapability",
+      "file": "lib/src/models/models/model_capabilities.dart",
+      "schema": "BetaEffortCapability",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Beta variant of EffortCapability within ModelCapabilities; same Dart class covers both surfaces."
     }
   }
 }

--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/specs.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/specs.json
@@ -27,9 +27,9 @@
       "fetch_mode": "remote",
       "local_file": "openapi.yaml",
       "name": "Anthropic API",
-      "pinned_hash": "f4d4f18820ecfbe244fb1bbc2232939afca73dfcb21ce23bc296571ee7320e3a",
+      "pinned_hash": "e0696f59ae07dc1a9c5a8fc87a4eb05eb35afabaac0b5ff0ea38810fa9dd4a74",
       "requires_auth": false,
-      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic%2Fanthropic-f4d4f18820ecfbe244fb1bbc2232939afca73dfcb21ce23bc296571ee7320e3a.yml"
+      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic%2Fanthropic-e0696f59ae07dc1a9c5a8fc87a4eb05eb35afabaac0b5ff0ea38810fa9dd4a74.yml"
     }
   },
   "specs_dir": "packages/anthropic_sdk_dart/specs"

--- a/packages/anthropic_sdk_dart/example/advisor_example.dart
+++ b/packages/anthropic_sdk_dart/example/advisor_example.dart
@@ -23,7 +23,7 @@ void main() async {
         model: 'claude-sonnet-4-6',
         maxTokens: 4096,
         tools: [
-          ToolDefinition.builtIn(const AdvisorTool(model: 'claude-opus-4-6')),
+          ToolDefinition.builtIn(const AdvisorTool(model: 'claude-opus-4-7')),
         ],
         messages: [
           InputMessage.user(
@@ -80,7 +80,7 @@ For long agent loops, enable advisor-side caching to reduce costs:
 final tools = [
   ToolDefinition.builtIn(
     AdvisorTool(
-      model: 'claude-opus-4-6',
+      model: 'claude-opus-4-7',
       maxUses: 3,
       caching: CacheControlEphemeral(ttl: CacheTtl.ttl5m),
     ),
@@ -117,7 +117,7 @@ final response2 = await client.messages.create(
   MessageCreateRequest(
     model: 'claude-sonnet-4-6',
     maxTokens: 4096,
-    tools: [ToolDefinition.builtIn(AdvisorTool(model: 'claude-opus-4-6'))],
+    tools: [ToolDefinition.builtIn(AdvisorTool(model: 'claude-opus-4-7'))],
     messages: messages,
   ),
   betas: ['advisor-tool-2026-03-01'],

--- a/packages/anthropic_sdk_dart/lib/anthropic_sdk_dart.dart
+++ b/packages/anthropic_sdk_dart/lib/anthropic_sdk_dart.dart
@@ -65,6 +65,7 @@ export 'src/models/batches/message_batch.dart';
 // Models - Beta Config
 export 'src/models/beta/config/container.dart';
 export 'src/models/beta/config/output_config.dart';
+export 'src/models/beta/config/token_task_budget.dart';
 
 // Models - Beta Tools
 // Note: ComputerUseTool and McpToolset are exported via built_in_tools.dart

--- a/packages/anthropic_sdk_dart/lib/src/models/beta/config/output_config.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/beta/config/output_config.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../../common/copy_with_sentinel.dart';
 import '../../common/equality_helpers.dart';
+import 'token_task_budget.dart';
 
 /// Response effort level for model generation.
 enum EffortLevel {
@@ -13,6 +14,9 @@ enum EffortLevel {
 
   /// Higher effort.
   high('high'),
+
+  /// Between high and maximum effort.
+  xhigh('xhigh'),
 
   /// Maximum effort.
   max('max');
@@ -27,6 +31,7 @@ enum EffortLevel {
     'low' => EffortLevel.low,
     'medium' => EffortLevel.medium,
     'high' => EffortLevel.high,
+    'xhigh' => EffortLevel.xhigh,
     'max' => EffortLevel.max,
     _ => throw FormatException('Unknown EffortLevel: $value'),
   };
@@ -44,8 +49,11 @@ class OutputConfig {
   /// Optional structured output format configuration.
   final JsonOutputFormat? format;
 
+  /// Optional token-based task budget for managed-agents compaction.
+  final TokenTaskBudget? taskBudget;
+
   /// Creates an [OutputConfig].
-  const OutputConfig({this.effort, this.format});
+  const OutputConfig({this.effort, this.format, this.taskBudget});
 
   /// Creates an [OutputConfig] from JSON.
   factory OutputConfig.fromJson(Map<String, dynamic> json) {
@@ -56,6 +64,11 @@ class OutputConfig {
       format: json['format'] != null
           ? JsonOutputFormat.fromJson(json['format'] as Map<String, dynamic>)
           : null,
+      taskBudget: json['task_budget'] != null
+          ? TokenTaskBudget.fromJson(
+              json['task_budget'] as Map<String, dynamic>,
+            )
+          : null,
     );
   }
 
@@ -63,12 +76,14 @@ class OutputConfig {
   Map<String, dynamic> toJson() => {
     if (effort != null) 'effort': effort!.toJson(),
     if (format != null) 'format': format!.toJson(),
+    if (taskBudget != null) 'task_budget': taskBudget!.toJson(),
   };
 
   /// Creates a copy with replaced values.
   OutputConfig copyWith({
     Object? effort = unsetCopyWithValue,
     Object? format = unsetCopyWithValue,
+    Object? taskBudget = unsetCopyWithValue,
   }) {
     return OutputConfig(
       effort: effort == unsetCopyWithValue
@@ -77,6 +92,9 @@ class OutputConfig {
       format: format == unsetCopyWithValue
           ? this.format
           : format as JsonOutputFormat?,
+      taskBudget: taskBudget == unsetCopyWithValue
+          ? this.taskBudget
+          : taskBudget as TokenTaskBudget?,
     );
   }
 
@@ -86,13 +104,15 @@ class OutputConfig {
       other is OutputConfig &&
           runtimeType == other.runtimeType &&
           effort == other.effort &&
-          format == other.format;
+          format == other.format &&
+          taskBudget == other.taskBudget;
 
   @override
-  int get hashCode => Object.hash(effort, format);
+  int get hashCode => Object.hash(effort, format, taskBudget);
 
   @override
-  String toString() => 'OutputConfig(effort: $effort, format: $format)';
+  String toString() =>
+      'OutputConfig(effort: $effort, format: $format, taskBudget: $taskBudget)';
 }
 
 /// JSON schema output format for structured outputs.

--- a/packages/anthropic_sdk_dart/lib/src/models/beta/config/token_task_budget.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/beta/config/token_task_budget.dart
@@ -1,0 +1,73 @@
+import 'package:meta/meta.dart';
+
+import '../../common/copy_with_sentinel.dart';
+
+/// Token-based task budget for managed-agents compaction.
+///
+/// Tracks total and remaining tokens so clients can implement compaction
+/// client-side across multiple contexts in a session.
+@immutable
+class TokenTaskBudget {
+  /// The budget type. Currently only 'tokens' is supported.
+  final String type;
+
+  /// Total token budget across all contexts in the session. Minimum 1024.
+  final int total;
+
+  /// Remaining tokens in the budget. Defaults to [total] when not provided.
+  final int? remaining;
+
+  /// Creates a [TokenTaskBudget].
+  const TokenTaskBudget({
+    required this.total,
+    this.remaining,
+    this.type = 'tokens',
+  });
+
+  /// Creates a [TokenTaskBudget] from JSON.
+  factory TokenTaskBudget.fromJson(Map<String, dynamic> json) {
+    return TokenTaskBudget(
+      type: json['type'] as String? ?? 'tokens',
+      total: json['total'] as int,
+      remaining: json['remaining'] as int?,
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'total': total,
+    if (remaining != null) 'remaining': remaining,
+  };
+
+  /// Creates a copy with replaced values.
+  TokenTaskBudget copyWith({
+    String? type,
+    int? total,
+    Object? remaining = unsetCopyWithValue,
+  }) {
+    return TokenTaskBudget(
+      type: type ?? this.type,
+      total: total ?? this.total,
+      remaining: remaining == unsetCopyWithValue
+          ? this.remaining
+          : remaining as int?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TokenTaskBudget &&
+          runtimeType == other.runtimeType &&
+          type == other.type &&
+          total == other.total &&
+          remaining == other.remaining;
+
+  @override
+  int get hashCode => Object.hash(type, total, remaining);
+
+  @override
+  String toString() =>
+      'TokenTaskBudget(type: $type, total: $total, remaining: $remaining)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/beta/config/token_task_budget.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/beta/config/token_task_budget.dart
@@ -14,7 +14,9 @@ class TokenTaskBudget {
   /// Total token budget across all contexts in the session. Minimum 1024.
   final int total;
 
-  /// Remaining tokens in the budget. Defaults to [total] when not provided.
+  /// Remaining tokens in the budget, used to track usage across contexts when
+  /// implementing compaction client-side. `null` when unset; the server
+  /// treats an absent value as equivalent to [total].
   final int? remaining;
 
   /// Creates a [TokenTaskBudget].

--- a/packages/anthropic_sdk_dart/lib/src/models/beta/tools/advisor_tool.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/beta/tools/advisor_tool.dart
@@ -16,7 +16,7 @@ part of '../../tools/built_in_tools.dart';
 ///     maxTokens: 4096,
 ///     tools: [
 ///       ToolDefinition.builtIn(
-///         AdvisorTool(model: 'claude-opus-4-6'),
+///         AdvisorTool(model: 'claude-opus-4-7'),
 ///       ),
 ///     ],
 ///     messages: [InputMessage.user('Plan a Go worker pool.')],
@@ -29,7 +29,7 @@ class AdvisorTool extends BuiltInTool {
   /// The tool type version.
   final String type;
 
-  /// The advisor model ID (e.g., `'claude-opus-4-6'`).
+  /// The advisor model ID (e.g., `'claude-opus-4-7'`).
   final String model;
 
   /// Maximum number of advisor calls allowed in a single request.

--- a/packages/anthropic_sdk_dart/lib/src/models/content/content_block.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/content_block.dart
@@ -789,7 +789,7 @@ class CompactionBlock extends ContentBlock {
   Map<String, dynamic> toJson() => {
     'type': 'compaction',
     'content': content,
-    if (encryptedContent != null) 'encrypted_content': encryptedContent,
+    'encrypted_content': encryptedContent,
   };
 
   /// Creates a copy with replaced values.

--- a/packages/anthropic_sdk_dart/lib/src/models/content/content_block.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/content_block.dart
@@ -820,7 +820,8 @@ class CompactionBlock extends ContentBlock {
 
   @override
   String toString() =>
-      'CompactionBlock(content: $content, encryptedContent: $encryptedContent)';
+      'CompactionBlock(content: $content, '
+      'encryptedContent: ${encryptedContent == null ? 'null' : '[${encryptedContent!.length} chars]'})';
 }
 
 /// Web search result content.

--- a/packages/anthropic_sdk_dart/lib/src/models/content/content_block.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/content_block.dart
@@ -771,23 +771,39 @@ class CompactionBlock extends ContentBlock {
   /// When `null`, compaction failed and the block is a no-op if round-tripped.
   final String? content;
 
+  /// Encrypted compaction payload for server-side context restoration.
+  final String? encryptedContent;
+
   /// Creates a [CompactionBlock].
-  const CompactionBlock({required this.content});
+  const CompactionBlock({required this.content, this.encryptedContent});
 
   /// Creates a [CompactionBlock] from JSON.
   factory CompactionBlock.fromJson(Map<String, dynamic> json) {
-    return CompactionBlock(content: json['content'] as String?);
+    return CompactionBlock(
+      content: json['content'] as String?,
+      encryptedContent: json['encrypted_content'] as String?,
+    );
   }
 
   @override
-  Map<String, dynamic> toJson() => {'type': 'compaction', 'content': content};
+  Map<String, dynamic> toJson() => {
+    'type': 'compaction',
+    'content': content,
+    if (encryptedContent != null) 'encrypted_content': encryptedContent,
+  };
 
   /// Creates a copy with replaced values.
-  CompactionBlock copyWith({Object? content = unsetCopyWithValue}) {
+  CompactionBlock copyWith({
+    Object? content = unsetCopyWithValue,
+    Object? encryptedContent = unsetCopyWithValue,
+  }) {
     return CompactionBlock(
       content: content == unsetCopyWithValue
           ? this.content
           : content as String?,
+      encryptedContent: encryptedContent == unsetCopyWithValue
+          ? this.encryptedContent
+          : encryptedContent as String?,
     );
   }
 
@@ -796,13 +812,15 @@ class CompactionBlock extends ContentBlock {
       identical(this, other) ||
       other is CompactionBlock &&
           runtimeType == other.runtimeType &&
-          content == other.content;
+          content == other.content &&
+          encryptedContent == other.encryptedContent;
 
   @override
-  int get hashCode => content.hashCode;
+  int get hashCode => Object.hash(content, encryptedContent);
 
   @override
-  String toString() => 'CompactionBlock(content: $content)';
+  String toString() =>
+      'CompactionBlock(content: $content, encryptedContent: $encryptedContent)';
 }
 
 /// Web search result content.

--- a/packages/anthropic_sdk_dart/lib/src/models/content/input_content_block.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/input_content_block.dart
@@ -1273,16 +1273,24 @@ class CompactionInputBlock extends InputContentBlock {
   /// When `null`, represents a failed compaction and is treated as a no-op.
   final String? content;
 
+  /// Encrypted compaction payload for server-side context restoration.
+  final String? encryptedContent;
+
   /// Cache control for this block.
   final CacheControlEphemeral? cacheControl;
 
   /// Creates a [CompactionInputBlock].
-  const CompactionInputBlock({required this.content, this.cacheControl});
+  const CompactionInputBlock({
+    required this.content,
+    this.encryptedContent,
+    this.cacheControl,
+  });
 
   /// Creates a [CompactionInputBlock] from JSON.
   factory CompactionInputBlock.fromJson(Map<String, dynamic> json) {
     return CompactionInputBlock(
       content: json['content'] as String?,
+      encryptedContent: json['encrypted_content'] as String?,
       cacheControl: json['cache_control'] != null
           ? CacheControlEphemeral.fromJson(
               json['cache_control'] as Map<String, dynamic>,
@@ -1295,18 +1303,23 @@ class CompactionInputBlock extends InputContentBlock {
   Map<String, dynamic> toJson() => {
     'type': 'compaction',
     'content': content,
+    if (encryptedContent != null) 'encrypted_content': encryptedContent,
     if (cacheControl != null) 'cache_control': cacheControl!.toJson(),
   };
 
   /// Creates a copy with replaced values.
   CompactionInputBlock copyWith({
     Object? content = unsetCopyWithValue,
+    Object? encryptedContent = unsetCopyWithValue,
     Object? cacheControl = unsetCopyWithValue,
   }) {
     return CompactionInputBlock(
       content: content == unsetCopyWithValue
           ? this.content
           : content as String?,
+      encryptedContent: encryptedContent == unsetCopyWithValue
+          ? this.encryptedContent
+          : encryptedContent as String?,
       cacheControl: cacheControl == unsetCopyWithValue
           ? this.cacheControl
           : cacheControl as CacheControlEphemeral?,
@@ -1319,14 +1332,16 @@ class CompactionInputBlock extends InputContentBlock {
       other is CompactionInputBlock &&
           runtimeType == other.runtimeType &&
           content == other.content &&
+          encryptedContent == other.encryptedContent &&
           cacheControl == other.cacheControl;
 
   @override
-  int get hashCode => Object.hash(content, cacheControl);
+  int get hashCode => Object.hash(content, encryptedContent, cacheControl);
 
   @override
   String toString() =>
-      'CompactionInputBlock(content: $content, cacheControl: $cacheControl)';
+      'CompactionInputBlock(content: $content, '
+      'encryptedContent: $encryptedContent, cacheControl: $cacheControl)';
 }
 
 /// Tool reference block in input.

--- a/packages/anthropic_sdk_dart/lib/src/models/content/input_content_block.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/input_content_block.dart
@@ -1341,7 +1341,8 @@ class CompactionInputBlock extends InputContentBlock {
   @override
   String toString() =>
       'CompactionInputBlock(content: $content, '
-      'encryptedContent: $encryptedContent, cacheControl: $cacheControl)';
+      'encryptedContent: ${encryptedContent == null ? 'null' : '[${encryptedContent!.length} chars]'}, '
+      'cacheControl: $cacheControl)';
 }
 
 /// Tool reference block in input.

--- a/packages/anthropic_sdk_dart/lib/src/models/messages/message_create_request.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/messages/message_create_request.dart
@@ -212,6 +212,9 @@ class MessageCreateRequest {
   /// in the request.
   final CacheControlEphemeral? cacheControl;
 
+  /// Optional identifier of the end-user profile this request belongs to.
+  final String? userProfileId;
+
   /// Creates a [MessageCreateRequest].
   const MessageCreateRequest({
     required this.model,
@@ -233,6 +236,7 @@ class MessageCreateRequest {
     this.container,
     this.speed,
     this.cacheControl,
+    this.userProfileId,
   });
 
   /// Creates a [MessageCreateRequest] from JSON.
@@ -279,6 +283,7 @@ class MessageCreateRequest {
               json['cache_control'] as Map<String, dynamic>,
             )
           : null,
+      userProfileId: json['user_profile_id'] as String?,
     );
   }
 
@@ -303,6 +308,7 @@ class MessageCreateRequest {
     if (container != null) 'container': container,
     if (speed != null) 'speed': speed!.toJson(),
     if (cacheControl != null) 'cache_control': cacheControl!.toJson(),
+    if (userProfileId != null) 'user_profile_id': userProfileId,
   };
 
   /// Creates a copy with replaced values.
@@ -326,6 +332,7 @@ class MessageCreateRequest {
     Object? container = unsetCopyWithValue,
     Object? speed = unsetCopyWithValue,
     Object? cacheControl = unsetCopyWithValue,
+    Object? userProfileId = unsetCopyWithValue,
   }) {
     return MessageCreateRequest(
       model: model ?? this.model,
@@ -371,6 +378,9 @@ class MessageCreateRequest {
       cacheControl: cacheControl == unsetCopyWithValue
           ? this.cacheControl
           : cacheControl as CacheControlEphemeral?,
+      userProfileId: userProfileId == unsetCopyWithValue
+          ? this.userProfileId
+          : userProfileId as String?,
     );
   }
 
@@ -397,7 +407,8 @@ class MessageCreateRequest {
           outputConfig == other.outputConfig &&
           container == other.container &&
           speed == other.speed &&
-          cacheControl == other.cacheControl;
+          cacheControl == other.cacheControl &&
+          userProfileId == other.userProfileId;
 
   @override
   int get hashCode => Object.hash(
@@ -420,6 +431,7 @@ class MessageCreateRequest {
     container,
     speed,
     cacheControl,
+    userProfileId,
   );
 
   @override
@@ -430,5 +442,6 @@ class MessageCreateRequest {
       'stream: $stream, temperature: $temperature, thinking: $thinking, '
       'toolChoice: $toolChoice, tools: $tools, topP: $topP, topK: $topK, '
       'inferenceGeo: $inferenceGeo, outputConfig: $outputConfig, '
-      'container: $container, speed: $speed, cacheControl: $cacheControl)';
+      'container: $container, speed: $speed, cacheControl: $cacheControl, '
+      'userProfileId: $userProfileId)';
 }

--- a/packages/anthropic_sdk_dart/lib/src/models/models/model_capabilities.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/models/model_capabilities.dart
@@ -215,8 +215,8 @@ class EffortCapability {
 
   /// Whether the model supports xhigh effort level.
   ///
-  /// Required by the spec; value may be `null` when the model does not
-  /// expose xhigh support.
+  /// `null` when the model does not expose xhigh support. The `xhigh` key is
+  /// always present in serialized JSON (matching the upstream Python/TS SDKs).
   final CapabilitySupport? xhigh;
 
   /// Whether this capability is supported by the model.
@@ -228,7 +228,7 @@ class EffortCapability {
     required this.low,
     required this.max,
     required this.medium,
-    required this.xhigh,
+    this.xhigh,
     required this.supported,
   });
 

--- a/packages/anthropic_sdk_dart/lib/src/models/models/model_capabilities.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/models/model_capabilities.dart
@@ -214,6 +214,9 @@ class EffortCapability {
   final CapabilitySupport medium;
 
   /// Whether the model supports xhigh effort level.
+  ///
+  /// Required by the spec; value may be `null` when the model does not
+  /// expose xhigh support.
   final CapabilitySupport? xhigh;
 
   /// Whether this capability is supported by the model.
@@ -225,7 +228,7 @@ class EffortCapability {
     required this.low,
     required this.max,
     required this.medium,
-    this.xhigh,
+    required this.xhigh,
     required this.supported,
   });
 
@@ -251,7 +254,7 @@ class EffortCapability {
     'low': low.toJson(),
     'max': max.toJson(),
     'medium': medium.toJson(),
-    if (xhigh != null) 'xhigh': xhigh!.toJson(),
+    'xhigh': xhigh?.toJson(),
     'supported': supported,
   };
 

--- a/packages/anthropic_sdk_dart/lib/src/models/models/model_capabilities.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/models/model_capabilities.dart
@@ -213,6 +213,9 @@ class EffortCapability {
   /// Whether the model supports medium effort level.
   final CapabilitySupport medium;
 
+  /// Whether the model supports xhigh effort level.
+  final CapabilitySupport? xhigh;
+
   /// Whether this capability is supported by the model.
   final bool supported;
 
@@ -222,6 +225,7 @@ class EffortCapability {
     required this.low,
     required this.max,
     required this.medium,
+    this.xhigh,
     required this.supported,
   });
 
@@ -234,6 +238,9 @@ class EffortCapability {
       medium: CapabilitySupport.fromJson(
         json['medium'] as Map<String, dynamic>,
       ),
+      xhigh: json['xhigh'] != null
+          ? CapabilitySupport.fromJson(json['xhigh'] as Map<String, dynamic>)
+          : null,
       supported: json['supported'] as bool,
     );
   }
@@ -244,6 +251,7 @@ class EffortCapability {
     'low': low.toJson(),
     'max': max.toJson(),
     'medium': medium.toJson(),
+    if (xhigh != null) 'xhigh': xhigh!.toJson(),
     'supported': supported,
   };
 
@@ -256,15 +264,16 @@ class EffortCapability {
           low == other.low &&
           max == other.max &&
           medium == other.medium &&
+          xhigh == other.xhigh &&
           supported == other.supported;
 
   @override
-  int get hashCode => Object.hash(high, low, max, medium, supported);
+  int get hashCode => Object.hash(high, low, max, medium, xhigh, supported);
 
   @override
   String toString() =>
       'EffortCapability(high: $high, low: $low, max: $max, '
-      'medium: $medium, supported: $supported)';
+      'medium: $medium, xhigh: $xhigh, supported: $supported)';
 }
 
 /// Model capability information.

--- a/packages/anthropic_sdk_dart/lib/src/models/streaming/content_block_delta.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/streaming/content_block_delta.dart
@@ -218,7 +218,8 @@ class CompactionDelta extends ContentBlockDelta {
 
   @override
   String toString() =>
-      'CompactionDelta(content: $content, encryptedContent: $encryptedContent)';
+      'CompactionDelta(content: $content, '
+      'encryptedContent: ${encryptedContent == null ? 'null' : '[${encryptedContent!.length} chars]'})';
 }
 
 /// Delta for signature content updates (extended thinking verification).

--- a/packages/anthropic_sdk_dart/lib/src/models/streaming/content_block_delta.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/streaming/content_block_delta.dart
@@ -27,10 +27,10 @@ sealed class ContentBlockDelta {
   factory ContentBlockDelta.citations(Citation citation) = CitationsDelta;
 
   /// Creates a compaction delta.
-  factory ContentBlockDelta.compaction(
-    String? content, {
-    String? encryptedContent,
-  }) = CompactionDelta;
+  ///
+  /// To include the encrypted compaction payload, construct [CompactionDelta]
+  /// directly.
+  factory ContentBlockDelta.compaction(String? content) = CompactionDelta;
 
   /// Creates a [ContentBlockDelta] from JSON.
   factory ContentBlockDelta.fromJson(Map<String, dynamic> json) {
@@ -189,7 +189,7 @@ class CompactionDelta extends ContentBlockDelta {
   Map<String, dynamic> toJson() => {
     'type': 'compaction_delta',
     'content': content,
-    if (encryptedContent != null) 'encrypted_content': encryptedContent,
+    'encrypted_content': encryptedContent,
   };
 
   /// Creates a copy with replaced values.

--- a/packages/anthropic_sdk_dart/lib/src/models/streaming/content_block_delta.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/streaming/content_block_delta.dart
@@ -27,7 +27,10 @@ sealed class ContentBlockDelta {
   factory ContentBlockDelta.citations(Citation citation) = CitationsDelta;
 
   /// Creates a compaction delta.
-  factory ContentBlockDelta.compaction(String? content) = CompactionDelta;
+  factory ContentBlockDelta.compaction(
+    String? content, {
+    String? encryptedContent,
+  }) = CompactionDelta;
 
   /// Creates a [ContentBlockDelta] from JSON.
   factory ContentBlockDelta.fromJson(Map<String, dynamic> json) {
@@ -168,24 +171,37 @@ class CompactionDelta extends ContentBlockDelta {
   /// The partial or final compaction summary content.
   final String? content;
 
+  /// Encrypted compaction payload for server-side context restoration.
+  final String? encryptedContent;
+
   /// Creates a [CompactionDelta].
-  const CompactionDelta(this.content);
+  const CompactionDelta(this.content, {this.encryptedContent});
 
   /// Creates a [CompactionDelta] from JSON.
   factory CompactionDelta.fromJson(Map<String, dynamic> json) {
-    return CompactionDelta(json['content'] as String?);
+    return CompactionDelta(
+      json['content'] as String?,
+      encryptedContent: json['encrypted_content'] as String?,
+    );
   }
 
   @override
   Map<String, dynamic> toJson() => {
     'type': 'compaction_delta',
     'content': content,
+    if (encryptedContent != null) 'encrypted_content': encryptedContent,
   };
 
   /// Creates a copy with replaced values.
-  CompactionDelta copyWith({Object? content = unsetCopyWithValue}) {
+  CompactionDelta copyWith({
+    Object? content = unsetCopyWithValue,
+    Object? encryptedContent = unsetCopyWithValue,
+  }) {
     return CompactionDelta(
       content == unsetCopyWithValue ? this.content : content as String?,
+      encryptedContent: encryptedContent == unsetCopyWithValue
+          ? this.encryptedContent
+          : encryptedContent as String?,
     );
   }
 
@@ -194,13 +210,15 @@ class CompactionDelta extends ContentBlockDelta {
       identical(this, other) ||
       other is CompactionDelta &&
           runtimeType == other.runtimeType &&
-          content == other.content;
+          content == other.content &&
+          encryptedContent == other.encryptedContent;
 
   @override
-  int get hashCode => content.hashCode;
+  int get hashCode => Object.hash(content, encryptedContent);
 
   @override
-  String toString() => 'CompactionDelta(content: $content)';
+  String toString() =>
+      'CompactionDelta(content: $content, encryptedContent: $encryptedContent)';
 }
 
 /// Delta for signature content updates (extended thinking verification).

--- a/packages/anthropic_sdk_dart/llms.txt
+++ b/packages/anthropic_sdk_dart/llms.txt
@@ -5,8 +5,8 @@
 ## Docs
 
 - [README](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/README.md) (~4.4k tokens): Primary package documentation with installation, configuration, and usage examples.
-- [CHANGELOG](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/CHANGELOG.md) (~6.9k tokens): Release history and version-by-version changes.
-- [MIGRATION](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/MIGRATION.md) (~4.1k tokens): Upgrade notes and breaking-change guidance.
+- [CHANGELOG](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/CHANGELOG.md) (~7.4k tokens): Release history and version-by-version changes.
+- [MIGRATION](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/MIGRATION.md) (~4.5k tokens): Upgrade notes and breaking-change guidance.
 
 ## Examples
 
@@ -33,4 +33,4 @@
 
 - [Package directory](https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/anthropic_sdk_dart): Source tree, pubspec, and package-local files.
 
-**Total: ~31.3k tokens**
+**Total: ~32.2k tokens**

--- a/packages/anthropic_sdk_dart/specs/openapi.yaml
+++ b/packages/anthropic_sdk_dart/specs/openapi.yaml
@@ -60,7 +60,8 @@
               "skills-2025-10-02",
               "fast-mode-2026-02-01",
               "output-300k-2026-03-24",
-              "advisor-tool-2026-03-01"
+              "advisor-tool-2026-03-01",
+              "user-profiles-2026-03-24"
             ],
             "type": "string",
             "x-stainless-nominal": false
@@ -1468,6 +1469,19 @@
             ],
             "title": "Content"
           },
+          "encrypted_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Opaque metadata from prior compaction, to be round-tripped verbatim",
+            "title": "Encrypted Content"
+          },
           "type": {
             "const": "compaction_delta",
             "default": "compaction_delta",
@@ -1477,6 +1491,7 @@
         },
         "required": [
           "content",
+          "encrypted_content",
           "type"
         ],
         "title": "CompactionContentBlockDelta",
@@ -2912,6 +2927,18 @@
             "title": "Top P",
             "type": "number",
             "x-stainless-deprecation-message": "Deprecated. Models released after Claude Opus 4.6 do not support setting top_p. A value >= 0.99 will be accepted for backwards compatibility, all other values will be rejected with a 400 error."
+          },
+          "user_profile_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The user profile ID to attribute this request to. Use when acting on behalf of a party other than your organization.",
+            "title": "User Profile Id"
           }
         },
         "required": [
@@ -3083,6 +3110,36 @@
         "title": "CreateSkillVersionResponse",
         "type": "object"
       },
+      "BetaCreateUserProfileRequest": {
+        "additionalProperties": false,
+        "example": {
+          "external_id": "user_12345",
+          "metadata": {}
+        },
+        "properties": {
+          "external_id": {
+            "description": "Platform's own identifier for this user. Not enforced unique. Maximum 255 characters.",
+            "examples": [
+              "user_12345"
+            ],
+            "maxLength": 255,
+            "minLength": 1,
+            "nullable": true,
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Free-form key-value data to attach to this user profile. Maximum 16 keys, with keys up to 64 characters and values up to 512 characters. Values must be non-empty strings.",
+            "examples": [
+              {}
+            ],
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
       "BetaDeleteMessageBatchResponse": {
         "properties": {
           "id": {
@@ -3195,6 +3252,17 @@
             "description": "Whether this capability is supported by the model.",
             "title": "Supported",
             "type": "boolean"
+          },
+          "xhigh": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BetaCapabilitySupport"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Whether the model supports xhigh effort level."
           }
         },
         "required": [
@@ -3202,7 +3270,8 @@
           "low",
           "max",
           "medium",
-          "supported"
+          "supported",
+          "xhigh"
         ],
         "title": "EffortCapability",
         "type": "object"
@@ -3213,10 +3282,55 @@
           "low",
           "medium",
           "high",
+          "xhigh",
           "max"
         ],
         "title": "EffortLevel",
         "type": "string"
+      },
+      "BetaEnrollmentUrl": {
+        "additionalProperties": false,
+        "example": {
+          "expires_at": "2026-03-15T10:15:00Z",
+          "type": "enrollment_url",
+          "url": "https://platform.claude.com/user-profiles/enrollment/M3J0bGJxZ2ppMnptbnB1"
+        },
+        "properties": {
+          "expires_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "When this enrollment URL expires, in RFC 3339 format.",
+            "examples": [
+              "2026-03-15T10:15:00Z"
+            ]
+          },
+          "type": {
+            "description": "Object type. Always `enrollment_url`.",
+            "enum": [
+              "enrollment_url"
+            ],
+            "examples": [
+              "enrollment_url"
+            ],
+            "type": "string"
+          },
+          "url": {
+            "description": "Enrollment URL to send to the end user. Valid until `expires_at`.",
+            "examples": [
+              "https://platform.claude.com/user-profiles/enrollment/M3J0bGJxZ2ppMnptbnB1"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "expires_at",
+          "type"
+        ],
+        "type": "object"
       },
       "BetaEnvironment": {
         "description": "Unified Environment resource for both cloud and BYOC environments.",
@@ -4607,6 +4721,65 @@
         "title": "ListSkillsResponse",
         "type": "object"
       },
+      "BetaListUserProfilesResponse": {
+        "additionalProperties": false,
+        "example": {
+          "data": [
+            {
+              "created_at": "2026-03-15T10:00:00Z",
+              "external_id": "user_12345",
+              "id": "uprof_011CZkZCu8hGbp5mYRQgUmz9",
+              "metadata": {},
+              "trust_grants": {
+                "cyber": {
+                  "status": "active"
+                }
+              },
+              "type": "user_profile",
+              "updated_at": "2026-03-15T10:00:00Z"
+            }
+          ],
+          "next_page": "page_MjAyNS0wNS0xNFQwMDowMDowMFo="
+        },
+        "properties": {
+          "data": {
+            "description": "User profiles on this page.",
+            "examples": [
+              [
+                {
+                  "created_at": "2026-03-15T10:00:00Z",
+                  "external_id": "user_12345",
+                  "id": "uprof_011CZkZCu8hGbp5mYRQgUmz9",
+                  "metadata": {},
+                  "trust_grants": {
+                    "cyber": {
+                      "status": "active"
+                    }
+                  },
+                  "type": "user_profile",
+                  "updated_at": "2026-03-15T10:00:00Z"
+                }
+              ]
+            ],
+            "items": {
+              "$ref": "#/components/schemas/BetaUserProfile"
+            },
+            "type": "array"
+          },
+          "next_page": {
+            "description": "Cursor for the next page, or `null` when there are no more results.",
+            "examples": [
+              "page_MjAyNS0wNS0xNFQwMDowMDowMFo="
+            ],
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "data"
+        ],
+        "type": "object"
+      },
       "BetaMCPToolConfig": {
         "additionalProperties": false,
         "description": "Configuration for a specific tool in an MCP toolset.",
@@ -4743,6 +4916,7 @@
         "additionalProperties": false,
         "description": "A Managed Agents `agent`.",
         "example": {
+          "archived_at": null,
           "created_at": "2026-03-15T10:00:00Z",
           "description": "A general-purpose starter agent.",
           "id": "agent_011CZkYpogX7uDKUyvBTophP",
@@ -4798,6 +4972,9 @@
               }
             ],
             "description": "When the agent was archived. Null if not archived.",
+            "examples": [
+              null
+            ],
             "nullable": true
           },
           "created_at": {
@@ -7816,7 +7993,7 @@
         "properties": {
           "client_id": {
             "description": "OAuth client ID.",
-            "maxLength": 255,
+            "maxLength": 1024,
             "minLength": 1,
             "type": "string"
           },
@@ -7835,7 +8012,7 @@
           },
           "scope": {
             "description": "OAuth scope for the refresh request.",
-            "maxLength": 2048,
+            "maxLength": 8192,
             "minLength": 1,
             "nullable": true,
             "type": "string"
@@ -7942,7 +8119,7 @@
           },
           "scope": {
             "description": "Updated OAuth scope for the refresh request.",
-            "maxLength": 2048,
+            "maxLength": 8192,
             "nullable": true,
             "type": "string"
           },
@@ -8007,6 +8184,11 @@
         "anyOf": [
           {
             "type": "string"
+          },
+          {
+            "const": "claude-opus-4-7",
+            "description": "Frontier intelligence for long-running agents and coding",
+            "x-stainless-nominal": false
           },
           {
             "const": "claude-opus-4-6",
@@ -8456,6 +8638,7 @@
             "type": "agent",
             "version": 1
           },
+          "archived_at": null,
           "created_at": "2026-03-15T10:00:00Z",
           "environment_id": "env_011CZkZ9X2dpNyB7HsEFoRfW",
           "id": "sesn_011CZkZAtmR3yMPDzynEDxu7",
@@ -8555,6 +8738,9 @@
               }
             ],
             "description": "When the session was archived. Null if not archived.",
+            "examples": [
+              null
+            ],
             "nullable": true
           },
           "created_at": {
@@ -8707,37 +8893,135 @@
       "BetaManagedAgentsSessionAgent": {
         "additionalProperties": false,
         "description": "Resolved `agent` definition for a `session`. Snapshot of the `agent` at `session` creation time.",
+        "example": {
+          "description": "A general-purpose starter agent.",
+          "id": "agent_011CZkYpogX7uDKUyvBTophP",
+          "mcp_servers": [
+            {
+              "name": "example-mcp",
+              "type": "url",
+              "url": "https://example-server.modelcontextprotocol.io/sse"
+            }
+          ],
+          "model": {
+            "id": "claude-sonnet-4-6",
+            "speed": "standard"
+          },
+          "name": "My First Agent",
+          "skills": [
+            {
+              "skill_id": "xlsx",
+              "type": "anthropic",
+              "version": "1"
+            },
+            {
+              "skill_id": "skill_011CZkZFNu9hAbo3jZPRgTlx",
+              "type": "custom",
+              "version": "2"
+            }
+          ],
+          "system": "You are a general-purpose agent that can research, write code, run commands, and use connected tools to complete the user's task end to end.",
+          "tools": [
+            {
+              "configs": [],
+              "default_config": {
+                "enabled": true,
+                "permission_policy": {
+                  "type": "always_ask"
+                }
+              },
+              "type": "agent_toolset_20260401"
+            }
+          ],
+          "type": "agent",
+          "version": 1
+        },
         "properties": {
           "description": {
+            "examples": [
+              "A general-purpose starter agent."
+            ],
             "nullable": true,
             "type": "string"
           },
           "id": {
+            "examples": [
+              "agent_011CZkYpogX7uDKUyvBTophP"
+            ],
             "type": "string"
           },
           "mcp_servers": {
+            "examples": [
+              [
+                {
+                  "name": "example-mcp",
+                  "type": "url",
+                  "url": "https://example-server.modelcontextprotocol.io/sse"
+                }
+              ]
+            ],
             "items": {
               "$ref": "#/components/schemas/BetaManagedAgentsMCPServer"
             },
             "type": "array"
           },
           "model": {
-            "$ref": "#/components/schemas/BetaManagedAgentsModelConfig"
+            "$ref": "#/components/schemas/BetaManagedAgentsModelConfig",
+            "examples": [
+              {
+                "id": "claude-sonnet-4-6",
+                "speed": "standard"
+              }
+            ]
           },
           "name": {
+            "examples": [
+              "My First Agent"
+            ],
             "type": "string"
           },
           "skills": {
+            "examples": [
+              [
+                {
+                  "skill_id": "xlsx",
+                  "type": "anthropic",
+                  "version": "1"
+                },
+                {
+                  "skill_id": "skill_011CZkZFNu9hAbo3jZPRgTlx",
+                  "type": "custom",
+                  "version": "2"
+                }
+              ]
+            ],
             "items": {
               "$ref": "#/components/schemas/BetaManagedAgentsSkill"
             },
             "type": "array"
           },
           "system": {
+            "examples": [
+              "You are a general-purpose agent that can research, write code, run commands, and use connected tools to complete the user's task end to end."
+            ],
             "nullable": true,
             "type": "string"
           },
           "tools": {
+            "examples": [
+              [
+                {
+                  "configs": [],
+                  "default_config": {
+                    "enabled": true,
+                    "permission_policy": {
+                      "type": "always_ask"
+                    }
+                  },
+                  "type": "agent_toolset_20260401"
+                }
+              ]
+            ],
             "items": {
               "$ref": "#/components/schemas/BetaManagedAgentsAgentTool"
             },
@@ -8747,9 +9031,15 @@
             "enum": [
               "agent"
             ],
+            "examples": [
+              "agent"
+            ],
             "type": "string"
           },
           "version": {
+            "examples": [
+              1
+            ],
             "format": "int32",
             "type": "integer"
           }
@@ -11800,6 +12090,17 @@
               }
             ],
             "description": "A schema to specify Claude's output format in responses. See [structured outputs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs)"
+          },
+          "task_budget": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BetaTokenTaskBudget"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Configuration for token budget tracking across contexts."
           }
         },
         "title": "OutputConfig",
@@ -12789,6 +13090,18 @@
             ],
             "description": "Summary of previously compacted content, or null if compaction failed",
             "title": "Content"
+          },
+          "encrypted_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Opaque metadata from prior compaction, to be round-tripped verbatim",
+            "title": "Encrypted Content"
           },
           "type": {
             "const": "compaction",
@@ -15101,6 +15414,19 @@
             "description": "Summary of compacted content, or null if compaction failed",
             "title": "Content"
           },
+          "encrypted_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Opaque metadata from prior compaction, to be round-tripped verbatim",
+            "title": "Encrypted Content"
+          },
           "type": {
             "const": "compaction",
             "default": "compaction",
@@ -15110,6 +15436,7 @@
         },
         "required": [
           "content",
+          "encrypted_content",
           "type"
         ],
         "title": "ResponseCompactionBlock",
@@ -17209,6 +17536,44 @@
         "format": "date-time",
         "type": "string"
       },
+      "BetaTokenTaskBudget": {
+        "additionalProperties": false,
+        "description": "User-configurable total token budget across contexts.",
+        "properties": {
+          "remaining": {
+            "anyOf": [
+              {
+                "minimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Remaining tokens in the budget. Use this to track usage across contexts when implementing compaction client-side. Defaults to total if not provided.",
+            "minimum": 0,
+            "title": "Remaining"
+          },
+          "total": {
+            "description": "Total token budget across all contexts in the session.",
+            "minimum": 1024,
+            "title": "Total",
+            "type": "integer"
+          },
+          "type": {
+            "const": "tokens",
+            "description": "The budget type. Currently only 'tokens' is supported.",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "total",
+          "type"
+        ],
+        "title": "TokenTaskBudget",
+        "type": "object"
+      },
       "BetaTool": {
         "additionalProperties": false,
         "properties": {
@@ -17681,6 +18046,32 @@
         "title": "UnrestrictedNetwork",
         "type": "object"
       },
+      "BetaUpdateUserProfileRequestBody": {
+        "additionalProperties": false,
+        "example": {
+          "external_id": "user_12345"
+        },
+        "properties": {
+          "external_id": {
+            "description": "If present, replaces the stored external_id. Omit to leave unchanged. Maximum 255 characters.",
+            "examples": [
+              "user_12345"
+            ],
+            "maxLength": 255,
+            "minLength": 1,
+            "nullable": true,
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Key-value pairs to merge into the stored metadata. Keys provided overwrite existing values. To remove a key, set its value to an empty string. Keys not provided are left unchanged. Maximum 16 keys, with keys up to 64 characters and values up to 512 characters.",
+            "type": "object"
+          }
+        },
+        "type": "object"
+      },
       "BetaUsage": {
         "properties": {
           "cache_creation": {
@@ -17910,6 +18301,136 @@
           "type"
         ],
         "title": "UserLocation",
+        "type": "object"
+      },
+      "BetaUserProfile": {
+        "additionalProperties": false,
+        "example": {
+          "created_at": "2026-03-15T10:00:00Z",
+          "external_id": "user_12345",
+          "id": "uprof_011CZkZCu8hGbp5mYRQgUmz9",
+          "metadata": {},
+          "trust_grants": {
+            "cyber": {
+              "status": "active"
+            }
+          },
+          "type": "user_profile",
+          "updated_at": "2026-03-15T10:00:00Z"
+        },
+        "properties": {
+          "created_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "When this user profile was created, in RFC 3339 format.",
+            "examples": [
+              "2026-03-15T10:00:00Z"
+            ]
+          },
+          "external_id": {
+            "description": "Platform's own identifier for this user. Not enforced unique.",
+            "examples": [
+              "user_12345"
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for this user profile, prefixed `uprof_`.",
+            "examples": [
+              "uprof_011CZkZCu8hGbp5mYRQgUmz9"
+            ],
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Arbitrary key-value metadata. Maximum 16 pairs, keys up to 64 chars, values up to 512 chars.",
+            "examples": [
+              {}
+            ],
+            "type": "object"
+          },
+          "trust_grants": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/BetaUserProfileTrustGrant"
+            },
+            "description": "Trust grants for this profile, keyed by grant name. Key omitted when no grant is active or in flight.",
+            "examples": [
+              {
+                "cyber": {
+                  "status": "active"
+                }
+              }
+            ],
+            "type": "object"
+          },
+          "type": {
+            "description": "Object type. Always `user_profile`.",
+            "enum": [
+              "user_profile"
+            ],
+            "examples": [
+              "user_profile"
+            ],
+            "type": "string"
+          },
+          "updated_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "When this user profile was last modified, in RFC 3339 format. Trust-grant status changes also bump this timestamp.",
+            "examples": [
+              "2026-03-15T10:00:00Z"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "trust_grants",
+          "created_at",
+          "metadata",
+          "updated_at"
+        ],
+        "type": "object"
+      },
+      "BetaUserProfileListOrder": {
+        "description": "ListOrder enum",
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "type": "string"
+      },
+      "BetaUserProfileTrustGrant": {
+        "additionalProperties": false,
+        "example": {
+          "status": "active"
+        },
+        "properties": {
+          "status": {
+            "description": "Status of the trust grant.",
+            "enum": [
+              "active",
+              "pending",
+              "rejected"
+            ],
+            "examples": [
+              "active"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
         "type": "object"
       },
       "BetaWebFetchToolResultErrorCode": {
@@ -20542,6 +21063,17 @@
             "description": "Whether this capability is supported by the model.",
             "title": "Supported",
             "type": "boolean"
+          },
+          "xhigh": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CapabilitySupport"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Whether the model supports xhigh effort level."
           }
         },
         "required": [
@@ -20549,7 +21081,8 @@
           "low",
           "max",
           "medium",
-          "supported"
+          "supported",
+          "xhigh"
         ],
         "title": "EffortCapability",
         "type": "object"
@@ -20560,6 +21093,7 @@
           "low",
           "medium",
           "high",
+          "xhigh",
           "max"
         ],
         "title": "EffortLevel",
@@ -22158,6 +22692,11 @@
         "anyOf": [
           {
             "type": "string"
+          },
+          {
+            "const": "claude-opus-4-7",
+            "description": "Frontier intelligence for long-running agents and coding",
+            "x-stainless-nominal": false
           },
           {
             "const": "claude-mythos-preview",
@@ -27981,7 +28520,7 @@
     }
   },
   "info": {
-    "title": "Anthropic API + advisor-tool"
+    "title": "Anthropic API + model-launch-april"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -37102,6 +37641,1086 @@
           }
         },
         "summary": "Create Skill"
+      }
+    },
+    "/v1/user_profiles/{user_profile_id}/enrollment_url?beta=true": {
+      "post": {
+        "operationId": "BetaCreateEnrollmentUrl",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Path parameter user_profile_id",
+            "example": "uprof_011CZkZCu8hGbp5mYRQgUmz9",
+            "in": "path",
+            "name": "user_profile_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaEnrollmentUrl"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "Create Enrollment URL"
+      }
+    },
+    "/v1/user_profiles/{user_profile_id}?beta=true": {
+      "get": {
+        "operationId": "BetaGetUserProfile",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Path parameter user_profile_id",
+            "example": "uprof_011CZkZCu8hGbp5mYRQgUmz9",
+            "in": "path",
+            "name": "user_profile_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaUserProfile"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "Get User Profile"
+      },
+      "post": {
+        "operationId": "BetaUpdateUserProfile",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Path parameter user_profile_id",
+            "example": "uprof_011CZkZCu8hGbp5mYRQgUmz9",
+            "in": "path",
+            "name": "user_profile_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaUpdateUserProfileRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaUserProfile"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "Update User Profile"
+      }
+    },
+    "/v1/user_profiles?beta=true": {
+      "get": {
+        "operationId": "BetaListUserProfiles",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Query parameter for limit",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Query parameter for page",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Query parameter for order",
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/BetaUserProfileListOrder"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaListUserProfilesResponse"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "List User Profiles"
+      },
+      "post": {
+        "operationId": "BetaCreateUserProfile",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaCreateUserProfileRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaUserProfile"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "Create User Profile"
       }
     },
     "/v1/vaults/{vault_id}/archive?beta=true": {

--- a/packages/anthropic_sdk_dart/specs/spec_metadata.json
+++ b/packages/anthropic_sdk_dart/specs/spec_metadata.json
@@ -2,9 +2,9 @@
   "specs": {
     "main": {
       "current_version": "unknown",
-      "last_fetched": "2026-04-16T07:18:58.355996Z",
-      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic%2Fanthropic-f4d4f18820ecfbe244fb1bbc2232939afca73dfcb21ce23bc296571ee7320e3a.yml",
-      "title": "Anthropic API + advisor-tool",
+      "last_fetched": "2026-04-16T20:34:31.482425Z",
+      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic%2Fanthropic-e0696f59ae07dc1a9c5a8fc87a4eb05eb35afabaac0b5ff0ea38810fa9dd4a74.yml",
+      "title": "Anthropic API + model-launch-april",
       "version_history": [
         {
           "fetched_at": "2026-03-20T12:00:00Z",

--- a/packages/anthropic_sdk_dart/test/integration/server_tools_integration_test.dart
+++ b/packages/anthropic_sdk_dart/test/integration/server_tools_integration_test.dart
@@ -121,7 +121,7 @@ void main() {
             maxTokens: 4096,
             tools: [
               ToolDefinition.builtIn(
-                const AdvisorTool(model: 'claude-opus-4-6'),
+                const AdvisorTool(model: 'claude-opus-4-7'),
               ),
             ],
             messages: [
@@ -194,7 +194,7 @@ void main() {
             maxTokens: 4096,
             tools: [
               ToolDefinition.builtIn(
-                const AdvisorTool(model: 'claude-opus-4-6'),
+                const AdvisorTool(model: 'claude-opus-4-7'),
               ),
             ],
             messages: [

--- a/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
@@ -418,6 +418,19 @@ void main() {
         expect(block, isA<CompactionBlock>());
         final compaction = block as CompactionBlock;
         expect(compaction.content, 'Conversation summary');
+        expect(compaction.encryptedContent, isNull);
+      });
+
+      test('round-trips compaction block with encrypted_content', () {
+        final json = {
+          'type': 'compaction',
+          'content': 'Conversation summary',
+          'encrypted_content': 'enc_payload_xyz',
+        };
+
+        final block = ContentBlock.fromJson(json) as CompactionBlock;
+        expect(block.encryptedContent, 'enc_payload_xyz');
+        expect(block.toJson(), json);
       });
     });
   });
@@ -576,10 +589,25 @@ void main() {
 
         expect(json['type'], 'compaction');
         expect(json['content'], 'Compacted summary');
+        expect(json.containsKey('encrypted_content'), isFalse);
 
         final parsed = InputContentBlock.fromJson(json);
         expect(parsed, isA<CompactionInputBlock>());
         expect((parsed as CompactionInputBlock).content, 'Compacted summary');
+        expect(parsed.encryptedContent, isNull);
+      });
+
+      test('round-trips compaction content with encrypted_content', () {
+        const block = CompactionInputBlock(
+          content: 'Compacted summary',
+          encryptedContent: 'enc_payload_abc',
+        );
+        final json = block.toJson();
+
+        expect(json['encrypted_content'], 'enc_payload_abc');
+
+        final parsed = InputContentBlock.fromJson(json) as CompactionInputBlock;
+        expect(parsed.encryptedContent, 'enc_payload_abc');
       });
     });
 

--- a/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
@@ -432,6 +432,14 @@ void main() {
         expect(block.encryptedContent, 'enc_payload_xyz');
         expect(block.toJson(), json);
       });
+
+      test('compaction block always serializes encrypted_content key', () {
+        const block = CompactionBlock(content: 'Summary');
+        final json = block.toJson();
+
+        expect(json.containsKey('encrypted_content'), isTrue);
+        expect(json['encrypted_content'], isNull);
+      });
     });
   });
 

--- a/packages/anthropic_sdk_dart/test/unit/models/message_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/message_test.dart
@@ -160,7 +160,7 @@ void main() {
         'id': 'msg_ctx',
         'type': 'message',
         'role': 'assistant',
-        'model': 'claude-opus-4-6-20260205',
+        'model': 'claude-opus-4-7',
         'content': [
           {'type': 'text', 'text': 'Response truncated by context window.'},
         ],

--- a/packages/anthropic_sdk_dart/test/unit/models/models_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/models_test.dart
@@ -68,6 +68,7 @@ void main() {
       expect(caps.effort.low.supported, isTrue);
       expect(caps.effort.max.supported, isTrue);
       expect(caps.effort.medium.supported, isTrue);
+      expect(caps.effort.xhigh, isNull);
       expect(caps.imageInput.supported, isTrue);
       expect(caps.pdfInput.supported, isTrue);
       expect(caps.structuredOutputs.supported, isTrue);
@@ -91,6 +92,32 @@ void main() {
 
       expect(a, equals(b));
       expect(a.hashCode, b.hashCode);
+    });
+
+    test('EffortCapability round-trips xhigh when present', () {
+      final json = fullCapabilitiesJson();
+      (json['effort'] as Map<String, dynamic>)['xhigh'] = {'supported': true};
+
+      final caps = ModelCapabilities.fromJson(json);
+      expect(caps.effort.xhigh?.supported, isTrue);
+
+      final roundTripped = ModelCapabilities.fromJson(caps.toJson());
+      expect(roundTripped.effort.xhigh?.supported, isTrue);
+    });
+
+    test('EffortCapability omits xhigh from JSON when null', () {
+      final json = fullCapabilitiesJson();
+      final caps = ModelCapabilities.fromJson(json);
+
+      final effortJson = caps.effort.toJson();
+      expect(effortJson.containsKey('xhigh'), isFalse);
+    });
+  });
+
+  group('EffortLevel', () {
+    test('xhigh round-trips', () {
+      expect(EffortLevel.fromJson('xhigh'), EffortLevel.xhigh);
+      expect(EffortLevel.xhigh.toJson(), 'xhigh');
     });
   });
 

--- a/packages/anthropic_sdk_dart/test/unit/models/models_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/models_test.dart
@@ -38,6 +38,7 @@ void main() {
         'low': {'supported': true},
         'max': {'supported': true},
         'medium': {'supported': true},
+        'xhigh': null,
         'supported': true,
       },
       'image_input': {'supported': true},
@@ -105,12 +106,13 @@ void main() {
       expect(roundTripped.effort.xhigh?.supported, isTrue);
     });
 
-    test('EffortCapability omits xhigh from JSON when null', () {
+    test('EffortCapability always serializes xhigh key (null when absent)', () {
       final json = fullCapabilitiesJson();
       final caps = ModelCapabilities.fromJson(json);
 
       final effortJson = caps.effort.toJson();
-      expect(effortJson.containsKey('xhigh'), isFalse);
+      expect(effortJson.containsKey('xhigh'), isTrue);
+      expect(effortJson['xhigh'], isNull);
     });
   });
 

--- a/packages/anthropic_sdk_dart/test/unit/models/streaming_events_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/streaming_events_test.dart
@@ -338,6 +338,20 @@ void main() {
 
       expect(delta, isA<CompactionDelta>());
       expect((delta as CompactionDelta).content, 'Compacted context summary');
+      expect(delta.encryptedContent, isNull);
+    });
+
+    test('compaction_delta round-trips encrypted_content', () {
+      final json = {
+        'type': 'compaction_delta',
+        'content': 'Compacted context summary',
+        'encrypted_content': 'enc_delta_payload',
+      };
+
+      final delta = ContentBlockDelta.fromJson(json) as CompactionDelta;
+
+      expect(delta.encryptedContent, 'enc_delta_payload');
+      expect(delta.toJson(), json);
     });
   });
 

--- a/packages/anthropic_sdk_dart/test/unit/models/streaming_events_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/streaming_events_test.dart
@@ -353,6 +353,14 @@ void main() {
       expect(delta.encryptedContent, 'enc_delta_payload');
       expect(delta.toJson(), json);
     });
+
+    test('compaction_delta always serializes encrypted_content key', () {
+      const delta = CompactionDelta('Partial summary');
+      final json = delta.toJson();
+
+      expect(json.containsKey('encrypted_content'), isTrue);
+      expect(json['encrypted_content'], isNull);
+    });
   });
 
   group('Citations delta', () {

--- a/packages/anthropic_sdk_dart/test/unit/models/token_task_budget_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/token_task_budget_test.dart
@@ -1,0 +1,78 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TokenTaskBudget', () {
+    test('round-trips with remaining', () {
+      const budget = TokenTaskBudget(total: 32768, remaining: 16000);
+      final json = budget.toJson();
+
+      expect(json, {'type': 'tokens', 'total': 32768, 'remaining': 16000});
+
+      final parsed = TokenTaskBudget.fromJson(json);
+      expect(parsed, equals(budget));
+    });
+
+    test('omits remaining when null', () {
+      const budget = TokenTaskBudget(total: 32768);
+      final json = budget.toJson();
+
+      expect(json.containsKey('remaining'), isFalse);
+
+      final parsed = TokenTaskBudget.fromJson(json);
+      expect(parsed.total, 32768);
+      expect(parsed.remaining, isNull);
+    });
+
+    test('copyWith clears remaining', () {
+      const budget = TokenTaskBudget(total: 32768, remaining: 1000);
+      final cleared = budget.copyWith(remaining: null);
+
+      expect(cleared.remaining, isNull);
+      expect(cleared.total, 32768);
+    });
+  });
+
+  group('OutputConfig', () {
+    test('round-trips task_budget', () {
+      const config = OutputConfig(
+        effort: EffortLevel.xhigh,
+        taskBudget: TokenTaskBudget(total: 8192),
+      );
+      final json = config.toJson();
+
+      expect(json['effort'], 'xhigh');
+      expect(json['task_budget'], {'type': 'tokens', 'total': 8192});
+
+      final parsed = OutputConfig.fromJson(json);
+      expect(parsed, equals(config));
+    });
+  });
+
+  group('MessageCreateRequest.userProfileId', () {
+    test('serializes user_profile_id when set', () {
+      final request = MessageCreateRequest(
+        model: 'claude-opus-4-7',
+        messages: [InputMessage.user('hi')],
+        maxTokens: 16,
+        userProfileId: 'uprof_abc123',
+      );
+
+      final json = request.toJson();
+      expect(json['user_profile_id'], 'uprof_abc123');
+
+      final parsed = MessageCreateRequest.fromJson(json);
+      expect(parsed.userProfileId, 'uprof_abc123');
+    });
+
+    test('omits user_profile_id when null', () {
+      final request = MessageCreateRequest(
+        model: 'claude-opus-4-7',
+        messages: [InputMessage.user('hi')],
+        maxTokens: 16,
+      );
+
+      expect(request.toJson().containsKey('user_profile_id'), isFalse);
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/tools/advisor_tool_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/tools/advisor_tool_test.dart
@@ -4,12 +4,12 @@ import 'package:test/test.dart';
 void main() {
   group('AdvisorTool', () {
     test('toJson with minimal fields', () {
-      const tool = AdvisorTool(model: 'claude-opus-4-6');
+      const tool = AdvisorTool(model: 'claude-opus-4-7');
       final json = tool.toJson();
 
       expect(json['type'], 'advisor_20260301');
       expect(json['name'], 'advisor');
-      expect(json['model'], 'claude-opus-4-6');
+      expect(json['model'], 'claude-opus-4-7');
       expect(json.containsKey('max_uses'), isFalse);
       expect(json.containsKey('caching'), isFalse);
       expect(json.containsKey('cache_control'), isFalse);
@@ -17,7 +17,7 @@ void main() {
 
     test('toJson with all fields', () {
       const tool = AdvisorTool(
-        model: 'claude-opus-4-6',
+        model: 'claude-opus-4-7',
         maxUses: 3,
         caching: CacheControlEphemeral(ttl: CacheTtl.ttl5m),
         cacheControl: CacheControlEphemeral(ttl: CacheTtl.ttl1h),
@@ -26,7 +26,7 @@ void main() {
 
       expect(json['type'], 'advisor_20260301');
       expect(json['name'], 'advisor');
-      expect(json['model'], 'claude-opus-4-6');
+      expect(json['model'], 'claude-opus-4-7');
       expect(json['max_uses'], 3);
       expect(json['caching'], {'type': 'ephemeral', 'ttl': '5m'});
       expect(json['cache_control'], {'type': 'ephemeral', 'ttl': '1h'});
@@ -36,12 +36,12 @@ void main() {
       final json = {
         'type': 'advisor_20260301',
         'name': 'advisor',
-        'model': 'claude-opus-4-6',
+        'model': 'claude-opus-4-7',
       };
       final tool = AdvisorTool.fromJson(json);
 
       expect(tool.type, 'advisor_20260301');
-      expect(tool.model, 'claude-opus-4-6');
+      expect(tool.model, 'claude-opus-4-7');
       expect(tool.maxUses, isNull);
       expect(tool.caching, isNull);
       expect(tool.cacheControl, isNull);
@@ -49,7 +49,7 @@ void main() {
       expect(tool.toJson(), {
         'type': 'advisor_20260301',
         'name': 'advisor',
-        'model': 'claude-opus-4-6',
+        'model': 'claude-opus-4-7',
       });
     });
 
@@ -57,7 +57,7 @@ void main() {
       final json = {
         'type': 'advisor_20260301',
         'name': 'advisor',
-        'model': 'claude-opus-4-6',
+        'model': 'claude-opus-4-7',
         'max_uses': 5,
         'caching': {'type': 'ephemeral', 'ttl': '1h'},
         'cache_control': {'type': 'ephemeral', 'ttl': '5m'},
@@ -77,36 +77,36 @@ void main() {
       final json = {
         'type': 'advisor_20260301',
         'name': 'advisor',
-        'model': 'claude-opus-4-6',
+        'model': 'claude-opus-4-7',
       };
       final tool = BuiltInTool.fromJson(json);
 
       expect(tool, isA<AdvisorTool>());
-      expect((tool as AdvisorTool).model, 'claude-opus-4-6');
+      expect((tool as AdvisorTool).model, 'claude-opus-4-7');
     });
 
     test('BuiltInTool.advisor factory', () {
-      final tool = BuiltInTool.advisor(model: 'claude-opus-4-6', maxUses: 2);
+      final tool = BuiltInTool.advisor(model: 'claude-opus-4-7', maxUses: 2);
 
       expect(tool, isA<AdvisorTool>());
-      expect((tool as AdvisorTool).model, 'claude-opus-4-6');
+      expect((tool as AdvisorTool).model, 'claude-opus-4-7');
       expect(tool.maxUses, 2);
     });
 
     test('ToolDefinition.builtIn wraps AdvisorTool', () {
-      const advisorTool = AdvisorTool(model: 'claude-opus-4-6');
+      const advisorTool = AdvisorTool(model: 'claude-opus-4-7');
       final toolDef = ToolDefinition.builtIn(advisorTool);
       final json = toolDef.toJson();
 
       expect(json['type'], 'advisor_20260301');
       expect(json['name'], 'advisor');
-      expect(json['model'], 'claude-opus-4-6');
+      expect(json['model'], 'claude-opus-4-7');
     });
 
     test('equality', () {
-      const a = AdvisorTool(model: 'claude-opus-4-6');
-      const b = AdvisorTool(model: 'claude-opus-4-6');
-      const c = AdvisorTool(model: 'claude-opus-4-6', maxUses: 3);
+      const a = AdvisorTool(model: 'claude-opus-4-7');
+      const b = AdvisorTool(model: 'claude-opus-4-7');
+      const c = AdvisorTool(model: 'claude-opus-4-7', maxUses: 3);
 
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));
@@ -114,10 +114,10 @@ void main() {
     });
 
     test('copyWith', () {
-      const original = AdvisorTool(model: 'claude-opus-4-6');
+      const original = AdvisorTool(model: 'claude-opus-4-7');
 
       final withMaxUses = original.copyWith(maxUses: 5);
-      expect(withMaxUses.model, 'claude-opus-4-6');
+      expect(withMaxUses.model, 'claude-opus-4-7');
       expect(withMaxUses.maxUses, 5);
 
       final withCaching = original.copyWith(
@@ -133,23 +133,23 @@ void main() {
     });
 
     test('toString', () {
-      const tool = AdvisorTool(model: 'claude-opus-4-6');
+      const tool = AdvisorTool(model: 'claude-opus-4-7');
       expect(tool.toString(), contains('AdvisorTool'));
-      expect(tool.toString(), contains('claude-opus-4-6'));
+      expect(tool.toString(), contains('claude-opus-4-7'));
     });
 
     test('ToolDefinition.fromJson routes advisor tool correctly', () {
       final json = {
         'type': 'advisor_20260301',
         'name': 'advisor',
-        'model': 'claude-opus-4-6',
+        'model': 'claude-opus-4-7',
       };
       final toolDef = ToolDefinition.fromJson(json);
 
       expect(toolDef, isA<BuiltInToolDefinition>());
       final builtIn = (toolDef as BuiltInToolDefinition).tool;
       expect(builtIn, isA<AdvisorTool>());
-      expect((builtIn as AdvisorTool).model, 'claude-opus-4-6');
+      expect((builtIn as AdvisorTool).model, 'claude-opus-4-7');
     });
   });
 }

--- a/packages/anthropic_sdk_dart/test/unit/models/usage_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/usage_test.dart
@@ -22,7 +22,7 @@ void main() {
     test('fromJson parses advisor_message iteration with model', () {
       final json = {
         'type': 'advisor_message',
-        'model': 'claude-opus-4-6',
+        'model': 'claude-opus-4-7',
         'input_tokens': 823,
         'output_tokens': 1612,
         'cache_creation_input_tokens': 0,
@@ -31,7 +31,7 @@ void main() {
       final usage = IterationUsage.fromJson(json);
 
       expect(usage.type, 'advisor_message');
-      expect(usage.model, 'claude-opus-4-6');
+      expect(usage.model, 'claude-opus-4-7');
       expect(usage.inputTokens, 823);
       expect(usage.outputTokens, 1612);
     });
@@ -41,12 +41,12 @@ void main() {
         type: 'advisor_message',
         inputTokens: 100,
         outputTokens: 200,
-        model: 'claude-opus-4-6',
+        model: 'claude-opus-4-7',
       );
       final json = usage.toJson();
 
       expect(json['type'], 'advisor_message');
-      expect(json['model'], 'claude-opus-4-6');
+      expect(json['model'], 'claude-opus-4-7');
     });
 
     test('toJson omits model when null', () {
@@ -63,7 +63,7 @@ void main() {
     test('round-trip advisor_message iteration', () {
       final original = {
         'type': 'advisor_message',
-        'model': 'claude-opus-4-6',
+        'model': 'claude-opus-4-7',
         'input_tokens': 823,
         'output_tokens': 1612,
         'cache_creation_input_tokens': 0,
@@ -78,13 +78,13 @@ void main() {
         type: 'advisor_message',
         inputTokens: 100,
         outputTokens: 200,
-        model: 'claude-opus-4-6',
+        model: 'claude-opus-4-7',
       );
       const b = IterationUsage(
         type: 'advisor_message',
         inputTokens: 100,
         outputTokens: 200,
-        model: 'claude-opus-4-6',
+        model: 'claude-opus-4-7',
       );
       const c = IterationUsage(
         type: 'advisor_message',
@@ -103,7 +103,7 @@ void main() {
         type: 'advisor_message',
         inputTokens: 100,
         outputTokens: 200,
-        model: 'claude-opus-4-6',
+        model: 'claude-opus-4-7',
       );
 
       final changed = original.copyWith(model: 'claude-sonnet-4-6');
@@ -129,7 +129,7 @@ void main() {
           },
           {
             'type': 'advisor_message',
-            'model': 'claude-opus-4-6',
+            'model': 'claude-opus-4-7',
             'input_tokens': 823,
             'output_tokens': 1612,
             'cache_creation_input_tokens': 0,
@@ -153,7 +153,7 @@ void main() {
       expect(usage.iterations![0].model, isNull);
 
       expect(usage.iterations![1].type, 'advisor_message');
-      expect(usage.iterations![1].model, 'claude-opus-4-6');
+      expect(usage.iterations![1].model, 'claude-opus-4-7');
       expect(usage.iterations![1].inputTokens, 823);
 
       expect(usage.iterations![2].type, 'message');


### PR DESCRIPTION
## Summary
- Adds support for the newly released **Claude Opus 4.7** (`claude-opus-4-7`) and refreshes the package to the latest Anthropic OpenAPI spec (`model-launch-april`, hash `e0696f5`).
- Adds `encrypted_content` to all three compaction block shapes (streaming delta, request, response) so managed-agents compaction can round-trip server-side context.
- Extends `EffortLevel`/`EffortCapability` with the new `xhigh` value and introduces `TokenTaskBudget` + `OutputConfig.taskBudget` for client-side compaction budgets.
- Adds optional `MessageCreateRequest.userProfileId` for end-user profile routing.

## Details

### Model support
The spec now lists `claude-opus-4-7` alongside `claude-opus-4-6`. Example code (`example/advisor_example.dart`) and test fixtures across `test/unit/` and `test/integration/` have been migrated from `claude-opus-4-6` to `claude-opus-4-7`. The dated fixture `claude-opus-4-6-20260205` was rewritten to the undated alias `claude-opus-4-7` because the spec does not yet publish a release date for 4.7. `claude-sonnet-4-6` usages in the README were left as-is (still current).

### Compaction `encrypted_content`
`CompactionBlock`, `CompactionInputBlock`, and `CompactionDelta` gain an optional `String? encryptedContent` field wired through `fromJson`/`toJson`/`copyWith`/`==`/`hashCode`/`toString`. `CompactionBlock` and `CompactionDelta` always serialize the `encrypted_content` key (spec marks it required-nullable); `CompactionInputBlock` omits it when null (spec marks it optional on request). Round-trip unit tests cover both presence and absence of the field. In `toString()`, the payload is redacted as `[N chars]` to avoid leaking opaque encrypted data into logs.

### Effort levels
```dart
// New xhigh tier sits between high and max.
enum EffortLevel { low, medium, high, xhigh, max }
```

`EffortCapability.xhigh` is typed `CapabilitySupport | null` to match the spec's `anyOf [CapabilitySupport, null]`. It's an optional constructor parameter (defaulting to `null`) — matching the reference Python SDK (`Optional[CapabilitySupport] = None`) — and the `xhigh` key is always present in serialized JSON, mirroring both the Python and TypeScript SDKs.

### Token-based task budget
```dart
const config = OutputConfig(
  effort: EffortLevel.xhigh,
  taskBudget: TokenTaskBudget(total: 32768, remaining: 16000),
);
```

`TokenTaskBudget.remaining` is `null` when unset; the default-to-total behavior is applied server-side, not by the client (matching the Python SDK).

### User profile routing
```dart
final request = MessageCreateRequest(
  model: 'claude-opus-4-7',
  messages: [InputMessage.user('hello')],
  maxTokens: 1024,
  userProfileId: 'uprof_abc123',
);
```

### Deferred: User Profiles beta endpoints
The spec also adds 5 new `/v1/user_profiles` beta endpoints and their supporting types (BetaUserProfile, BetaEnrollmentUrl, etc.). These are deferred to a dedicated follow-up PR to keep this review focused. The verify toolkit reports this as the only new coverage gap; all other pre-existing gaps (`CacheCreationUsage`, `Session.title`, `SpanModelRequestEndEvent.is_error`) are unchanged on `main`.

## References
- [Introducing Claude Opus 4.7](https://www.anthropic.com/news/claude-opus-4-7) — Anthropic's launch announcement for the new Opus model that motivated this refresh.
- [Best practices for using Claude Opus 4.7 with Claude Code](https://claude.com/blog/best-practices-for-using-claude-opus-4-7-with-claude-code) — guidance on getting the most out of Opus 4.7 in agentic coding workflows.

## Test Plan
- [x] `dart analyze --fatal-infos` clean
- [x] `dart format --set-exit-if-changed .` clean
- [x] `dart test --reporter=failures-only test/unit/` — 652 tests pass (4 skipped due to local `ANTHROPIC_API_KEY` env var)
- [x] Toolkit verify reports no new errors vs. `main` (only the expected deferred-`user_profiles` coverage gap)
- [x] Round-trip unit tests added for every new/changed field (`TokenTaskBudget`, `OutputConfig.taskBudget`, `CreateMessageParams.userProfileId`, `EffortLevel.xhigh`, `EffortCapability.xhigh`, and `encryptedContent` on all three compaction block shapes)
- [ ] Integration tests not run in this PR (require live API + spend); Opus 4.7 end-to-end validation deferred
