### PR TITLE
feat(openai_dart): add none, minimal, xhigh to ReasoningEffort enum

### DIFF
--- a/packages/openai_dart/lib/src/models/responses/config/reasoning_effort.dart
+++ b/packages/openai_dart/lib/src/models/responses/config/reasoning_effort.dart
@@ -1,19 +1,19 @@
 /// Reasoning effort level for reasoning models.
 ///
-/// Constrains effort on reasoning for reasoning models. Reducing reasoning effort
-/// can result in faster responses and fewer tokens used on reasoning in a response.
+/// Constrains effort on reasoning for reasoning models. Reducing reasoning
+/// effort can result in faster responses and fewer tokens used on reasoning
+/// in a response.
+///
+/// Supported values: [none], [minimal], [low], [medium], [high], [xhigh].
 ///
 /// **Model-Specific Support:**
 ///
-/// - **gpt-5.1**: Defaults to [none] (no reasoning). Supported values: [none],
-///   [low], [medium], [high]. Tool calls supported for all reasoning values.
-///
-/// - **gpt-5-pro**: Defaults to and only supports [high] reasoning effort.
-///
-/// - **Models before gpt-5.1**: Default to [medium] reasoning effort and do not
-///   support [none].
-///
-/// - **Models after gpt-5.1-codex-max**: Support all values including [xhigh].
+/// - **gpt-5.1**: Defaults to [none] (no reasoning). Supported values are
+///   [none], [low], [medium], and [high]. Tool calls are supported for all
+///   reasoning values.
+/// - **Models before gpt-5.1**: Default to [medium] and do not support [none].
+/// - **gpt-5-pro**: Defaults to and only supports [high].
+/// - **[xhigh]**: Supported for all models after gpt-5.1-codex-max.
 enum ReasoningEffort {
   /// Unknown effort level (fallback for unrecognized values).
   unknown('unknown'),

--- a/packages/openai_dart/lib/src/models/responses/config/reasoning_effort.dart
+++ b/packages/openai_dart/lib/src/models/responses/config/reasoning_effort.dart
@@ -1,16 +1,40 @@
 /// Reasoning effort level for reasoning models.
+///
+/// Constrains effort on reasoning for reasoning models. Reducing reasoning effort
+/// can result in faster responses and fewer tokens used on reasoning in a response.
+///
+/// **Model-Specific Support:**
+///
+/// - **gpt-5.1**: Defaults to [none] (no reasoning). Supported values: [none],
+///   [low], [medium], [high]. Tool calls supported for all reasoning values.
+///
+/// - **gpt-5-pro**: Defaults to and only supports [high] reasoning effort.
+///
+/// - **Models before gpt-5.1**: Default to [medium] reasoning effort and do not
+///   support [none].
+///
+/// - **Models after gpt-5.1-codex-max**: Support all values including [xhigh].
 enum ReasoningEffort {
   /// Unknown effort level (fallback for unrecognized values).
   unknown('unknown'),
 
+  /// No reasoning effort. Only supported by gpt-5.1 and later models.
+  none('none'),
+
+  /// Minimal reasoning effort.
+  minimal('minimal'),
+
   /// Low reasoning effort.
   low('low'),
 
-  /// Medium reasoning effort.
+  /// Medium reasoning effort. Default for models before gpt-5.1.
   medium('medium'),
 
-  /// High reasoning effort.
-  high('high');
+  /// High reasoning effort. Only supported value for gpt-5-pro.
+  high('high'),
+
+  /// Extra-high reasoning effort. Supported for models after gpt-5.1-codex-max.
+  xhigh('xhigh');
 
   /// The JSON value for this effort level.
   final String value;

--- a/packages/openai_dart/test/unit/models/chat_completion_test.dart
+++ b/packages/openai_dart/test/unit/models/chat_completion_test.dart
@@ -748,6 +748,33 @@ void main() {
     });
   });
 
+  group('ReasoningEffort', () {
+    test('has correct values matching spec', () {
+      expect(ReasoningEffort.none.toJson(), 'none');
+      expect(ReasoningEffort.minimal.toJson(), 'minimal');
+      expect(ReasoningEffort.low.toJson(), 'low');
+      expect(ReasoningEffort.medium.toJson(), 'medium');
+      expect(ReasoningEffort.high.toJson(), 'high');
+      expect(ReasoningEffort.xhigh.toJson(), 'xhigh');
+    });
+
+    test('fromJson parses all valid values', () {
+      expect(ReasoningEffort.fromJson('none'), ReasoningEffort.none);
+      expect(ReasoningEffort.fromJson('minimal'), ReasoningEffort.minimal);
+      expect(ReasoningEffort.fromJson('low'), ReasoningEffort.low);
+      expect(ReasoningEffort.fromJson('medium'), ReasoningEffort.medium);
+      expect(ReasoningEffort.fromJson('high'), ReasoningEffort.high);
+      expect(ReasoningEffort.fromJson('xhigh'), ReasoningEffort.xhigh);
+    });
+
+    test('fromJson returns unknown for unrecognized values', () {
+      expect(
+        ReasoningEffort.fromJson('something_else'),
+        ReasoningEffort.unknown,
+      );
+    });
+  });
+
   // OpenAI-Compatible APIs Tests
   group('OpenAI-Compatible APIs', () {
     group('ChatCompletion nullable fields', () {


### PR DESCRIPTION
## Summary

- Add `none`, `minimal`, and `xhigh` to `ReasoningEffort` to match the latest OpenAI spec, which expands per-model reasoning support (notably `gpt-5.1`, `gpt-5-pro`, and models after `gpt-5.1-codex-max`).
- Document the per-model support matrix on the enum doc comment so callers know which values are valid for which models.
- Add a `ReasoningEffort` test group covering `toJson`, `fromJson` round-trips for every spec value, and the `unknown` fallback for forward compatibility.

## Details

The spec enum is now `[none, minimal, low, medium, high, xhigh]`. Per the upstream description:

- `gpt-5.1` defaults to `none`; supported values are `none`, `low`, `medium`, and `high` (tool calls supported for all reasoning values).
- Models before `gpt-5.1` default to `medium` and do not support `none`.
- `gpt-5-pro` defaults to and only supports `high`.
- `xhigh` is supported for all models after `gpt-5.1-codex-max`.

`ReasoningEffort.fromJson` continues to fall back to `ReasoningEffort.unknown` for any string not in the enum, so unknown upstream values remain safe to parse on clients that aren't yet updated.

## References

- [OpenAI API reference — `reasoning_effort`](https://developers.openai.com/api/reference/resources/$shared#(resource)%20%24shared%20%3E%20(model)%20reasoning_effort%20%3E%20(schema))

## Test Plan

- [x] `dart format --set-exit-if-changed .` clean
- [x] `dart analyze --fatal-infos` clean
- [x] `dart test test/unit/` passes (1177 tests)
- [x] New `ReasoningEffort` test group covers all variants and the `unknown` fallback
- [x] `api_toolkit.py verify --checks all --scope all` reports 0 errors / 0 failing checks

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
