### PR TITLE
feat(openai_dart): support GPT Image 2 (gpt-image-2)

### DIFF
--- a/packages/openai_dart/README.md
+++ b/packages/openai_dart/README.md
@@ -49,6 +49,15 @@ Dart client for the **[OpenAI API](https://platform.openai.com/docs/api-referenc
 
 See [API Coverage](#api-coverage) for the full coverage table.
 
+## Why choose this client?
+
+- Pure Dart with no Flutter dependency — works in mobile apps, backends, and CLIs.
+- Type-safe request and response models with minimal dependencies (`http`, `logging`, `meta`).
+- Streaming, retries, interceptors, and error handling built into the client.
+- Covers the full OpenAI API surface, including Responses, Realtime, and legacy Assistants.
+- Resource-based API design matching official SDKs.
+- Strict [semver](https://semver.org/) versioning so downstream packages can depend on stable, predictable version ranges.
+
 ## Quickstart
 
 ```yaml
@@ -92,15 +101,6 @@ import 'package:openai_dart/openai_dart_assistants.dart' as assistants;
 // Realtime API — WebSocket and WebRTC sessions
 import 'package:openai_dart/openai_dart_realtime.dart' as realtime;
 ```
-
-## Why choose this client?
-
-- Pure Dart with no Flutter dependency — works in mobile apps, backends, and CLIs.
-- Type-safe request and response models with minimal dependencies (`http`, `logging`, `meta`).
-- Streaming, retries, interceptors, and error handling built into the client.
-- Covers the full OpenAI API surface, including Responses, Realtime, and legacy Assistants.
-- Resource-based API design matching official SDKs.
-- Strict [semver](https://semver.org/) versioning so downstream packages can depend on stable, predictable version ranges.
 
 ## Configuration
 
@@ -351,24 +351,40 @@ print('Embedding dimensions: ${vector.length}');
 
 </details>
 
-### How do I generate images?
+### How do I generate images with GPT Image 2?
 
 <details>
 <summary><b>Show example</b></summary>
 
-Use `client.images.generate(...)` to create images from text prompts. Configure size, quality, and other options as needed.
+Use `client.images.generate(...)` with `ImageModels.gptImage2` to create images.
+GPT Image 2 brings:
+
+- **Flexible image sizes** — `1024x1024`, `1536x1024`, `1024x1536`, plus `auto`
+- **High-fidelity inputs** — see `client.images.edit(...)` with `ImageInputFidelity.high`
+- **Token-based pricing** — exposed via `response.usage` (total / input / output tokens, plus per-modality breakdowns)
+- **Batch API with 50% discount** — submit jobs via `client.batches` with `BatchEndpoint.imagesGenerations` / `BatchEndpoint.imagesEdits`
 
 ```dart
+import 'dart:convert';
+import 'dart:io';
+import 'package:openai_dart/openai_dart.dart';
+
 final response = await client.images.generate(
-  ImageGenerationRequest(
-    model: 'gpt-image-1.5',
+  const ImageGenerationRequest(
+    model: ImageModels.gptImage2,
     prompt: 'A white cat wearing a top hat',
-    size: ImageSize.size1024x1024,
-    quality: ImageQuality.hd,
+    size: ImageSize.size1536x1024,
+    quality: ImageQuality.high,
+    background: ImageBackground.transparent,
+    outputFormat: ImageOutputFormat.webp,
   ),
 );
 
-print('Image URL: ${response.data.first.url}');
+// GPT Image 2 always returns base64 — decode and save.
+final bytes = base64Decode(response.data.first.b64Json!);
+File('cat.webp').writeAsBytesSync(bytes);
+
+print('Tokens used: ${response.usage?.totalTokens}');
 ```
 
 → [Full example](example/images_example.dart)

--- a/packages/openai_dart/example/images_example.dart
+++ b/packages/openai_dart/example/images_example.dart
@@ -1,8 +1,11 @@
 // ignore_for_file: avoid_print
-/// Example demonstrating GPT Image generation.
+/// Example demonstrating GPT Image 2 generation and editing.
 ///
 /// Run with: dart run example/images_example.dart
 library;
+
+import 'dart:convert';
+import 'dart:io';
 
 import 'package:openai_dart/openai_dart.dart';
 
@@ -10,69 +13,105 @@ Future<void> main() async {
   final client = OpenAIClient.fromEnvironment();
 
   try {
-    // Basic image generation
-    print('=== GPT Image Generation ===\n');
+    // Basic GPT Image 2 generation.
+    print('=== GPT Image 2 — Basic Generation ===\n');
 
-    final response = await client.images.generate(
+    final basic = await client.images.generate(
       const ImageGenerationRequest(
-        model: 'gpt-image-1',
+        model: ImageModels.gptImage2,
         prompt: 'A white Siamese cat wearing a top hat, digital art',
         size: ImageSize.size1024x1024,
-        quality: ImageQuality.standard,
-        style: ImageStyle.vivid,
       ),
     );
 
-    print('Generated ${response.data.length} image(s)');
-    for (final image in response.data) {
-      if (image.url case final url?) {
-        print('URL: $url');
-      }
-      if (image.revisedPrompt case final revised?) {
-        print('Revised prompt: $revised');
-      }
-    }
-    print('');
+    _saveFirstImage(basic, path: 'cat.png');
+    _printUsage(basic);
 
-    // HD quality image
-    print('=== HD Quality Image ===\n');
+    // Flagship: transparent background + flexible size + webp output.
+    print('\n=== GPT Image 2 — Flagship Features ===\n');
 
-    final response2 = await client.images.generate(
+    final flagship = await client.images.generate(
       const ImageGenerationRequest(
-        model: 'gpt-image-1',
-        prompt:
-            'A beautiful sunset over mountains with a lake in the foreground',
-        size: ImageSize.size1792x1024, // Wide format
-        quality: ImageQuality.hd,
-        style: ImageStyle.natural,
+        model: ImageModels.gptImage2,
+        prompt: 'A cute robot holding a single flower on a white card',
+        size: ImageSize.size1536x1024, // Flexible landscape size.
+        quality: ImageQuality.high, // GPT image quality tiers.
+        background: ImageBackground.transparent, // Transparent PNG/WebP only.
+        outputFormat: ImageOutputFormat.webp,
+        outputCompression: 80,
+        moderation: ImageModerationLevel.low,
       ),
     );
 
-    print('Generated HD image');
-    if (response2.data.first.url case final url?) {
-      print('URL: $url');
+    _saveFirstImage(flagship, path: 'robot.webp');
+    _printUsage(flagship);
+
+    // Image edit with high input fidelity (GPT Image 2 edit surface).
+    print('\n=== GPT Image 2 — Edit with High Input Fidelity ===\n');
+
+    final sourceFile = File('cat.png');
+    if (sourceFile.existsSync()) {
+      final edit = await client.images.edit(
+        ImageEditRequest(
+          image: sourceFile.readAsBytesSync(),
+          imageFilename: 'cat.png',
+          prompt: 'Make the cat wear a tiny monocle too',
+          model: ImageModels.gptImage2,
+          inputFidelity: ImageInputFidelity.high,
+          size: ImageSize.size1024x1024,
+          quality: ImageQuality.high,
+        ),
+      );
+
+      _saveFirstImage(edit, path: 'cat_edited.png');
+      _printUsage(edit);
+    } else {
+      print('(skipping edit — cat.png was not saved)');
     }
-    print('');
 
-    // Multiple images
-    print('=== Multiple Images ===\n');
+    // Multiple images in one call.
+    print('\n=== GPT Image 2 — Multiple Images ===\n');
 
-    final response3 = await client.images.generate(
+    final multi = await client.images.generate(
       const ImageGenerationRequest(
-        model: 'gpt-image-1',
-        prompt: 'A cute robot holding a flower',
-        n: 2, // Generate 2 images
-        size: ImageSize.size512x512,
+        model: ImageModels.gptImage2,
+        prompt: 'A minimalist logo for a coffee shop',
+        n: 2,
+        size: ImageSize.size1024x1024,
       ),
     );
 
-    print('Generated ${response3.data.length} images');
-    for (var i = 0; i < response3.data.length; i++) {
-      if (response3.data[i].url case final url?) {
-        print('Image ${i + 1}: $url');
-      }
+    for (var i = 0; i < multi.data.length; i++) {
+      _saveFirstImage(
+        ImageResponse(created: multi.created, data: [multi.data[i]]),
+        path: 'logo_${i + 1}.png',
+      );
     }
+    _printUsage(multi);
   } finally {
     client.close();
   }
+}
+
+void _saveFirstImage(ImageResponse response, {required String path}) {
+  final image = response.data.first;
+  if (image.b64Json case final b64?) {
+    File(path).writeAsBytesSync(base64Decode(b64));
+    print('Saved $path (${b64.length} base64 chars)');
+  } else if (image.url case final url?) {
+    // DALL-E URL path — GPT Image 2 always returns base64.
+    print('URL: $url');
+  }
+  if (image.revisedPrompt case final revised?) {
+    print('Revised prompt: $revised');
+  }
+}
+
+void _printUsage(ImageResponse response) {
+  final u = response.usage;
+  if (u == null) return;
+  print(
+    'Tokens — total: ${u.totalTokens}, input: ${u.inputTokens}, '
+    'output: ${u.outputTokens}',
+  );
 }

--- a/packages/openai_dart/example/images_example.dart
+++ b/packages/openai_dart/example/images_example.dart
@@ -69,6 +69,45 @@ Future<void> main() async {
       print('(skipping edit — cat.png was not saved)');
     }
 
+    // Streaming generation with partial images.
+    print('\n=== GPT Image 2 — Streaming (partial + final) ===\n');
+
+    final stream = client.images.generateStream(
+      const ImageGenerationRequest(
+        model: ImageModels.gptImage2,
+        prompt: 'A simple orange circle on a white card',
+        size: ImageSize.size1024x1024,
+        partialImages: 2,
+      ),
+    );
+
+    var partialCount = 0;
+    ImageGenCompletedEvent? completed;
+    await for (final event in stream) {
+      switch (event) {
+        case ImageGenPartialImageEvent():
+          partialCount++;
+          print(
+            'partial #${event.partialImageIndex} '
+            '(${event.b64Json.length} base64 chars)',
+          );
+        case ImageGenCompletedEvent():
+          completed = event;
+        case ImageGenUnknownEvent():
+          print('unknown event type: ${event.type}');
+      }
+    }
+    print('Received $partialCount partial image(s)');
+    if (completed != null) {
+      File(
+        'stream_final.png',
+      ).writeAsBytesSync(base64Decode(completed.b64Json));
+      print(
+        'Stream tokens — total: ${completed.usage.totalTokens}, '
+        'out: ${completed.usage.outputTokens}',
+      );
+    }
+
     // Multiple images in one call.
     print('\n=== GPT Image 2 — Multiple Images ===\n');
 

--- a/packages/openai_dart/lib/src/client/openai_client.dart
+++ b/packages/openai_dart/lib/src/client/openai_client.dart
@@ -387,6 +387,7 @@ class OpenAIClient {
     interceptorChain: _interceptorChain,
     requestBuilder: _requestBuilder,
     ensureNotClosed: _ensureNotClosed,
+    streamClientFactory: _streamClientFactory,
   );
 
   FilesResource? _files;

--- a/packages/openai_dart/lib/src/models/images/image_common.dart
+++ b/packages/openai_dart/lib/src/models/images/image_common.dart
@@ -1,0 +1,189 @@
+/// Shared enums for the images API (generate / edit / edit-json).
+///
+/// GPT image models (e.g. `gpt-image-2`) accept a richer set of parameters
+/// than the legacy DALL-E models. These enums cover the full spec surface;
+/// individual parameter docs call out which values apply to which model.
+library;
+
+/// Image quality options.
+///
+/// `standard` and `hd` apply to DALL-E 3. `low`, `medium`, `high`, and `auto`
+/// apply to GPT image models (including `gpt-image-2`).
+enum ImageQuality {
+  /// Standard DALL-E 3 quality.
+  standard._('standard'),
+
+  /// HD (higher detail) DALL-E 3 quality.
+  hd._('hd'),
+
+  /// Low quality output for GPT image models.
+  low._('low'),
+
+  /// Medium quality output for GPT image models.
+  medium._('medium'),
+
+  /// High quality output for GPT image models.
+  high._('high'),
+
+  /// Let the server pick the quality (GPT image default).
+  auto._('auto');
+
+  const ImageQuality._(this._value);
+
+  /// Creates from JSON string.
+  factory ImageQuality.fromJson(String json) {
+    return values.firstWhere(
+      (e) => e._value == json,
+      orElse: () => throw FormatException('Unknown quality: $json'),
+    );
+  }
+
+  final String _value;
+
+  /// Converts to JSON string.
+  String toJson() => _value;
+
+  @override
+  String toString() => _value;
+}
+
+/// Image size options.
+///
+/// DALL-E 2 supports `256x256`, `512x512`, `1024x1024`. DALL-E 3 supports
+/// `1024x1024`, `1792x1024`, `1024x1792`. GPT image models (including
+/// `gpt-image-2`) support `auto`, `1024x1024`, `1536x1024`, `1024x1536`.
+enum ImageSize {
+  /// 256×256 (DALL-E 2 only).
+  size256x256._('256x256'),
+
+  /// 512×512 (DALL-E 2 only).
+  size512x512._('512x512'),
+
+  /// 1024×1024 square output.
+  size1024x1024._('1024x1024'),
+
+  /// 1792×1024 landscape (DALL-E 3 only).
+  size1792x1024._('1792x1024'),
+
+  /// 1024×1792 portrait (DALL-E 3 only).
+  size1024x1792._('1024x1792'),
+
+  /// 1536×1024 landscape (GPT image models).
+  size1536x1024._('1536x1024'),
+
+  /// 1024×1536 portrait (GPT image models).
+  size1024x1536._('1024x1536'),
+
+  /// Automatically choose the output size (GPT image models).
+  auto._('auto');
+
+  const ImageSize._(this._value);
+
+  /// Creates from JSON string.
+  factory ImageSize.fromJson(String json) {
+    return values.firstWhere(
+      (e) => e._value == json,
+      orElse: () => throw FormatException('Unknown size: $json'),
+    );
+  }
+
+  final String _value;
+
+  /// Converts to JSON string.
+  String toJson() => _value;
+
+  @override
+  String toString() => _value;
+}
+
+/// Output format options for GPT image models.
+enum ImageOutputFormat {
+  /// PNG lossless output.
+  png._('png'),
+
+  /// JPEG lossy output.
+  jpeg._('jpeg'),
+
+  /// WebP output.
+  webp._('webp');
+
+  const ImageOutputFormat._(this._value);
+  final String _value;
+
+  /// Creates from JSON string.
+  factory ImageOutputFormat.fromJson(String json) => values.firstWhere(
+    (e) => e._value == json,
+    orElse: () => throw FormatException('Unknown output format: $json'),
+  );
+
+  /// Converts to JSON string.
+  String toJson() => _value;
+}
+
+/// Moderation level for GPT image models.
+enum ImageModerationLevel {
+  /// Low moderation; fewer content restrictions applied.
+  low._('low'),
+
+  /// Let the server pick the moderation level (default).
+  auto._('auto');
+
+  const ImageModerationLevel._(this._value);
+  final String _value;
+
+  /// Creates from JSON string.
+  factory ImageModerationLevel.fromJson(String json) => values.firstWhere(
+    (e) => e._value == json,
+    orElse: () => throw FormatException('Unknown moderation: $json'),
+  );
+
+  /// Converts to JSON string.
+  String toJson() => _value;
+}
+
+/// Background handling for GPT image models.
+enum ImageBackground {
+  /// Transparent background.
+  transparent._('transparent'),
+
+  /// Opaque (solid) background.
+  opaque._('opaque'),
+
+  /// Let the server pick the background (default).
+  auto._('auto');
+
+  const ImageBackground._(this._value);
+  final String _value;
+
+  /// Creates from JSON string.
+  factory ImageBackground.fromJson(String json) => values.firstWhere(
+    (e) => e._value == json,
+    orElse: () => throw FormatException('Unknown background: $json'),
+  );
+
+  /// Converts to JSON string.
+  String toJson() => _value;
+}
+
+/// Input fidelity for GPT image edits.
+///
+/// Controls how closely the edit follows the input image.
+enum ImageInputFidelity {
+  /// High fidelity; closely follows the input image.
+  high._('high'),
+
+  /// Low fidelity; allows more creative deviation from the input.
+  low._('low');
+
+  const ImageInputFidelity._(this._value);
+  final String _value;
+
+  /// Creates from JSON string.
+  factory ImageInputFidelity.fromJson(String json) => values.firstWhere(
+    (e) => e._value == json,
+    orElse: () => throw FormatException('Unknown input_fidelity: $json'),
+  );
+
+  /// Converts to JSON string.
+  String toJson() => _value;
+}

--- a/packages/openai_dart/lib/src/models/images/image_common.dart
+++ b/packages/openai_dart/lib/src/models/images/image_common.dart
@@ -3,6 +3,13 @@
 /// GPT image models (e.g. `gpt-image-2`) accept a richer set of parameters
 /// than the legacy DALL-E models. These enums cover the full spec surface;
 /// individual parameter docs call out which values apply to which model.
+///
+/// Every enum includes an `unknown` variant for forward compatibility —
+/// [fromJson] returns `unknown` rather than throwing when the server emits
+/// a value outside the current spec. Note that this is lossy: round-tripping
+/// an unknown value will serialize as `'unknown'`. If you need to preserve
+/// the raw wire value, read it from the surrounding response object
+/// (e.g. [ImageGenCompletedEvent.size] stores the raw string).
 library;
 
 /// Image quality options.
@@ -10,6 +17,9 @@ library;
 /// `standard` and `hd` apply to DALL-E 3. `low`, `medium`, `high`, and `auto`
 /// apply to GPT image models (including `gpt-image-2`).
 enum ImageQuality {
+  /// Unknown quality — forward-compat fallback for unrecognized server values.
+  unknown._('unknown'),
+
   /// Standard DALL-E 3 quality.
   standard._('standard'),
 
@@ -30,11 +40,11 @@ enum ImageQuality {
 
   const ImageQuality._(this._value);
 
-  /// Creates from JSON string.
+  /// Creates from JSON string. Unknown values map to [ImageQuality.unknown].
   factory ImageQuality.fromJson(String json) {
     return values.firstWhere(
       (e) => e._value == json,
-      orElse: () => throw FormatException('Unknown quality: $json'),
+      orElse: () => ImageQuality.unknown,
     );
   }
 
@@ -53,6 +63,12 @@ enum ImageQuality {
 /// `1024x1024`, `1792x1024`, `1024x1792`. GPT image models (including
 /// `gpt-image-2`) support `auto`, `1024x1024`, `1536x1024`, `1024x1536`.
 enum ImageSize {
+  /// Unknown size — forward-compat fallback for unrecognized server values.
+  ///
+  /// Streaming partial-image events sometimes carry transient sizes like
+  /// `1254x1254` that don't appear in the spec; those map here.
+  unknown._('unknown'),
+
   /// 256×256 (DALL-E 2 only).
   size256x256._('256x256'),
 
@@ -79,11 +95,11 @@ enum ImageSize {
 
   const ImageSize._(this._value);
 
-  /// Creates from JSON string.
+  /// Creates from JSON string. Unknown values map to [ImageSize.unknown].
   factory ImageSize.fromJson(String json) {
     return values.firstWhere(
       (e) => e._value == json,
-      orElse: () => throw FormatException('Unknown size: $json'),
+      orElse: () => ImageSize.unknown,
     );
   }
 
@@ -98,6 +114,9 @@ enum ImageSize {
 
 /// Output format options for GPT image models.
 enum ImageOutputFormat {
+  /// Unknown format — forward-compat fallback for unrecognized server values.
+  unknown._('unknown'),
+
   /// PNG lossless output.
   png._('png'),
 
@@ -110,10 +129,11 @@ enum ImageOutputFormat {
   const ImageOutputFormat._(this._value);
   final String _value;
 
-  /// Creates from JSON string.
+  /// Creates from JSON string. Unknown values map to
+  /// [ImageOutputFormat.unknown].
   factory ImageOutputFormat.fromJson(String json) => values.firstWhere(
     (e) => e._value == json,
-    orElse: () => throw FormatException('Unknown output format: $json'),
+    orElse: () => ImageOutputFormat.unknown,
   );
 
   /// Converts to JSON string.
@@ -122,6 +142,9 @@ enum ImageOutputFormat {
 
 /// Moderation level for GPT image models.
 enum ImageModerationLevel {
+  /// Unknown level — forward-compat fallback for unrecognized server values.
+  unknown._('unknown'),
+
   /// Low moderation; fewer content restrictions applied.
   low._('low'),
 
@@ -131,10 +154,11 @@ enum ImageModerationLevel {
   const ImageModerationLevel._(this._value);
   final String _value;
 
-  /// Creates from JSON string.
+  /// Creates from JSON string. Unknown values map to
+  /// [ImageModerationLevel.unknown].
   factory ImageModerationLevel.fromJson(String json) => values.firstWhere(
     (e) => e._value == json,
-    orElse: () => throw FormatException('Unknown moderation: $json'),
+    orElse: () => ImageModerationLevel.unknown,
   );
 
   /// Converts to JSON string.
@@ -143,6 +167,9 @@ enum ImageModerationLevel {
 
 /// Background handling for GPT image models.
 enum ImageBackground {
+  /// Unknown background — forward-compat fallback for unrecognized values.
+  unknown._('unknown'),
+
   /// Transparent background.
   transparent._('transparent'),
 
@@ -155,10 +182,11 @@ enum ImageBackground {
   const ImageBackground._(this._value);
   final String _value;
 
-  /// Creates from JSON string.
+  /// Creates from JSON string. Unknown values map to
+  /// [ImageBackground.unknown].
   factory ImageBackground.fromJson(String json) => values.firstWhere(
     (e) => e._value == json,
-    orElse: () => throw FormatException('Unknown background: $json'),
+    orElse: () => ImageBackground.unknown,
   );
 
   /// Converts to JSON string.
@@ -169,6 +197,9 @@ enum ImageBackground {
 ///
 /// Controls how closely the edit follows the input image.
 enum ImageInputFidelity {
+  /// Unknown fidelity — forward-compat fallback for unrecognized values.
+  unknown._('unknown'),
+
   /// High fidelity; closely follows the input image.
   high._('high'),
 
@@ -178,10 +209,11 @@ enum ImageInputFidelity {
   const ImageInputFidelity._(this._value);
   final String _value;
 
-  /// Creates from JSON string.
+  /// Creates from JSON string. Unknown values map to
+  /// [ImageInputFidelity.unknown].
   factory ImageInputFidelity.fromJson(String json) => values.firstWhere(
     (e) => e._value == json,
-    orElse: () => throw FormatException('Unknown input_fidelity: $json'),
+    orElse: () => ImageInputFidelity.unknown,
   );
 
   /// Converts to JSON string.

--- a/packages/openai_dart/lib/src/models/images/image_common.dart
+++ b/packages/openai_dart/lib/src/models/images/image_common.dart
@@ -7,9 +7,8 @@
 /// Every enum includes an `unknown` variant for forward compatibility —
 /// [fromJson] returns `unknown` rather than throwing when the server emits
 /// a value outside the current spec. Note that this is lossy: round-tripping
-/// an unknown value will serialize as `'unknown'`. If you need to preserve
-/// the raw wire value, read it from the surrounding response object
-/// (e.g. [ImageGenCompletedEvent.size] stores the raw string).
+/// an unknown value will serialize as `'unknown'`, and these enum types do
+/// not preserve the original raw wire value.
 library;
 
 /// Image quality options.

--- a/packages/openai_dart/lib/src/models/images/image_edit_json_request.dart
+++ b/packages/openai_dart/lib/src/models/images/image_edit_json_request.dart
@@ -1,5 +1,7 @@
 import 'package:meta/meta.dart';
 
+import 'image_common.dart';
+
 /// Reference an input image by URL/data URL or uploaded file ID.
 @immutable
 class ImageReference {
@@ -69,20 +71,20 @@ class ImageEditJsonRequest {
   /// Optional mask reference.
   final ImageReference? mask;
 
-  /// Optional model to use.
+  /// Optional model to use (e.g. `gpt-image-2`).
   final String? model;
 
   /// Number of images to generate.
   final int? n;
 
   /// Output quality.
-  final ImageEditJsonQuality? quality;
+  final ImageQuality? quality;
 
   /// Input fidelity.
   final ImageInputFidelity? inputFidelity;
 
   /// Requested output size.
-  final ImageEditJsonSize? size;
+  final ImageSize? size;
 
   /// End-user identifier.
   final String? user;
@@ -137,13 +139,13 @@ class ImageEditJsonRequest {
       model: json['model'] as String?,
       n: json['n'] as int?,
       quality: json['quality'] != null
-          ? ImageEditJsonQuality.fromJson(json['quality'] as String)
+          ? ImageQuality.fromJson(json['quality'] as String)
           : null,
       inputFidelity: json['input_fidelity'] != null
           ? ImageInputFidelity.fromJson(json['input_fidelity'] as String)
           : null,
       size: json['size'] != null
-          ? ImageEditJsonSize.fromJson(json['size'] as String)
+          ? ImageSize.fromJson(json['size'] as String)
           : null,
       user: json['user'] as String?,
       outputFormat: json['output_format'] != null
@@ -181,140 +183,12 @@ class ImageEditJsonRequest {
   };
 }
 
-/// JSON image edit quality options.
-enum ImageEditJsonQuality {
-  /// Low quality output.
-  low._('low'),
+/// Backwards-compatible alias — quality values for JSON image edits now share
+/// the unified [ImageQuality] enum.
+@Deprecated('Use ImageQuality instead.')
+typedef ImageEditJsonQuality = ImageQuality;
 
-  /// Medium quality output.
-  medium._('medium'),
-
-  /// High quality output.
-  high._('high'),
-
-  /// Automatically select quality.
-  auto._('auto');
-
-  const ImageEditJsonQuality._(this._value);
-  final String _value;
-
-  factory ImageEditJsonQuality.fromJson(String json) => values.firstWhere(
-    (e) => e._value == json,
-    orElse: () => throw FormatException('Unknown quality: $json'),
-  );
-
-  /// Converts to JSON string.
-  String toJson() => _value;
-}
-
-/// Input fidelity options.
-enum ImageInputFidelity {
-  /// High fidelity; closely follows the input image.
-  high._('high'),
-
-  /// Low fidelity; allows more creative deviation from the input.
-  low._('low');
-
-  const ImageInputFidelity._(this._value);
-  final String _value;
-
-  factory ImageInputFidelity.fromJson(String json) => values.firstWhere(
-    (e) => e._value == json,
-    orElse: () => throw FormatException('Unknown input_fidelity: $json'),
-  );
-
-  /// Converts to JSON string.
-  String toJson() => _value;
-}
-
-/// JSON image edit size options.
-enum ImageEditJsonSize {
-  /// Automatically select the output size.
-  auto._('auto'),
-
-  /// 1024×1024 square output.
-  size1024x1024._('1024x1024'),
-
-  /// 1536×1024 landscape output.
-  size1536x1024._('1536x1024'),
-
-  /// 1024×1536 portrait output.
-  size1024x1536._('1024x1536');
-
-  const ImageEditJsonSize._(this._value);
-  final String _value;
-
-  factory ImageEditJsonSize.fromJson(String json) => values.firstWhere(
-    (e) => e._value == json,
-    orElse: () => throw FormatException('Unknown size: $json'),
-  );
-
-  /// Converts to JSON string.
-  String toJson() => _value;
-}
-
-/// Output format options for JSON image edits.
-enum ImageOutputFormat {
-  /// PNG lossless output.
-  png._('png'),
-
-  /// JPEG lossy output.
-  jpeg._('jpeg'),
-
-  /// WebP output.
-  webp._('webp');
-
-  const ImageOutputFormat._(this._value);
-  final String _value;
-
-  factory ImageOutputFormat.fromJson(String json) => values.firstWhere(
-    (e) => e._value == json,
-    orElse: () => throw FormatException('Unknown output format: $json'),
-  );
-
-  /// Converts to JSON string.
-  String toJson() => _value;
-}
-
-/// Moderation level options for JSON image edits.
-enum ImageModerationLevel {
-  /// Low moderation; fewer content restrictions applied.
-  low._('low'),
-
-  /// Automatically determine moderation level.
-  auto._('auto');
-
-  const ImageModerationLevel._(this._value);
-  final String _value;
-
-  factory ImageModerationLevel.fromJson(String json) => values.firstWhere(
-    (e) => e._value == json,
-    orElse: () => throw FormatException('Unknown moderation: $json'),
-  );
-
-  /// Converts to JSON string.
-  String toJson() => _value;
-}
-
-/// Background options for JSON image edits.
-enum ImageBackground {
-  /// Transparent background.
-  transparent._('transparent'),
-
-  /// Opaque (solid) background.
-  opaque._('opaque'),
-
-  /// Automatically determine background handling.
-  auto._('auto');
-
-  const ImageBackground._(this._value);
-  final String _value;
-
-  factory ImageBackground.fromJson(String json) => values.firstWhere(
-    (e) => e._value == json,
-    orElse: () => throw FormatException('Unknown background: $json'),
-  );
-
-  /// Converts to JSON string.
-  String toJson() => _value;
-}
+/// Backwards-compatible alias — size values for JSON image edits now share
+/// the unified [ImageSize] enum.
+@Deprecated('Use ImageSize instead.')
+typedef ImageEditJsonSize = ImageSize;

--- a/packages/openai_dart/lib/src/models/images/image_request.dart
+++ b/packages/openai_dart/lib/src/models/images/image_request.dart
@@ -373,12 +373,78 @@ class ImageEditRequest {
   /// Number of partial images to emit while streaming. GPT image models only.
   final int? partialImages;
 
+  /// Creates a copy with the given fields replaced.
+  ///
+  /// Nullable fields can be explicitly set to `null` to clear them. The
+  /// required `image`, `imageFilename`, and `prompt` are passed through
+  /// unchanged unless explicitly overridden.
+  ImageEditRequest copyWith({
+    Uint8List? image,
+    String? imageFilename,
+    String? prompt,
+    Object? mask = unsetCopyWithValue,
+    Object? maskFilename = unsetCopyWithValue,
+    Object? model = unsetCopyWithValue,
+    Object? n = unsetCopyWithValue,
+    Object? size = unsetCopyWithValue,
+    Object? responseFormat = unsetCopyWithValue,
+    Object? user = unsetCopyWithValue,
+    Object? background = unsetCopyWithValue,
+    Object? inputFidelity = unsetCopyWithValue,
+    Object? quality = unsetCopyWithValue,
+    Object? outputFormat = unsetCopyWithValue,
+    Object? outputCompression = unsetCopyWithValue,
+    Object? moderation = unsetCopyWithValue,
+    Object? stream = unsetCopyWithValue,
+    Object? partialImages = unsetCopyWithValue,
+  }) {
+    return ImageEditRequest(
+      image: image ?? this.image,
+      imageFilename: imageFilename ?? this.imageFilename,
+      prompt: prompt ?? this.prompt,
+      mask: mask == unsetCopyWithValue ? this.mask : mask as Uint8List?,
+      maskFilename: maskFilename == unsetCopyWithValue
+          ? this.maskFilename
+          : maskFilename as String?,
+      model: model == unsetCopyWithValue ? this.model : model as String?,
+      n: n == unsetCopyWithValue ? this.n : n as int?,
+      size: size == unsetCopyWithValue ? this.size : size as ImageSize?,
+      responseFormat: responseFormat == unsetCopyWithValue
+          ? this.responseFormat
+          : responseFormat as ImageResponseFormat?,
+      user: user == unsetCopyWithValue ? this.user : user as String?,
+      background: background == unsetCopyWithValue
+          ? this.background
+          : background as ImageBackground?,
+      inputFidelity: inputFidelity == unsetCopyWithValue
+          ? this.inputFidelity
+          : inputFidelity as ImageInputFidelity?,
+      quality: quality == unsetCopyWithValue
+          ? this.quality
+          : quality as ImageQuality?,
+      outputFormat: outputFormat == unsetCopyWithValue
+          ? this.outputFormat
+          : outputFormat as ImageOutputFormat?,
+      outputCompression: outputCompression == unsetCopyWithValue
+          ? this.outputCompression
+          : outputCompression as int?,
+      moderation: moderation == unsetCopyWithValue
+          ? this.moderation
+          : moderation as ImageModerationLevel?,
+      stream: stream == unsetCopyWithValue ? this.stream : stream as bool?,
+      partialImages: partialImages == unsetCopyWithValue
+          ? this.partialImages
+          : partialImages as int?,
+    );
+  }
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is ImageEditRequest &&
           runtimeType == other.runtimeType &&
           imageFilename == other.imageFilename &&
+          maskFilename == other.maskFilename &&
           prompt == other.prompt &&
           model == other.model &&
           n == other.n &&
@@ -397,6 +463,7 @@ class ImageEditRequest {
   @override
   int get hashCode => Object.hash(
     imageFilename,
+    maskFilename,
     prompt,
     model,
     n,
@@ -486,6 +553,9 @@ class ImageVariationRequest {
 
 /// Image response format options.
 enum ImageResponseFormat {
+  /// Unknown format — forward-compat fallback for unrecognized values.
+  unknown._('unknown'),
+
   /// Return a URL to the generated image.
   url._('url'),
 
@@ -494,11 +564,12 @@ enum ImageResponseFormat {
 
   const ImageResponseFormat._(this._value);
 
-  /// Creates from JSON string.
+  /// Creates from JSON string. Unknown values map to
+  /// [ImageResponseFormat.unknown].
   factory ImageResponseFormat.fromJson(String json) {
     return values.firstWhere(
       (e) => e._value == json,
-      orElse: () => throw FormatException('Unknown format: $json'),
+      orElse: () => ImageResponseFormat.unknown,
     );
   }
 
@@ -513,6 +584,9 @@ enum ImageResponseFormat {
 
 /// Image style options.
 enum ImageStyle {
+  /// Unknown style — forward-compat fallback for unrecognized values.
+  unknown._('unknown'),
+
   /// Vivid style (more hyper-real and dramatic).
   vivid._('vivid'),
 
@@ -521,11 +595,11 @@ enum ImageStyle {
 
   const ImageStyle._(this._value);
 
-  /// Creates from JSON string.
+  /// Creates from JSON string. Unknown values map to [ImageStyle.unknown].
   factory ImageStyle.fromJson(String json) {
     return values.firstWhere(
       (e) => e._value == json,
-      orElse: () => throw FormatException('Unknown style: $json'),
+      orElse: () => ImageStyle.unknown,
     );
   }
 

--- a/packages/openai_dart/lib/src/models/images/image_request.dart
+++ b/packages/openai_dart/lib/src/models/images/image_request.dart
@@ -3,18 +3,21 @@ import 'dart:typed_data';
 import 'package:meta/meta.dart';
 
 import '../common/copy_with_sentinel.dart';
+import 'image_common.dart';
 
 /// A request to generate images from a text prompt.
 ///
-/// Uses DALL-E models to create images from textual descriptions.
+/// Supports DALL-E and GPT image models (including `gpt-image-2`).
 ///
 /// ## Example
 ///
 /// ```dart
 /// final request = ImageGenerationRequest(
 ///   prompt: 'A white cat wearing a top hat',
-///   model: 'dall-e-3',
+///   model: 'gpt-image-2',
 ///   size: ImageSize.size1024x1024,
+///   quality: ImageQuality.high,
+///   background: ImageBackground.transparent,
 /// );
 /// ```
 @immutable
@@ -29,6 +32,12 @@ class ImageGenerationRequest {
     this.size,
     this.style,
     this.user,
+    this.background,
+    this.moderation,
+    this.outputFormat,
+    this.outputCompression,
+    this.stream,
+    this.partialImages,
   });
 
   /// Creates an [ImageGenerationRequest] from JSON.
@@ -50,6 +59,18 @@ class ImageGenerationRequest {
           ? ImageStyle.fromJson(json['style'] as String)
           : null,
       user: json['user'] as String?,
+      background: json['background'] != null
+          ? ImageBackground.fromJson(json['background'] as String)
+          : null,
+      moderation: json['moderation'] != null
+          ? ImageModerationLevel.fromJson(json['moderation'] as String)
+          : null,
+      outputFormat: json['output_format'] != null
+          ? ImageOutputFormat.fromJson(json['output_format'] as String)
+          : null,
+      outputCompression: json['output_compression'] as int?,
+      stream: json['stream'] as bool?,
+      partialImages: json['partial_images'] as int?,
     );
   }
 
@@ -58,33 +79,39 @@ class ImageGenerationRequest {
   /// Maximum length:
   /// - DALL-E 2: 1000 characters
   /// - DALL-E 3: 4000 characters
+  /// - GPT image models: 32000 characters
   final String prompt;
 
   /// The model to use for generation.
   ///
-  /// Available models:
-  /// - `dall-e-3` - Higher quality, more expensive
-  /// - `dall-e-2` - Faster, more affordable
+  /// Examples:
+  /// - `gpt-image-2` — flagship GPT image model (token-based pricing,
+  ///   flexible sizes, high-fidelity inputs, Batch API support)
+  /// - `gpt-image-1.5`, `gpt-image-1`, `gpt-image-1-mini`
+  /// - `dall-e-3`, `dall-e-2`
   final String? model;
 
   /// The number of images to generate.
   ///
-  /// For DALL-E 3, only 1 is supported. For DALL-E 2, 1-10 images.
+  /// For DALL-E 3, only 1 is supported. For DALL-E 2 and GPT image models,
+  /// 1-10 images.
   final int? n;
 
   /// The quality of the generated images.
   ///
-  /// Only supported for DALL-E 3.
+  /// `standard`/`hd` apply to DALL-E 3. `low`/`medium`/`high`/`auto` apply to
+  /// GPT image models.
   final ImageQuality? quality;
 
   /// The format for the generated images.
   ///
-  /// Defaults to `url`.
+  /// Only supported for DALL-E 2 and DALL-E 3. GPT image models always
+  /// return base64-encoded data.
   final ImageResponseFormat? responseFormat;
 
   /// The size of the generated images.
   ///
-  /// Supported sizes vary by model.
+  /// Supported sizes vary by model — see [ImageSize].
   final ImageSize? size;
 
   /// The style of the generated images.
@@ -94,6 +121,36 @@ class ImageGenerationRequest {
 
   /// A unique identifier representing your end-user.
   final String? user;
+
+  /// Transparency of the background.
+  ///
+  /// Only supported for GPT image models.
+  final ImageBackground? background;
+
+  /// Content-moderation level.
+  ///
+  /// Only supported for GPT image models.
+  final ImageModerationLevel? moderation;
+
+  /// The format in which generated images are returned.
+  ///
+  /// Only supported for GPT image models.
+  final ImageOutputFormat? outputFormat;
+
+  /// Compression level (0-100) for `jpeg`/`webp` outputs.
+  ///
+  /// Only supported for GPT image models.
+  final int? outputCompression;
+
+  /// Whether to stream partial images via SSE.
+  ///
+  /// Only supported for GPT image models.
+  final bool? stream;
+
+  /// Number of partial images to emit while streaming.
+  ///
+  /// Only supported for GPT image models.
+  final int? partialImages;
 
   /// Converts to JSON.
   Map<String, dynamic> toJson() => {
@@ -105,6 +162,12 @@ class ImageGenerationRequest {
     if (size != null) 'size': size!.toJson(),
     if (style != null) 'style': style!.toJson(),
     if (user != null) 'user': user,
+    if (background != null) 'background': background!.toJson(),
+    if (moderation != null) 'moderation': moderation!.toJson(),
+    if (outputFormat != null) 'output_format': outputFormat!.toJson(),
+    if (outputCompression != null) 'output_compression': outputCompression,
+    if (stream != null) 'stream': stream,
+    if (partialImages != null) 'partial_images': partialImages,
   };
 
   /// Creates a copy with the given fields replaced.
@@ -119,6 +182,12 @@ class ImageGenerationRequest {
     Object? size = unsetCopyWithValue,
     Object? style = unsetCopyWithValue,
     Object? user = unsetCopyWithValue,
+    Object? background = unsetCopyWithValue,
+    Object? moderation = unsetCopyWithValue,
+    Object? outputFormat = unsetCopyWithValue,
+    Object? outputCompression = unsetCopyWithValue,
+    Object? stream = unsetCopyWithValue,
+    Object? partialImages = unsetCopyWithValue,
   }) {
     return ImageGenerationRequest(
       prompt: prompt ?? this.prompt,
@@ -133,6 +202,22 @@ class ImageGenerationRequest {
       size: size == unsetCopyWithValue ? this.size : size as ImageSize?,
       style: style == unsetCopyWithValue ? this.style : style as ImageStyle?,
       user: user == unsetCopyWithValue ? this.user : user as String?,
+      background: background == unsetCopyWithValue
+          ? this.background
+          : background as ImageBackground?,
+      moderation: moderation == unsetCopyWithValue
+          ? this.moderation
+          : moderation as ImageModerationLevel?,
+      outputFormat: outputFormat == unsetCopyWithValue
+          ? this.outputFormat
+          : outputFormat as ImageOutputFormat?,
+      outputCompression: outputCompression == unsetCopyWithValue
+          ? this.outputCompression
+          : outputCompression as int?,
+      stream: stream == unsetCopyWithValue ? this.stream : stream as bool?,
+      partialImages: partialImages == unsetCopyWithValue
+          ? this.partialImages
+          : partialImages as int?,
     );
   }
 
@@ -142,19 +227,50 @@ class ImageGenerationRequest {
       other is ImageGenerationRequest &&
           runtimeType == other.runtimeType &&
           prompt == other.prompt &&
-          model == other.model;
+          model == other.model &&
+          n == other.n &&
+          quality == other.quality &&
+          responseFormat == other.responseFormat &&
+          size == other.size &&
+          style == other.style &&
+          user == other.user &&
+          background == other.background &&
+          moderation == other.moderation &&
+          outputFormat == other.outputFormat &&
+          outputCompression == other.outputCompression &&
+          stream == other.stream &&
+          partialImages == other.partialImages;
 
   @override
-  int get hashCode => Object.hash(prompt, model);
+  int get hashCode => Object.hash(
+    prompt,
+    model,
+    n,
+    quality,
+    responseFormat,
+    size,
+    style,
+    user,
+    background,
+    moderation,
+    outputFormat,
+    outputCompression,
+    stream,
+    partialImages,
+  );
 
   @override
   String toString() =>
-      'ImageGenerationRequest(prompt: ${prompt.length} chars, model: $model)';
+      'ImageGenerationRequest(prompt: ${prompt.length} chars, model: $model, '
+      'size: $size, quality: $quality, background: $background, '
+      'outputFormat: $outputFormat)';
 }
 
-/// A request to edit an existing image.
+/// A request to edit an existing image via multipart upload.
 ///
-/// Creates edits or extensions of an existing image using a prompt.
+/// Creates edits or extensions of an existing image using a prompt. For
+/// GPT image models (e.g. `gpt-image-2`), supports high-fidelity inputs,
+/// custom backgrounds, output format, and token-based pricing.
 ///
 /// ## Example
 ///
@@ -163,6 +279,8 @@ class ImageGenerationRequest {
 ///   image: originalImageBytes,
 ///   imageFilename: 'original.png',
 ///   prompt: 'Add a rainbow in the sky',
+///   model: 'gpt-image-2',
+///   inputFidelity: ImageInputFidelity.high,
 /// );
 /// ```
 @immutable
@@ -179,11 +297,20 @@ class ImageEditRequest {
     this.size,
     this.responseFormat,
     this.user,
+    this.background,
+    this.inputFidelity,
+    this.quality,
+    this.outputFormat,
+    this.outputCompression,
+    this.moderation,
+    this.stream,
+    this.partialImages,
   });
 
   /// The image to edit.
   ///
-  /// Must be a valid PNG file, less than 4MB, and square.
+  /// For DALL-E 2: PNG, square, ≤4MB. For GPT image models: PNG/JPEG/WebP,
+  /// any supported size.
   final Uint8List image;
 
   /// The filename of the image.
@@ -191,13 +318,12 @@ class ImageEditRequest {
 
   /// The text description of the desired edit.
   ///
-  /// Maximum length: 1000 characters.
+  /// Maximum length: 1000 characters (DALL-E 2) or 32000 (GPT image models).
   final String prompt;
 
   /// An optional mask image for inpainting.
   ///
-  /// Must be a valid PNG file, less than 4MB, same dimensions as the image,
-  /// with transparent areas indicating where edits should be made.
+  /// Transparent areas indicate where edits should be made.
   final Uint8List? mask;
 
   /// The filename of the mask image.
@@ -205,8 +331,8 @@ class ImageEditRequest {
 
   /// The model to use.
   ///
-  /// For multipart edits this can be `dall-e-2` or GPT image models
-  /// (for example `gpt-image-1.5`).
+  /// Examples: `gpt-image-2`, `gpt-image-1.5`, `gpt-image-1-mini`,
+  /// `chatgpt-image-latest`, `dall-e-2`.
   final String? model;
 
   /// The number of images to generate.
@@ -216,10 +342,36 @@ class ImageEditRequest {
   final ImageSize? size;
 
   /// The format for the generated images.
+  ///
+  /// Only supported for DALL-E 2.
   final ImageResponseFormat? responseFormat;
 
   /// A unique identifier representing your end-user.
   final String? user;
+
+  /// Transparency of the background. GPT image models only.
+  final ImageBackground? background;
+
+  /// How closely the edit follows the input image. GPT image models only.
+  final ImageInputFidelity? inputFidelity;
+
+  /// Output quality. GPT image models only.
+  final ImageQuality? quality;
+
+  /// Output format. GPT image models only.
+  final ImageOutputFormat? outputFormat;
+
+  /// Compression level (0-100) for `jpeg`/`webp`. GPT image models only.
+  final int? outputCompression;
+
+  /// Content-moderation level. GPT image models only.
+  final ImageModerationLevel? moderation;
+
+  /// Whether to stream partial edits via SSE. GPT image models only.
+  final bool? stream;
+
+  /// Number of partial images to emit while streaming. GPT image models only.
+  final int? partialImages;
 
   @override
   bool operator ==(Object other) =>
@@ -227,14 +379,44 @@ class ImageEditRequest {
       other is ImageEditRequest &&
           runtimeType == other.runtimeType &&
           imageFilename == other.imageFilename &&
-          prompt == other.prompt;
+          prompt == other.prompt &&
+          model == other.model &&
+          n == other.n &&
+          size == other.size &&
+          responseFormat == other.responseFormat &&
+          user == other.user &&
+          background == other.background &&
+          inputFidelity == other.inputFidelity &&
+          quality == other.quality &&
+          outputFormat == other.outputFormat &&
+          outputCompression == other.outputCompression &&
+          moderation == other.moderation &&
+          stream == other.stream &&
+          partialImages == other.partialImages;
 
   @override
-  int get hashCode => Object.hash(imageFilename, prompt);
+  int get hashCode => Object.hash(
+    imageFilename,
+    prompt,
+    model,
+    n,
+    size,
+    responseFormat,
+    user,
+    background,
+    inputFidelity,
+    quality,
+    outputFormat,
+    outputCompression,
+    moderation,
+    stream,
+    partialImages,
+  );
 
   @override
   String toString() =>
-      'ImageEditRequest(image: $imageFilename, prompt: ${prompt.length} chars)';
+      'ImageEditRequest(image: $imageFilename, prompt: ${prompt.length} chars, '
+      'model: $model, inputFidelity: $inputFidelity, quality: $quality)';
 }
 
 /// A request to create variations of an image.
@@ -302,33 +484,6 @@ class ImageVariationRequest {
   String toString() => 'ImageVariationRequest(image: $imageFilename)';
 }
 
-/// Image quality options.
-enum ImageQuality {
-  /// Standard quality.
-  standard._('standard'),
-
-  /// HD quality (higher detail).
-  hd._('hd');
-
-  const ImageQuality._(this._value);
-
-  /// Creates from JSON string.
-  factory ImageQuality.fromJson(String json) {
-    return values.firstWhere(
-      (e) => e._value == json,
-      orElse: () => throw FormatException('Unknown quality: $json'),
-    );
-  }
-
-  final String _value;
-
-  /// Converts to JSON string.
-  String toJson() => _value;
-
-  @override
-  String toString() => _value;
-}
-
 /// Image response format options.
 enum ImageResponseFormat {
   /// Return a URL to the generated image.
@@ -344,42 +499,6 @@ enum ImageResponseFormat {
     return values.firstWhere(
       (e) => e._value == json,
       orElse: () => throw FormatException('Unknown format: $json'),
-    );
-  }
-
-  final String _value;
-
-  /// Converts to JSON string.
-  String toJson() => _value;
-
-  @override
-  String toString() => _value;
-}
-
-/// Image size options.
-enum ImageSize {
-  /// 256x256 pixels.
-  size256x256._('256x256'),
-
-  /// 512x512 pixels.
-  size512x512._('512x512'),
-
-  /// 1024x1024 pixels.
-  size1024x1024._('1024x1024'),
-
-  /// 1792x1024 pixels (DALL-E 3 only).
-  size1792x1024._('1792x1024'),
-
-  /// 1024x1792 pixels (DALL-E 3 only).
-  size1024x1792._('1024x1792');
-
-  const ImageSize._(this._value);
-
-  /// Creates from JSON string.
-  factory ImageSize.fromJson(String json) {
-    return values.firstWhere(
-      (e) => e._value == json,
-      orElse: () => throw FormatException('Unknown size: $json'),
     );
   }
 

--- a/packages/openai_dart/lib/src/models/images/image_response.dart
+++ b/packages/openai_dart/lib/src/models/images/image_response.dart
@@ -201,7 +201,10 @@ class GeneratedImage {
 
   @override
   String toString() {
-    if (hasUrl) return 'GeneratedImage(url: ${url!.substring(0, 50)}...)';
+    if (hasUrl) {
+      final preview = url!.length > 50 ? '${url!.substring(0, 50)}...' : url!;
+      return 'GeneratedImage(url: $preview)';
+    }
     if (hasBase64) return 'GeneratedImage(b64_json: ${b64Json!.length} chars)';
     return 'GeneratedImage()';
   }

--- a/packages/openai_dart/lib/src/models/images/image_response.dart
+++ b/packages/openai_dart/lib/src/models/images/image_response.dart
@@ -1,5 +1,6 @@
 import 'package:meta/meta.dart';
 
+import '../common/equality_helpers.dart';
 import 'image_common.dart';
 
 /// A response from the images API.
@@ -37,9 +38,16 @@ class ImageResponse {
 
   /// Creates an [ImageResponse] from JSON.
   factory ImageResponse.fromJson(Map<String, dynamic> json) {
+    final dataJson = json['data'];
+    if (dataJson is! List) {
+      throw FormatException(
+        'ImageResponse.data is required — expected a List, '
+        'got ${dataJson.runtimeType}',
+      );
+    }
     return ImageResponse(
       created: json['created'] as int,
-      data: (json['data'] as List<dynamic>? ?? const [])
+      data: dataJson
           .map((e) => GeneratedImage.fromJson(e as Map<String, dynamic>))
           .toList(),
       background: json['background'] != null
@@ -111,7 +119,7 @@ class ImageResponse {
       other is ImageResponse &&
           runtimeType == other.runtimeType &&
           created == other.created &&
-          data.length == other.data.length &&
+          listsEqual(data, other.data) &&
           background == other.background &&
           outputFormat == other.outputFormat &&
           quality == other.quality &&
@@ -121,7 +129,7 @@ class ImageResponse {
   @override
   int get hashCode => Object.hash(
     created,
-    data.length,
+    listHash(data),
     background,
     outputFormat,
     quality,

--- a/packages/openai_dart/lib/src/models/images/image_response.dart
+++ b/packages/openai_dart/lib/src/models/images/image_response.dart
@@ -194,10 +194,11 @@ class GeneratedImage {
       other is GeneratedImage &&
           runtimeType == other.runtimeType &&
           url == other.url &&
-          b64Json == other.b64Json;
+          b64Json == other.b64Json &&
+          revisedPrompt == other.revisedPrompt;
 
   @override
-  int get hashCode => Object.hash(url, b64Json);
+  int get hashCode => Object.hash(url, b64Json, revisedPrompt);
 
   @override
   String toString() {

--- a/packages/openai_dart/lib/src/models/images/image_response.dart
+++ b/packages/openai_dart/lib/src/models/images/image_response.dart
@@ -1,8 +1,13 @@
 import 'package:meta/meta.dart';
 
+import 'image_common.dart';
+
 /// A response from the images API.
 ///
-/// Contains the generated image(s) as URLs or base64-encoded data.
+/// Contains the generated image(s) as URLs or base64-encoded data. For GPT
+/// image models (e.g. `gpt-image-2`), also includes token-based pricing info
+/// in [usage] and request-echo metadata ([background], [outputFormat],
+/// [quality], [size]). These extra fields are `null` for DALL-E responses.
 ///
 /// ## Example
 ///
@@ -10,23 +15,48 @@ import 'package:meta/meta.dart';
 /// final response = await client.images.generate(request);
 ///
 /// for (final image in response.data) {
-///   if (image.url != null) {
-///     print('Image URL: ${image.url}');
+///   if (image.b64Json case final b64?) {
+///     final bytes = base64Decode(b64);
+///     // …save bytes to disk
 ///   }
 /// }
+/// print('Total tokens: ${response.usage?.totalTokens}');
 /// ```
 @immutable
 class ImageResponse {
   /// Creates an [ImageResponse].
-  const ImageResponse({required this.created, required this.data});
+  const ImageResponse({
+    required this.created,
+    required this.data,
+    this.background,
+    this.outputFormat,
+    this.quality,
+    this.size,
+    this.usage,
+  });
 
   /// Creates an [ImageResponse] from JSON.
   factory ImageResponse.fromJson(Map<String, dynamic> json) {
     return ImageResponse(
       created: json['created'] as int,
-      data: (json['data'] as List<dynamic>)
+      data: (json['data'] as List<dynamic>? ?? const [])
           .map((e) => GeneratedImage.fromJson(e as Map<String, dynamic>))
           .toList(),
+      background: json['background'] != null
+          ? ImageBackground.fromJson(json['background'] as String)
+          : null,
+      outputFormat: json['output_format'] != null
+          ? ImageOutputFormat.fromJson(json['output_format'] as String)
+          : null,
+      quality: json['quality'] != null
+          ? ImageQuality.fromJson(json['quality'] as String)
+          : null,
+      size: json['size'] != null
+          ? ImageSize.fromJson(json['size'] as String)
+          : null,
+      usage: json['usage'] != null
+          ? ImagesUsage.fromJson(json['usage'] as Map<String, dynamic>)
+          : null,
     );
   }
 
@@ -35,6 +65,21 @@ class ImageResponse {
 
   /// The list of generated images.
   final List<GeneratedImage> data;
+
+  /// Background used (GPT image models only).
+  final ImageBackground? background;
+
+  /// Output format used (GPT image models only).
+  final ImageOutputFormat? outputFormat;
+
+  /// Quality used (GPT image models only).
+  final ImageQuality? quality;
+
+  /// Size used (GPT image models only).
+  final ImageSize? size;
+
+  /// Token usage (GPT image models only).
+  final ImagesUsage? usage;
 
   /// Gets the first generated image.
   GeneratedImage get first => data.first;
@@ -53,6 +98,11 @@ class ImageResponse {
   Map<String, dynamic> toJson() => {
     'created': created,
     'data': data.map((i) => i.toJson()).toList(),
+    if (background != null) 'background': background!.toJson(),
+    if (outputFormat != null) 'output_format': outputFormat!.toJson(),
+    if (quality != null) 'quality': quality!.toJson(),
+    if (size != null) 'size': size!.toJson(),
+    if (usage != null) 'usage': usage!.toJson(),
   };
 
   @override
@@ -61,20 +111,34 @@ class ImageResponse {
       other is ImageResponse &&
           runtimeType == other.runtimeType &&
           created == other.created &&
-          data.length == other.data.length;
+          data.length == other.data.length &&
+          background == other.background &&
+          outputFormat == other.outputFormat &&
+          quality == other.quality &&
+          size == other.size &&
+          usage == other.usage;
 
   @override
-  int get hashCode => Object.hash(created, data.length);
+  int get hashCode => Object.hash(
+    created,
+    data.length,
+    background,
+    outputFormat,
+    quality,
+    size,
+    usage,
+  );
 
   @override
   String toString() =>
-      'ImageResponse(created: $created, images: ${data.length})';
+      'ImageResponse(created: $created, images: ${data.length}, '
+      'size: $size, usage: $usage)';
 }
 
 /// A generated image.
 ///
 /// Contains either a URL or base64-encoded data depending on the
-/// requested response format.
+/// requested response format. GPT image models always return `b64Json`.
 @immutable
 class GeneratedImage {
   /// Creates a [GeneratedImage].
@@ -89,20 +153,18 @@ class GeneratedImage {
     );
   }
 
-  /// The URL of the generated image.
+  /// The URL of the generated image (DALL-E only).
   ///
-  /// The URL expires after 1 hour. Download the image if you need
-  /// to persist it.
+  /// The URL expires after 60 minutes — download the image to persist it.
   final String? url;
 
-  /// The base64-encoded image data.
+  /// The base64-encoded image data (GPT image models always use this).
   ///
-  /// Present when `response_format` is set to `b64_json`.
+  /// Present when `response_format` is `b64_json` or when the model is a
+  /// GPT image model.
   final String? b64Json;
 
-  /// The prompt that was used to generate the image.
-  ///
-  /// For DALL-E 3, the model may revise the prompt for safety or quality.
+  /// The prompt used after server-side revision (DALL-E 3 only).
   final String? revisedPrompt;
 
   /// Whether this image has a URL.
@@ -135,4 +197,205 @@ class GeneratedImage {
     if (hasBase64) return 'GeneratedImage(b64_json: ${b64Json!.length} chars)';
     return 'GeneratedImage()';
   }
+}
+
+/// Token usage for a GPT image generation or edit request.
+///
+/// Only emitted for GPT image models (e.g. `gpt-image-2`). DALL-E responses
+/// have `null` usage.
+@immutable
+class ImagesUsage {
+  /// Creates an [ImagesUsage].
+  const ImagesUsage({
+    required this.totalTokens,
+    required this.inputTokens,
+    required this.outputTokens,
+    required this.inputTokensDetails,
+    this.outputTokensDetails,
+  });
+
+  /// Creates an [ImagesUsage] from JSON.
+  factory ImagesUsage.fromJson(Map<String, dynamic> json) {
+    return ImagesUsage(
+      totalTokens: json['total_tokens'] as int,
+      inputTokens: json['input_tokens'] as int,
+      outputTokens: json['output_tokens'] as int,
+      inputTokensDetails: ImagesUsageInputTokensDetails.fromJson(
+        json['input_tokens_details'] as Map<String, dynamic>,
+      ),
+      outputTokensDetails: json['output_tokens_details'] != null
+          ? ImagesUsageOutputTokensDetails.fromJson(
+              json['output_tokens_details'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+
+  /// Total tokens (images + text) used for the request.
+  final int totalTokens;
+
+  /// Input tokens (images + text).
+  final int inputTokens;
+
+  /// Output image tokens generated.
+  final int outputTokens;
+
+  /// Breakdown of input tokens.
+  final ImagesUsageInputTokensDetails inputTokensDetails;
+
+  /// Breakdown of output tokens (not always emitted).
+  final ImagesUsageOutputTokensDetails? outputTokensDetails;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'total_tokens': totalTokens,
+    'input_tokens': inputTokens,
+    'output_tokens': outputTokens,
+    'input_tokens_details': inputTokensDetails.toJson(),
+    if (outputTokensDetails != null)
+      'output_tokens_details': outputTokensDetails!.toJson(),
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ImagesUsage &&
+          runtimeType == other.runtimeType &&
+          totalTokens == other.totalTokens &&
+          inputTokens == other.inputTokens &&
+          outputTokens == other.outputTokens &&
+          inputTokensDetails == other.inputTokensDetails &&
+          outputTokensDetails == other.outputTokensDetails;
+
+  @override
+  int get hashCode => Object.hash(
+    totalTokens,
+    inputTokens,
+    outputTokens,
+    inputTokensDetails,
+    outputTokensDetails,
+  );
+
+  @override
+  String toString() =>
+      'ImagesUsage(total: $totalTokens, in: $inputTokens, out: $outputTokens)';
+}
+
+/// Breakdown of input tokens for an image request.
+@immutable
+class ImagesUsageInputTokensDetails {
+  /// Creates an [ImagesUsageInputTokensDetails].
+  const ImagesUsageInputTokensDetails({
+    required this.textTokens,
+    required this.imageTokens,
+  });
+
+  /// Creates from JSON.
+  factory ImagesUsageInputTokensDetails.fromJson(Map<String, dynamic> json) {
+    return ImagesUsageInputTokensDetails(
+      textTokens: json['text_tokens'] as int,
+      imageTokens: json['image_tokens'] as int,
+    );
+  }
+
+  /// Text tokens in the input prompt.
+  final int textTokens;
+
+  /// Image tokens in the input prompt.
+  final int imageTokens;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'text_tokens': textTokens,
+    'image_tokens': imageTokens,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ImagesUsageInputTokensDetails &&
+          runtimeType == other.runtimeType &&
+          textTokens == other.textTokens &&
+          imageTokens == other.imageTokens;
+
+  @override
+  int get hashCode => Object.hash(textTokens, imageTokens);
+
+  @override
+  String toString() =>
+      'ImagesUsageInputTokensDetails(text: $textTokens, image: $imageTokens)';
+}
+
+/// Breakdown of output tokens for an image request.
+@immutable
+class ImagesUsageOutputTokensDetails {
+  /// Creates an [ImagesUsageOutputTokensDetails].
+  const ImagesUsageOutputTokensDetails({
+    required this.textTokens,
+    required this.imageTokens,
+  });
+
+  /// Creates from JSON.
+  factory ImagesUsageOutputTokensDetails.fromJson(Map<String, dynamic> json) {
+    return ImagesUsageOutputTokensDetails(
+      textTokens: json['text_tokens'] as int,
+      imageTokens: json['image_tokens'] as int,
+    );
+  }
+
+  /// Text tokens in the output.
+  final int textTokens;
+
+  /// Image tokens in the output.
+  final int imageTokens;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'text_tokens': textTokens,
+    'image_tokens': imageTokens,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ImagesUsageOutputTokensDetails &&
+          runtimeType == other.runtimeType &&
+          textTokens == other.textTokens &&
+          imageTokens == other.imageTokens;
+
+  @override
+  int get hashCode => Object.hash(textTokens, imageTokens);
+
+  @override
+  String toString() =>
+      'ImagesUsageOutputTokensDetails(text: $textTokens, image: $imageTokens)';
+}
+
+/// Well-known OpenAI image model IDs.
+///
+/// Mirrors the `ImageModel` literal in the official Python SDK, extended
+/// with `gpt-image-2`. The request `model` field is a free-form `String`;
+/// use these constants or pass any custom model id directly.
+abstract final class ImageModels {
+  /// GPT Image 2 — flagship image model with token-based pricing,
+  /// flexible sizes, high-fidelity inputs, and Batch API support.
+  static const String gptImage2 = 'gpt-image-2';
+
+  /// GPT Image 1.5.
+  static const String gptImage15 = 'gpt-image-1.5';
+
+  /// GPT Image 1.
+  static const String gptImage1 = 'gpt-image-1';
+
+  /// GPT Image 1 mini.
+  static const String gptImage1Mini = 'gpt-image-1-mini';
+
+  /// ChatGPT image latest (snapshot routed to the current ChatGPT image model).
+  static const String chatgptImageLatest = 'chatgpt-image-latest';
+
+  /// DALL-E 3.
+  static const String dallE3 = 'dall-e-3';
+
+  /// DALL-E 2.
+  static const String dallE2 = 'dall-e-2';
 }

--- a/packages/openai_dart/lib/src/models/images/image_stream_event.dart
+++ b/packages/openai_dart/lib/src/models/images/image_stream_event.dart
@@ -11,8 +11,11 @@ import 'image_response.dart';
 /// [ImagesResource.generateStream].
 ///
 /// Unknown event types are surfaced as [ImageGenUnknownEvent] with the raw
-/// JSON preserved, so newer server-side event variants do not cause parse
-/// failures.
+/// JSON preserved. Typed fields ([ImageSize], [ImageQuality],
+/// [ImageBackground], [ImageOutputFormat]) fall back to their `.unknown`
+/// variant when the server emits a value outside the current spec — for
+/// example, partial-image events sometimes carry transient sizes like
+/// `1254x1254`.
 @immutable
 sealed class ImageGenStreamEvent {
   const ImageGenStreamEvent();
@@ -74,16 +77,16 @@ class ImageGenPartialImageEvent extends ImageGenStreamEvent {
   /// Unix timestamp when the event was created.
   final int createdAt;
 
-  /// Requested image size.
+  /// Image size. May be [ImageSize.unknown] for out-of-spec values.
   final ImageSize size;
 
-  /// Requested image quality.
+  /// Image quality. May be [ImageQuality.unknown] for out-of-spec values.
   final ImageQuality quality;
 
-  /// Requested background handling.
+  /// Background. May be [ImageBackground.unknown] for out-of-spec values.
   final ImageBackground background;
 
-  /// Requested output format.
+  /// Output format. May be [ImageOutputFormat.unknown] for out-of-spec values.
   final ImageOutputFormat outputFormat;
 
   /// 0-based index of this partial image.
@@ -172,13 +175,13 @@ class ImageGenCompletedEvent extends ImageGenStreamEvent {
   /// Unix timestamp when the event was created.
   final int createdAt;
 
-  /// Final image size.
+  /// Final image size. May be [ImageSize.unknown] for out-of-spec values.
   final ImageSize size;
 
   /// Final image quality.
   final ImageQuality quality;
 
-  /// Final background handling.
+  /// Final background.
   final ImageBackground background;
 
   /// Final output format.
@@ -265,6 +268,9 @@ class ImageGenUnknownEvent extends ImageGenStreamEvent {
 }
 
 /// A Server-Sent Event from a streaming image edit request.
+///
+/// See [ImageGenStreamEvent] for the forward-compatibility contract on the
+/// typed fields.
 @immutable
 sealed class ImageEditStreamEvent {
   const ImageEditStreamEvent();
@@ -324,16 +330,16 @@ class ImageEditPartialImageEvent extends ImageEditStreamEvent {
   /// Unix timestamp when the event was created.
   final int createdAt;
 
-  /// Requested image size.
+  /// Image size. May be [ImageSize.unknown] for out-of-spec values.
   final ImageSize size;
 
-  /// Requested image quality.
+  /// Image quality.
   final ImageQuality quality;
 
-  /// Requested background handling.
+  /// Background.
   final ImageBackground background;
 
-  /// Requested output format.
+  /// Output format.
   final ImageOutputFormat outputFormat;
 
   /// 0-based index of this partial image.
@@ -428,7 +434,7 @@ class ImageEditCompletedEvent extends ImageEditStreamEvent {
   /// Final image quality.
   final ImageQuality quality;
 
-  /// Final background handling.
+  /// Final background.
   final ImageBackground background;
 
   /// Final output format.

--- a/packages/openai_dart/lib/src/models/images/image_stream_event.dart
+++ b/packages/openai_dart/lib/src/models/images/image_stream_event.dart
@@ -1,5 +1,6 @@
 import 'package:meta/meta.dart';
 
+import '../common/equality_helpers.dart';
 import 'image_common.dart';
 import 'image_response.dart';
 
@@ -264,6 +265,17 @@ class ImageGenUnknownEvent extends ImageGenStreamEvent {
   Map<String, dynamic> toJson() => Map<String, dynamic>.from(rawJson);
 
   @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ImageGenUnknownEvent &&
+          runtimeType == other.runtimeType &&
+          rawType == other.rawType &&
+          mapsDeepEqual(rawJson, other.rawJson);
+
+  @override
+  int get hashCode => Object.hash(rawType, mapDeepHashCode(rawJson));
+
+  @override
   String toString() => 'ImageGenUnknownEvent(type: $rawType)';
 }
 
@@ -513,6 +525,17 @@ class ImageEditUnknownEvent extends ImageEditStreamEvent {
 
   @override
   Map<String, dynamic> toJson() => Map<String, dynamic>.from(rawJson);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ImageEditUnknownEvent &&
+          runtimeType == other.runtimeType &&
+          rawType == other.rawType &&
+          mapsDeepEqual(rawJson, other.rawJson);
+
+  @override
+  int get hashCode => Object.hash(rawType, mapDeepHashCode(rawJson));
 
   @override
   String toString() => 'ImageEditUnknownEvent(type: $rawType)';

--- a/packages/openai_dart/lib/src/models/images/image_stream_event.dart
+++ b/packages/openai_dart/lib/src/models/images/image_stream_event.dart
@@ -1,0 +1,513 @@
+import 'package:meta/meta.dart';
+
+import 'image_common.dart';
+import 'image_response.dart';
+
+/// A Server-Sent Event from a streaming image generation request.
+///
+/// GPT image models (e.g. `gpt-image-2`) emit one or more
+/// [ImageGenPartialImageEvent]s followed by a terminal
+/// [ImageGenCompletedEvent] when `stream: true` is set on
+/// [ImagesResource.generateStream].
+///
+/// Unknown event types are surfaced as [ImageGenUnknownEvent] with the raw
+/// JSON preserved, so newer server-side event variants do not cause parse
+/// failures.
+@immutable
+sealed class ImageGenStreamEvent {
+  const ImageGenStreamEvent();
+
+  /// Creates a [ImageGenStreamEvent] from JSON, dispatching on `type`.
+  factory ImageGenStreamEvent.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    return switch (type) {
+      'image_generation.partial_image' => ImageGenPartialImageEvent.fromJson(
+        json,
+      ),
+      'image_generation.completed' => ImageGenCompletedEvent.fromJson(json),
+      _ => ImageGenUnknownEvent.fromJson(json),
+    };
+  }
+
+  /// The discriminator value.
+  String get type;
+
+  /// Serializes the event.
+  Map<String, dynamic> toJson();
+}
+
+/// Partial image chunk emitted during streaming generation.
+@immutable
+class ImageGenPartialImageEvent extends ImageGenStreamEvent {
+  /// Creates an [ImageGenPartialImageEvent].
+  const ImageGenPartialImageEvent({
+    required this.b64Json,
+    required this.createdAt,
+    required this.size,
+    required this.quality,
+    required this.background,
+    required this.outputFormat,
+    required this.partialImageIndex,
+  });
+
+  /// Creates an [ImageGenPartialImageEvent] from JSON.
+  factory ImageGenPartialImageEvent.fromJson(Map<String, dynamic> json) {
+    if (json['type'] != 'image_generation.partial_image') {
+      throw FormatException(
+        'Expected type "image_generation.partial_image", got "${json['type']}"',
+      );
+    }
+    return ImageGenPartialImageEvent(
+      b64Json: json['b64_json'] as String,
+      createdAt: json['created_at'] as int,
+      size: ImageSize.fromJson(json['size'] as String),
+      quality: ImageQuality.fromJson(json['quality'] as String),
+      background: ImageBackground.fromJson(json['background'] as String),
+      outputFormat: ImageOutputFormat.fromJson(json['output_format'] as String),
+      partialImageIndex: json['partial_image_index'] as int,
+    );
+  }
+
+  /// Base64-encoded partial image data.
+  final String b64Json;
+
+  /// Unix timestamp when the event was created.
+  final int createdAt;
+
+  /// Requested image size.
+  final ImageSize size;
+
+  /// Requested image quality.
+  final ImageQuality quality;
+
+  /// Requested background handling.
+  final ImageBackground background;
+
+  /// Requested output format.
+  final ImageOutputFormat outputFormat;
+
+  /// 0-based index of this partial image.
+  final int partialImageIndex;
+
+  @override
+  String get type => 'image_generation.partial_image';
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'b64_json': b64Json,
+    'created_at': createdAt,
+    'size': size.toJson(),
+    'quality': quality.toJson(),
+    'background': background.toJson(),
+    'output_format': outputFormat.toJson(),
+    'partial_image_index': partialImageIndex,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ImageGenPartialImageEvent &&
+          runtimeType == other.runtimeType &&
+          b64Json == other.b64Json &&
+          createdAt == other.createdAt &&
+          size == other.size &&
+          quality == other.quality &&
+          background == other.background &&
+          outputFormat == other.outputFormat &&
+          partialImageIndex == other.partialImageIndex;
+
+  @override
+  int get hashCode => Object.hash(
+    b64Json,
+    createdAt,
+    size,
+    quality,
+    background,
+    outputFormat,
+    partialImageIndex,
+  );
+
+  @override
+  String toString() =>
+      'ImageGenPartialImageEvent(index: $partialImageIndex, '
+      'b64: ${b64Json.length} chars, size: $size)';
+}
+
+/// Terminal event for streaming image generation.
+@immutable
+class ImageGenCompletedEvent extends ImageGenStreamEvent {
+  /// Creates an [ImageGenCompletedEvent].
+  const ImageGenCompletedEvent({
+    required this.b64Json,
+    required this.createdAt,
+    required this.size,
+    required this.quality,
+    required this.background,
+    required this.outputFormat,
+    required this.usage,
+  });
+
+  /// Creates an [ImageGenCompletedEvent] from JSON.
+  factory ImageGenCompletedEvent.fromJson(Map<String, dynamic> json) {
+    if (json['type'] != 'image_generation.completed') {
+      throw FormatException(
+        'Expected type "image_generation.completed", got "${json['type']}"',
+      );
+    }
+    return ImageGenCompletedEvent(
+      b64Json: json['b64_json'] as String,
+      createdAt: json['created_at'] as int,
+      size: ImageSize.fromJson(json['size'] as String),
+      quality: ImageQuality.fromJson(json['quality'] as String),
+      background: ImageBackground.fromJson(json['background'] as String),
+      outputFormat: ImageOutputFormat.fromJson(json['output_format'] as String),
+      usage: ImagesUsage.fromJson(json['usage'] as Map<String, dynamic>),
+    );
+  }
+
+  /// Base64-encoded final image data.
+  final String b64Json;
+
+  /// Unix timestamp when the event was created.
+  final int createdAt;
+
+  /// Final image size.
+  final ImageSize size;
+
+  /// Final image quality.
+  final ImageQuality quality;
+
+  /// Final background handling.
+  final ImageBackground background;
+
+  /// Final output format.
+  final ImageOutputFormat outputFormat;
+
+  /// Token-based usage for the full generation.
+  final ImagesUsage usage;
+
+  @override
+  String get type => 'image_generation.completed';
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'b64_json': b64Json,
+    'created_at': createdAt,
+    'size': size.toJson(),
+    'quality': quality.toJson(),
+    'background': background.toJson(),
+    'output_format': outputFormat.toJson(),
+    'usage': usage.toJson(),
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ImageGenCompletedEvent &&
+          runtimeType == other.runtimeType &&
+          b64Json == other.b64Json &&
+          createdAt == other.createdAt &&
+          size == other.size &&
+          quality == other.quality &&
+          background == other.background &&
+          outputFormat == other.outputFormat &&
+          usage == other.usage;
+
+  @override
+  int get hashCode => Object.hash(
+    b64Json,
+    createdAt,
+    size,
+    quality,
+    background,
+    outputFormat,
+    usage,
+  );
+
+  @override
+  String toString() =>
+      'ImageGenCompletedEvent(b64: ${b64Json.length} chars, '
+      'size: $size, usage: $usage)';
+}
+
+/// Forward-compatibility fallback for unrecognized image-generation stream
+/// events. Preserves the raw JSON so `copyWith`-like updates and
+/// round-trip re-serialization do not drop forward-compatible fields.
+@immutable
+class ImageGenUnknownEvent extends ImageGenStreamEvent {
+  /// Creates an [ImageGenUnknownEvent].
+  const ImageGenUnknownEvent({required this.rawType, required this.rawJson});
+
+  /// Creates an [ImageGenUnknownEvent] from JSON.
+  factory ImageGenUnknownEvent.fromJson(Map<String, dynamic> json) {
+    return ImageGenUnknownEvent(
+      rawType: json['type'] as String? ?? '',
+      rawJson: Map<String, dynamic>.from(json),
+    );
+  }
+
+  /// The unknown `type` value from the server.
+  final String rawType;
+
+  /// The original JSON payload (preserved verbatim).
+  final Map<String, dynamic> rawJson;
+
+  @override
+  String get type => rawType;
+
+  @override
+  Map<String, dynamic> toJson() => Map<String, dynamic>.from(rawJson);
+
+  @override
+  String toString() => 'ImageGenUnknownEvent(type: $rawType)';
+}
+
+/// A Server-Sent Event from a streaming image edit request.
+@immutable
+sealed class ImageEditStreamEvent {
+  const ImageEditStreamEvent();
+
+  /// Creates an [ImageEditStreamEvent] from JSON, dispatching on `type`.
+  factory ImageEditStreamEvent.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    return switch (type) {
+      'image_edit.partial_image' => ImageEditPartialImageEvent.fromJson(json),
+      'image_edit.completed' => ImageEditCompletedEvent.fromJson(json),
+      _ => ImageEditUnknownEvent.fromJson(json),
+    };
+  }
+
+  /// The discriminator value.
+  String get type;
+
+  /// Serializes the event.
+  Map<String, dynamic> toJson();
+}
+
+/// Partial image chunk emitted during streaming edit.
+@immutable
+class ImageEditPartialImageEvent extends ImageEditStreamEvent {
+  /// Creates an [ImageEditPartialImageEvent].
+  const ImageEditPartialImageEvent({
+    required this.b64Json,
+    required this.createdAt,
+    required this.size,
+    required this.quality,
+    required this.background,
+    required this.outputFormat,
+    required this.partialImageIndex,
+  });
+
+  /// Creates an [ImageEditPartialImageEvent] from JSON.
+  factory ImageEditPartialImageEvent.fromJson(Map<String, dynamic> json) {
+    if (json['type'] != 'image_edit.partial_image') {
+      throw FormatException(
+        'Expected type "image_edit.partial_image", got "${json['type']}"',
+      );
+    }
+    return ImageEditPartialImageEvent(
+      b64Json: json['b64_json'] as String,
+      createdAt: json['created_at'] as int,
+      size: ImageSize.fromJson(json['size'] as String),
+      quality: ImageQuality.fromJson(json['quality'] as String),
+      background: ImageBackground.fromJson(json['background'] as String),
+      outputFormat: ImageOutputFormat.fromJson(json['output_format'] as String),
+      partialImageIndex: json['partial_image_index'] as int,
+    );
+  }
+
+  /// Base64-encoded partial image data.
+  final String b64Json;
+
+  /// Unix timestamp when the event was created.
+  final int createdAt;
+
+  /// Requested image size.
+  final ImageSize size;
+
+  /// Requested image quality.
+  final ImageQuality quality;
+
+  /// Requested background handling.
+  final ImageBackground background;
+
+  /// Requested output format.
+  final ImageOutputFormat outputFormat;
+
+  /// 0-based index of this partial image.
+  final int partialImageIndex;
+
+  @override
+  String get type => 'image_edit.partial_image';
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'b64_json': b64Json,
+    'created_at': createdAt,
+    'size': size.toJson(),
+    'quality': quality.toJson(),
+    'background': background.toJson(),
+    'output_format': outputFormat.toJson(),
+    'partial_image_index': partialImageIndex,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ImageEditPartialImageEvent &&
+          runtimeType == other.runtimeType &&
+          b64Json == other.b64Json &&
+          createdAt == other.createdAt &&
+          size == other.size &&
+          quality == other.quality &&
+          background == other.background &&
+          outputFormat == other.outputFormat &&
+          partialImageIndex == other.partialImageIndex;
+
+  @override
+  int get hashCode => Object.hash(
+    b64Json,
+    createdAt,
+    size,
+    quality,
+    background,
+    outputFormat,
+    partialImageIndex,
+  );
+
+  @override
+  String toString() =>
+      'ImageEditPartialImageEvent(index: $partialImageIndex, '
+      'b64: ${b64Json.length} chars, size: $size)';
+}
+
+/// Terminal event for streaming image edit.
+@immutable
+class ImageEditCompletedEvent extends ImageEditStreamEvent {
+  /// Creates an [ImageEditCompletedEvent].
+  const ImageEditCompletedEvent({
+    required this.b64Json,
+    required this.createdAt,
+    required this.size,
+    required this.quality,
+    required this.background,
+    required this.outputFormat,
+    required this.usage,
+  });
+
+  /// Creates an [ImageEditCompletedEvent] from JSON.
+  factory ImageEditCompletedEvent.fromJson(Map<String, dynamic> json) {
+    if (json['type'] != 'image_edit.completed') {
+      throw FormatException(
+        'Expected type "image_edit.completed", got "${json['type']}"',
+      );
+    }
+    return ImageEditCompletedEvent(
+      b64Json: json['b64_json'] as String,
+      createdAt: json['created_at'] as int,
+      size: ImageSize.fromJson(json['size'] as String),
+      quality: ImageQuality.fromJson(json['quality'] as String),
+      background: ImageBackground.fromJson(json['background'] as String),
+      outputFormat: ImageOutputFormat.fromJson(json['output_format'] as String),
+      usage: ImagesUsage.fromJson(json['usage'] as Map<String, dynamic>),
+    );
+  }
+
+  /// Base64-encoded final image data.
+  final String b64Json;
+
+  /// Unix timestamp when the event was created.
+  final int createdAt;
+
+  /// Final image size.
+  final ImageSize size;
+
+  /// Final image quality.
+  final ImageQuality quality;
+
+  /// Final background handling.
+  final ImageBackground background;
+
+  /// Final output format.
+  final ImageOutputFormat outputFormat;
+
+  /// Token-based usage for the full edit.
+  final ImagesUsage usage;
+
+  @override
+  String get type => 'image_edit.completed';
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'b64_json': b64Json,
+    'created_at': createdAt,
+    'size': size.toJson(),
+    'quality': quality.toJson(),
+    'background': background.toJson(),
+    'output_format': outputFormat.toJson(),
+    'usage': usage.toJson(),
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ImageEditCompletedEvent &&
+          runtimeType == other.runtimeType &&
+          b64Json == other.b64Json &&
+          createdAt == other.createdAt &&
+          size == other.size &&
+          quality == other.quality &&
+          background == other.background &&
+          outputFormat == other.outputFormat &&
+          usage == other.usage;
+
+  @override
+  int get hashCode => Object.hash(
+    b64Json,
+    createdAt,
+    size,
+    quality,
+    background,
+    outputFormat,
+    usage,
+  );
+
+  @override
+  String toString() =>
+      'ImageEditCompletedEvent(b64: ${b64Json.length} chars, '
+      'size: $size, usage: $usage)';
+}
+
+/// Forward-compatibility fallback for unrecognized image-edit stream events.
+@immutable
+class ImageEditUnknownEvent extends ImageEditStreamEvent {
+  /// Creates an [ImageEditUnknownEvent].
+  const ImageEditUnknownEvent({required this.rawType, required this.rawJson});
+
+  /// Creates an [ImageEditUnknownEvent] from JSON.
+  factory ImageEditUnknownEvent.fromJson(Map<String, dynamic> json) {
+    return ImageEditUnknownEvent(
+      rawType: json['type'] as String? ?? '',
+      rawJson: Map<String, dynamic>.from(json),
+    );
+  }
+
+  /// The unknown `type` value from the server.
+  final String rawType;
+
+  /// The original JSON payload (preserved verbatim).
+  final Map<String, dynamic> rawJson;
+
+  @override
+  String get type => rawType;
+
+  @override
+  Map<String, dynamic> toJson() => Map<String, dynamic>.from(rawJson);
+
+  @override
+  String toString() => 'ImageEditUnknownEvent(type: $rawType)';
+}

--- a/packages/openai_dart/lib/src/models/images/images.dart
+++ b/packages/openai_dart/lib/src/models/images/images.dart
@@ -5,3 +5,4 @@ export 'image_common.dart';
 export 'image_edit_json_request.dart';
 export 'image_request.dart';
 export 'image_response.dart';
+export 'image_stream_event.dart';

--- a/packages/openai_dart/lib/src/models/images/images.dart
+++ b/packages/openai_dart/lib/src/models/images/images.dart
@@ -1,6 +1,7 @@
-/// Image models for DALL-E generation, editing, and variations.
+/// Image models for GPT image and DALL-E generation, editing, and variations.
 library;
 
+export 'image_common.dart';
 export 'image_edit_json_request.dart';
 export 'image_request.dart';
 export 'image_response.dart';

--- a/packages/openai_dart/lib/src/resources/images_resource.dart
+++ b/packages/openai_dart/lib/src/resources/images_resource.dart
@@ -1,9 +1,13 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
+import '../errors/exceptions.dart';
 import '../models/images/images.dart';
+import '../utils/streaming_parser.dart';
 import 'base_resource.dart';
+import 'streaming_resource.dart';
 
 /// Resource for image operations.
 ///
@@ -28,7 +32,7 @@ import 'base_resource.dart';
 /// final bytes = response.data.first.b64Json; // GPT image returns base64
 /// print('Tokens used: ${response.usage?.totalTokens}');
 /// ```
-class ImagesResource extends ResourceBase {
+class ImagesResource extends ResourceBase with StreamingResource {
   /// Creates an [ImagesResource].
   ImagesResource({
     required super.config,
@@ -84,6 +88,68 @@ class ImagesResource extends ResourceBase {
     );
   }
 
+  /// Streams image generation as Server-Sent Events (GPT image models only).
+  ///
+  /// Forces `stream: true` on the request. Yields one or more
+  /// [ImageGenPartialImageEvent]s followed by a terminal
+  /// [ImageGenCompletedEvent] carrying the final image and token-based usage.
+  ///
+  /// ## Example
+  ///
+  /// ```dart
+  /// final stream = client.images.generateStream(
+  ///   ImageGenerationRequest(
+  ///     model: ImageModels.gptImage2,
+  ///     prompt: 'A white cat wearing a top hat',
+  ///     partialImages: 2,
+  ///   ),
+  /// );
+  ///
+  /// await for (final event in stream) {
+  ///   switch (event) {
+  ///     case ImageGenPartialImageEvent():
+  ///       print('partial #${event.partialImageIndex}');
+  ///     case ImageGenCompletedEvent():
+  ///       print('done — ${event.usage.totalTokens} tokens');
+  ///     case ImageGenUnknownEvent():
+  ///       // Forward-compatibility fallback.
+  ///   }
+  /// }
+  /// ```
+  Stream<ImageGenStreamEvent> generateStream(
+    ImageGenerationRequest request, {
+    Future<void>? abortTrigger,
+  }) {
+    ensureNotClosed?.call();
+    final body = request.toJson()..['stream'] = true;
+    return streamSseEvents(
+      endpoint: _generateEndpoint,
+      body: body,
+      abortTrigger: abortTrigger,
+    ).map((json) {
+      final sseEvent = json['_event'] as String?;
+      final error = json['error'];
+      if (sseEvent == 'error' || error != null) {
+        throwInlineStreamError(json, sseEvent, error);
+      }
+      try {
+        return ImageGenStreamEvent.fromJson(json);
+      } on FormatException catch (e) {
+        throw ParseException(
+          message: 'Failed to parse image generation stream event: $e',
+          responseBody: json.toString(),
+          cause: e,
+        );
+      } on TypeError catch (e) {
+        throw ParseException(
+          message: 'Failed to parse image generation stream event: $e',
+          responseBody: json.toString(),
+          cause: e,
+        );
+      }
+    });
+  }
+
   /// Creates edited or extended images.
   ///
   /// Given an original image and a mask, generates new images where
@@ -136,6 +202,96 @@ class ImagesResource extends ResourceBase {
     return ImageResponse.fromJson(
       jsonDecode(response.body) as Map<String, dynamic>,
     );
+  }
+
+  /// Streams an image edit using a JSON payload (GPT image models only).
+  ///
+  /// Forces `stream: true` on the request. Yields
+  /// [ImageEditPartialImageEvent]s then a terminal [ImageEditCompletedEvent].
+  Stream<ImageEditStreamEvent> editJsonStream(
+    ImageEditJsonRequest request, {
+    Future<void>? abortTrigger,
+  }) {
+    ensureNotClosed?.call();
+    final body = request.toJson()..['stream'] = true;
+    return streamSseEvents(
+      endpoint: _editEndpoint,
+      body: body,
+      abortTrigger: abortTrigger,
+    ).map(_mapEditEvent);
+  }
+
+  /// Streams a multipart image edit (GPT image models only).
+  ///
+  /// Forces `stream: true` on the request. Yields
+  /// [ImageEditPartialImageEvent]s then a terminal [ImageEditCompletedEvent].
+  Stream<ImageEditStreamEvent> editStream(
+    ImageEditRequest request, {
+    Future<void>? abortTrigger,
+  }) async* {
+    ensureNotClosed?.call();
+
+    final multipart = _createEditMultipartRequest(
+      ImageEditRequest(
+        image: request.image,
+        imageFilename: request.imageFilename,
+        prompt: request.prompt,
+        mask: request.mask,
+        maskFilename: request.maskFilename,
+        model: request.model,
+        n: request.n,
+        size: request.size,
+        responseFormat: request.responseFormat,
+        user: request.user,
+        background: request.background,
+        inputFidelity: request.inputFidelity,
+        quality: request.quality,
+        outputFormat: request.outputFormat,
+        outputCompression: request.outputCompression,
+        moderation: request.moderation,
+        stream: true,
+        partialImages: request.partialImages,
+      ),
+    )..headers.addAll(requestBuilder.buildMultipartHeaders());
+
+    final response = await httpClient.send(multipart);
+    final requestId =
+        response.headers['x-request-id'] ??
+        response.request?.headers['X-Request-ID'] ??
+        'unknown';
+
+    if (response.statusCode >= 400) {
+      final body = await response.stream.bytesToString();
+      throw parseStreamError(response.statusCode, body, requestId);
+    }
+
+    const parser = SseParser();
+    await for (final json in parser.parse(response.stream)) {
+      yield _mapEditEvent(json);
+    }
+  }
+
+  ImageEditStreamEvent _mapEditEvent(Map<String, dynamic> json) {
+    final sseEvent = json['_event'] as String?;
+    final error = json['error'];
+    if (sseEvent == 'error' || error != null) {
+      throwInlineStreamError(json, sseEvent, error);
+    }
+    try {
+      return ImageEditStreamEvent.fromJson(json);
+    } on FormatException catch (e) {
+      throw ParseException(
+        message: 'Failed to parse image edit stream event: $e',
+        responseBody: json.toString(),
+        cause: e,
+      );
+    } on TypeError catch (e) {
+      throw ParseException(
+        message: 'Failed to parse image edit stream event: $e',
+        responseBody: json.toString(),
+        cause: e,
+      );
+    }
   }
 
   /// Creates variations of an existing image.

--- a/packages/openai_dart/lib/src/resources/images_resource.dart
+++ b/packages/openai_dart/lib/src/resources/images_resource.dart
@@ -259,14 +259,28 @@ class ImagesResource extends ResourceBase with StreamingResource {
   Stream<ImageEditStreamEvent> editStream(
     ImageEditRequest request, {
     Future<void>? abortTrigger,
+  }) {
+    // Perform the closed-client check eagerly (before the stream is
+    // listened to), matching the pattern used by generateStream and
+    // editJsonStream. Without this, the `async*` body is lazy and defers
+    // the check inside sendStream until subscription time.
+    ensureNotClosed?.call();
+    return _editStreamImpl(request, abortTrigger: abortTrigger);
+  }
+
+  Stream<ImageEditStreamEvent> _editStreamImpl(
+    ImageEditRequest request, {
+    Future<void>? abortTrigger,
   }) async* {
     final multipart = _createEditMultipartRequest(
       request.copyWith(stream: true),
-    )..headers.addAll(requestBuilder.buildMultipartHeaders());
+    );
 
     // Route through sendStream so abortTrigger closes the underlying client
     // and terminates the in-flight connection, matching the JSON streaming
-    // paths above.
+    // paths above. sendStream adds auth/org/project + Accept via
+    // buildStreamingHeaders and drops the JSON content-type for multipart,
+    // so there's no need to pre-apply buildMultipartHeaders here.
     final response = await sendStream(
       request: multipart,
       abortTrigger: abortTrigger,

--- a/packages/openai_dart/lib/src/resources/images_resource.dart
+++ b/packages/openai_dart/lib/src/resources/images_resource.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import 'package:http_parser/http_parser.dart';
 
 import '../errors/exceptions.dart';
 import '../models/images/images.dart';
@@ -228,38 +229,27 @@ class ImagesResource extends ResourceBase with StreamingResource {
 
   /// Streams a multipart image edit (GPT image models only).
   ///
-  /// Forces `stream: true` on the request. Yields
+  /// Forces `stream: true` on the multipart body. Yields
   /// [ImageEditPartialImageEvent]s then a terminal [ImageEditCompletedEvent].
+  ///
+  /// When [abortTrigger] completes, the underlying HTTP connection is closed
+  /// and the stream terminates — same contract as [generateStream] and
+  /// [editJsonStream].
   Stream<ImageEditStreamEvent> editStream(
     ImageEditRequest request, {
     Future<void>? abortTrigger,
   }) async* {
-    ensureNotClosed?.call();
-
     final multipart = _createEditMultipartRequest(
-      ImageEditRequest(
-        image: request.image,
-        imageFilename: request.imageFilename,
-        prompt: request.prompt,
-        mask: request.mask,
-        maskFilename: request.maskFilename,
-        model: request.model,
-        n: request.n,
-        size: request.size,
-        responseFormat: request.responseFormat,
-        user: request.user,
-        background: request.background,
-        inputFidelity: request.inputFidelity,
-        quality: request.quality,
-        outputFormat: request.outputFormat,
-        outputCompression: request.outputCompression,
-        moderation: request.moderation,
-        stream: true,
-        partialImages: request.partialImages,
-      ),
+      request.copyWith(stream: true),
     )..headers.addAll(requestBuilder.buildMultipartHeaders());
 
-    final response = await httpClient.send(multipart);
+    // Route through sendStream so abortTrigger closes the underlying client
+    // and terminates the in-flight connection, matching the JSON streaming
+    // paths above.
+    final response = await sendStream(
+      request: multipart,
+      abortTrigger: abortTrigger,
+    );
     final requestId =
         response.headers['x-request-id'] ??
         response.request?.headers['X-Request-ID'] ??
@@ -339,22 +329,28 @@ class ImagesResource extends ResourceBase with StreamingResource {
     final url = requestBuilder.buildUrl(_editEndpoint);
     final httpRequest = http.MultipartRequest('POST', url);
 
-    // Add image file
+    // Add image file. Passing an explicit Content-Type is required for
+    // GPT image models when `stream=true` — the server's streaming
+    // multipart parser rejects parts with the default
+    // `application/octet-stream` content-type.
     httpRequest.files.add(
       http.MultipartFile.fromBytes(
         'image',
         request.image,
         filename: request.imageFilename,
+        contentType: _inferImageContentType(request.imageFilename),
       ),
     );
 
     // Add mask if provided
     if (request.mask != null) {
+      final maskName = request.maskFilename ?? 'mask.png';
       httpRequest.files.add(
         http.MultipartFile.fromBytes(
           'mask',
           request.mask!,
-          filename: request.maskFilename ?? 'mask.png',
+          filename: maskName,
+          contentType: _inferImageContentType(maskName),
         ),
       );
     }
@@ -413,12 +409,14 @@ class ImagesResource extends ResourceBase with StreamingResource {
     final url = requestBuilder.buildUrl(_variationEndpoint);
     final httpRequest = http.MultipartRequest('POST', url);
 
-    // Add image file
+    // Add image file with an explicit Content-Type — keeps parity with
+    // the edit endpoint so consumers get predictable behavior.
     httpRequest.files.add(
       http.MultipartFile.fromBytes(
         'image',
         request.image,
         filename: request.imageFilename,
+        contentType: _inferImageContentType(request.imageFilename),
       ),
     );
 
@@ -440,5 +438,22 @@ class ImagesResource extends ResourceBase with StreamingResource {
     }
 
     return httpRequest;
+  }
+
+  /// Infers a multipart `Content-Type` from an image filename.
+  ///
+  /// Covers the formats accepted by the OpenAI images endpoints
+  /// (`png`, `jpeg`/`jpg`, `webp`, `gif`). Falls back to
+  /// `application/octet-stream` for unknown extensions — callers can still
+  /// set their filename precisely to match a supported extension.
+  static MediaType _inferImageContentType(String filename) {
+    final lower = filename.toLowerCase();
+    if (lower.endsWith('.png')) return MediaType('image', 'png');
+    if (lower.endsWith('.jpg') || lower.endsWith('.jpeg')) {
+      return MediaType('image', 'jpeg');
+    }
+    if (lower.endsWith('.webp')) return MediaType('image', 'webp');
+    if (lower.endsWith('.gif')) return MediaType('image', 'gif');
+    return MediaType('application', 'octet-stream');
   }
 }

--- a/packages/openai_dart/lib/src/resources/images_resource.dart
+++ b/packages/openai_dart/lib/src/resources/images_resource.dart
@@ -29,7 +29,12 @@ import 'streaming_resource.dart';
 ///   ),
 /// );
 ///
-/// final bytes = response.data.first.b64Json; // GPT image returns base64
+/// // GPT image models always return base64; decode before using as bytes.
+/// final b64Json = response.data.first.b64Json;
+/// if (b64Json == null) {
+///   throw StateError('Expected base64 image data but got null');
+/// }
+/// final bytes = base64Decode(b64Json);
 /// print('Tokens used: ${response.usage?.totalTokens}');
 /// ```
 class ImagesResource extends ResourceBase with StreamingResource {

--- a/packages/openai_dart/lib/src/resources/images_resource.dart
+++ b/packages/openai_dart/lib/src/resources/images_resource.dart
@@ -46,6 +46,7 @@ class ImagesResource extends ResourceBase with StreamingResource {
     required super.interceptorChain,
     required super.requestBuilder,
     super.ensureNotClosed,
+    super.streamClientFactory,
   });
 
   static const _generateEndpoint = '/images/generations';
@@ -83,6 +84,13 @@ class ImagesResource extends ResourceBase with StreamingResource {
   /// ```
   Future<ImageResponse> generate(ImageGenerationRequest request) async {
     ensureNotClosed?.call();
+    if (request.stream ?? false) {
+      throw ArgumentError(
+        'generate() does not support stream: true. The server returns SSE '
+        'for streaming generations, which this method cannot parse. Use '
+        'generateStream() instead.',
+      );
+    }
     final url = requestBuilder.buildUrl(_generateEndpoint);
     final headers = requestBuilder.buildHeaders();
     final httpRequest = http.Request('POST', url)
@@ -186,6 +194,13 @@ class ImagesResource extends ResourceBase with StreamingResource {
   /// ```
   Future<ImageResponse> edit(ImageEditRequest request) async {
     ensureNotClosed?.call();
+    if (request.stream ?? false) {
+      throw ArgumentError(
+        'edit() does not support stream: true. The server returns SSE for '
+        'streaming edits, which this method cannot parse. Use editStream() '
+        'instead.',
+      );
+    }
     final httpRequest = _createEditMultipartRequest(request);
     httpRequest.headers.addAll(requestBuilder.buildMultipartHeaders());
     final response = await interceptorChain.execute(httpRequest);
@@ -199,6 +214,12 @@ class ImagesResource extends ResourceBase with StreamingResource {
   /// editing workflows where images are referenced by URL or File ID.
   Future<ImageResponse> editJson(ImageEditJsonRequest request) async {
     ensureNotClosed?.call();
+    if (request.stream ?? false) {
+      throw ArgumentError(
+        'editJson() does not support stream: true. Use editJsonStream() '
+        'instead.',
+      );
+    }
     final url = requestBuilder.buildUrl(_editEndpoint);
     final headers = requestBuilder.buildHeaders();
     final httpRequest = http.Request('POST', url)

--- a/packages/openai_dart/lib/src/resources/images_resource.dart
+++ b/packages/openai_dart/lib/src/resources/images_resource.dart
@@ -7,24 +7,26 @@ import 'base_resource.dart';
 
 /// Resource for image operations.
 ///
-/// Provides image generation, editing, and variation capabilities
-/// using DALL-E models.
+/// Provides image generation, editing, and variation capabilities using
+/// GPT image models (e.g. `gpt-image-2`) and DALL-E.
 ///
 /// Access this resource through [OpenAIClient.images].
 ///
 /// ## Example
 ///
 /// ```dart
-/// // Generate an image
+/// // Generate an image with GPT Image 2
 /// final response = await client.images.generate(
 ///   ImageGenerationRequest(
-///     model: 'dall-e-3',
+///     model: ImageModels.gptImage2,
 ///     prompt: 'A white cat sitting on a windowsill',
 ///     size: ImageSize.size1024x1024,
+///     background: ImageBackground.transparent,
 ///   ),
 /// );
 ///
-/// final imageUrl = response.data.first.url;
+/// final bytes = response.data.first.b64Json; // GPT image returns base64
+/// print('Tokens used: ${response.usage?.totalTokens}');
 /// ```
 class ImagesResource extends ResourceBase {
   /// Creates an [ImagesResource].
@@ -57,16 +59,16 @@ class ImagesResource extends ResourceBase {
   /// ```dart
   /// final response = await client.images.generate(
   ///   ImageGenerationRequest(
-  ///     model: 'dall-e-3',
+  ///     model: ImageModels.gptImage2,
   ///     prompt: 'A beautiful sunset over mountains',
-  ///     size: ImageSize.size1024x1024,
-  ///     quality: ImageQuality.hd,
-  ///     style: ImageStyle.vivid,
+  ///     size: ImageSize.size1536x1024,
+  ///     quality: ImageQuality.high,
+  ///     outputFormat: ImageOutputFormat.webp,
   ///   ),
   /// );
   ///
   /// for (final image in response.data) {
-  ///   print('Image URL: ${image.url}');
+  ///   print('Base64 image: ${image.b64Json?.length} chars');
   /// }
   /// ```
   Future<ImageResponse> generate(ImageGenerationRequest request) async {
@@ -99,16 +101,14 @@ class ImagesResource extends ResourceBase {
   ///
   /// ```dart
   /// final imageBytes = File('original.png').readAsBytesSync();
-  /// final maskBytes = File('mask.png').readAsBytesSync();
   ///
   /// final response = await client.images.edit(
   ///   ImageEditRequest(
   ///     image: imageBytes,
   ///     imageFilename: 'original.png',
-  ///     mask: maskBytes,
-  ///     maskFilename: 'mask.png',
-  ///     prompt: 'Add a red hat',
-  ///     model: 'dall-e-2',
+  ///     prompt: 'Add a rainbow in the sky',
+  ///     model: ImageModels.gptImage2,
+  ///     inputFidelity: ImageInputFidelity.high,
   ///   ),
   /// );
   /// ```
@@ -216,6 +216,31 @@ class ImagesResource extends ResourceBase {
     }
     if (request.user != null) {
       httpRequest.fields['user'] = request.user!;
+    }
+    if (request.background != null) {
+      httpRequest.fields['background'] = request.background!.toJson();
+    }
+    if (request.inputFidelity != null) {
+      httpRequest.fields['input_fidelity'] = request.inputFidelity!.toJson();
+    }
+    if (request.quality != null) {
+      httpRequest.fields['quality'] = request.quality!.toJson();
+    }
+    if (request.outputFormat != null) {
+      httpRequest.fields['output_format'] = request.outputFormat!.toJson();
+    }
+    if (request.outputCompression != null) {
+      httpRequest.fields['output_compression'] = request.outputCompression
+          .toString();
+    }
+    if (request.moderation != null) {
+      httpRequest.fields['moderation'] = request.moderation!.toJson();
+    }
+    if (request.stream != null) {
+      httpRequest.fields['stream'] = request.stream! ? 'true' : 'false';
+    }
+    if (request.partialImages != null) {
+      httpRequest.fields['partial_images'] = request.partialImages.toString();
     }
 
     return httpRequest;

--- a/packages/openai_dart/lib/src/resources/streaming_resource.dart
+++ b/packages/openai_dart/lib/src/resources/streaming_resource.dart
@@ -28,7 +28,7 @@ mixin StreamingResource on ResourceBase {
   /// The interceptor chain is bypassed since streaming requires low-level
   /// access to the response stream.
   Future<http.StreamedResponse> sendStream({
-    required http.Request request,
+    required http.BaseRequest request,
     String? jsonBody,
     Map<String, String>? additionalHeaders,
     Future<void>? abortTrigger,
@@ -41,9 +41,24 @@ mixin StreamingResource on ResourceBase {
     );
     request.headers.addAll(streamHeaders);
 
+    // Multipart requests set their own Content-Type (with a boundary) at
+    // finalize time. Drop the JSON content-type added by buildStreamingHeaders
+    // so the multipart header isn't shadowed on the wire.
+    if (request is http.MultipartRequest) {
+      request.headers.removeWhere((k, _) => k.toLowerCase() == 'content-type');
+    }
+
     // Set body AFTER headers so body setter adds charset to Content-Type
-    // (e.g., application/json → application/json; charset=utf-8)
+    // (e.g., application/json → application/json; charset=utf-8).
+    // `jsonBody` only applies to `http.Request`; multipart/stream callers
+    // configure their body on the request before calling sendStream.
     if (jsonBody != null) {
+      if (request is! http.Request) {
+        throw ArgumentError(
+          'jsonBody is only supported for http.Request, '
+          'got ${request.runtimeType}',
+        );
+      }
       request.body = jsonBody;
     }
 

--- a/packages/openai_dart/llms.txt
+++ b/packages/openai_dart/llms.txt
@@ -4,7 +4,7 @@
 
 ## Docs
 
-- [README](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/openai_dart/README.md) (~5.6k tokens): Primary package documentation with installation, configuration, and usage examples.
+- [README](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/openai_dart/README.md) (~5.8k tokens): Primary package documentation with installation, configuration, and usage examples.
 - [CHANGELOG](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/openai_dart/CHANGELOG.md) (~17.5k tokens): Release history and version-by-version changes.
 - [MIGRATION](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/openai_dart/MIGRATION.md) (~9k tokens): Upgrade notes and breaking-change guidance.
 
@@ -16,7 +16,7 @@
 - [tool_calling_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/openai_dart/example/tool_calling_example.dart) (~742 tokens): Function calling with tool definitions.
 - [vision_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/openai_dart/example/vision_example.dart) (~840 tokens): Image analysis with vision models.
 - [embeddings_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/openai_dart/example/embeddings_example.dart) (~837 tokens): Text embeddings with dimension control.
-- [images_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/openai_dart/example/images_example.dart) (~503 tokens): GPT Image generation.
+- [images_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/openai_dart/example/images_example.dart) (~860 tokens): GPT Image 2 generation, editing, and token usage.
 - [audio_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/openai_dart/example/audio_example.dart) (~1k tokens): Text-to-speech and transcription.
 - [realtime_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/openai_dart/example/realtime_example.dart) (~1.3k tokens): Realtime API (WebSocket and WebRTC).
 - [videos_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/openai_dart/example/videos_example.dart) (~1.6k tokens): Sora video generation, editing, and extension.
@@ -42,4 +42,4 @@
 
 - [Package directory](https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/openai_dart): Source tree, pubspec, and package-local files.
 
-**Total: ~59.5k tokens**
+**Total: ~60k tokens**

--- a/packages/openai_dart/llms.txt
+++ b/packages/openai_dart/llms.txt
@@ -16,7 +16,7 @@
 - [tool_calling_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/openai_dart/example/tool_calling_example.dart) (~742 tokens): Function calling with tool definitions.
 - [vision_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/openai_dart/example/vision_example.dart) (~840 tokens): Image analysis with vision models.
 - [embeddings_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/openai_dart/example/embeddings_example.dart) (~837 tokens): Text embeddings with dimension control.
-- [images_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/openai_dart/example/images_example.dart) (~860 tokens): GPT Image 2 generation, editing, and token usage.
+- [images_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/openai_dart/example/images_example.dart) (~1.2k tokens): GPT Image 2 generation, editing, streaming (partial images), and token usage.
 - [audio_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/openai_dart/example/audio_example.dart) (~1k tokens): Text-to-speech and transcription.
 - [realtime_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/openai_dart/example/realtime_example.dart) (~1.3k tokens): Realtime API (WebSocket and WebRTC).
 - [videos_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/openai_dart/example/videos_example.dart) (~1.6k tokens): Sora video generation, editing, and extension.
@@ -42,4 +42,4 @@
 
 - [Package directory](https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/openai_dart): Source tree, pubspec, and package-local files.
 
-**Total: ~60k tokens**
+**Total: ~60.4k tokens**

--- a/packages/openai_dart/pubspec.yaml
+++ b/packages/openai_dart/pubspec.yaml
@@ -22,6 +22,7 @@ resolution: workspace
 
 dependencies:
   http: ^1.6.0
+  http_parser: ^4.1.2
   logging: ^1.3.0
   meta: ^1.16.0
   web_socket: ^1.0.1

--- a/packages/openai_dart/specs/spec_metadata.json
+++ b/packages/openai_dart/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "2.3.0",
-      "last_fetched": "2026-04-16T09:40:55.880616Z",
+      "last_fetched": "2026-04-21T21:42:49.769622Z",
       "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai%2Fopenai-7c540cce6eb30401259f4831ea9803b6d88501605d13734f98212cbb3b199e10.yml",
       "title": "OpenAI API",
       "version_history": []

--- a/packages/openai_dart/test/integration/images_test.dart
+++ b/packages/openai_dart/test/integration/images_test.dart
@@ -113,6 +113,91 @@ void main() {
       },
     );
 
+    test(
+      'generates image with GPT Image 2 and token-based usage',
+      timeout: const Timeout(Duration(minutes: 5)),
+      () async {
+        if (apiKey == null) {
+          markTestSkipped('API key not available');
+          return;
+        }
+
+        final response = await client!.images.generate(
+          const ImageGenerationRequest(
+            model: ImageModels.gptImage2,
+            prompt: 'A red apple on a white background',
+            size: ImageSize.size1024x1024,
+            quality: ImageQuality.low,
+            background: ImageBackground.opaque,
+            outputFormat: ImageOutputFormat.png,
+            moderation: ImageModerationLevel.auto,
+          ),
+        );
+
+        // GPT Image 2 always returns base64, never a URL.
+        expect(response.data, hasLength(1));
+        expect(response.data.first.b64Json, isNotNull);
+        expect(response.data.first.b64Json!.length, greaterThan(100));
+        expect(response.data.first.url, isNull);
+
+        // Response metadata must echo the request.
+        expect(response.size, ImageSize.size1024x1024);
+        expect(response.background, ImageBackground.opaque);
+        expect(response.outputFormat, ImageOutputFormat.png);
+        expect(response.quality, ImageQuality.low);
+
+        // Token-based pricing: usage must be populated.
+        final usage = response.usage;
+        expect(usage, isNotNull);
+        expect(usage!.totalTokens, greaterThan(0));
+        expect(usage.inputTokens, greaterThan(0));
+        expect(usage.outputTokens, greaterThan(0));
+        expect(usage.inputTokensDetails.textTokens, greaterThanOrEqualTo(0));
+        expect(usage.inputTokensDetails.imageTokens, greaterThanOrEqualTo(0));
+      },
+    );
+
+    test(
+      'streams GPT Image 2 generation with partial + completed events',
+      timeout: const Timeout(Duration(minutes: 5)),
+      () async {
+        if (apiKey == null) {
+          markTestSkipped('API key not available');
+          return;
+        }
+
+        final events = await client!.images
+            .generateStream(
+              const ImageGenerationRequest(
+                model: ImageModels.gptImage2,
+                prompt: 'A simple green square on a white background',
+                size: ImageSize.size1024x1024,
+                quality: ImageQuality.low,
+                partialImages: 1,
+              ),
+            )
+            .toList();
+
+        expect(events, isNotEmpty);
+        final completed = events.whereType<ImageGenCompletedEvent>().toList();
+        expect(
+          completed,
+          hasLength(1),
+          reason: 'exactly one image_generation.completed event expected',
+        );
+        expect(completed.single.b64Json, isNotEmpty);
+        expect(completed.single.usage.totalTokens, greaterThan(0));
+
+        // Partial events are optional per API, but we requested them and
+        // the server may emit 0+ depending on how quickly it generates.
+        final partials = events.whereType<ImageGenPartialImageEvent>().toList();
+        for (final p in partials) {
+          expect(p.b64Json, isNotEmpty);
+          expect(p.partialImageIndex, greaterThanOrEqualTo(0));
+        }
+      },
+    );
+
     // Note: DALL-E 3 tests are more expensive, keeping minimal
     test(
       'generates image with DALL-E 3',

--- a/packages/openai_dart/test/integration/images_test.dart
+++ b/packages/openai_dart/test/integration/images_test.dart
@@ -2,6 +2,7 @@
 @Tags(['integration'])
 library;
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:openai_dart/openai_dart.dart';
@@ -195,6 +196,49 @@ void main() {
           expect(p.b64Json, isNotEmpty);
           expect(p.partialImageIndex, greaterThanOrEqualTo(0));
         }
+      },
+    );
+
+    test(
+      'streams GPT Image 2 multipart edit with partial + completed events',
+      timeout: const Timeout(Duration(minutes: 5)),
+      () async {
+        if (apiKey == null) {
+          markTestSkipped('API key not available');
+          return;
+        }
+
+        // Generate a small seed image first so we have real bytes to edit.
+        final seed = await client!.images.generate(
+          const ImageGenerationRequest(
+            model: ImageModels.gptImage2,
+            prompt: 'A plain white card',
+            size: ImageSize.size1024x1024,
+            quality: ImageQuality.low,
+          ),
+        );
+        final seedBytes = base64Decode(seed.data.first.b64Json!);
+
+        final events = await client!.images
+            .editStream(
+              ImageEditRequest(
+                image: seedBytes,
+                imageFilename: 'seed.png',
+                prompt: 'Add a small orange dot in the center',
+                model: ImageModels.gptImage2,
+              ),
+            )
+            .toList();
+
+        expect(events, isNotEmpty);
+        final completed = events.whereType<ImageEditCompletedEvent>().toList();
+        expect(
+          completed,
+          hasLength(1),
+          reason: 'exactly one image_edit.completed event expected',
+        );
+        expect(completed.single.b64Json, isNotEmpty);
+        expect(completed.single.usage.totalTokens, greaterThan(0));
       },
     );
 

--- a/packages/openai_dart/test/unit/models/images_test.dart
+++ b/packages/openai_dart/test/unit/models/images_test.dart
@@ -71,6 +71,96 @@ void main() {
       expect(modified.model, 'dall-e-2'); // Preserved
       expect(modified.size, ImageSize.size512x512);
     });
+
+    test('serializes GPT Image 2 fields', () {
+      const request = ImageGenerationRequest(
+        prompt: 'A red apple',
+        model: ImageModels.gptImage2,
+        size: ImageSize.size1536x1024,
+        quality: ImageQuality.high,
+        background: ImageBackground.transparent,
+        moderation: ImageModerationLevel.low,
+        outputFormat: ImageOutputFormat.webp,
+        outputCompression: 80,
+        stream: true,
+        partialImages: 3,
+      );
+
+      final json = request.toJson();
+
+      expect(json['model'], 'gpt-image-2');
+      expect(json['size'], '1536x1024');
+      expect(json['quality'], 'high');
+      expect(json['background'], 'transparent');
+      expect(json['moderation'], 'low');
+      expect(json['output_format'], 'webp');
+      expect(json['output_compression'], 80);
+      expect(json['stream'], true);
+      expect(json['partial_images'], 3);
+    });
+
+    test('fromJson round-trips GPT Image 2 fields', () {
+      final json = {
+        'prompt': 'A red apple',
+        'model': 'gpt-image-2',
+        'size': '1024x1536',
+        'quality': 'auto',
+        'background': 'opaque',
+        'moderation': 'auto',
+        'output_format': 'png',
+        'output_compression': 50,
+        'stream': false,
+        'partial_images': 0,
+      };
+
+      final request = ImageGenerationRequest.fromJson(json);
+
+      expect(request.model, 'gpt-image-2');
+      expect(request.size, ImageSize.size1024x1536);
+      expect(request.quality, ImageQuality.auto);
+      expect(request.background, ImageBackground.opaque);
+      expect(request.moderation, ImageModerationLevel.auto);
+      expect(request.outputFormat, ImageOutputFormat.png);
+      expect(request.outputCompression, 50);
+      expect(request.stream, false);
+      expect(request.partialImages, 0);
+    });
+
+    test('omits new fields when unset', () {
+      const request = ImageGenerationRequest(prompt: 'plain');
+      final json = request.toJson();
+      for (final key in const [
+        'background',
+        'moderation',
+        'output_format',
+        'output_compression',
+        'stream',
+        'partial_images',
+      ]) {
+        expect(json.containsKey(key), isFalse, reason: 'key $key');
+      }
+    });
+
+    test('equality includes all fields', () {
+      const a = ImageGenerationRequest(
+        prompt: 'p',
+        background: ImageBackground.transparent,
+        outputFormat: ImageOutputFormat.webp,
+      );
+      const b = ImageGenerationRequest(
+        prompt: 'p',
+        background: ImageBackground.transparent,
+        outputFormat: ImageOutputFormat.webp,
+      );
+      const c = ImageGenerationRequest(
+        prompt: 'p',
+        background: ImageBackground.opaque,
+        outputFormat: ImageOutputFormat.webp,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
   });
 
   group('ImageResponse', () {
@@ -119,6 +209,77 @@ void main() {
 
       final response = ImageResponse.fromJson(json);
       expect(response.firstBase64, 'base64encodeddata');
+    });
+
+    test('parses GPT Image 2 payload with usage + metadata', () {
+      final json = {
+        'created': 1776808255,
+        'background': 'opaque',
+        'size': '1024x1024',
+        'quality': 'low',
+        'output_format': 'png',
+        'usage': {
+          'total_tokens': 209,
+          'input_tokens': 13,
+          'input_tokens_details': {'text_tokens': 13, 'image_tokens': 0},
+          'output_tokens': 196,
+          'output_tokens_details': {'text_tokens': 0, 'image_tokens': 196},
+        },
+        'data': [
+          {'b64_json': 'iVBORw0KGgo='},
+        ],
+      };
+
+      final response = ImageResponse.fromJson(json);
+
+      expect(response.created, 1776808255);
+      expect(response.background, ImageBackground.opaque);
+      expect(response.size, ImageSize.size1024x1024);
+      expect(response.quality, ImageQuality.low);
+      expect(response.outputFormat, ImageOutputFormat.png);
+
+      final usage = response.usage;
+      expect(usage, isNotNull);
+      expect(usage!.totalTokens, 209);
+      expect(usage.inputTokens, 13);
+      expect(usage.outputTokens, 196);
+      expect(usage.inputTokensDetails.textTokens, 13);
+      expect(usage.inputTokensDetails.imageTokens, 0);
+      expect(usage.outputTokensDetails?.textTokens, 0);
+      expect(usage.outputTokensDetails?.imageTokens, 196);
+
+      // Round-trip: toJson should emit the new fields and re-parse.
+      final parsed = ImageResponse.fromJson(response.toJson());
+      expect(parsed, equals(response));
+    });
+
+    test('parses minimal DALL-E response (no usage, no metadata)', () {
+      final json = {
+        'created': 1677649420,
+        'data': [
+          {'url': 'https://example.com/image.png'},
+        ],
+      };
+
+      final response = ImageResponse.fromJson(json);
+
+      expect(response.data.length, 1);
+      expect(response.background, isNull);
+      expect(response.outputFormat, isNull);
+      expect(response.quality, isNull);
+      expect(response.size, isNull);
+      expect(response.usage, isNull);
+    });
+
+    test('ImagesUsage without output_tokens_details parses', () {
+      final usage = ImagesUsage.fromJson(const {
+        'total_tokens': 50,
+        'input_tokens': 10,
+        'input_tokens_details': {'text_tokens': 10, 'image_tokens': 0},
+        'output_tokens': 40,
+      });
+      expect(usage.outputTokensDetails, isNull);
+      expect(usage.totalTokens, 50);
     });
   });
 
@@ -228,11 +389,19 @@ void main() {
     test('parses all values correctly', () {
       expect(ImageQuality.fromJson('standard'), ImageQuality.standard);
       expect(ImageQuality.fromJson('hd'), ImageQuality.hd);
+      expect(ImageQuality.fromJson('low'), ImageQuality.low);
+      expect(ImageQuality.fromJson('medium'), ImageQuality.medium);
+      expect(ImageQuality.fromJson('high'), ImageQuality.high);
+      expect(ImageQuality.fromJson('auto'), ImageQuality.auto);
     });
 
     test('toJson returns correct values', () {
       expect(ImageQuality.standard.toJson(), 'standard');
       expect(ImageQuality.hd.toJson(), 'hd');
+      expect(ImageQuality.low.toJson(), 'low');
+      expect(ImageQuality.medium.toJson(), 'medium');
+      expect(ImageQuality.high.toJson(), 'high');
+      expect(ImageQuality.auto.toJson(), 'auto');
     });
   });
 
@@ -243,11 +412,55 @@ void main() {
       expect(ImageSize.fromJson('1024x1024'), ImageSize.size1024x1024);
       expect(ImageSize.fromJson('1792x1024'), ImageSize.size1792x1024);
       expect(ImageSize.fromJson('1024x1792'), ImageSize.size1024x1792);
+      expect(ImageSize.fromJson('1536x1024'), ImageSize.size1536x1024);
+      expect(ImageSize.fromJson('1024x1536'), ImageSize.size1024x1536);
+      expect(ImageSize.fromJson('auto'), ImageSize.auto);
     });
 
     test('toJson returns correct values', () {
       expect(ImageSize.size256x256.toJson(), '256x256');
       expect(ImageSize.size1024x1024.toJson(), '1024x1024');
+      expect(ImageSize.size1536x1024.toJson(), '1536x1024');
+      expect(ImageSize.size1024x1536.toJson(), '1024x1536');
+      expect(ImageSize.auto.toJson(), 'auto');
+    });
+  });
+
+  group('Image common enums', () {
+    test('ImageBackground round-trips', () {
+      for (final v in ImageBackground.values) {
+        expect(ImageBackground.fromJson(v.toJson()), v);
+      }
+    });
+
+    test('ImageOutputFormat round-trips', () {
+      for (final v in ImageOutputFormat.values) {
+        expect(ImageOutputFormat.fromJson(v.toJson()), v);
+      }
+    });
+
+    test('ImageModerationLevel round-trips', () {
+      for (final v in ImageModerationLevel.values) {
+        expect(ImageModerationLevel.fromJson(v.toJson()), v);
+      }
+    });
+
+    test('ImageInputFidelity round-trips', () {
+      for (final v in ImageInputFidelity.values) {
+        expect(ImageInputFidelity.fromJson(v.toJson()), v);
+      }
+    });
+  });
+
+  group('ImageModels constants', () {
+    test('exposes well-known model ids', () {
+      expect(ImageModels.gptImage2, 'gpt-image-2');
+      expect(ImageModels.gptImage15, 'gpt-image-1.5');
+      expect(ImageModels.gptImage1, 'gpt-image-1');
+      expect(ImageModels.gptImage1Mini, 'gpt-image-1-mini');
+      expect(ImageModels.chatgptImageLatest, 'chatgpt-image-latest');
+      expect(ImageModels.dallE3, 'dall-e-3');
+      expect(ImageModels.dallE2, 'dall-e-2');
     });
   });
 

--- a/packages/openai_dart/test/unit/models/images_test.dart
+++ b/packages/openai_dart/test/unit/models/images_test.dart
@@ -447,6 +447,19 @@ void main() {
       final image = GeneratedImage.fromJson(json);
       expect(image.revisedPrompt, 'The revised prompt text');
     });
+
+    test('== distinguishes images that differ only in revisedPrompt', () {
+      const a = GeneratedImage(
+        url: 'https://example.com/image.png',
+        revisedPrompt: 'A',
+      );
+      const b = GeneratedImage(
+        url: 'https://example.com/image.png',
+        revisedPrompt: 'B',
+      );
+      expect(a, isNot(equals(b)));
+      expect(a.hashCode, isNot(equals(b.hashCode)));
+    });
   });
 
   group('ImageQuality', () {

--- a/packages/openai_dart/test/unit/models/images_test.dart
+++ b/packages/openai_dart/test/unit/models/images_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:openai_dart/openai_dart.dart';
 import 'package:test/test.dart';
 
@@ -160,6 +162,45 @@ void main() {
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));
       expect(a, isNot(equals(c)));
+    });
+  });
+
+  group('ImageEditRequest', () {
+    final imageBytes = Uint8List.fromList([1, 2, 3, 4]);
+
+    test('copyWith overrides specified fields only', () {
+      final original = ImageEditRequest(
+        image: imageBytes,
+        imageFilename: 'a.png',
+        prompt: 'p',
+        inputFidelity: ImageInputFidelity.low,
+        quality: ImageQuality.medium,
+      );
+      final modified = original.copyWith(
+        stream: true,
+        quality: ImageQuality.high,
+      );
+      expect(modified.stream, isTrue);
+      expect(modified.quality, ImageQuality.high);
+      expect(modified.inputFidelity, ImageInputFidelity.low); // preserved
+      expect(modified.prompt, 'p'); // preserved
+    });
+
+    test('== distinguishes requests that differ only in maskFilename', () {
+      final a = ImageEditRequest(
+        image: imageBytes,
+        imageFilename: 'a.png',
+        prompt: 'p',
+        maskFilename: 'maskA.png',
+      );
+      final b = ImageEditRequest(
+        image: imageBytes,
+        imageFilename: 'a.png',
+        prompt: 'p',
+        maskFilename: 'maskB.png',
+      );
+      expect(a, isNot(equals(b)));
+      expect(a.hashCode, isNot(equals(b.hashCode)));
     });
   });
 

--- a/packages/openai_dart/test/unit/models/images_test.dart
+++ b/packages/openai_dart/test/unit/models/images_test.dart
@@ -251,6 +251,29 @@ void main() {
       // Round-trip: toJson should emit the new fields and re-parse.
       final parsed = ImageResponse.fromJson(response.toJson());
       expect(parsed, equals(response));
+      expect(parsed.data, hasLength(1));
+      expect(parsed.data.first.b64Json, 'iVBORw0KGgo=');
+      expect(parsed.data.first.revisedPrompt, isNull);
+    });
+
+    test('fromJson throws FormatException when data is missing', () {
+      expect(
+        () => ImageResponse.fromJson(const {'created': 0}),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('ImageResponse == compares data contents, not just length', () {
+      const a = ImageResponse(
+        created: 1,
+        data: [GeneratedImage(b64Json: 'AAAA')],
+      );
+      const b = ImageResponse(
+        created: 1,
+        data: [GeneratedImage(b64Json: 'BBBB')],
+      );
+      expect(a, isNot(equals(b)));
+      expect(a.hashCode, isNot(equals(b.hashCode)));
     });
 
     test('parses minimal DALL-E response (no usage, no metadata)', () {

--- a/packages/openai_dart/test/unit/resources/images_edit_multipart_test.dart
+++ b/packages/openai_dart/test/unit/resources/images_edit_multipart_test.dart
@@ -23,6 +23,8 @@ void main() {
         httpClient: mockClient,
       );
 
+      // Non-streaming edit: stream / partialImages are rejected by edit()
+      // and covered in the dedicated streaming test for editStream.
       await client.images.edit(
         ImageEditRequest(
           image: Uint8List.fromList([1, 2, 3, 4]),
@@ -35,8 +37,6 @@ void main() {
           outputFormat: ImageOutputFormat.webp,
           outputCompression: 75,
           moderation: ImageModerationLevel.low,
-          stream: true,
-          partialImages: 2,
           size: ImageSize.size1536x1024,
           n: 1,
         ),
@@ -66,8 +66,6 @@ void main() {
       expectMultipartField('output_format', 'webp');
       expectMultipartField('output_compression', '75');
       expectMultipartField('moderation', 'low');
-      expectMultipartField('stream', 'true');
-      expectMultipartField('partial_images', '2');
       expectMultipartField('size', '1536x1024');
 
       client.close();
@@ -115,6 +113,81 @@ void main() {
           reason: '$key should not be present when unset',
         );
       }
+
+      client.close();
+    });
+
+    test('edit() rejects stream: true with ArgumentError', () async {
+      final client = OpenAIClient(
+        config: const OpenAIConfig(authProvider: ApiKeyProvider('sk-test-key')),
+        httpClient: MockClient((_) async => http.Response('{}', 200)),
+      );
+
+      await expectLater(
+        client.images.edit(
+          ImageEditRequest(
+            image: Uint8List.fromList([1, 2, 3, 4]),
+            imageFilename: 'a.png',
+            prompt: 'edit',
+            stream: true,
+          ),
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('editStream()'),
+          ),
+        ),
+      );
+
+      client.close();
+    });
+
+    test('generate() rejects stream: true with ArgumentError', () async {
+      final client = OpenAIClient(
+        config: const OpenAIConfig(authProvider: ApiKeyProvider('sk-test-key')),
+        httpClient: MockClient((_) async => http.Response('{}', 200)),
+      );
+
+      await expectLater(
+        client.images.generate(
+          const ImageGenerationRequest(prompt: 'p', stream: true),
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('generateStream()'),
+          ),
+        ),
+      );
+
+      client.close();
+    });
+
+    test('editJson() rejects stream: true with ArgumentError', () async {
+      final client = OpenAIClient(
+        config: const OpenAIConfig(authProvider: ApiKeyProvider('sk-test-key')),
+        httpClient: MockClient((_) async => http.Response('{}', 200)),
+      );
+
+      await expectLater(
+        client.images.editJson(
+          const ImageEditJsonRequest(
+            images: [ImageReference.url('https://example.com/x.png')],
+            prompt: 'edit',
+            stream: true,
+          ),
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('editJsonStream()'),
+          ),
+        ),
+      );
 
       client.close();
     });

--- a/packages/openai_dart/test/unit/resources/images_edit_multipart_test.dart
+++ b/packages/openai_dart/test/unit/resources/images_edit_multipart_test.dart
@@ -1,0 +1,115 @@
+import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:openai_dart/openai_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Images Edit Multipart Fields', () {
+    test('emits all GPT Image 2 fields in multipart body', () async {
+      String? body;
+
+      final mockClient = MockClient((request) async {
+        body = request.body;
+        return http.Response(
+          '{"created":1776808255,"data":[{"b64_json":"xxx"}]}',
+          200,
+        );
+      });
+
+      final client = OpenAIClient(
+        config: const OpenAIConfig(authProvider: ApiKeyProvider('sk-test-key')),
+        httpClient: mockClient,
+      );
+
+      await client.images.edit(
+        ImageEditRequest(
+          image: Uint8List.fromList([1, 2, 3, 4]),
+          imageFilename: 'original.png',
+          prompt: 'Add a rainbow',
+          model: ImageModels.gptImage2,
+          background: ImageBackground.transparent,
+          inputFidelity: ImageInputFidelity.high,
+          quality: ImageQuality.high,
+          outputFormat: ImageOutputFormat.webp,
+          outputCompression: 75,
+          moderation: ImageModerationLevel.low,
+          stream: true,
+          partialImages: 2,
+          size: ImageSize.size1536x1024,
+          n: 1,
+        ),
+      );
+
+      expect(body, isNotNull);
+      expect(body, contains('name="model"'));
+      expect(body, contains('gpt-image-2'));
+      expect(body, contains('name="background"'));
+      expect(body, contains('\r\ntransparent\r\n'));
+      expect(body, contains('name="input_fidelity"'));
+      expect(body, contains('\r\nhigh\r\n'));
+      expect(body, contains('name="quality"'));
+      expect(body, contains('name="output_format"'));
+      expect(body, contains('\r\nwebp\r\n'));
+      expect(body, contains('name="output_compression"'));
+      expect(body, contains('\r\n75\r\n'));
+      expect(body, contains('name="moderation"'));
+      expect(body, contains('\r\nlow\r\n'));
+      expect(body, contains('name="stream"'));
+      expect(body, contains('\r\ntrue\r\n'));
+      expect(body, contains('name="partial_images"'));
+      expect(body, contains('\r\n2\r\n'));
+      expect(body, contains('name="size"'));
+      expect(body, contains('\r\n1536x1024\r\n'));
+
+      client.close();
+    });
+
+    test('omits new fields when unset', () async {
+      String? body;
+
+      final mockClient = MockClient((request) async {
+        body = request.body;
+        return http.Response(
+          '{"created":0,"data":[{"url":"https://example.com/x.png"}]}',
+          200,
+        );
+      });
+
+      final client = OpenAIClient(
+        config: const OpenAIConfig(authProvider: ApiKeyProvider('sk-test-key')),
+        httpClient: mockClient,
+      );
+
+      await client.images.edit(
+        ImageEditRequest(
+          image: Uint8List.fromList([1, 2, 3, 4]),
+          imageFilename: 'original.png',
+          prompt: 'edit',
+          model: 'dall-e-2',
+        ),
+      );
+
+      expect(body, isNotNull);
+      for (final key in const [
+        'background',
+        'input_fidelity',
+        'output_format',
+        'output_compression',
+        'moderation',
+        'stream',
+        'partial_images',
+        'quality',
+      ]) {
+        expect(
+          body,
+          isNot(contains('name="$key"')),
+          reason: '$key should not be present when unset',
+        );
+      }
+
+      client.close();
+    });
+  });
+}

--- a/packages/openai_dart/test/unit/resources/images_edit_multipart_test.dart
+++ b/packages/openai_dart/test/unit/resources/images_edit_multipart_test.dart
@@ -43,25 +43,32 @@ void main() {
       );
 
       expect(body, isNotNull);
-      expect(body, contains('name="model"'));
-      expect(body, contains('gpt-image-2'));
-      expect(body, contains('name="background"'));
-      expect(body, contains('\r\ntransparent\r\n'));
-      expect(body, contains('name="input_fidelity"'));
-      expect(body, contains('\r\nhigh\r\n'));
-      expect(body, contains('name="quality"'));
-      expect(body, contains('name="output_format"'));
-      expect(body, contains('\r\nwebp\r\n'));
-      expect(body, contains('name="output_compression"'));
-      expect(body, contains('\r\n75\r\n'));
-      expect(body, contains('name="moderation"'));
-      expect(body, contains('\r\nlow\r\n'));
-      expect(body, contains('name="stream"'));
-      expect(body, contains('\r\ntrue\r\n'));
-      expect(body, contains('name="partial_images"'));
-      expect(body, contains('\r\n2\r\n'));
-      expect(body, contains('name="size"'));
-      expect(body, contains('\r\n1536x1024\r\n'));
+      // Scoped field=value assertions — guard against a value matching
+      // a different part (e.g. "high" is emitted for both quality and
+      // input_fidelity, so a bare contains() check isn't sufficient).
+      void expectMultipartField(String name, String value) {
+        expect(
+          body,
+          matches(
+            RegExp(
+              'name="${RegExp.escape(name)}"\\r\\n\\r\\n'
+              '${RegExp.escape(value)}\\r\\n',
+            ),
+          ),
+          reason: 'multipart field $name should carry value "$value"',
+        );
+      }
+
+      expectMultipartField('model', 'gpt-image-2');
+      expectMultipartField('background', 'transparent');
+      expectMultipartField('input_fidelity', 'high');
+      expectMultipartField('quality', 'high');
+      expectMultipartField('output_format', 'webp');
+      expectMultipartField('output_compression', '75');
+      expectMultipartField('moderation', 'low');
+      expectMultipartField('stream', 'true');
+      expectMultipartField('partial_images', '2');
+      expectMultipartField('size', '1536x1024');
 
       client.close();
     });

--- a/packages/openai_dart/test/unit/resources/images_stream_test.dart
+++ b/packages/openai_dart/test/unit/resources/images_stream_test.dart
@@ -1,0 +1,195 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:openai_dart/openai_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ImageGenStreamEvent parsing', () {
+    test('dispatches partial_image and completed variants', () {
+      const partialJson = {
+        'type': 'image_generation.partial_image',
+        'b64_json': 'AAAA',
+        'created_at': 111,
+        'size': '1024x1024',
+        'quality': 'high',
+        'background': 'transparent',
+        'output_format': 'png',
+        'partial_image_index': 0,
+      };
+      const completedJson = {
+        'type': 'image_generation.completed',
+        'b64_json': 'BBBB',
+        'created_at': 222,
+        'size': '1536x1024',
+        'quality': 'auto',
+        'background': 'opaque',
+        'output_format': 'webp',
+        'usage': {
+          'total_tokens': 10,
+          'input_tokens': 3,
+          'output_tokens': 7,
+          'input_tokens_details': {'text_tokens': 3, 'image_tokens': 0},
+          'output_tokens_details': {'text_tokens': 0, 'image_tokens': 7},
+        },
+      };
+
+      final partial = ImageGenStreamEvent.fromJson(partialJson);
+      expect(partial, isA<ImageGenPartialImageEvent>());
+      final p = partial as ImageGenPartialImageEvent;
+      expect(p.partialImageIndex, 0);
+      expect(p.size, ImageSize.size1024x1024);
+      expect(p.background, ImageBackground.transparent);
+
+      final completed = ImageGenStreamEvent.fromJson(completedJson);
+      expect(completed, isA<ImageGenCompletedEvent>());
+      final c = completed as ImageGenCompletedEvent;
+      expect(c.usage.totalTokens, 10);
+      expect(c.size, ImageSize.size1536x1024);
+
+      // Round-trip.
+      expect(ImageGenStreamEvent.fromJson(partial.toJson()), equals(partial));
+      expect(
+        ImageGenStreamEvent.fromJson(completed.toJson()),
+        equals(completed),
+      );
+    });
+
+    test('unknown discriminator falls back without throwing', () {
+      const json = {
+        'type': 'image_generation.some_future_event',
+        'something_new': 'value',
+      };
+      final event = ImageGenStreamEvent.fromJson(json);
+      expect(event, isA<ImageGenUnknownEvent>());
+      expect(event.type, 'image_generation.some_future_event');
+      // Raw JSON preserved on round-trip.
+      expect(event.toJson()['something_new'], 'value');
+    });
+  });
+
+  group('ImageEditStreamEvent parsing', () {
+    test('dispatches partial_image and completed variants', () {
+      const partialJson = {
+        'type': 'image_edit.partial_image',
+        'b64_json': 'AAAA',
+        'created_at': 111,
+        'size': '1024x1536',
+        'quality': 'medium',
+        'background': 'auto',
+        'output_format': 'jpeg',
+        'partial_image_index': 1,
+      };
+      const completedJson = {
+        'type': 'image_edit.completed',
+        'b64_json': 'BBBB',
+        'created_at': 222,
+        'size': '1024x1024',
+        'quality': 'high',
+        'background': 'transparent',
+        'output_format': 'png',
+        'usage': {
+          'total_tokens': 50,
+          'input_tokens': 10,
+          'output_tokens': 40,
+          'input_tokens_details': {'text_tokens': 10, 'image_tokens': 0},
+        },
+      };
+
+      final partial = ImageEditStreamEvent.fromJson(partialJson);
+      expect(partial, isA<ImageEditPartialImageEvent>());
+      final completed = ImageEditStreamEvent.fromJson(completedJson);
+      expect(completed, isA<ImageEditCompletedEvent>());
+      expect(
+        (completed as ImageEditCompletedEvent).usage.outputTokensDetails,
+        isNull,
+      );
+
+      expect(ImageEditStreamEvent.fromJson(partial.toJson()), equals(partial));
+      expect(
+        ImageEditStreamEvent.fromJson(completed.toJson()),
+        equals(completed),
+      );
+    });
+
+    test('unknown discriminator falls back without throwing', () {
+      const json = {'type': 'image_edit.v3', 'foo': 'bar'};
+      final event = ImageEditStreamEvent.fromJson(json);
+      expect(event, isA<ImageEditUnknownEvent>());
+    });
+  });
+
+  group('ImagesResource.generateStream', () {
+    test('forces stream=true and yields typed SSE events', () async {
+      final requestCompleter = Completer<http.BaseRequest>();
+
+      final partialLine = jsonEncode({
+        'type': 'image_generation.partial_image',
+        'b64_json': 'AAAA',
+        'created_at': 1,
+        'size': '1024x1024',
+        'quality': 'high',
+        'background': 'transparent',
+        'output_format': 'png',
+        'partial_image_index': 0,
+      });
+      final completedLine = jsonEncode({
+        'type': 'image_generation.completed',
+        'b64_json': 'BBBB',
+        'created_at': 2,
+        'size': '1024x1024',
+        'quality': 'high',
+        'background': 'transparent',
+        'output_format': 'png',
+        'usage': {
+          'total_tokens': 9,
+          'input_tokens': 3,
+          'output_tokens': 6,
+          'input_tokens_details': {'text_tokens': 3, 'image_tokens': 0},
+        },
+      });
+
+      final mockClient = MockClient.streaming((request, _) async {
+        requestCompleter.complete(request);
+        return http.StreamedResponse(
+          Stream.fromIterable([
+            utf8.encode('data: $partialLine\n\n'),
+            utf8.encode('data: $completedLine\n\n'),
+            utf8.encode('data: [DONE]\n\n'),
+          ]),
+          200,
+        );
+      });
+
+      final client = OpenAIClient(
+        config: const OpenAIConfig(authProvider: ApiKeyProvider('sk-test-key')),
+        httpClient: mockClient,
+      );
+
+      final events = await client.images
+          .generateStream(
+            const ImageGenerationRequest(
+              model: ImageModels.gptImage2,
+              prompt: 'A red apple',
+              partialImages: 1,
+            ),
+          )
+          .toList();
+
+      expect(events, hasLength(2));
+      expect(events[0], isA<ImageGenPartialImageEvent>());
+      expect(events[1], isA<ImageGenCompletedEvent>());
+      expect((events[1] as ImageGenCompletedEvent).usage.totalTokens, 9);
+
+      final sentRequest = await requestCompleter.future as http.Request;
+      final body = jsonDecode(sentRequest.body) as Map<String, dynamic>;
+      expect(body['stream'], isTrue);
+      expect(body['model'], 'gpt-image-2');
+      expect(sentRequest.headers['Accept'], 'text/event-stream');
+
+      client.close();
+    });
+  });
+}

--- a/packages/openai_dart/test/unit/resources/images_stream_test.dart
+++ b/packages/openai_dart/test/unit/resources/images_stream_test.dart
@@ -206,6 +206,29 @@ void main() {
       client.close();
     });
 
+    test('editStream throws eagerly on a closed client (not on listen)', () {
+      final client = OpenAIClient(
+        config: const OpenAIConfig(authProvider: ApiKeyProvider('sk-test-key')),
+        httpClient: MockClient.streaming(
+          (_, _) async =>
+              http.StreamedResponse(const Stream<List<int>>.empty(), 200),
+        ),
+      )..close();
+
+      // Must throw synchronously — before any stream subscription — so it
+      // matches generateStream/editJsonStream which check eagerly.
+      expect(
+        () => client.images.editStream(
+          ImageEditRequest(
+            image: Uint8List.fromList([1, 2, 3, 4]),
+            imageFilename: 'a.png',
+            prompt: 'edit',
+          ),
+        ),
+        throwsStateError,
+      );
+    });
+
     test('accepts abortTrigger parameter (type-signature check)', () {
       // When abortTrigger is provided, sendStream() creates its own
       // internal HTTP client, so end-to-end abort behavior must be

--- a/packages/openai_dart/test/unit/resources/images_stream_test.dart
+++ b/packages/openai_dart/test/unit/resources/images_stream_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -118,6 +119,70 @@ void main() {
       const json = {'type': 'image_edit.v3', 'foo': 'bar'};
       final event = ImageEditStreamEvent.fromJson(json);
       expect(event, isA<ImageEditUnknownEvent>());
+    });
+  });
+
+  group('ImagesResource.editStream', () {
+    test('forces stream=true and uses multipart body', () async {
+      final requestCompleter = Completer<http.BaseRequest>();
+
+      final mockClient = MockClient.streaming((request, _) async {
+        requestCompleter.complete(request);
+        return http.StreamedResponse(
+          Stream.fromIterable([utf8.encode('data: [DONE]\n\n')]),
+          200,
+        );
+      });
+
+      final client = OpenAIClient(
+        config: const OpenAIConfig(authProvider: ApiKeyProvider('sk-test-key')),
+        httpClient: mockClient,
+      );
+
+      // No abortTrigger — sendStream uses the injected mock client.
+      await client.images
+          .editStream(
+            ImageEditRequest(
+              image: Uint8List.fromList([1, 2, 3, 4]),
+              imageFilename: 'a.png',
+              prompt: 'edit',
+              model: ImageModels.gptImage2,
+              inputFidelity: ImageInputFidelity.high,
+            ),
+          )
+          .drain<void>();
+
+      final sent = await requestCompleter.future;
+      expect(sent, isA<http.MultipartRequest>());
+      final multipart = sent as http.MultipartRequest;
+      expect(multipart.fields['stream'], 'true');
+      expect(multipart.fields['model'], 'gpt-image-2');
+      expect(multipart.fields['input_fidelity'], 'high');
+      expect(sent.headers['Accept'], 'text/event-stream');
+      expect(sent.headers['Content-Type'], contains('multipart/form-data'));
+
+      client.close();
+    });
+
+    test('accepts abortTrigger parameter (type-signature check)', () {
+      // When abortTrigger is provided, sendStream() creates its own
+      // internal HTTP client, so end-to-end abort behavior must be
+      // validated against the real API (integration tests).
+      void verify(OpenAIClient c) {
+        // ignore: unused_local_variable
+        final stream = c.images.editStream(
+          ImageEditRequest(
+            image: Uint8List.fromList([1, 2, 3, 4]),
+            imageFilename: 'a.png',
+            prompt: 'edit',
+          ),
+          abortTrigger: Completer<void>().future,
+        );
+      }
+
+      // Compile-time check only.
+      // ignore: unused_local_variable
+      final _ = verify;
     });
   });
 

--- a/packages/openai_dart/test/unit/resources/images_stream_test.dart
+++ b/packages/openai_dart/test/unit/resources/images_stream_test.dart
@@ -69,6 +69,30 @@ void main() {
       // Raw JSON preserved on round-trip.
       expect(event.toJson()['something_new'], 'value');
     });
+
+    test('ImageGenUnknownEvent implements deep value equality', () {
+      final a = ImageGenUnknownEvent.fromJson(const {
+        'type': 'image_generation.future',
+        'nested': {
+          'arr': [1, 2, 3],
+        },
+      });
+      final b = ImageGenUnknownEvent.fromJson(const {
+        'type': 'image_generation.future',
+        'nested': {
+          'arr': [1, 2, 3],
+        },
+      });
+      final c = ImageGenUnknownEvent.fromJson(const {
+        'type': 'image_generation.future',
+        'nested': {
+          'arr': [1, 2, 4],
+        },
+      });
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
   });
 
   group('ImageEditStreamEvent parsing', () {
@@ -119,6 +143,24 @@ void main() {
       const json = {'type': 'image_edit.v3', 'foo': 'bar'};
       final event = ImageEditStreamEvent.fromJson(json);
       expect(event, isA<ImageEditUnknownEvent>());
+    });
+
+    test('ImageEditUnknownEvent implements deep value equality', () {
+      final a = ImageEditUnknownEvent.fromJson(const {
+        'type': 'image_edit.future',
+        'extras': {'k': 'v'},
+      });
+      final b = ImageEditUnknownEvent.fromJson(const {
+        'type': 'image_edit.future',
+        'extras': {'k': 'v'},
+      });
+      final c = ImageEditUnknownEvent.fromJson(const {
+        'type': 'image_edit.future',
+        'extras': {'k': 'different'},
+      });
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
     });
   });
 

--- a/packages/openai_dart/test/unit/resources/images_stream_test.dart
+++ b/packages/openai_dart/test/unit/resources/images_stream_test.dart
@@ -201,7 +201,9 @@ void main() {
       expect(multipart.fields['model'], 'gpt-image-2');
       expect(multipart.fields['input_fidelity'], 'high');
       expect(sent.headers['Accept'], 'text/event-stream');
-      expect(sent.headers['Content-Type'], contains('multipart/form-data'));
+      // MultipartRequest.finalize() sets the boundary header under the
+      // lowercase key.
+      expect(sent.headers['content-type'], contains('multipart/form-data'));
 
       client.close();
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ melos:
         sdk: ">=3.9.0 <4.0.0"
       dependencies:
         http: ^1.6.0
+        http_parser: ^4.1.2
         logging: ^1.3.0
         meta: ^1.16.0
         web_socket: ^1.0.1


### PR DESCRIPTION
## Summary

- Surface GPT Image 2 (API model id `gpt-image-2`) in `openai_dart` — the new fields already present in the v2.3.0 OpenAPI spec for GPT-image family models but missing from the hand-written Dart wrappers.
- Add `ImageModels` constants (mirroring the Python SDK's `ImageModel` literal, extended with `gpt-image-2`) for discoverable, typo-safe model ids.
- Refresh examples, README, and `llms.txt` around `gpt-image-2` (flexible sizes, high-fidelity inputs, token-based pricing, Batch API discount).

## Details

### Request additions

`ImageGenerationRequest` and `ImageEditRequest` now expose the full GPT-image parameter surface:

- `background` (`ImageBackground`: `transparent` / `opaque` / `auto`)
- `moderation` (`ImageModerationLevel`: `low` / `auto`)
- `outputFormat` (`ImageOutputFormat`: `png` / `jpeg` / `webp`)
- `outputCompression` (`int` 0–100, for `jpeg`/`webp`)
- `stream` (`bool`) + `partialImages` (`int`) — opt-in streaming; typed SSE event parsing is a follow-up
- `inputFidelity` on `ImageEditRequest` only (`ImageInputFidelity.high` / `.low`)

Enum extensions:

- `ImageQuality` gains `low`, `medium`, `high`, `auto` (keeping `standard`, `hd` for DALL-E 3)
- `ImageSize` gains `auto`, `size1536x1024`, `size1024x1536`

The previously-duplicated `ImageEditJsonQuality` / `ImageEditJsonSize` enums are unified with `ImageQuality` / `ImageSize` via deprecated typedefs — existing code keeps compiling.

### Response additions

`ImageResponse` now carries the GPT-image response fields — all nullable so DALL-E responses still parse cleanly:

- `usage: ImagesUsage?` with `totalTokens`, `inputTokens`, `outputTokens`, and per-modality breakdowns (`ImagesUsageInputTokensDetails` and `ImagesUsageOutputTokensDetails`, matching the official Python SDK's structure).
- Echo metadata: `background`, `outputFormat`, `quality`, `size`.

```dart
final response = await client.images.generate(
  const ImageGenerationRequest(
    model: ImageModels.gptImage2,
    prompt: 'A white cat wearing a top hat',
    size: ImageSize.size1536x1024,
    quality: ImageQuality.high,
    background: ImageBackground.transparent,
    outputFormat: ImageOutputFormat.webp,
  ),
);

final bytes = base64Decode(response.data.first.b64Json!);
print('Tokens used: \${response.usage?.totalTokens}');
```

GPT Image 2 always returns base64 (no `url`), so examples now decode `b64Json` and write to disk.

### Batch API

Image batches were already wired (`BatchEndpoint.imagesGenerations` / `imagesEdits`). The README now points to that path so users can take advantage of the 50% Batch discount.

### Ancillary cleanup

- Extracted shared image enums into `lib/src/models/images/image_common.dart` to prevent drift between generate/edit paths.
- Reordered README H2 sections to satisfy the toolkit's canonical-order check (`Why choose this client?` now precedes `Quickstart` per the verifier's expected ordering).
- Bumped `llms.txt` token counts for the updated example and README.

### Verification

Confirmed live via `POST /v1/images/generations` with `model: gpt-image-2` — returned HTTP 200 with the full `usage` and metadata envelope used by the new parsers. Spec source (`openai-python` `.stats.yml`) is pinned to the same Stainless hash as this package, so no spec bump is needed; the `anyOf` enum listing `gpt-image-2` will flow in automatically on the next upstream spec refresh.

## References

- [Introducing ChatGPT Images 2.0](https://openai.com/index/introducing-chatgpt-images-2-0/#textmode) — OpenAI's announcement of GPT Image 2 (flexible sizes, high-fidelity inputs, token-based pricing, Batch API).
- [\`gpt-image-2\` API docs](https://developers.openai.com/api/docs/models/gpt-image-2) — model id reference.

## Test Plan

- [x] \`dart analyze --fatal-infos\` clean
- [x] \`dart format --set-exit-if-changed .\` clean
- [x] \`dart test --reporter=failures-only test/unit/\` — 1191 passing
- [x] New unit tests cover new request fields, enum values, full GPT Image 2 response payload, and minimal DALL-E response (multi-model nullability)
- [x] New multipart-body test asserts every new \`ImageEditRequest\` field is emitted with correct wire values
- [x] \`==\`/\`hashCode\` contract updated on \`ImageGenerationRequest\` and \`ImageEditRequest\` to cover all new fields
- [x] \`fromJson\`/\`toJson\` round-trip verified for \`ImageResponse\` with \`usage\`
- [x] Toolkit \`fetch\` / \`review\` / \`verify --checks all --scope all\` — no errors, no warnings
- [x] Live API probe with \`gpt-image-2\` returned HTTP 200 with expected response shape
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/195" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
