### PR TITLE
feat(chromadb): add index_and_bounded_wal read level

### DIFF
--- a/packages/chromadb/lib/src/models/records/read_level.dart
+++ b/packages/chromadb/lib/src/models/records/read_level.dart
@@ -4,6 +4,9 @@
 /// recently added data) or also include the write-ahead log (slower, but
 /// fully consistent).
 enum ReadLevel {
+  /// Read from the index and a bounded portion of the write-ahead log.
+  indexAndBoundedWal('index_and_bounded_wal'),
+
   /// Read from both the index and the write-ahead log.
   indexAndWal('index_and_wal'),
 

--- a/packages/chromadb/specs/openapi.json
+++ b/packages/chromadb/specs/openapi.json
@@ -1345,7 +1345,8 @@
       "ReadLevel": {
         "enum": [
           "index_and_wal",
-          "index_only"
+          "index_only",
+          "index_and_bounded_wal"
         ],
         "type": "string"
       },

--- a/packages/chromadb/specs/spec_metadata.json
+++ b/packages/chromadb/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "1.0.0",
-      "last_fetched": "2026-04-16T09:58:41.000000Z",
+      "last_fetched": "2026-04-22T18:44:41.229992Z",
       "source_url": "https://api.trychroma.com/openapi.json",
       "title": "chroma-frontend",
       "version_history": []


### PR DESCRIPTION
## Summary
- Add new `ReadLevel.indexAndBoundedWal` variant (`index_and_bounded_wal`) to match the upstream ChromaDB API, enabling reads from the index plus a bounded portion of the write-ahead log.
- Refresh `specs/openapi.json` from `api.trychroma.com/openapi.json`.

## Details

Upstream added a third `ReadLevel` value between the existing `index_only` and `index_and_wal` options — a bounded-WAL read offering a middle ground between raw-index speed and full-WAL consistency.

```dart
// Before: unrecognized values fell back to ReadLevel.unknown
// After: the new variant is first-class
final level = ReadLevel.indexAndBoundedWal;
```

No breaking changes; the enum's `fromJson` fallback to `ReadLevel.unknown` means pre-upgrade clients talking to servers returning this value degraded gracefully — this PR simply makes the variant usable directly.

## Test Plan
- [x] `api_toolkit verify --checks all --scope all` — 0 errors, 0 warnings
- [x] `dart analyze --fatal-infos` — clean
- [x] `dart format --set-exit-if-changed .` — clean
- [x] `dart test test/unit/` — 304/304 passing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/196" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
