### PR TITLE
feat(googleai_dart): update to latest Gemini OpenAPI spec

### DIFF
--- a/packages/googleai_dart/.agents/skills/openapi-googleai/config/manifest.json
+++ b/packages/googleai_dart/.agents/skills/openapi-googleai/config/manifest.json
@@ -156,6 +156,22 @@
       "schema": "EmbedContentResponse",
       "tags": []
     },
+    "EmbedContentRequest": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "EmbedContentRequest",
+      "file": "lib/src/models/embeddings/embed_content_request.dart",
+      "schema": "EmbedContentRequest",
+      "tags": []
+    },
+    "EmbedContentConfig": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "EmbedContentConfig",
+      "file": "lib/src/models/embeddings/embed_content_config.dart",
+      "schema": "EmbedContentConfig",
+      "tags": []
+    },
     "BatchEmbedContentsResponse": {
       "spec": "main",
       "kind": "object",

--- a/packages/googleai_dart/lib/googleai_dart.dart
+++ b/packages/googleai_dart/lib/googleai_dart.dart
@@ -79,6 +79,7 @@ export 'src/models/corpus/list_documents_response.dart';
 export 'src/models/embeddings/batch_embed_contents_request.dart';
 export 'src/models/embeddings/batch_embed_contents_response.dart';
 export 'src/models/embeddings/content_embedding.dart';
+export 'src/models/embeddings/embed_content_config.dart';
 export 'src/models/embeddings/embed_content_request.dart';
 export 'src/models/embeddings/embed_content_response.dart';
 export 'src/models/embeddings/embedding_usage_metadata.dart';

--- a/packages/googleai_dart/lib/src/models/embeddings/embed_content_config.dart
+++ b/packages/googleai_dart/lib/src/models/embeddings/embed_content_config.dart
@@ -1,0 +1,91 @@
+import '../copy_with_sentinel.dart';
+import 'task_type.dart';
+
+/// Configuration for the `EmbedContent` request.
+class EmbedContentConfig {
+  /// The task type of the embedding.
+  final TaskType? taskType;
+
+  /// The title for the text.
+  final String? title;
+
+  /// Reduced dimension for the output embedding.
+  ///
+  /// If set, excessive values in the output embedding are truncated from the
+  /// end.
+  final int? outputDimensionality;
+
+  /// Whether to silently truncate the input content if it's longer than the
+  /// maximum sequence length.
+  final bool? autoTruncate;
+
+  /// Whether to enable OCR for document content.
+  final bool? documentOcr;
+
+  /// Whether to extract audio from video content.
+  final bool? audioTrackExtraction;
+
+  /// Creates an [EmbedContentConfig].
+  const EmbedContentConfig({
+    this.taskType,
+    this.title,
+    this.outputDimensionality,
+    this.autoTruncate,
+    this.documentOcr,
+    this.audioTrackExtraction,
+  });
+
+  /// Creates an [EmbedContentConfig] from JSON.
+  factory EmbedContentConfig.fromJson(Map<String, dynamic> json) =>
+      EmbedContentConfig(
+        taskType: json['taskType'] != null
+            ? taskTypeFromString(json['taskType'] as String?)
+            : null,
+        title: json['title'] as String?,
+        outputDimensionality: json['outputDimensionality'] as int?,
+        autoTruncate: json['autoTruncate'] as bool?,
+        documentOcr: json['documentOcr'] as bool?,
+        audioTrackExtraction: json['audioTrackExtraction'] as bool?,
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (taskType != null) 'taskType': taskTypeToString(taskType!),
+    if (title != null) 'title': title,
+    if (outputDimensionality != null)
+      'outputDimensionality': outputDimensionality,
+    if (autoTruncate != null) 'autoTruncate': autoTruncate,
+    if (documentOcr != null) 'documentOcr': documentOcr,
+    if (audioTrackExtraction != null)
+      'audioTrackExtraction': audioTrackExtraction,
+  };
+
+  /// Creates a copy with replaced values.
+  EmbedContentConfig copyWith({
+    Object? taskType = unsetCopyWithValue,
+    Object? title = unsetCopyWithValue,
+    Object? outputDimensionality = unsetCopyWithValue,
+    Object? autoTruncate = unsetCopyWithValue,
+    Object? documentOcr = unsetCopyWithValue,
+    Object? audioTrackExtraction = unsetCopyWithValue,
+  }) {
+    return EmbedContentConfig(
+      taskType: taskType == unsetCopyWithValue
+          ? this.taskType
+          : taskType as TaskType?,
+      title: title == unsetCopyWithValue ? this.title : title as String?,
+      outputDimensionality: outputDimensionality == unsetCopyWithValue
+          ? this.outputDimensionality
+          : outputDimensionality as int?,
+      autoTruncate: autoTruncate == unsetCopyWithValue
+          ? this.autoTruncate
+          : autoTruncate as bool?,
+      documentOcr: documentOcr == unsetCopyWithValue
+          ? this.documentOcr
+          : documentOcr as bool?,
+      audioTrackExtraction: audioTrackExtraction == unsetCopyWithValue
+          ? this.audioTrackExtraction
+          : audioTrackExtraction as bool?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/embeddings/embed_content_request.dart
+++ b/packages/googleai_dart/lib/src/models/embeddings/embed_content_request.dart
@@ -4,6 +4,11 @@ import 'embed_content_config.dart';
 import 'task_type.dart';
 
 /// Request to embed content.
+///
+/// Prefer [embedContentConfig] over the deprecated top-level [taskType],
+/// [title], and [outputDimensionality] fields. If both are provided the server
+/// treats [embedContentConfig] as authoritative, per the upstream deprecation
+/// notes on the legacy fields.
 class EmbedContentRequest {
   /// The content to embed. Only the `parts.text` fields will be counted.
   final Content content;

--- a/packages/googleai_dart/lib/src/models/embeddings/embed_content_request.dart
+++ b/packages/googleai_dart/lib/src/models/embeddings/embed_content_request.dart
@@ -1,30 +1,39 @@
 import '../content/content.dart';
 import '../copy_with_sentinel.dart';
+import 'embed_content_config.dart';
 import 'task_type.dart';
 
 /// Request to embed content.
 class EmbedContentRequest {
-  /// The content to embed.
+  /// The content to embed. Only the `parts.text` fields will be counted.
   final Content content;
 
+  /// Configuration for the `EmbedContent` request.
+  final EmbedContentConfig? embedContentConfig;
+
   /// Optional task type hint.
+  @Deprecated('Use EmbedContentConfig.taskType instead.')
   final TaskType? taskType;
 
   /// Optional title (only valid with taskType RETRIEVAL_DOCUMENT).
+  @Deprecated('Use EmbedContentConfig.title instead.')
   final String? title;
 
   /// Optional reduced dimension for the output embedding.
   ///
   /// If set, excessive values in the output embedding are truncated from the end.
   /// Supported by newer models since 2024 only. You cannot set this value if
-  /// using the earlier model (models/gemini-embedding-001).
+  /// using the earlier model (models/embedding-001).
+  @Deprecated('Use EmbedContentConfig.outputDimensionality instead.')
   final int? outputDimensionality;
 
   /// Creates an [EmbedContentRequest].
   const EmbedContentRequest({
     required this.content,
-    this.taskType,
-    this.title,
+    this.embedContentConfig,
+    @Deprecated('Use EmbedContentConfig.taskType instead.') this.taskType,
+    @Deprecated('Use EmbedContentConfig.title instead.') this.title,
+    @Deprecated('Use EmbedContentConfig.outputDimensionality instead.')
     this.outputDimensionality,
   });
 
@@ -32,6 +41,11 @@ class EmbedContentRequest {
   factory EmbedContentRequest.fromJson(Map<String, dynamic> json) =>
       EmbedContentRequest(
         content: Content.fromJson(json['content'] as Map<String, dynamic>),
+        embedContentConfig: json['embedContentConfig'] != null
+            ? EmbedContentConfig.fromJson(
+                json['embedContentConfig'] as Map<String, dynamic>,
+              )
+            : null,
         taskType: json['taskType'] != null
             ? taskTypeFromString(json['taskType'] as String?)
             : null,
@@ -42,6 +56,8 @@ class EmbedContentRequest {
   /// Converts to JSON.
   Map<String, dynamic> toJson() => {
     'content': content.toJson(),
+    if (embedContentConfig != null)
+      'embedContentConfig': embedContentConfig!.toJson(),
     if (taskType != null) 'taskType': taskTypeToString(taskType!),
     if (title != null) 'title': title,
     if (outputDimensionality != null)
@@ -51,6 +67,7 @@ class EmbedContentRequest {
   /// Creates a copy with replaced values.
   EmbedContentRequest copyWith({
     Object? content = unsetCopyWithValue,
+    Object? embedContentConfig = unsetCopyWithValue,
     Object? taskType = unsetCopyWithValue,
     Object? title = unsetCopyWithValue,
     Object? outputDimensionality = unsetCopyWithValue,
@@ -59,6 +76,9 @@ class EmbedContentRequest {
       content: content == unsetCopyWithValue
           ? this.content
           : content! as Content,
+      embedContentConfig: embedContentConfig == unsetCopyWithValue
+          ? this.embedContentConfig
+          : embedContentConfig as EmbedContentConfig?,
       taskType: taskType == unsetCopyWithValue
           ? this.taskType
           : taskType as TaskType?,

--- a/packages/googleai_dart/lib/src/models/interactions/agent_config.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/agent_config.dart
@@ -2,6 +2,10 @@ import '../copy_with_sentinel.dart';
 import 'thinking_summaries.dart';
 
 /// Base class for agent configurations.
+///
+/// Subtypes:
+/// - [DynamicAgentConfig] (type `dynamic`)
+/// - [DeepResearchAgentConfig] (type `deep-research`)
 sealed class AgentConfig {
   /// The type of agent configuration.
   String get type;
@@ -59,6 +63,36 @@ class DynamicAgentConfig extends AgentConfig {
   }
 }
 
+/// Whether to include visualizations in the Deep Research response.
+enum DeepResearchVisualization {
+  /// Do not include visualizations.
+  off,
+
+  /// Automatically include visualizations.
+  auto,
+}
+
+/// Converts string to [DeepResearchVisualization] enum.
+///
+/// Returns `null` for `null` input or unrecognized values (forward-compatible:
+/// a new server-side enum value will surface as `null` rather than silently
+/// collapsing into an existing member).
+DeepResearchVisualization? deepResearchVisualizationFromString(String? value) {
+  return switch (value) {
+    'off' => DeepResearchVisualization.off,
+    'auto' => DeepResearchVisualization.auto,
+    _ => null,
+  };
+}
+
+/// Converts [DeepResearchVisualization] enum to string.
+String deepResearchVisualizationToString(DeepResearchVisualization value) {
+  return switch (value) {
+    DeepResearchVisualization.off => 'off',
+    DeepResearchVisualization.auto => 'auto',
+  };
+}
+
 /// Configuration for the Deep Research agent.
 class DeepResearchAgentConfig extends AgentConfig {
   @override
@@ -67,8 +101,22 @@ class DeepResearchAgentConfig extends AgentConfig {
   /// Whether to include thought summaries in the response.
   final InteractionThinkingSummaries? thinkingSummaries;
 
+  /// Enables human-in-the-loop planning for the Deep Research agent.
+  ///
+  /// If set to true, the Deep Research agent will provide a research plan in
+  /// its response. The agent will then proceed only if the user confirms the
+  /// plan in the next turn.
+  final bool? collaborativePlanning;
+
+  /// Whether to include visualizations in the response.
+  final DeepResearchVisualization? visualization;
+
   /// Creates a [DeepResearchAgentConfig] instance.
-  const DeepResearchAgentConfig({this.thinkingSummaries});
+  const DeepResearchAgentConfig({
+    this.thinkingSummaries,
+    this.collaborativePlanning,
+    this.visualization,
+  });
 
   /// Creates a [DeepResearchAgentConfig] from JSON.
   factory DeepResearchAgentConfig.fromJson(Map<String, dynamic> json) =>
@@ -78,6 +126,10 @@ class DeepResearchAgentConfig extends AgentConfig {
                 json['thinking_summaries'] as String?,
               )
             : null,
+        collaborativePlanning: json['collaborative_planning'] as bool?,
+        visualization: deepResearchVisualizationFromString(
+          json['visualization'] as String?,
+        ),
       );
 
   @override
@@ -87,16 +139,28 @@ class DeepResearchAgentConfig extends AgentConfig {
       'thinking_summaries': interactionThinkingSummariesToString(
         thinkingSummaries!,
       ),
+    if (collaborativePlanning != null)
+      'collaborative_planning': collaborativePlanning,
+    if (visualization != null)
+      'visualization': deepResearchVisualizationToString(visualization!),
   };
 
   /// Creates a copy with replaced values.
   DeepResearchAgentConfig copyWith({
     Object? thinkingSummaries = unsetCopyWithValue,
+    Object? collaborativePlanning = unsetCopyWithValue,
+    Object? visualization = unsetCopyWithValue,
   }) {
     return DeepResearchAgentConfig(
       thinkingSummaries: thinkingSummaries == unsetCopyWithValue
           ? this.thinkingSummaries
           : thinkingSummaries as InteractionThinkingSummaries?,
+      collaborativePlanning: collaborativePlanning == unsetCopyWithValue
+          ? this.collaborativePlanning
+          : collaborativePlanning as bool?,
+      visualization: visualization == unsetCopyWithValue
+          ? this.visualization
+          : visualization as DeepResearchVisualization?,
     );
   }
 }

--- a/packages/googleai_dart/lib/src/models/interactions/agent_config.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/agent_config.dart
@@ -127,9 +127,11 @@ class DeepResearchAgentConfig extends AgentConfig {
               )
             : null,
         collaborativePlanning: json['collaborative_planning'] as bool?,
-        visualization: deepResearchVisualizationFromString(
-          json['visualization'] as String?,
-        ),
+        visualization: json['visualization'] != null
+            ? deepResearchVisualizationFromString(
+                json['visualization'] as String?,
+              )
+            : null,
       );
 
   @override

--- a/packages/googleai_dart/specs/openapi-interactions.json
+++ b/packages/googleai_dart/specs/openapi-interactions.json
@@ -20,6 +20,16 @@
             "const": "deep-research-pro-preview-12-2025",
             "description": "Gemini Deep Research Agent",
             "x-stainless-nominal": false
+          },
+          {
+            "const": "deep-research-preview-04-2026",
+            "description": "Gemini Deep Research Agent",
+            "x-stainless-nominal": false
+          },
+          {
+            "const": "deep-research-max-preview-04-2026",
+            "description": "Gemini Deep Research Max Agent",
+            "x-stainless-nominal": false
           }
         ],
         "description": "The agent to interact with.",
@@ -96,7 +106,10 @@
               "audio/flac",
               "audio/mpeg",
               "audio/m4a",
-              "audio/l16"
+              "audio/l16",
+              "audio/opus",
+              "audio/alaw",
+              "audio/mulaw"
             ],
             "type": "string",
             "x-google-enum-descriptions": [
@@ -108,7 +121,10 @@
               "FLAC audio format",
               "MPEG audio format",
               "M4A audio format",
-              "L16 audio format"
+              "L16 audio format",
+              "OPUS audio format",
+              "ALAW audio format",
+              "MULAW audio format"
             ]
           },
           "rate": {
@@ -150,7 +166,10 @@
               "audio/flac",
               "audio/mpeg",
               "audio/m4a",
-              "audio/l16"
+              "audio/l16",
+              "audio/opus",
+              "audio/alaw",
+              "audio/mulaw"
             ],
             "type": "string",
             "x-google-enum-descriptions": [
@@ -162,7 +181,10 @@
               "FLAC audio format",
               "MPEG audio format",
               "M4A audio format",
-              "L16 audio format"
+              "L16 audio format",
+              "OPUS audio format",
+              "ALAW audio format",
+              "MULAW audio format"
             ]
           },
           "rate": {
@@ -766,11 +788,11 @@
             "type": "string",
             "x-google-enum-descriptions": [
               "The interaction is in progress.",
-              "The interaction requires action.",
+              "The interaction requires action/input from the user.",
               "The interaction is completed.",
-              "The interaction is failed.",
-              "The interaction is cancelled.",
-              "The interaction is incomplete."
+              "The interaction failed.",
+              "The interaction was cancelled.",
+              "The interaction is completed, but contains incomplete results (e.g.\nhitting max_tokens)."
             ]
           },
           "store": {
@@ -901,11 +923,11 @@
             "type": "string",
             "x-google-enum-descriptions": [
               "The interaction is in progress.",
-              "The interaction requires action.",
+              "The interaction requires action/input from the user.",
               "The interaction is completed.",
-              "The interaction is failed.",
-              "The interaction is cancelled.",
-              "The interaction is incomplete."
+              "The interaction failed.",
+              "The interaction was cancelled.",
+              "The interaction is completed, but contains incomplete results (e.g.\nhitting max_tokens)."
             ]
           },
           "store": {
@@ -949,12 +971,28 @@
       "DeepResearchAgentConfig": {
         "description": "Configuration for the Deep Research agent.",
         "properties": {
+          "collaborative_planning": {
+            "description": "Enables human-in-the-loop planning for the Deep Research agent. If set to\ntrue, the Deep Research agent will provide a research plan in its response.\nThe agent will then proceed only if the user confirms the plan in the next\nturn.",
+            "type": "boolean"
+          },
           "thinking_summaries": {
             "$ref": "#/components/schemas/ThinkingSummaries",
             "description": "Whether to include thought summaries in the response."
           },
           "type": {
             "const": "deep-research"
+          },
+          "visualization": {
+            "description": "Whether to include visualizations in the response.",
+            "enum": [
+              "off",
+              "auto"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Do not include visualizations.",
+              "Automatically include visualizations."
+            ]
           }
         },
         "required": [
@@ -2367,11 +2405,11 @@
             "type": "string",
             "x-google-enum-descriptions": [
               "The interaction is in progress.",
-              "The interaction requires action.",
+              "The interaction requires action/input from the user.",
               "The interaction is completed.",
-              "The interaction is failed.",
-              "The interaction is cancelled.",
-              "The interaction is incomplete."
+              "The interaction failed.",
+              "The interaction was cancelled.",
+              "The interaction is completed, but contains incomplete results (e.g.\nhitting max_tokens)."
             ]
           },
           "system_instruction": {
@@ -2557,11 +2595,11 @@
             "type": "string",
             "x-google-enum-descriptions": [
               "The interaction is in progress.",
-              "The interaction requires action.",
+              "The interaction requires action/input from the user.",
               "The interaction is completed.",
-              "The interaction is failed.",
-              "The interaction is cancelled.",
-              "The interaction is incomplete."
+              "The interaction failed.",
+              "The interaction was cancelled.",
+              "The interaction is completed, but contains incomplete results (e.g.\nhitting max_tokens)."
             ]
           }
         },
@@ -2961,6 +2999,11 @@
           {
             "const": "gemini-3.1-flash-lite-preview",
             "description": "Our most cost-efficient model, optimized for high-volume agentic tasks, translation, and simple data processing.",
+            "x-stainless-nominal": false
+          },
+          {
+            "const": "gemini-3.1-flash-tts-preview",
+            "description": "Gemini 3.1 Flash TTS: Powerful, low-latency speech generation. Enjoy natural outputs, steerable prompts, and new expressive audio tags for precise narration control.",
             "x-stainless-nominal": false
           },
           {

--- a/packages/googleai_dart/specs/openapi.json
+++ b/packages/googleai_dart/specs/openapi.json
@@ -1329,6 +1329,41 @@
         },
         "type": "object"
       },
+      "EmbedContentConfig": {
+        "description": "Configurations for the EmbedContent request.",
+        "properties": {
+          "audioTrackExtraction": {
+            "description": "Optional. Whether to extract audio from video content.",
+            "type": "boolean"
+          },
+          "autoTruncate": {
+            "description": "Optional. Whether to silently truncate the input content if it's longer\nthan the maximum sequence length.",
+            "type": "boolean"
+          },
+          "documentOcr": {
+            "description": "Optional. Whether to enable OCR for document content.",
+            "type": "boolean"
+          },
+          "outputDimensionality": {
+            "description": "Optional. Reduced dimension for the output embedding. If set, excessive\nvalues in the output embedding are truncated from the end.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "taskType": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TaskType"
+              }
+            ],
+            "description": "Optional. The task type of the embedding."
+          },
+          "title": {
+            "description": "Optional. The title for the text.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "EmbedContentRequest": {
         "description": "Request containing the `Content` for the model to embed.",
         "properties": {
@@ -1340,12 +1375,21 @@
             ],
             "description": "Required. The content to embed. Only the `parts.text` fields will be counted."
           },
+          "embedContentConfig": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EmbedContentConfig"
+              }
+            ],
+            "description": "Optional. Configuration for the EmbedContent request."
+          },
           "model": {
             "description": "Required. The model's resource name. This serves as an ID for the Model to use.\n\nThis name should match a model name returned by the `ListModels` method.\n\nFormat: `models/{model}`",
             "type": "string"
           },
           "outputDimensionality": {
-            "description": "Optional. Optional reduced dimension for the output embedding. If set, excessive\nvalues in the output embedding are truncated from the end. Supported by\nnewer models since 2024 only. You cannot set this value if using the\nearlier model (`models/embedding-001`).",
+            "deprecated": true,
+            "description": "Optional. Deprecated: Please use EmbedContentConfig.output_dimensionality instead.\nOptional reduced dimension for the output embedding. If set, excessive\nvalues in the output embedding are truncated from the end. Supported by\nnewer models since 2024 only. You cannot set this value if using the\nearlier model (`models/embedding-001`).",
             "format": "int32",
             "type": "integer"
           },
@@ -1355,10 +1399,12 @@
                 "$ref": "#/components/schemas/TaskType"
               }
             ],
-            "description": "Optional. Optional task type for which the embeddings will be used. Not supported on\nearlier models (`models/embedding-001`)."
+            "deprecated": true,
+            "description": "Optional. Deprecated: Please use EmbedContentConfig.task_type instead.\nOptional task type for which the embeddings will be used. Not supported on\nearlier models (`models/embedding-001`)."
           },
           "title": {
-            "description": "Optional. An optional title for the text. Only applicable when TaskType is\n`RETRIEVAL_DOCUMENT`.\n\nNote: Specifying a `title` for `RETRIEVAL_DOCUMENT` provides better quality\nembeddings for retrieval.",
+            "deprecated": true,
+            "description": "Optional. Deprecated: Please use EmbedContentConfig.title instead.\nAn optional title for the text. Only applicable when TaskType is\n`RETRIEVAL_DOCUMENT`.\n\nNote: Specifying a `title` for `RETRIEVAL_DOCUMENT` provides better quality\nembeddings for retrieval.",
             "type": "string"
           }
         },
@@ -5639,7 +5685,7 @@
     "description": "The Gemini API allows developers to build generative AI applications using Gemini models. Gemini is our most capable model, built from the ground up to be multimodal. It can generalize and seamlessly understand, operate across, and combine different types of information including language, images, audio, video, and code. You can use the Gemini API for use cases like reasoning across text and images, content generation, dialogue agents, summarization and classification systems, and more.",
     "title": "Gemini API",
     "version": "v1beta",
-    "x-google-revision": "20260415"
+    "x-google-revision": "20260421"
   },
   "openapi": "3.0.3",
   "paths": {

--- a/packages/googleai_dart/specs/spec_metadata.json
+++ b/packages/googleai_dart/specs/spec_metadata.json
@@ -2,14 +2,14 @@
   "specs": {
     "interactions": {
       "current_version": "v1beta",
-      "last_fetched": "2026-04-16T21:12:00.747055Z",
+      "last_fetched": "2026-04-22T18:45:26.530625Z",
       "source_url": "https://ai.google.dev/static/api/interactions.openapi.json",
       "title": "Gemini API",
       "version_history": []
     },
     "main": {
       "current_version": "v1beta",
-      "last_fetched": "2026-04-16T21:11:47.906709Z",
+      "last_fetched": "2026-04-22T18:45:15.787993Z",
       "source_url": "https://generativelanguage.googleapis.com/$discovery/OPENAPI3_0?version=v1beta",
       "title": "Gemini API",
       "version_history": []

--- a/packages/googleai_dart/test/unit/models/embeddings/embed_content_config_test.dart
+++ b/packages/googleai_dart/test/unit/models/embeddings/embed_content_config_test.dart
@@ -1,0 +1,134 @@
+import 'package:googleai_dart/googleai_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('EmbedContentConfig', () {
+    group('constructor', () {
+      test('creates with all fields', () {
+        const config = EmbedContentConfig(
+          taskType: TaskType.retrievalDocument,
+          title: 'A doc',
+          outputDimensionality: 256,
+          autoTruncate: true,
+          documentOcr: true,
+          audioTrackExtraction: false,
+        );
+        expect(config.taskType, TaskType.retrievalDocument);
+        expect(config.title, 'A doc');
+        expect(config.outputDimensionality, 256);
+        expect(config.autoTruncate, isTrue);
+        expect(config.documentOcr, isTrue);
+        expect(config.audioTrackExtraction, isFalse);
+      });
+
+      test('creates with no fields', () {
+        const config = EmbedContentConfig();
+        expect(config.taskType, isNull);
+        expect(config.title, isNull);
+        expect(config.outputDimensionality, isNull);
+        expect(config.autoTruncate, isNull);
+        expect(config.documentOcr, isNull);
+        expect(config.audioTrackExtraction, isNull);
+      });
+    });
+
+    group('fromJson', () {
+      test('deserializes with all fields', () {
+        final json = {
+          'taskType': 'RETRIEVAL_QUERY',
+          'title': 'Title',
+          'outputDimensionality': 128,
+          'autoTruncate': true,
+          'documentOcr': false,
+          'audioTrackExtraction': true,
+        };
+        final config = EmbedContentConfig.fromJson(json);
+        expect(config.taskType, TaskType.retrievalQuery);
+        expect(config.title, 'Title');
+        expect(config.outputDimensionality, 128);
+        expect(config.autoTruncate, isTrue);
+        expect(config.documentOcr, isFalse);
+        expect(config.audioTrackExtraction, isTrue);
+      });
+
+      test('deserializes with empty JSON', () {
+        final config = EmbedContentConfig.fromJson(<String, dynamic>{});
+        expect(config.taskType, isNull);
+        expect(config.title, isNull);
+        expect(config.outputDimensionality, isNull);
+        expect(config.autoTruncate, isNull);
+        expect(config.documentOcr, isNull);
+        expect(config.audioTrackExtraction, isNull);
+      });
+    });
+
+    group('toJson', () {
+      test('serializes all set fields', () {
+        const config = EmbedContentConfig(
+          taskType: TaskType.semanticSimilarity,
+          title: 'T',
+          outputDimensionality: 64,
+          autoTruncate: true,
+          documentOcr: true,
+          audioTrackExtraction: true,
+        );
+        final json = config.toJson();
+        expect(json['taskType'], 'SEMANTIC_SIMILARITY');
+        expect(json['title'], 'T');
+        expect(json['outputDimensionality'], 64);
+        expect(json['autoTruncate'], isTrue);
+        expect(json['documentOcr'], isTrue);
+        expect(json['audioTrackExtraction'], isTrue);
+      });
+
+      test('omits null fields', () {
+        const config = EmbedContentConfig();
+        expect(config.toJson(), isEmpty);
+      });
+    });
+
+    group('round-trip', () {
+      test('fromJson/toJson preserves all fields', () {
+        final original = {
+          'taskType': 'CLASSIFICATION',
+          'title': 'Round',
+          'outputDimensionality': 32,
+          'autoTruncate': false,
+          'documentOcr': true,
+          'audioTrackExtraction': false,
+        };
+        final result = EmbedContentConfig.fromJson(original).toJson();
+        expect(result, equals(original));
+      });
+    });
+
+    group('copyWith', () {
+      test('copies with no changes', () {
+        const config = EmbedContentConfig(
+          taskType: TaskType.clustering,
+          title: 'X',
+        );
+        final copy = config.copyWith();
+        expect(copy.taskType, TaskType.clustering);
+        expect(copy.title, 'X');
+      });
+
+      test('copies with updated fields', () {
+        const config = EmbedContentConfig(outputDimensionality: 100);
+        final copy = config.copyWith(outputDimensionality: 200, title: 'new');
+        expect(copy.outputDimensionality, 200);
+        expect(copy.title, 'new');
+      });
+
+      test('copies with null to clear fields', () {
+        const config = EmbedContentConfig(
+          taskType: TaskType.factVerification,
+          documentOcr: true,
+        );
+        final copy = config.copyWith(taskType: null, documentOcr: null);
+        expect(copy.taskType, isNull);
+        expect(copy.documentOcr, isNull);
+      });
+    });
+  });
+}

--- a/packages/googleai_dart/test/unit/models/embeddings/embed_content_request_test.dart
+++ b/packages/googleai_dart/test/unit/models/embeddings/embed_content_request_test.dart
@@ -1,0 +1,136 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
+import 'package:googleai_dart/googleai_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('EmbedContentRequest', () {
+    group('fromJson', () {
+      test('deserializes with embedContentConfig', () {
+        final json = {
+          'content': {
+            'parts': [
+              {'text': 'hello'},
+            ],
+          },
+          'embedContentConfig': {
+            'taskType': 'RETRIEVAL_DOCUMENT',
+            'title': 'Doc',
+            'outputDimensionality': 64,
+          },
+        };
+        final request = EmbedContentRequest.fromJson(json);
+        expect(request.embedContentConfig, isNotNull);
+        expect(
+          request.embedContentConfig!.taskType,
+          TaskType.retrievalDocument,
+        );
+        expect(request.embedContentConfig!.title, 'Doc');
+        expect(request.embedContentConfig!.outputDimensionality, 64);
+        expect(request.taskType, isNull);
+        expect(request.title, isNull);
+        expect(request.outputDimensionality, isNull);
+      });
+
+      test('deserializes with deprecated top-level fields', () {
+        final json = {
+          'content': {
+            'parts': [
+              {'text': 'hi'},
+            ],
+          },
+          'taskType': 'RETRIEVAL_QUERY',
+          'title': 'Legacy',
+          'outputDimensionality': 128,
+        };
+        final request = EmbedContentRequest.fromJson(json);
+        expect(request.embedContentConfig, isNull);
+        expect(request.taskType, TaskType.retrievalQuery);
+        expect(request.title, 'Legacy');
+        expect(request.outputDimensionality, 128);
+      });
+    });
+
+    group('toJson', () {
+      test('serializes with embedContentConfig', () {
+        const request = EmbedContentRequest(
+          content: Content(parts: [TextPart('hi')]),
+          embedContentConfig: EmbedContentConfig(
+            taskType: TaskType.retrievalQuery,
+            outputDimensionality: 64,
+          ),
+        );
+        final json = request.toJson();
+        expect(json['embedContentConfig'], isA<Map<String, dynamic>>());
+        final cfg = json['embedContentConfig'] as Map<String, dynamic>;
+        expect(cfg['taskType'], 'RETRIEVAL_QUERY');
+        expect(cfg['outputDimensionality'], 64);
+        expect(json.containsKey('taskType'), isFalse);
+        expect(json.containsKey('outputDimensionality'), isFalse);
+      });
+
+      test('serializes deprecated top-level fields alongside config', () {
+        const request = EmbedContentRequest(
+          content: Content(parts: [TextPart('x')]),
+          embedContentConfig: EmbedContentConfig(title: 'New'),
+          title: 'Legacy',
+        );
+        final json = request.toJson();
+        expect(json['title'], 'Legacy');
+        expect(
+          (json['embedContentConfig']! as Map<String, dynamic>)['title'],
+          'New',
+        );
+      });
+
+      test('omits embedContentConfig when null', () {
+        const request = EmbedContentRequest(
+          content: Content(parts: [TextPart('x')]),
+        );
+        final json = request.toJson();
+        expect(json.containsKey('embedContentConfig'), isFalse);
+      });
+    });
+
+    group('round-trip', () {
+      test('fromJson/toJson preserves embedContentConfig', () {
+        final original = {
+          'content': {
+            'parts': [
+              {'text': 'round'},
+            ],
+          },
+          'embedContentConfig': {
+            'taskType': 'CLASSIFICATION',
+            'autoTruncate': true,
+          },
+        };
+        final result = EmbedContentRequest.fromJson(original).toJson();
+        expect(result['embedContentConfig'], original['embedContentConfig']);
+      });
+    });
+
+    group('copyWith', () {
+      test('updates embedContentConfig', () {
+        const request = EmbedContentRequest(
+          content: Content(parts: [TextPart('hi')]),
+        );
+        final copy = request.copyWith(
+          embedContentConfig: const EmbedContentConfig(
+            taskType: TaskType.clustering,
+          ),
+        );
+        expect(copy.embedContentConfig!.taskType, TaskType.clustering);
+      });
+
+      test('clears embedContentConfig with null', () {
+        const request = EmbedContentRequest(
+          content: Content(parts: [TextPart('hi')]),
+          embedContentConfig: EmbedContentConfig(title: 't'),
+        );
+        final copy = request.copyWith(embedContentConfig: null);
+        expect(copy.embedContentConfig, isNull);
+      });
+    });
+  });
+}

--- a/packages/googleai_dart/test/unit/models/interactions/agent_config_test.dart
+++ b/packages/googleai_dart/test/unit/models/interactions/agent_config_test.dart
@@ -1,0 +1,174 @@
+import 'package:googleai_dart/googleai_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DeepResearchVisualization', () {
+    test('deepResearchVisualizationFromString converts known values', () {
+      expect(
+        deepResearchVisualizationFromString('off'),
+        DeepResearchVisualization.off,
+      );
+      expect(
+        deepResearchVisualizationFromString('auto'),
+        DeepResearchVisualization.auto,
+      );
+    });
+
+    test('deepResearchVisualizationFromString returns null for unknown', () {
+      expect(deepResearchVisualizationFromString(null), isNull);
+      expect(deepResearchVisualizationFromString(''), isNull);
+      expect(deepResearchVisualizationFromString('future_value'), isNull);
+      expect(deepResearchVisualizationFromString('OFF'), isNull);
+    });
+
+    test('deepResearchVisualizationToString converts all enum values', () {
+      expect(
+        deepResearchVisualizationToString(DeepResearchVisualization.off),
+        'off',
+      );
+      expect(
+        deepResearchVisualizationToString(DeepResearchVisualization.auto),
+        'auto',
+      );
+    });
+
+    test('round-trip for all values', () {
+      for (final value in DeepResearchVisualization.values) {
+        expect(
+          deepResearchVisualizationFromString(
+            deepResearchVisualizationToString(value),
+          ),
+          value,
+        );
+      }
+    });
+  });
+
+  group('DeepResearchAgentConfig', () {
+    group('constructor', () {
+      test('creates with all new fields', () {
+        const config = DeepResearchAgentConfig(
+          thinkingSummaries: InteractionThinkingSummaries.auto,
+          collaborativePlanning: true,
+          visualization: DeepResearchVisualization.auto,
+        );
+        expect(config.type, 'deep-research');
+        expect(config.thinkingSummaries, InteractionThinkingSummaries.auto);
+        expect(config.collaborativePlanning, isTrue);
+        expect(config.visualization, DeepResearchVisualization.auto);
+      });
+
+      test('creates with no fields', () {
+        const config = DeepResearchAgentConfig();
+        expect(config.thinkingSummaries, isNull);
+        expect(config.collaborativePlanning, isNull);
+        expect(config.visualization, isNull);
+      });
+    });
+
+    group('fromJson', () {
+      test('deserializes all fields', () {
+        final json = {
+          'type': 'deep-research',
+          'thinking_summaries': 'auto',
+          'collaborative_planning': true,
+          'visualization': 'off',
+        };
+        final config = DeepResearchAgentConfig.fromJson(json);
+        expect(config.thinkingSummaries, InteractionThinkingSummaries.auto);
+        expect(config.collaborativePlanning, isTrue);
+        expect(config.visualization, DeepResearchVisualization.off);
+      });
+
+      test('deserializes via sealed AgentConfig.fromJson', () {
+        final json = {
+          'type': 'deep-research',
+          'collaborative_planning': false,
+          'visualization': 'auto',
+        };
+        final config = AgentConfig.fromJson(json);
+        expect(config, isA<DeepResearchAgentConfig>());
+        final deep = config as DeepResearchAgentConfig;
+        expect(deep.collaborativePlanning, isFalse);
+        expect(deep.visualization, DeepResearchVisualization.auto);
+      });
+
+      test('tolerates unrecognized visualization value', () {
+        final json = {'type': 'deep-research', 'visualization': 'future_value'};
+        final config = DeepResearchAgentConfig.fromJson(json);
+        expect(config.visualization, isNull);
+      });
+    });
+
+    group('toJson', () {
+      test('serializes all set fields with snake_case keys', () {
+        const config = DeepResearchAgentConfig(
+          thinkingSummaries: InteractionThinkingSummaries.none,
+          collaborativePlanning: true,
+          visualization: DeepResearchVisualization.auto,
+        );
+        final json = config.toJson();
+        expect(json['type'], 'deep-research');
+        expect(json['thinking_summaries'], 'none');
+        expect(json['collaborative_planning'], isTrue);
+        expect(json['visualization'], 'auto');
+      });
+
+      test('omits null fields', () {
+        const config = DeepResearchAgentConfig();
+        final json = config.toJson();
+        expect(json, {'type': 'deep-research'});
+      });
+    });
+
+    group('round-trip', () {
+      test('fromJson/toJson preserves all fields', () {
+        final original = {
+          'type': 'deep-research',
+          'thinking_summaries': 'auto',
+          'collaborative_planning': true,
+          'visualization': 'off',
+        };
+        final result = DeepResearchAgentConfig.fromJson(original).toJson();
+        expect(result, equals(original));
+      });
+    });
+
+    group('copyWith', () {
+      test('copies with no changes', () {
+        const config = DeepResearchAgentConfig(
+          collaborativePlanning: true,
+          visualization: DeepResearchVisualization.auto,
+        );
+        final copy = config.copyWith();
+        expect(copy.collaborativePlanning, isTrue);
+        expect(copy.visualization, DeepResearchVisualization.auto);
+      });
+
+      test('copies with updated fields', () {
+        const config = DeepResearchAgentConfig(
+          visualization: DeepResearchVisualization.off,
+        );
+        final copy = config.copyWith(
+          visualization: DeepResearchVisualization.auto,
+          collaborativePlanning: true,
+        );
+        expect(copy.visualization, DeepResearchVisualization.auto);
+        expect(copy.collaborativePlanning, isTrue);
+      });
+
+      test('copies with null to clear fields', () {
+        const config = DeepResearchAgentConfig(
+          collaborativePlanning: true,
+          visualization: DeepResearchVisualization.auto,
+        );
+        final copy = config.copyWith(
+          collaborativePlanning: null,
+          visualization: null,
+        );
+        expect(copy.collaborativePlanning, isNull);
+        expect(copy.visualization, isNull);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add new `EmbedContentConfig` schema consolidating embedding request parameters, with new fields `autoTruncate`, `documentOcr`, and `audioTrackExtraction`.
- Add `embedContentConfig` property to `EmbedContentRequest`; deprecate the equivalent top-level `taskType`, `title`, and `outputDimensionality` fields.
- Add `collaborativePlanning` and `visualization` fields to `DeepResearchAgentConfig`, enabling human-in-the-loop planning and inline visualizations for the Deep Research agent.

## Details

### Embeddings — `EmbedContentConfig`

The Gemini API groups embedding configuration under a single `embedContentConfig` object. The flat fields on `EmbedContentRequest` still round-trip but are now annotated `@Deprecated` — new code should use the nested config:

```dart
final request = EmbedContentRequest(
  content: Content(parts: [TextPart('hello')]),
  embedContentConfig: const EmbedContentConfig(
    taskType: TaskType.retrievalDocument,
    title: 'My doc',
    outputDimensionality: 256,
    autoTruncate: true,
    documentOcr: true,
    audioTrackExtraction: false,
  ),
);
```

New fields (per spec):
- `autoTruncate` — silently truncate input content if longer than the max sequence length.
- `documentOcr` — enable OCR for document content.
- `audioTrackExtraction` — extract audio from video content.

### Interactions — Deep Research

Two new fields on `DeepResearchAgentConfig`:

- `collaborativePlanning` (bool) — when `true`, the Deep Research agent returns a research plan and only proceeds after the user confirms it in the next turn.
- `visualization` (enum: `off` / `auto`) — whether to include visualizations in the response.

```dart
final config = DeepResearchAgentConfig(
  collaborativePlanning: true,
  visualization: DeepResearchVisualization.auto,
);
```

A new `DeepResearchVisualization` enum is added; its `fromString` returns `null` for unrecognized values (forward-compatible — new server-side enum members surface as `null` rather than silently collapsing into an existing member).

The parent sealed class `AgentConfig` doc comment now enumerates both subtypes (`DynamicAgentConfig`, `DeepResearchAgentConfig`).

### Verification against official SDK

Field names, wire casing (camelCase for main API, snake_case for Interactions), and enum values were cross-checked against the official `google-genai` Python SDK and `@google/genai` TypeScript SDK — all align 1:1. The `mimeType` field that appears on `EmbedContentConfig` in the SDKs is Vertex-only and intentionally absent from the Gemini OpenAPI spec.

## References

- [Next-generation Gemini Deep Research](https://blog.google/innovation-and-ai/models-and-research/gemini-models/next-generation-gemini-deep-research/) — the two new `DeepResearchAgentConfig` fields (`collaborativePlanning`, `visualization`) are the Gemini API surface for the collaborative planning and visualization features announced in this post.

## Test Plan

- [x] Unit tests pass (`dart test test/unit/` — 1422 tests pass, +33 new).
- [x] New `EmbedContentConfig` has constructor / `fromJson` / `toJson` / round-trip / `copyWith` coverage.
- [x] Updated `EmbedContentRequest` tests cover the new `embedContentConfig` field, the deprecated top-level fields, and coexistence of both.
- [x] `DeepResearchAgentConfig` tests cover all new fields, dispatch via sealed `AgentConfig.fromJson`, and forward-compatibility for unknown `visualization` values.
- [x] `DeepResearchVisualization` enum round-trip + unknown-value fallback tested.
- [x] `dart format --set-exit-if-changed .` clean.
- [x] `dart analyze --fatal-infos` clean.
- [x] `api_toolkit verify --checks all --scope changed` passes on both `main` and `interactions` specs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
