### PR TITLE
chore(ollama_dart): refresh OpenAPI spec metadata

### DIFF
--- a/packages/ollama_dart/specs/spec_metadata.json
+++ b/packages/ollama_dart/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "0.1.0",
-      "last_fetched": "2026-04-16T09:46:56.281077Z",
+      "last_fetched": "2026-04-22T18:50:30.910994Z",
       "source_url": "https://raw.githubusercontent.com/ollama/ollama/refs/heads/main/docs/openapi.yaml",
       "title": "Ollama API",
       "version_history": []


### PR DESCRIPTION
## Summary
- Refreshes `specs/spec_metadata.json` after re-running the openapi-ollama fetch/review workflow.
- Confirms the upstream Ollama OpenAPI spec is unchanged (still v0.1.0) — no endpoint or schema changes.

## Details

Only the `last_fetched` timestamp was updated. The review step reported zero added, modified, or removed endpoints/schemas and no coverage gaps. No generated code or models needed updating.

## Test Plan

- [x] `api_toolkit.py fetch` succeeded for the `main` spec
- [x] `api_toolkit.py review` reported no diff (0 added / 0 modified / 0 removed for endpoints and schemas)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
