### PR TITLE
chore(openai_dart): refresh OpenAPI spec metadata timestamp

### DIFF
--- a/packages/openai_dart/specs/spec_metadata.json
+++ b/packages/openai_dart/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "2.3.0",
-      "last_fetched": "2026-04-21T21:42:49.769622Z",
+      "last_fetched": "2026-04-22T18:51:34.561333Z",
       "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai%2Fopenai-7c540cce6eb30401259f4831ea9803b6d88501605d13734f98212cbb3b199e10.yml",
       "title": "OpenAI API",
       "version_history": []


### PR DESCRIPTION
## Summary
- Refresh `last_fetched` timestamp in `packages/openai_dart/specs/spec_metadata.json` after verifying the upstream OpenAI OpenAPI spec is unchanged (hash `7c540cce…`, version `2.3.0`).

## Details

No endpoint, schema, or generated-code changes — only the metadata timestamp is updated to record that the spec was re-fetched and confirmed current.

## Test Plan

- [x] `api_toolkit.py fetch` reports `outdated: false`
- [x] `api_toolkit.py review` reports zero endpoint/schema diffs and zero issues
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
