### PR TITLE
fix(mistralai_dart): add missing copyWith to ObservabilityError models

### DIFF
--- a/packages/mistralai_dart/lib/src/models/observability/observability_error.dart
+++ b/packages/mistralai_dart/lib/src/models/observability/observability_error.dart
@@ -22,6 +22,10 @@ class ObservabilityError {
   /// Converts to JSON.
   Map<String, dynamic> toJson() => {'detail': detail.toJson()};
 
+  /// Creates a copy with the specified fields replaced.
+  ObservabilityError copyWith({ObservabilityErrorDetail? detail}) =>
+      ObservabilityError(detail: detail ?? this.detail);
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;

--- a/packages/mistralai_dart/lib/src/models/observability/observability_error_detail.dart
+++ b/packages/mistralai_dart/lib/src/models/observability/observability_error_detail.dart
@@ -1,5 +1,6 @@
 import 'package:meta/meta.dart';
 
+import '../common/copy_with_sentinel.dart';
 import 'observability_error_code.dart';
 
 /// Detail of an observability error.
@@ -28,6 +29,19 @@ class ObservabilityErrorDetail {
     'message': message,
     'error_code': errorCode?.value,
   };
+
+  /// Creates a copy with the specified fields replaced.
+  ///
+  /// Pass `null` explicitly to clear [errorCode].
+  ObservabilityErrorDetail copyWith({
+    String? message,
+    Object? errorCode = unsetCopyWithValue,
+  }) => ObservabilityErrorDetail(
+    message: message ?? this.message,
+    errorCode: errorCode == unsetCopyWithValue
+        ? this.errorCode
+        : errorCode as ObservabilityErrorCode?,
+  );
 
   @override
   bool operator ==(Object other) {


### PR DESCRIPTION
## Summary
- Add `copyWith` to `ObservabilityError` and `ObservabilityErrorDetail` — both were missing this method even though every other immutable model in the package implements it.

## Details

Both classes were flagged by \`api_toolkit verify --checks implementation\` as \"Missing copyWith implementation\". The crash in the int-enum verifier (fixed in #TBD) had been hiding this finding until now, but the gap itself is pre-existing and unrelated to any recent Mistral spec change.

\`ObservabilityErrorDetail.copyWith\` uses the shared \`unsetCopyWithValue\` sentinel from \`models/common/copy_with_sentinel.dart\`, matching the pattern used by every other observability model with nullable fields (so callers can null out \`errorCode\` explicitly if needed).

```dart
final updated = error.copyWith(
  detail: error.detail.copyWith(message: 'Retry in progress'),
);
```

## Test Plan
- [x] \`dart format --set-exit-if-changed .\` — 0 changed
- [x] \`dart analyze --fatal-infos .\` — 0 issues
- [x] \`dart test --reporter=failures-only test/unit/\` — 1431 pass
- [x] \`api_toolkit verify\` no longer reports these as implementation errors
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
