### PR TITLE
fix(api-toolkit): verify --checks implementation handles int enum values

### DIFF
--- a/.agents/shared/api-toolkit/api_toolkit/operations.py
+++ b/.agents/shared/api-toolkit/api_toolkit/operations.py
@@ -1467,9 +1467,19 @@ def _verify_enum_entry(config: ToolkitConfig, spec_payload: dict[str, Any], entr
     if not values:
         issues.append(_type_issue("error", entry.key, f"No enum values found in spec for '{entry.schema_name}'", file=entry.file))
     for value in values:
-        # OpenAPI enums may be strings OR integers (e.g. int-coded state enums);
-        # stringify before substring check so we never TypeError on `int in str`.
-        if str(value) not in content:
+        # OpenAPI enums may be strings OR integers (e.g. int-coded state enums).
+        # For ints, use a digit-boundary regex so `1` doesn't falsely match
+        # inside `10`/`21`; for strings, keep the original substring behavior
+        # (string enum values live in quotes in Dart source, so substring
+        # matching rarely collides).
+        if isinstance(value, int) and not isinstance(value, bool):
+            found = (
+                re.search(rf"(?<!\d){re.escape(str(value))}(?!\d)", content)
+                is not None
+            )
+        else:
+            found = str(value) in content
+        if not found:
             issues.append(_type_issue("error", entry.key, f"Enum value '{value}' not found in file", file=entry.file))
     if not any(fallback in content for fallback in UNKNOWN_ENUM_FALLBACKS):
         issues.append(_type_issue("error", entry.key, "Enum fallback value ('unknown' or 'unspecified') not found", file=entry.file))

--- a/.agents/shared/api-toolkit/api_toolkit/operations.py
+++ b/.agents/shared/api-toolkit/api_toolkit/operations.py
@@ -1452,7 +1452,7 @@ def _verify_enum_entry(config: ToolkitConfig, spec_payload: dict[str, Any], entr
     if "enum " not in content:
         return [_type_issue("error", entry.key, "Expected enum declaration", file=entry.file)]
 
-    values: list[str]
+    values: list[Any]
     if config.manifest.surface == "openapi":
         values = _extract_openapi_schemas(spec_payload).get(entry.schema_name, {}).get("enum_values", [])
     else:
@@ -1467,8 +1467,10 @@ def _verify_enum_entry(config: ToolkitConfig, spec_payload: dict[str, Any], entr
     if not values:
         issues.append(_type_issue("error", entry.key, f"No enum values found in spec for '{entry.schema_name}'", file=entry.file))
     for value in values:
-        if value not in content:
-            issues.append(_type_issue("error", entry.key, f"Enum string value '{value}' not found in file", file=entry.file))
+        # OpenAPI enums may be strings OR integers (e.g. int-coded state enums);
+        # stringify before substring check so we never TypeError on `int in str`.
+        if str(value) not in content:
+            issues.append(_type_issue("error", entry.key, f"Enum value '{value}' not found in file", file=entry.file))
     if not any(fallback in content for fallback in UNKNOWN_ENUM_FALLBACKS):
         issues.append(_type_issue("error", entry.key, "Enum fallback value ('unknown' or 'unspecified') not found", file=entry.file))
     return issues

--- a/.agents/shared/api-toolkit/tests/test_api_toolkit_commands.py
+++ b/.agents/shared/api-toolkit/tests/test_api_toolkit_commands.py
@@ -2813,6 +2813,123 @@ class ApiToolkitCommandTests(unittest.TestCase):
             )
             self.assertEqual(exit_code, 0)
 
+    def test_verify_enum_with_integer_values(self) -> None:
+        """Int-valued OpenAPI enums must verify without TypeError (`int in str`)."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            self._write_workspace(root)
+            self._write_repo_license(root)
+            package_root, config_dir = self._create_openapi_config(root)
+            (package_root / "specs" / "openapi.json").write_text(
+                json.dumps(
+                    {
+                        "openapi": "3.1.0",
+                        "info": {"title": "Sample", "version": "1"},
+                        "paths": {},
+                        "components": {
+                            "schemas": {
+                                "Priority": {"type": "integer", "enum": [1, 2, 3]}
+                            }
+                        },
+                    }
+                )
+            )
+            self._write_specs_and_manifest(
+                config_dir,
+                specs_payload={
+                    "specs": {"main": {"name": "Sample", "local_file": "openapi.json", "fetch_mode": "local_file", "source_file": "specs/openapi.json"}},
+                    "specs_dir": "packages/sample_dart/specs",
+                    "output_dir": str(root / "tmp" / "sample"),
+                },
+                manifest_payload={
+                    "surface": "openapi",
+                    "type_mappings": {},
+                    "placement": {"categories": {}, "default_category": "common", "parent_model_patterns": {}},
+                    "coverage": {},
+                    "types": {
+                        "Priority": {"spec": "main", "kind": "enum", "dart_class": "Priority", "file": "lib/src/models/common/priority.dart", "schema": "Priority"}
+                    },
+                },
+            )
+            (package_root / "lib" / "src" / "models" / "common" / "priority.dart").write_text(
+                "enum Priority {\n"
+                "  low(1),\n"
+                "  medium(2),\n"
+                "  high(3),\n"
+                "  unknown(0);\n"
+                "  const Priority(this.value);\n"
+                "  final int value;\n"
+                "}\n"
+            )
+
+            exit_code, payload = command_verify(
+                SimpleNamespace(config_dir=config_dir, spec_name=None, checks="implementation", scope="all", type_name=None, baseline=None, git_ref=None)
+            )
+
+            issues = payload["results"]["implementation"]["issues"]
+            self.assertFalse(
+                any("not found in file" in issue["message"] for issue in issues),
+                f"Expected int enum values to be recognized, got: {issues}",
+            )
+            self.assertEqual(exit_code, 0)
+
+    def test_verify_enum_with_integer_values_missing_member_flagged(self) -> None:
+        """Int enum member missing from Dart source is still reported (not swallowed)."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            self._write_workspace(root)
+            self._write_repo_license(root)
+            package_root, config_dir = self._create_openapi_config(root)
+            (package_root / "specs" / "openapi.json").write_text(
+                json.dumps(
+                    {
+                        "openapi": "3.1.0",
+                        "info": {"title": "Sample", "version": "1"},
+                        "paths": {},
+                        "components": {
+                            "schemas": {
+                                "Priority": {"type": "integer", "enum": [1, 2, 99]}
+                            }
+                        },
+                    }
+                )
+            )
+            self._write_specs_and_manifest(
+                config_dir,
+                specs_payload={
+                    "specs": {"main": {"name": "Sample", "local_file": "openapi.json", "fetch_mode": "local_file", "source_file": "specs/openapi.json"}},
+                    "specs_dir": "packages/sample_dart/specs",
+                    "output_dir": str(root / "tmp" / "sample"),
+                },
+                manifest_payload={
+                    "surface": "openapi",
+                    "type_mappings": {},
+                    "placement": {"categories": {}, "default_category": "common", "parent_model_patterns": {}},
+                    "coverage": {},
+                    "types": {
+                        "Priority": {"spec": "main", "kind": "enum", "dart_class": "Priority", "file": "lib/src/models/common/priority.dart", "schema": "Priority"}
+                    },
+                },
+            )
+            (package_root / "lib" / "src" / "models" / "common" / "priority.dart").write_text(
+                "enum Priority {\n"
+                "  low(1),\n"
+                "  medium(2),\n"
+                "  unknown(0);\n"
+                "}\n"
+            )
+
+            exit_code, payload = command_verify(
+                SimpleNamespace(config_dir=config_dir, spec_name=None, checks="implementation", scope="all", type_name=None, baseline=None, git_ref=None)
+            )
+
+            issues = payload["results"]["implementation"]["issues"]
+            self.assertTrue(
+                any("'99'" in issue["message"] and "not found in file" in issue["message"] for issue in issues),
+                f"Expected missing '99' to be reported, got: {issues}",
+            )
+            self.assertEqual(exit_code, 1)
+
     def test_verify_coverage_gap_is_blocking(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)

--- a/.agents/shared/api-toolkit/tests/test_api_toolkit_commands.py
+++ b/.agents/shared/api-toolkit/tests/test_api_toolkit_commands.py
@@ -2930,6 +2930,73 @@ class ApiToolkitCommandTests(unittest.TestCase):
             )
             self.assertEqual(exit_code, 1)
 
+    def test_verify_enum_int_value_not_matched_as_substring_of_larger_int(self) -> None:
+        """Int `1` must NOT be considered present when Dart file only has `10` — no digit-substring false negatives."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            self._write_workspace(root)
+            self._write_repo_license(root)
+            package_root, config_dir = self._create_openapi_config(root)
+            (package_root / "specs" / "openapi.json").write_text(
+                json.dumps(
+                    {
+                        "openapi": "3.1.0",
+                        "info": {"title": "Sample", "version": "1"},
+                        "paths": {},
+                        "components": {
+                            "schemas": {
+                                "Priority": {"type": "integer", "enum": [1, 2]}
+                            }
+                        },
+                    }
+                )
+            )
+            self._write_specs_and_manifest(
+                config_dir,
+                specs_payload={
+                    "specs": {"main": {"name": "Sample", "local_file": "openapi.json", "fetch_mode": "local_file", "source_file": "specs/openapi.json"}},
+                    "specs_dir": "packages/sample_dart/specs",
+                    "output_dir": str(root / "tmp" / "sample"),
+                },
+                manifest_payload={
+                    "surface": "openapi",
+                    "type_mappings": {},
+                    "placement": {"categories": {}, "default_category": "common", "parent_model_patterns": {}},
+                    "coverage": {},
+                    "types": {
+                        "Priority": {"spec": "main", "kind": "enum", "dart_class": "Priority", "file": "lib/src/models/common/priority.dart", "schema": "Priority"}
+                    },
+                },
+            )
+            # Dart file contains `10` and `21` but neither `1` nor `2` as bare
+            # digits — naive substring matching would falsely pass.
+            (package_root / "lib" / "src" / "models" / "common" / "priority.dart").write_text(
+                "enum Priority {\n"
+                "  ten(10),\n"
+                "  twentyOne(21),\n"
+                "  unknown(0);\n"
+                "}\n"
+            )
+
+            exit_code, payload = command_verify(
+                SimpleNamespace(config_dir=config_dir, spec_name=None, checks="implementation", scope="all", type_name=None, baseline=None, git_ref=None)
+            )
+
+            issues = payload["results"]["implementation"]["issues"]
+            missing = {
+                msg for msg in (i["message"] for i in issues)
+                if "not found in file" in msg
+            }
+            self.assertTrue(
+                any("'1'" in m for m in missing),
+                f"Expected '1' to be reported missing, got: {missing}",
+            )
+            self.assertTrue(
+                any("'2'" in m for m in missing),
+                f"Expected '2' to be reported missing, got: {missing}",
+            )
+            self.assertEqual(exit_code, 1)
+
     def test_verify_coverage_gap_is_blocking(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)


### PR DESCRIPTION
## Summary
- Fix crash in \`api_toolkit verify --checks implementation\` when an OpenAPI schema declares an int-valued enum (e.g. Mistral's \`ScheduleOverlapPolicy\` with \`enum: [1, 2, 3, 4, 5, 6]\`).
- The crash aborted the whole check and masked any later findings — unblocks downstream reviews.
- Adds positive + negative regression tests.

## Details

\`_verify_enum_entry\` in \`operations.py\` iterates declared enum values and checks if each appears in the Dart source file (a heuristic \"did we forget a member\" lint). The previous implementation assumed values were \`str\`, so \`value not in content\` raised \`TypeError: 'in <string>' requires string as left operand, not int\` when the spec used integer enum values.

The fix is a one-line coercion: \`str(value) not in content\`. This preserves existing string-enum semantics byte-identically (\`str(\"foo\") == \"foo\"\`) and handles ints by checking whether their literal representation (e.g. \`1\`, \`2\`) appears anywhere in the Dart file — which it does for the standard pattern:

```dart
enum ScheduleOverlapPolicy {
  skip(1),
  bufferOne(2),
  // ...
  unknown(0);

  const ScheduleOverlapPolicy(this.value);
  final int value;
}
```

The type annotation is widened from \`list[str]\` to \`list[Any]\` to match reality, the error message drops \"string\" for accuracy, and a short inline comment explains why the coercion exists.

### Tests added
- \`test_verify_enum_with_integer_values\` — int enum \`[1, 2, 3]\` with all members present → exit 0.
- \`test_verify_enum_with_integer_values_missing_member_flagged\` — int enum \`[1, 2, 99]\` with \`99\` missing from the Dart source → exit 1, missing-member reported (proves we don't silently swallow real issues).

### Scope check
Grepped other \`enum_values\` usages (\`_extract_openapi_schemas\`, \`_compare_openapi\`, scaffold paths). Single-schema \`sorted()\` is homogeneous (all-int or all-str per enum); equality comparison works across types. No other int-blind call sites.

## Test Plan
- [x] \`python3 -m unittest tests.test_api_toolkit_commands -k enum\` — 9/9 pass including the two new ones
- [x] \`api_toolkit verify --checks implementation --scope all\` on mistralai_dart now completes (was crashing)
- [x] Existing string-enum behavior unchanged (\`str(\"foo\") == \"foo\"\`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
