### PR TITLE
feat(openai_dart): add GPT-5.5 model support

### DIFF
--- a/packages/openai_dart/README.md
+++ b/packages/openai_dart/README.md
@@ -74,7 +74,7 @@ Future<void> main() async {
   try {
     final response = await client.responses.create(
       CreateResponseRequest(
-        model: 'gpt-5.4',
+        model: 'gpt-5.5',
         input: ResponseInput.text('What is the capital of France?'),
       ),
     );
@@ -167,7 +167,7 @@ final client = OpenAIClient.fromEnvironment();
 
 final response = await client.responses.create(
   CreateResponseRequest(
-    model: 'gpt-5.4',
+    model: 'gpt-5.5',
     input: ResponseInput.text('What is the capital of France?'),
   ),
 );
@@ -196,7 +196,7 @@ final client = OpenAIClient.fromEnvironment();
 
 final response = await client.chat.completions.create(
   ChatCompletionCreateRequest(
-    model: 'gpt-5.4',
+    model: 'gpt-5.5',
     messages: [
       ChatMessage.system('You are a helpful assistant.'),
       ChatMessage.user('What is the capital of France?'),
@@ -232,7 +232,7 @@ Streaming returns token-by-token deltas as they arrive. You can iterate text del
 ```dart
 final stream = client.chat.completions.createStream(
   ChatCompletionCreateRequest(
-    model: 'gpt-5.4',
+    model: 'gpt-5.5',
     messages: [ChatMessage.user('Tell me a story')],
   ),
 );
@@ -268,7 +268,7 @@ Define tools with JSON Schema parameters and pass them in the request. The respo
 ```dart
 final response = await client.chat.completions.create(
   ChatCompletionCreateRequest(
-    model: 'gpt-5.4',
+    model: 'gpt-5.5',
     messages: [
       ChatMessage.user("What's the weather in Tokyo?"),
     ],
@@ -310,7 +310,7 @@ Pass image URLs or base64-encoded images as content parts alongside text in a us
 ```dart
 final response = await client.chat.completions.create(
   ChatCompletionCreateRequest(
-    model: 'gpt-5.4',
+    model: 'gpt-5.5',
     messages: [
       ChatMessage.user([
         ContentPart.text('What is in this image?'),
@@ -706,7 +706,7 @@ Future<void> main() async {
   try {
     await client.responses.create(
       CreateResponseRequest(
-        model: 'gpt-5.4',
+        model: 'gpt-5.5',
         input: ResponseInput.text('Ping'),
       ),
     );

--- a/packages/openai_dart/example/assistants_example.dart
+++ b/packages/openai_dart/example/assistants_example.dart
@@ -26,7 +26,7 @@ Future<void> main() async {
 
     final assistant = await client.beta.assistants.create(
       const CreateAssistantRequest(
-        model: 'gpt-4.1',
+        model: 'gpt-5.5',
         name: 'Math Tutor',
         instructions:
             'You are a helpful math tutor. '

--- a/packages/openai_dart/example/chat_example.dart
+++ b/packages/openai_dart/example/chat_example.dart
@@ -16,7 +16,7 @@ Future<void> main() async {
 
     final response = await client.chat.completions.create(
       ChatCompletionCreateRequest(
-        model: 'gpt-4.1',
+        model: 'gpt-5.5',
         messages: [ChatMessage.user('What is the capital of France?')],
         maxTokens: 100,
       ),
@@ -34,7 +34,7 @@ Future<void> main() async {
 
     final response2 = await client.chat.completions.create(
       ChatCompletionCreateRequest(
-        model: 'gpt-4.1',
+        model: 'gpt-5.5',
         messages: [
           ChatMessage.system('You are a helpful assistant that speaks French.'),
           ChatMessage.user('What is the capital of France?'),
@@ -50,7 +50,7 @@ Future<void> main() async {
 
     final response3 = await client.chat.completions.create(
       ChatCompletionCreateRequest(
-        model: 'gpt-4.1',
+        model: 'gpt-5.5',
         messages: [
           ChatMessage.user('My name is Alice.'),
           ChatMessage.assistant(content: 'Hello Alice! Nice to meet you.'),

--- a/packages/openai_dart/example/error_handling_example.dart
+++ b/packages/openai_dart/example/error_handling_example.dart
@@ -18,7 +18,7 @@ Future<void> main() async {
     try {
       await invalidClient.chat.completions.create(
         ChatCompletionCreateRequest(
-          model: 'gpt-4o',
+          model: 'gpt-5.5',
           messages: [ChatMessage.user('Hello')],
           maxTokens: 100,
         ),
@@ -35,7 +35,7 @@ Future<void> main() async {
     try {
       await client.chat.completions.create(
         ChatCompletionCreateRequest(
-          model: 'gpt-4o',
+          model: 'gpt-5.5',
           messages: [ChatMessage.user('Hello')],
           maxTokens: -1, // Invalid: must be positive
         ),
@@ -71,7 +71,7 @@ Future<void> main() async {
       // Make a normal request (rate limiting would occur with many requests)
       await client.chat.completions.create(
         ChatCompletionCreateRequest(
-          model: 'gpt-4o',
+          model: 'gpt-5.5',
           messages: [ChatMessage.user('Hello')],
           maxTokens: 10,
         ),
@@ -93,7 +93,7 @@ Future<void> main() async {
     try {
       await client.chat.completions.create(
         ChatCompletionCreateRequest(
-          model: 'gpt-4o',
+          model: 'gpt-5.5',
           messages: [ChatMessage.user('What is 2 + 2?')],
           maxTokens: 50,
         ),
@@ -137,7 +137,7 @@ Future<void> main() async {
     try {
       await client.chat.completions.create(
         ChatCompletionCreateRequest(
-          model: 'gpt-4o',
+          model: 'gpt-5.5',
           messages: [ChatMessage.user('Hello')],
           maxTokens: 0, // Invalid
         ),

--- a/packages/openai_dart/example/evals_example.dart
+++ b/packages/openai_dart/example/evals_example.dart
@@ -109,7 +109,7 @@ Future<void> createMultiGraderEvaluation(OpenAIClient client) async {
         // 3. Label model for sentiment classification
         EvalGrader.labelModel(
           name: 'positive_tone',
-          model: 'gpt-4o-mini',
+          model: 'gpt-5.5',
           labels: ['positive', 'negative', 'neutral'],
           passingLabels: ['positive', 'neutral'],
           input: [
@@ -178,7 +178,7 @@ Future<void> runEvaluationWithPolling(OpenAIClient client) async {
             },
           ],
         ),
-        model: 'gpt-4o-mini',
+        model: 'gpt-5.5',
         inputMessages: InputMessages.template([
           const InputMessage.system('You are a helpful assistant.'),
           const InputMessage.user('{{item.input}}'),

--- a/packages/openai_dart/example/input_tokens_example.dart
+++ b/packages/openai_dart/example/input_tokens_example.dart
@@ -17,7 +17,7 @@ Future<void> main() async {
     print('=== Count Input Tokens ===\n');
 
     final tokenCount = await client.responses.inputTokens.count(
-      model: 'gpt-4o',
+      model: 'gpt-5.5',
       input: const ResponseInput.text('Hello, how are you?'),
     );
 
@@ -27,7 +27,7 @@ Future<void> main() async {
     print('=== Count Tokens with Tools ===\n');
 
     final countWithTools = await client.responses.inputTokens.count(
-      model: 'gpt-4o',
+      model: 'gpt-5.5',
       input: const ResponseInput.text('What is the weather in Paris?'),
       tools: [
         ResponseTool.function(

--- a/packages/openai_dart/example/models_example.dart
+++ b/packages/openai_dart/example/models_example.dart
@@ -63,11 +63,11 @@ Future<void> main() async {
     // Retrieve a specific model
     print('=== Retrieve Specific Model ===\n');
 
-    final gpt4o = await client.models.retrieve('gpt-4o');
-    print('Model: ${gpt4o.id}');
-    print('  Object: ${gpt4o.object}');
-    print('  Owned by: ${gpt4o.ownedBy}');
-    print('  Created: ${gpt4o.createdAt}');
+    final model = await client.models.retrieve('gpt-5.5');
+    print('Model: ${model.id}');
+    print('  Object: ${model.object}');
+    print('  Owned by: ${model.ownedBy}');
+    print('  Created: ${model.createdAt}');
     print('');
 
     // Group models by owner

--- a/packages/openai_dart/example/openai_dart_example.dart
+++ b/packages/openai_dart/example/openai_dart_example.dart
@@ -20,7 +20,7 @@ Future<void> main() async {
 
     final response = await client.chat.completions.create(
       ChatCompletionCreateRequest(
-        model: 'gpt-4.1',
+        model: 'gpt-5.5',
         messages: [
           ChatMessage.system('You are a helpful assistant.'),
           ChatMessage.user('What is Dart programming language?'),
@@ -36,7 +36,7 @@ Future<void> main() async {
 
     final stream = client.chat.completions.createStream(
       ChatCompletionCreateRequest(
-        model: 'gpt-4.1',
+        model: 'gpt-5.5',
         messages: [ChatMessage.user('Count from 1 to 5')],
         maxTokens: 50,
       ),

--- a/packages/openai_dart/example/responses_example.dart
+++ b/packages/openai_dart/example/responses_example.dart
@@ -25,7 +25,7 @@ Future<void> simpleResponse(OpenAIClient client) async {
 
   final response = await client.responses.create(
     const CreateResponseRequest(
-      model: 'gpt-5.2',
+      model: 'gpt-5.5',
       input: ResponseInput.text('What is 2 + 2?'),
     ),
   );
@@ -41,7 +41,7 @@ Future<void> streamingResponse(OpenAIClient client) async {
 
   final stream = client.responses.createStream(
     const CreateResponseRequest(
-      model: 'gpt-5.2',
+      model: 'gpt-5.5',
       input: ResponseInput.text('Tell me a very short joke.'),
     ),
   );
@@ -76,7 +76,7 @@ Future<void> responseWithTools(OpenAIClient client) async {
 
   final response = await client.responses.create(
     CreateResponseRequest(
-      model: 'gpt-5.2',
+      model: 'gpt-5.5',
       input: const ResponseInput.text('What is the weather in San Francisco?'),
       tools: [weatherTool],
     ),
@@ -97,7 +97,7 @@ Future<void> responseWithWebSearch(OpenAIClient client) async {
 
   final response = await client.responses.create(
     CreateResponseRequest(
-      model: 'gpt-5.2',
+      model: 'gpt-5.5',
       input: const ResponseInput.text('What are the latest news about AI?'),
       tools: [ResponseTool.webSearch()],
     ),
@@ -114,7 +114,7 @@ Future<void> multiTurnConversation(OpenAIClient client) async {
   // First turn
   final response1 = await client.responses.create(
     const CreateResponseRequest(
-      model: 'gpt-5.2',
+      model: 'gpt-5.5',
       input: ResponseInput.text('My name is Alice.'),
     ),
   );
@@ -124,7 +124,7 @@ Future<void> multiTurnConversation(OpenAIClient client) async {
   // Second turn - continue the conversation using previous response ID
   final response2 = await client.responses.create(
     CreateResponseRequest(
-      model: 'gpt-5.2',
+      model: 'gpt-5.5',
       input: const ResponseInput.items([
         MessageItem(
           role: MessageRole.user,

--- a/packages/openai_dart/example/streaming_example.dart
+++ b/packages/openai_dart/example/streaming_example.dart
@@ -17,7 +17,7 @@ Future<void> main() async {
 
     final stream = client.chat.completions.createStream(
       ChatCompletionCreateRequest(
-        model: 'gpt-4.1',
+        model: 'gpt-5.5',
         messages: [ChatMessage.user('Count from 1 to 10 slowly.')],
         maxTokens: 100,
       ),
@@ -35,7 +35,7 @@ Future<void> main() async {
 
     final stream2 = client.chat.completions.createStream(
       ChatCompletionCreateRequest(
-        model: 'gpt-4.1',
+        model: 'gpt-5.5',
         messages: [ChatMessage.user('Say hello in 5 different languages.')],
         maxTokens: 200,
       ),
@@ -49,7 +49,7 @@ Future<void> main() async {
 
     final stream3 = client.chat.completions.createStream(
       ChatCompletionCreateRequest(
-        model: 'gpt-4.1',
+        model: 'gpt-5.5',
         messages: [ChatMessage.user('Write a short haiku about programming.')],
         maxTokens: 100,
       ),

--- a/packages/openai_dart/example/tool_calling_example.dart
+++ b/packages/openai_dart/example/tool_calling_example.dart
@@ -38,7 +38,7 @@ Future<void> main() async {
     // First request - model decides to call the tool
     final response = await client.chat.completions.create(
       ChatCompletionCreateRequest(
-        model: 'gpt-4.1',
+        model: 'gpt-5.5',
         messages: [ChatMessage.user("What's the weather like in Tokyo?")],
         tools: [weatherTool],
       ),
@@ -72,7 +72,7 @@ Future<void> main() async {
       // Second request - provide tool result
       final response2 = await client.chat.completions.create(
         ChatCompletionCreateRequest(
-          model: 'gpt-4.1',
+          model: 'gpt-5.5',
           messages: [
             ChatMessage.user("What's the weather like in Tokyo?"),
             ChatMessage.assistant(
@@ -95,7 +95,7 @@ Future<void> main() async {
 
     final response3 = await client.chat.completions.create(
       ChatCompletionCreateRequest(
-        model: 'gpt-4.1',
+        model: 'gpt-5.5',
         messages: [ChatMessage.user('Tell me about the weather.')],
         tools: [weatherTool],
         toolChoice: ToolChoice.function('get_weather'),

--- a/packages/openai_dart/example/vision_example.dart
+++ b/packages/openai_dart/example/vision_example.dart
@@ -1,7 +1,7 @@
 // ignore_for_file: avoid_print
-/// Example demonstrating GPT-4 Vision capabilities.
+/// Example demonstrating vision capabilities.
 ///
-/// This example shows how to analyze images using GPT-4 Vision.
+/// This example shows how to analyze images with a multimodal chat model.
 /// Run with: dart run example/vision_example.dart
 library;
 
@@ -20,7 +20,7 @@ Future<void> main() async {
 
     final response = await client.chat.completions.create(
       ChatCompletionCreateRequest(
-        model: 'gpt-4.1',
+        model: 'gpt-5.5',
         messages: [
           ChatMessage.user(
             UserMessageContent.parts([
@@ -43,7 +43,7 @@ Future<void> main() async {
 
     final response2 = await client.chat.completions.create(
       ChatCompletionCreateRequest(
-        model: 'gpt-4.1',
+        model: 'gpt-5.5',
         messages: [
           ChatMessage.user(
             UserMessageContent.parts([
@@ -86,7 +86,7 @@ ImageContentPart(
 
     final response3 = await client.chat.completions.create(
       ChatCompletionCreateRequest(
-        model: 'gpt-4.1',
+        model: 'gpt-5.5',
         messages: [
           ChatMessage.user(
             UserMessageContent.parts([

--- a/packages/openai_dart/example/web_search_example.dart
+++ b/packages/openai_dart/example/web_search_example.dart
@@ -21,7 +21,7 @@ Future<void> main() async {
 
     final response = await client.responses.create(
       CreateResponseRequest(
-        model: 'gpt-4o',
+        model: 'gpt-5.5',
         input: const ResponseInput.text(
           'What are the latest developments in AI as of today?',
         ),
@@ -36,7 +36,7 @@ Future<void> main() async {
 
     final stream = client.responses.createStream(
       CreateResponseRequest(
-        model: 'gpt-4o',
+        model: 'gpt-5.5',
         input: const ResponseInput.text(
           'What is the current weather forecast for San Francisco?',
         ),
@@ -56,7 +56,7 @@ Future<void> main() async {
 
     final locationResponse = await client.responses.create(
       CreateResponseRequest(
-        model: 'gpt-4o',
+        model: 'gpt-5.5',
         input: const ResponseInput.items([
           MessageItem(
             role: MessageRole.user,
@@ -85,7 +85,7 @@ Future<void> main() async {
 
     final combinedResponse = await client.responses.create(
       CreateResponseRequest(
-        model: 'gpt-4o',
+        model: 'gpt-5.5',
         input: const ResponseInput.text(
           'Find the latest stock price for Apple and calculate '
           r'how many shares I can buy with $10,000.',
@@ -133,7 +133,7 @@ Future<void> main() async {
     // First turn: search for information
     final turn1 = await client.responses.create(
       CreateResponseRequest(
-        model: 'gpt-4o',
+        model: 'gpt-5.5',
         input: const ResponseInput.text(
           'What are the top 3 news stories today?',
         ),
@@ -146,7 +146,7 @@ Future<void> main() async {
     // Second turn: follow up question using previous context
     final turn2 = await client.responses.create(
       CreateResponseRequest(
-        model: 'gpt-4o',
+        model: 'gpt-5.5',
         input: const ResponseInput.items([
           MessageItem(
             role: MessageRole.user,

--- a/packages/openai_dart/specs/openapi.json
+++ b/packages/openai_dart/specs/openapi.json
@@ -4176,6 +4176,8 @@
       },
       "ChatModel": {
         "enum": [
+          "gpt-5.5",
+          "gpt-5.5-2026-04-23",
           "gpt-5.4",
           "gpt-5.4-mini",
           "gpt-5.4-nano",

--- a/packages/openai_dart/specs/spec_metadata.json
+++ b/packages/openai_dart/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "2.3.0",
-      "last_fetched": "2026-04-22T18:51:34.561333Z",
+      "last_fetched": "2026-04-25T21:03:31.924795Z",
       "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai%2Fopenai-7c540cce6eb30401259f4831ea9803b6d88501605d13734f98212cbb3b199e10.yml",
       "title": "OpenAI API",
       "version_history": []


### PR DESCRIPTION
## Summary
- Add `gpt-5.5` and the `gpt-5.5-2026-04-23` snapshot ID to the `ChatModel` enum in the local OpenAPI spec so the new frontier model is part of the schema surface.
- Bump the model used in the README and 12 example files (chat, streaming, tool calling, vision, web search, evals, responses, assistants, input-tokens, models lookup, top-level `openai_dart_example`, error handling) from `gpt-4.1`/`gpt-4o`/`gpt-4o-mini`/`gpt-5.4` to `gpt-5.5` so docs and examples track the latest default.
- Refresh `specs/spec_metadata.json` `last_fetched` timestamp from the latest `fetch` run.

## References

- [GPT-5.5 model page](https://developers.openai.com/api/docs/models/gpt-5.5) — spec sheet, snapshot ID, supported endpoints, and pricing.
- [Introducing GPT-5.5](https://openai.com/index/introducing-gpt-5-5/) — OpenAI's launch announcement.

## Test Plan

- [x] `dart analyze example/` clean
- [x] `dart test --reporter=failures-only test/unit/` — 1209 tests pass
- [x] `python3 .agents/shared/api-toolkit/scripts/api_toolkit.py verify --checks all --scope all` clean
- [x] Smoke-run an example against a live API key once GPT-5.5 access is provisioned
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/davidmigloz/ai_clients_dart/pull/206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
