### PR TITLE
chore(mistralai_dart): refresh spec metadata timestamp

### DIFF
--- a/packages/mistralai_dart/specs/spec_metadata.json
+++ b/packages/mistralai_dart/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "1.0.0",
-      "last_fetched": "2026-04-22T18:50:18.902379Z",
+      "last_fetched": "2026-05-02T07:57:11.384628Z",
       "source_url": "https://docs.mistral.ai/openapi.yaml",
       "title": "Mistral AI API",
       "version_history": []


### PR DESCRIPTION
## Summary
- Records that the Mistral AI OpenAPI spec at https://docs.mistral.ai/openapi.yaml was checked on 2026-05-02 and is unchanged.
- No client updates required: still 154 endpoints / 447 schemas at version 1.0.0.

## Details

Ran the full `openapi-mistral` workflow:

- `fetch` against the upstream URL pulled `latest-main.json` into the toolkit cache.
- `review` reported 0 added / 0 modified / 0 removed endpoints and schemas.
- `verify --checks all --scope all` shows 0 failing checks; the only warnings are 77 pre-existing info-level notes on the implementation check that are unrelated to this run.

The diff is limited to the `last_fetched` field in `packages/mistralai_dart/specs/spec_metadata.json` so future runs can see when the spec was last reconciled.

## Test Plan
- [x] `api_toolkit.py fetch` succeeds against the live Mistral spec
- [x] `api_toolkit.py review` reports zero schema/endpoint diffs
- [x] `api_toolkit.py verify --checks all --scope all` reports zero failing checks