### PR TITLE
chore(ollama_dart): refresh spec metadata timestamp

### DIFF
--- a/packages/ollama_dart/specs/spec_metadata.json
+++ b/packages/ollama_dart/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "0.1.0",
-      "last_fetched": "2026-04-22T18:50:30.910994Z",
+      "last_fetched": "2026-05-02T07:57:28.923839Z",
       "source_url": "https://raw.githubusercontent.com/ollama/ollama/refs/heads/main/docs/openapi.yaml",
       "title": "Ollama API",
       "version_history": []


### PR DESCRIPTION
## Summary
- Records that the Ollama OpenAPI spec at https://raw.githubusercontent.com/ollama/ollama/refs/heads/main/docs/openapi.yaml was checked on 2026-05-02 and is unchanged.
- No client updates required: still 12 endpoints / 34 schemas at version 0.1.0.

## Details
Routine spec freshness check via the `openapi-ollama` skill. The `review` step reported zero diff (no schemas or endpoints added, modified, or removed) and `verify --checks all --scope all` passed with no errors or warnings. Only `last_fetched` in `specs/spec_metadata.json` is updated.

## Test Plan
- [x] `api_toolkit.py review` reports no diff
- [x] `api_toolkit.py verify --checks all --scope all` passes