### PR TITLE
feat(googleai_dart): add mediaId to RetrievedContext

### DIFF
--- a/packages/googleai_dart/lib/src/models/metadata/retrieved_context.dart
+++ b/packages/googleai_dart/lib/src/models/metadata/retrieved_context.dart
@@ -17,6 +17,12 @@ class RetrievedContext {
   /// Example: `fileSearchStores/123`
   final String? fileSearchStore;
 
+  /// Optional. The media blob resource name for multimodal file search
+  /// results.
+  ///
+  /// Format: `fileSearchStores/{file_search_store_id}/media/{blob_id}`
+  final String? mediaId;
+
   /// Optional. Page number of the retrieved context, if applicable.
   final int? pageNumber;
 
@@ -29,6 +35,7 @@ class RetrievedContext {
     this.title,
     this.text,
     this.fileSearchStore,
+    this.mediaId,
     this.pageNumber,
     this.customMetadata,
   });
@@ -40,6 +47,7 @@ class RetrievedContext {
         title: json['title'] as String?,
         text: json['text'] as String?,
         fileSearchStore: json['fileSearchStore'] as String?,
+        mediaId: json['mediaId'] as String?,
         pageNumber: json['pageNumber'] as int?,
         customMetadata: (json['customMetadata'] as List?)
             ?.map(
@@ -56,6 +64,7 @@ class RetrievedContext {
     if (title != null) 'title': title,
     if (text != null) 'text': text,
     if (fileSearchStore != null) 'fileSearchStore': fileSearchStore,
+    if (mediaId != null) 'mediaId': mediaId,
     if (pageNumber != null) 'pageNumber': pageNumber,
     if (customMetadata != null)
       'customMetadata': customMetadata!.map((e) => e.toJson()).toList(),
@@ -67,6 +76,7 @@ class RetrievedContext {
     Object? title = unsetCopyWithValue,
     Object? text = unsetCopyWithValue,
     Object? fileSearchStore = unsetCopyWithValue,
+    Object? mediaId = unsetCopyWithValue,
     Object? pageNumber = unsetCopyWithValue,
     Object? customMetadata = unsetCopyWithValue,
   }) {
@@ -77,6 +87,9 @@ class RetrievedContext {
       fileSearchStore: fileSearchStore == unsetCopyWithValue
           ? this.fileSearchStore
           : fileSearchStore as String?,
+      mediaId: mediaId == unsetCopyWithValue
+          ? this.mediaId
+          : mediaId as String?,
       pageNumber: pageNumber == unsetCopyWithValue
           ? this.pageNumber
           : pageNumber as int?,
@@ -88,5 +101,5 @@ class RetrievedContext {
 
   @override
   String toString() =>
-      'RetrievedContext(uri: $uri, title: $title, text: $text, fileSearchStore: $fileSearchStore, pageNumber: $pageNumber, customMetadata: $customMetadata)';
+      'RetrievedContext(uri: $uri, title: $title, text: $text, fileSearchStore: $fileSearchStore, mediaId: $mediaId, pageNumber: $pageNumber, customMetadata: $customMetadata)';
 }

--- a/packages/googleai_dart/specs/openapi.json
+++ b/packages/googleai_dart/specs/openapi.json
@@ -336,7 +336,7 @@
             "type": "string"
           },
           "mimeType": {
-            "description": "The IANA standard MIME type of the source data.\nExamples:\n  - image/png\n  - image/jpeg\nIf an unsupported MIME type is provided, an error will be returned. For a\ncomplete list of supported types, see [Supported file\nformats](https://ai.google.dev/gemini-api/docs/prompting_with_media#supported_file_formats).",
+            "description": "The IANA standard MIME type of the source data.\nExamples of supported types:\n- Images: image/png, image/jpeg, image/jpg, image/webp, image/heic,\nimage/heif, image/gif, image/avif\n- Audio: audio/*, video/audio/s16le, video/audio/wav\n- Video: video/*\n- Text: text/plain, text/html, text/css, text/javascript,\ntext/x-typescript, text/csv, text/markdown, text/x-python, text/xml,\ntext/rtf, video/text/timestamp\n- Applications: application/x-javascript, application/x-typescript,\napplication/x-python-code, application/json, application/x-ipynb+json,\napplication/rtf, application/pdf For additional context,\nsee [Supported file\nformats](https://ai.google.dev/gemini-api/docs/file-input-methods#supported-content-types).\n//",
             "type": "string"
           }
         },
@@ -4335,6 +4335,10 @@
             "description": "Optional. Name of the `FileSearchStore` containing the document.\nExample: `fileSearchStores/123`",
             "type": "string"
           },
+          "mediaId": {
+            "description": "Optional. The media blob resource name for multimodal file search results.\nFormat: fileSearchStores/{file_search_store_id}/media/{blob_id}",
+            "type": "string"
+          },
           "pageNumber": {
             "description": "Optional. Page number of the retrieved context, if applicable.",
             "format": "int32",
@@ -5685,7 +5689,7 @@
     "description": "The Gemini API allows developers to build generative AI applications using Gemini models. Gemini is our most capable model, built from the ground up to be multimodal. It can generalize and seamlessly understand, operate across, and combine different types of information including language, images, audio, video, and code. You can use the Gemini API for use cases like reasoning across text and images, content generation, dialogue agents, summarization and classification systems, and more.",
     "title": "Gemini API",
     "version": "v1beta",
-    "x-google-revision": "20260421"
+    "x-google-revision": "20260501"
   },
   "openapi": "3.0.3",
   "paths": {

--- a/packages/googleai_dart/specs/spec_metadata.json
+++ b/packages/googleai_dart/specs/spec_metadata.json
@@ -9,7 +9,7 @@
     },
     "main": {
       "current_version": "v1beta",
-      "last_fetched": "2026-04-22T18:45:15.787993Z",
+      "last_fetched": "2026-05-02T07:56:30.790985Z",
       "source_url": "https://generativelanguage.googleapis.com/$discovery/OPENAPI3_0?version=v1beta",
       "title": "Gemini API",
       "version_history": []

--- a/packages/googleai_dart/test/unit/models/metadata/grounding_metadata_test.dart
+++ b/packages/googleai_dart/test/unit/models/metadata/grounding_metadata_test.dart
@@ -434,6 +434,29 @@ void main() {
 
       expect(slv['values'], ['a', 'b']);
     });
+
+    test('mediaId round-trips through fromJson/toJson and copyWith', () {
+      const mediaId = 'fileSearchStores/abc/media/blob-123';
+      final json = {
+        'fileSearchStore': 'fileSearchStores/abc',
+        'mediaId': mediaId,
+      };
+
+      final ctx = RetrievedContext.fromJson(json);
+      expect(ctx.mediaId, mediaId);
+      expect(ctx.toJson()['mediaId'], mediaId);
+      expect(ctx.toString(), contains('mediaId: $mediaId'));
+
+      final cleared = ctx.copyWith(mediaId: null);
+      expect(cleared.mediaId, isNull);
+      expect(cleared.toJson().containsKey('mediaId'), isFalse);
+    });
+
+    test('toJson omits null mediaId', () {
+      const ctx = RetrievedContext(uri: 'gs://bucket/doc.pdf');
+
+      expect(ctx.toJson().containsKey('mediaId'), isFalse);
+    });
   });
 
   group('RetrievalMetadata', () {


### PR DESCRIPTION
## Summary
- Sync `googleai_dart` to the latest Gemini OpenAPI spec (`v1beta`, fetched 2026-05-02).
- Add optional `mediaId` field to `RetrievedContext` to carry the media blob resource name returned for multimodal file-search results.

## Details

The Gemini API now returns a `mediaId` on `RetrievedContext` chunks when a file-search result is multimodal. The value is a resource name pointing at the underlying blob in the `FileSearchStore`:

```
fileSearchStores/{file_search_store_id}/media/{blob_id}
```

Usage:

```dart
final ctx = RetrievedContext.fromJson(json);
if (ctx.mediaId != null) {
  // Fetch the blob via the FileSearchStore media resource.
}
```

The field is fully integrated into `fromJson` / `toJson` / `copyWith` / `toString`, and the spec snapshot in `specs/openapi.json` plus the `last_fetched` timestamp in `specs/spec_metadata.json` have been refreshed.

## Test Plan

- [x] `api_toolkit verify --spec-name main --scope type --type RetrievedContext` — 0 errors / 0 warnings / 0 infos
- [x] `dart format` — no changes
- [x] `dart analyze` — no issues
- [x] `dart test test/unit/` — 1422/1422 passing