### PR TITLE
chore(chromadb): refresh OpenAPI spec to upstream 1.0.0

### DIFF
--- a/packages/chromadb/.agents/skills/openapi-chromadb/config/manifest.json
+++ b/packages/chromadb/.agents/skills/openapi-chromadb/config/manifest.json
@@ -101,7 +101,9 @@
       "dart_class": "Collection",
       "file": "lib/src/models/collections/collection.dart",
       "schema": "Collection",
-      "tags": []
+      "tags": [],
+      "excluded_properties": ["id", "metadata", "schema"],
+      "note": "Type-comparison exclusions: 'id' (spec ref CollectionUuid is a {type: string, format: uuid} alias — Dart uses bare String, no typedef wrapper); 'metadata' (spec ref HashMap is an open dict {type: object, additionalProperties: oneOf[...]} — Dart uses idiomatic Map<String, dynamic>); 'schema' (Dart class renamed to CollectionSchema to avoid name conflict with the generic 'Schema' identifier per the API Design naming guideline)."
     },
     "QueryResponse": {
       "spec": "main",
@@ -109,7 +111,9 @@
       "dart_class": "QueryResponse",
       "file": "lib/src/models/records/query_response.dart",
       "schema": "QueryResponse",
-      "tags": []
+      "tags": [],
+      "excluded_properties": ["documents", "metadatas", "uris"],
+      "note": "Type-comparison exclusions: 'documents'/'uris' items are spec'd as {type: [string, null]} so Dart correctly uses List<List<String?>>; 'metadatas' items are oneOf[null, HashMap] so Dart uses List<List<Map<String, dynamic>?>>. The verifier doesn't propagate item-level nullability (or the HashMap → Map<String, dynamic> alias) into expected types, producing spurious mismatches."
     },
     "GetResponse": {
       "spec": "main",
@@ -117,7 +121,9 @@
       "dart_class": "GetResponse",
       "file": "lib/src/models/records/get_response.dart",
       "schema": "GetResponse",
-      "tags": []
+      "tags": [],
+      "excluded_properties": ["documents", "metadatas", "uris"],
+      "note": "Type-comparison exclusions: 'documents'/'uris' items are spec'd as {type: [string, null]} so Dart correctly uses List<String?>; 'metadatas' items are oneOf[null, HashMap] so Dart uses List<Map<String, dynamic>?>. The verifier doesn't propagate item-level nullability (or the HashMap → Map<String, dynamic> alias) into expected types, producing spurious mismatches."
     },
     "DeleteCollectionRecordsPayload": {
       "spec": "main",
@@ -193,6 +199,24 @@
       "file": "lib/src/models/collections/fork_count_response.dart",
       "schema": "ForkCountResponse",
       "tags": []
+    },
+    "SparseIndexAlgorithm": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "file": null,
+      "schema": "SparseIndexAlgorithm",
+      "tags": ["acknowledged"],
+      "note": "Sparse index algorithm enum nested inside CollectionSchema — schema stored as Map<String, dynamic>, no dedicated Dart model needed."
+    },
+    "SparseVectorIndexConfig": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "file": null,
+      "schema": "SparseVectorIndexConfig",
+      "tags": ["acknowledged"],
+      "note": "Sparse vector index config nested inside CollectionSchema — schema stored as Map<String, dynamic>, no dedicated Dart model needed."
     }
   }
 }

--- a/packages/chromadb/specs/openapi.json
+++ b/packages/chromadb/specs/openapi.json
@@ -1786,6 +1786,14 @@
         },
         "type": "object"
       },
+      "SparseIndexAlgorithm": {
+        "description": "Sparse vector index algorithm.\n\nControls which posting list format and query engine are used for\nsparse vector search within a collection.",
+        "enum": [
+          "wand",
+          "max_score"
+        ],
+        "type": "string"
+      },
       "SparseVector": {
         "description": "Represents a sparse vector using parallel arrays for indices and values.\n\nOn deserialization: accepts both old format `{\"indices\": [...], \"values\": [...]}`\nand new format `{\"#type\": \"sparse_vector\", \"indices\": [...], \"values\": [...]}`.\n\nOn serialization: always includes `#type` field with value `\"sparse_vector\"`.",
         "properties": {
@@ -1826,6 +1834,10 @@
       "SparseVectorIndexConfig": {
         "additionalProperties": false,
         "properties": {
+          "algorithm": {
+            "$ref": "#/components/schemas/SparseIndexAlgorithm",
+            "description": "Sparse index algorithm (cloud-only, tenant-gated).\nOmitted from JSON when set to the default (Wand) so that old\nservers/clients that do not know about this field can still\ndeserialize the schema."
+          },
           "bm25": {
             "description": "Whether this embedding is BM25",
             "type": [

--- a/packages/chromadb/specs/spec_metadata.json
+++ b/packages/chromadb/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "1.0.0",
-      "last_fetched": "2026-04-22T18:44:41.229992Z",
+      "last_fetched": "2026-05-02T07:56:05.163900Z",
       "source_url": "https://api.trychroma.com/openapi.json",
       "title": "chroma-frontend",
       "version_history": []


### PR DESCRIPTION
## Summary
- Refreshes the ChromaDB OpenAPI spec from `api.trychroma.com` (last fetched 2026-05-02). Two additive schema changes flow through the existing `CollectionSchema.defaults`/`keys` `Map<String, dynamic>` transparently — no Dart code changes.
- New `SparseIndexAlgorithm` enum (`wand`, `max_score`) and a new optional `algorithm` property on `SparseVectorIndexConfig` (cloud-only, tenant-gated; omitted on default for forward compatibility with older clients).
- Tightens the api-toolkit manifest by adding skip entries for the two new nested schemas and `excluded_properties` (with `note` rationale) on three existing entries to acknowledge known verifier limitations.

## Details

### Spec changes
The upstream spec adds:

```jsonc
"SparseIndexAlgorithm": {
  "enum": ["wand", "max_score"],
  "type": "string"
},
"SparseVectorIndexConfig": {
  "properties": {
    "algorithm": { "$ref": "#/components/schemas/SparseIndexAlgorithm" },
    // ...existing fields
  }
}
```

Both schemas live nested deep inside `CollectionSchema` (`SparseVectorIndexConfig` → `SparseVectorIndexType` → `SparseVectorValueType`). None of the parent schemas are exposed as dedicated Dart classes — `CollectionSchema.defaults`/`keys` use `Map<String, dynamic>` (matching every other index-config branch like `HnswConfiguration`, `BoolInvertedIndexConfig`, etc.). Adding one-off Dart classes here would be inconsistent with the rest of the index-config tree, so both new schemas get `kind: "skip"` manifest entries with explanatory `note` fields.

### Manifest hygiene
Three existing manifest entries (`Collection`, `GetResponse`, `QueryResponse`) gained `excluded_properties` with `note` fields documenting the rationale:

- **`Collection`** — `id` (`CollectionUuid` is a `{type: string, format: uuid}` alias; Dart uses bare `String`), `metadata` (`HashMap` is an open dict; Dart uses `Map<String, dynamic>`), `schema` (Dart class renamed to `CollectionSchema` to avoid the generic `Schema` collision per the API-Design naming guideline).
- **`GetResponse` / `QueryResponse`** — `documents`/`metadatas`/`uris` items are spec'd as `{type: [T, null]}` so Dart correctly uses `List<T?>` / `List<List<T?>>`. The verifier doesn't propagate item-level nullability into the expected list type, producing spurious mismatches.

These were previously emitted as info-level findings on every verify run; the exclusions clear them while keeping the rationale auditable.

## Test Plan
- [x] `api_toolkit.py review` — 0 errors, 0 warnings, 0 missing manifest entries
- [x] `api_toolkit.py verify --checks all --scope all` — 0 errors, 0 warnings, 0 infos (down from 9 infos)
- [x] `dart format --show=none --summary=line .` — 0 changed
- [x] `dart analyze --fatal-infos .` — no issues
- [x] `dart test test/unit/` — 304/304 pass