### PR TITLE
feat(open_responses)!: add response compaction and assistant phase

### DIFF
--- a/packages/open_responses/.agents/skills/openapi-open-responses/config/manifest.json
+++ b/packages/open_responses/.agents/skills/openapi-open-responses/config/manifest.json
@@ -791,7 +791,7 @@
       "file": "lib/src/models/items/output_item.dart",
       "schema": "ItemField",
       "tags": ["acknowledged"],
-      "note": "ItemField is the response-side union (Message, FunctionCall, FunctionCallOutput, ReasoningBody, CompactionBody) used by CompactResource.output. Mapped to the existing OutputItem hierarchy. FunctionCallOutput type 'function_call_output' is not yet implemented as an OutputItem variant."
+      "note": "ItemField is the response-side union (Message, FunctionCall, FunctionCallOutput, ReasoningBody, CompactionBody) used by ResponseResource.output and CompactResource.output. Mapped to the OutputItem sealed hierarchy."
     },
     "Message": {
       "spec": "main",
@@ -816,6 +816,14 @@
       "spec": "main",
       "kind": "extension",
       "dart_class": "CompactionOutputItem",
+      "file": "lib/src/models/items/output_item.dart",
+      "schema": null,
+      "parent": "OutputItem"
+    },
+    "OutputItem:FunctionCallOutputResponseItem": {
+      "spec": "main",
+      "kind": "extension",
+      "dart_class": "FunctionCallOutputResponseItem",
       "file": "lib/src/models/items/output_item.dart",
       "schema": null,
       "parent": "OutputItem"

--- a/packages/open_responses/.agents/skills/openapi-open-responses/config/manifest.json
+++ b/packages/open_responses/.agents/skills/openapi-open-responses/config/manifest.json
@@ -128,6 +128,20 @@
         "critical"
       ]
     },
+    "CompactResponseMethodPublicBody": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "CompactResponseRequest",
+      "file": "lib/src/models/request/compact_response_request.dart",
+      "schema": "CompactResponseMethodPublicBody"
+    },
+    "CompactResource": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "CompactResource",
+      "file": "lib/src/models/response/compact_resource.dart",
+      "schema": "CompactResource"
+    },
     "TextParam": {
       "spec": "main",
       "kind": "object",
@@ -655,7 +669,8 @@
           "ReasoningItemParam": "reasoning",
           "FunctionCallItemParam": "function_call",
           "FunctionCallOutputItemParam": "function_call_output",
-          "ItemReferenceParam": "item_reference"
+          "ItemReferenceParam": "item_reference",
+          "CompactionSummaryItemParam": "compaction"
         }
       },
       "excluded_properties": [
@@ -749,6 +764,61 @@
       "schema": "ReasoningItemParam",
       "parent": "Item",
       "excluded_properties": ["content"]
+    },
+    "CompactionSummaryItemParam": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "CompactionItem",
+      "file": "lib/src/models/items/item.dart",
+      "schema": "CompactionSummaryItemParam",
+      "parent": "Item"
+    },
+    "ItemParam": {
+      "spec": "main",
+      "kind": "sealed_parent",
+      "dart_class": "Item",
+      "file": "lib/src/models/items/item.dart",
+      "schema": "ItemParam",
+      "discriminator": {
+        "field": "type",
+        "mapping": {}
+      }
+    },
+    "ItemField": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "OutputItem",
+      "file": "lib/src/models/items/output_item.dart",
+      "schema": "ItemField",
+      "tags": ["acknowledged"],
+      "note": "ItemField is the response-side union (Message, FunctionCall, FunctionCallOutput, ReasoningBody, CompactionBody) used by CompactResource.output. Mapped to the existing OutputItem hierarchy. FunctionCallOutput type 'function_call_output' is not yet implemented as an OutputItem variant."
+    },
+    "Message": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "MessageOutputItem",
+      "file": "lib/src/models/items/output_item.dart",
+      "schema": "Message",
+      "tags": ["acknowledged"],
+      "note": "Message is the response-side message item. Mapped to the existing MessageOutputItem under OutputItem."
+    },
+    "CompactionBody": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "CompactionOutputItem",
+      "file": "lib/src/models/items/output_item.dart",
+      "schema": "CompactionBody",
+      "parent": "OutputItem",
+      "tags": ["acknowledged"],
+      "note": "Mapped as OutputItem variant. The spec 'type' property is a constant discriminator emitted by toJson, not stored as a Dart field."
+    },
+    "OutputItem:CompactionOutputItem": {
+      "spec": "main",
+      "kind": "extension",
+      "dart_class": "CompactionOutputItem",
+      "file": "lib/src/models/items/output_item.dart",
+      "schema": null,
+      "parent": "OutputItem"
     },
     "OutputItem": {
       "spec": "main",

--- a/packages/open_responses/lib/open_responses.dart
+++ b/packages/open_responses/lib/open_responses.dart
@@ -76,6 +76,7 @@ export 'src/models/common/equality_helpers.dart';
 export 'src/models/content/annotation.dart';
 export 'src/models/content/input_content.dart';
 export 'src/models/content/logprob.dart';
+export 'src/models/content/message_content_part.dart';
 export 'src/models/content/output_content.dart';
 export 'src/models/content/reasoning_summary_content.dart';
 

--- a/packages/open_responses/lib/open_responses.dart
+++ b/packages/open_responses/lib/open_responses.dart
@@ -88,6 +88,7 @@ export 'src/models/metadata/function_call_status.dart';
 export 'src/models/metadata/image_detail.dart';
 export 'src/models/metadata/include.dart';
 export 'src/models/metadata/item_status.dart';
+export 'src/models/metadata/message_phase.dart';
 export 'src/models/metadata/message_role.dart';
 export 'src/models/metadata/reasoning_effort.dart';
 export 'src/models/metadata/reasoning_summary.dart';
@@ -97,12 +98,14 @@ export 'src/models/metadata/truncation.dart';
 export 'src/models/metadata/verbosity.dart';
 
 // Models - Request
+export 'src/models/request/compact_response_request.dart';
 export 'src/models/request/create_response_request.dart';
 export 'src/models/request/reasoning_config.dart';
 export 'src/models/request/stream_options.dart';
 export 'src/models/request/text_config.dart';
 
 // Models - Response
+export 'src/models/response/compact_resource.dart';
 export 'src/models/response/error_payload.dart';
 export 'src/models/response/incomplete_details.dart';
 export 'src/models/response/response_resource.dart';

--- a/packages/open_responses/lib/src/models/content/input_content.dart
+++ b/packages/open_responses/lib/src/models/content/input_content.dart
@@ -2,9 +2,10 @@ import 'package:meta/meta.dart';
 
 import '../common/copy_with_sentinel.dart';
 import '../metadata/image_detail.dart';
+import 'message_content_part.dart';
 
 /// Input content for messages.
-sealed class InputContent {
+sealed class InputContent implements MessageContentPart {
   /// Creates an [InputContent].
   const InputContent();
 
@@ -56,6 +57,7 @@ sealed class InputContent {
   }
 
   /// Converts to JSON.
+  @override
   Map<String, dynamic> toJson();
 }
 

--- a/packages/open_responses/lib/src/models/content/message_content_part.dart
+++ b/packages/open_responses/lib/src/models/content/message_content_part.dart
@@ -1,0 +1,14 @@
+/// A content part that can appear inside a response-side `Message`.
+///
+/// Per the spec's `Message.content` union, response messages may carry both
+/// input content (`input_text`, `input_image`, `input_file`, `input_video`)
+/// and output content (`output_text`, `reasoning_text`, `summary_text`,
+/// `refusal`). Stored or compacted history echoes prior user messages whose
+/// parts are `input_*`, while the model's own messages emit `output_*`.
+///
+/// Both [InputContent] and [OutputContent] sealed hierarchies implement this
+/// interface so [MessageOutputItem.content] can hold either.
+abstract interface class MessageContentPart {
+  /// Converts to JSON.
+  Map<String, dynamic> toJson();
+}

--- a/packages/open_responses/lib/src/models/content/output_content.dart
+++ b/packages/open_responses/lib/src/models/content/output_content.dart
@@ -4,9 +4,10 @@ import '../common/copy_with_sentinel.dart';
 import '../common/equality_helpers.dart';
 import 'annotation.dart';
 import 'logprob.dart';
+import 'message_content_part.dart';
 
 /// Output content from model.
-sealed class OutputContent {
+sealed class OutputContent implements MessageContentPart {
   /// Creates an [OutputContent].
   const OutputContent();
 
@@ -45,6 +46,7 @@ sealed class OutputContent {
   }
 
   /// Converts to JSON.
+  @override
   Map<String, dynamic> toJson();
 }
 

--- a/packages/open_responses/lib/src/models/items/item.dart
+++ b/packages/open_responses/lib/src/models/items/item.dart
@@ -7,6 +7,7 @@ import '../content/output_content.dart';
 import '../content/reasoning_summary_content.dart';
 import '../metadata/function_call_status.dart';
 import '../metadata/item_status.dart';
+import '../metadata/message_phase.dart';
 import '../metadata/message_role.dart';
 
 /// Input item for a response request.
@@ -25,6 +26,7 @@ sealed class Item {
       'function_call_output' => FunctionCallOutputItem.fromJson(json),
       'reasoning' => ReasoningInputItem.fromJson(json),
       'item_reference' => ItemReference.fromJson(json),
+      'compaction' => CompactionItem.fromJson(json),
       _ => throw FormatException('Unknown Item type: $type'),
     };
   }
@@ -113,10 +115,12 @@ sealed class MessageItem extends Item {
     List<OutputContent> content, {
     String? id,
     ItemStatus? status,
+    MessagePhase? phase,
   }) => AssistantMessageItem(
     content: AssistantMessagePartsContent(content),
     id: id,
     status: status,
+    phase: phase,
   );
 
   /// Creates an assistant message with simple text.
@@ -124,10 +128,12 @@ sealed class MessageItem extends Item {
     String text, {
     String? id,
     ItemStatus? status,
+    MessagePhase? phase,
   }) => AssistantMessageItem(
     content: AssistantMessageTextContent(text),
     id: id,
     status: status,
+    phase: phase,
   );
 
   /// Creates a [MessageItem] from JSON.
@@ -619,8 +625,20 @@ class AssistantMessageItem extends MessageItem {
   @override
   final ItemStatus? status;
 
+  /// Labels this assistant message as intermediate commentary or the final
+  /// answer.
+  ///
+  /// Preserve and resend on follow-up requests for compatible models — see
+  /// [MessagePhase] for details.
+  final MessagePhase? phase;
+
   /// Creates an [AssistantMessageItem].
-  const AssistantMessageItem({this.id, required this.content, this.status});
+  const AssistantMessageItem({
+    this.id,
+    required this.content,
+    this.status,
+    this.phase,
+  });
 
   /// Creates an [AssistantMessageItem] from JSON.
   factory AssistantMessageItem.fromJson(Map<String, dynamic> json) {
@@ -629,6 +647,9 @@ class AssistantMessageItem extends MessageItem {
       content: AssistantMessageContent.fromJson(json['content']),
       status: json['status'] != null
           ? ItemStatus.fromJson(json['status'] as String)
+          : null,
+      phase: json['phase'] != null
+          ? MessagePhase.fromJson(json['phase'] as String)
           : null,
     );
   }
@@ -640,6 +661,7 @@ class AssistantMessageItem extends MessageItem {
     'role': role.toJson(),
     'content': content.toJson(),
     if (status != null) 'status': status!.toJson(),
+    if (phase != null) 'phase': phase!.toJson(),
   };
 
   /// Creates a copy with replaced values.
@@ -647,6 +669,7 @@ class AssistantMessageItem extends MessageItem {
     Object? id = unsetCopyWithValue,
     AssistantMessageContent? content,
     Object? status = unsetCopyWithValue,
+    Object? phase = unsetCopyWithValue,
   }) {
     return AssistantMessageItem(
       id: id == unsetCopyWithValue ? this.id : id as String?,
@@ -654,6 +677,7 @@ class AssistantMessageItem extends MessageItem {
       status: status == unsetCopyWithValue
           ? this.status
           : status as ItemStatus?,
+      phase: phase == unsetCopyWithValue ? this.phase : phase as MessagePhase?,
     );
   }
 
@@ -664,14 +688,15 @@ class AssistantMessageItem extends MessageItem {
           runtimeType == other.runtimeType &&
           id == other.id &&
           content == other.content &&
-          status == other.status;
+          status == other.status &&
+          phase == other.phase;
 
   @override
-  int get hashCode => Object.hash(id, content, status);
+  int get hashCode => Object.hash(id, content, status, phase);
 
   @override
   String toString() =>
-      'AssistantMessageItem(id: $id, content: $content, status: $status)';
+      'AssistantMessageItem(id: $id, content: $content, status: $status, phase: $phase)';
 }
 
 /// A function call item.
@@ -1044,4 +1069,63 @@ class ReasoningInputItem extends Item {
   @override
   String toString() =>
       'ReasoningInputItem(id: $id, summary: $summary, encryptedContent: $encryptedContent)';
+}
+
+/// A compaction item used as input.
+///
+/// Carries the encrypted summary produced by the
+/// [`/responses/compact` endpoint](https://www.openresponses.org/) so
+/// previous turns can be replayed in a new request without resending the
+/// full transcript.
+@immutable
+class CompactionItem extends Item {
+  /// The unique ID of the compaction item.
+  final String? id;
+
+  /// The encrypted content of the compaction summary.
+  final String encryptedContent;
+
+  /// Creates a [CompactionItem].
+  const CompactionItem({this.id, required this.encryptedContent});
+
+  /// Creates a [CompactionItem] from JSON.
+  factory CompactionItem.fromJson(Map<String, dynamic> json) {
+    return CompactionItem(
+      id: json['id'] as String?,
+      encryptedContent: json['encrypted_content'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'compaction',
+    if (id != null) 'id': id,
+    'encrypted_content': encryptedContent,
+  };
+
+  /// Creates a copy with replaced values.
+  CompactionItem copyWith({
+    Object? id = unsetCopyWithValue,
+    String? encryptedContent,
+  }) {
+    return CompactionItem(
+      id: id == unsetCopyWithValue ? this.id : id as String?,
+      encryptedContent: encryptedContent ?? this.encryptedContent,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CompactionItem &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          encryptedContent == other.encryptedContent;
+
+  @override
+  int get hashCode => Object.hash(id, encryptedContent);
+
+  @override
+  String toString() =>
+      'CompactionItem(id: $id, encryptedContent: [${encryptedContent.length} chars])';
 }

--- a/packages/open_responses/lib/src/models/items/output_item.dart
+++ b/packages/open_responses/lib/src/models/items/output_item.dart
@@ -3,6 +3,7 @@ import 'package:meta/meta.dart';
 import '../common/equality_helpers.dart';
 import '../content/output_content.dart';
 import '../content/reasoning_summary_content.dart';
+import '../metadata/function_call_status.dart';
 import '../metadata/item_status.dart';
 import '../metadata/message_phase.dart';
 import '../metadata/message_role.dart';
@@ -21,6 +22,7 @@ sealed class OutputItem {
     return switch (type) {
       'message' => MessageOutputItem.fromJson(json),
       'function_call' => FunctionCallOutputItemResponse.fromJson(json),
+      'function_call_output' => FunctionCallOutputResponseItem.fromJson(json),
       'reasoning' => ReasoningItem.fromJson(json),
       'compaction' => CompactionOutputItem.fromJson(json),
       _ => throw FormatException('Unknown OutputItem type: $type'),
@@ -335,4 +337,78 @@ class CompactionOutputItem extends OutputItem {
   @override
   String toString() =>
       'CompactionOutputItem(id: $id, encryptedContent: [${encryptedContent.length} chars], createdBy: $createdBy)';
+}
+
+/// A function call output item echoed back as part of a response's output.
+///
+/// Carries the result of a previously-submitted function call (the same shape
+/// as the user-sent [FunctionCallOutputItem]) so it can appear in stored or
+/// compacted response history.
+@immutable
+class FunctionCallOutputResponseItem extends OutputItem {
+  /// Unique identifier.
+  final String id;
+
+  /// The call ID this output corresponds to.
+  final String callId;
+
+  /// The output content.
+  final FunctionCallOutput output;
+
+  /// The status of the function call output.
+  final FunctionCallStatus? status;
+
+  /// Creates a [FunctionCallOutputResponseItem].
+  const FunctionCallOutputResponseItem({
+    required this.id,
+    required this.callId,
+    required this.output,
+    this.status,
+  });
+
+  /// Creates a [FunctionCallOutputResponseItem] from JSON.
+  factory FunctionCallOutputResponseItem.fromJson(Map<String, dynamic> json) {
+    return FunctionCallOutputResponseItem(
+      id: json['id'] as String,
+      callId: json['call_id'] as String,
+      output: FunctionCallOutput.fromJson(json['output']),
+      status: json['status'] != null
+          ? FunctionCallStatus.fromJson(json['status'] as String)
+          : null,
+    );
+  }
+
+  /// Converts to a [FunctionCallOutputItem] for use as input.
+  FunctionCallOutputItem toFunctionCallOutputItem() => FunctionCallOutputItem(
+    id: id,
+    callId: callId,
+    output: output,
+    status: status,
+  );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'function_call_output',
+    'id': id,
+    'call_id': callId,
+    'output': output.toJson(),
+    if (status != null) 'status': status!.toJson(),
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FunctionCallOutputResponseItem &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          callId == other.callId &&
+          output == other.output &&
+          status == other.status;
+
+  @override
+  int get hashCode => Object.hash(id, callId, output, status);
+
+  @override
+  String toString() =>
+      'FunctionCallOutputResponseItem(id: $id, callId: $callId, output: $output, status: $status)';
 }

--- a/packages/open_responses/lib/src/models/items/output_item.dart
+++ b/packages/open_responses/lib/src/models/items/output_item.dart
@@ -102,12 +102,21 @@ class MessageOutputItem extends OutputItem {
     );
   }
 
-  /// Combined text from all [OutputTextContent] parts.
+  /// Combined text from all text content parts in this message.
   ///
-  /// Returns `null` if there are no text content parts.
+  /// Includes both [OutputTextContent] (model output) and [InputTextContent]
+  /// (echoed user input in stored or compacted history). Returns `null` if
+  /// there are no text content parts.
   String? get text {
-    final texts = content.whereType<OutputTextContent>().map((c) => c.text);
-    return texts.isEmpty ? null : texts.join();
+    final buffer = StringBuffer();
+    for (final part in content) {
+      if (part is OutputTextContent) {
+        buffer.write(part.text);
+      } else if (part is InputTextContent) {
+        buffer.write(part.text);
+      }
+    }
+    return buffer.isEmpty ? null : buffer.toString();
   }
 
   /// Whether any content part is a refusal.

--- a/packages/open_responses/lib/src/models/items/output_item.dart
+++ b/packages/open_responses/lib/src/models/items/output_item.dart
@@ -4,6 +4,7 @@ import '../common/equality_helpers.dart';
 import '../content/output_content.dart';
 import '../content/reasoning_summary_content.dart';
 import '../metadata/item_status.dart';
+import '../metadata/message_phase.dart';
 import '../metadata/message_role.dart';
 import 'item.dart';
 
@@ -21,6 +22,7 @@ sealed class OutputItem {
       'message' => MessageOutputItem.fromJson(json),
       'function_call' => FunctionCallOutputItemResponse.fromJson(json),
       'reasoning' => ReasoningItem.fromJson(json),
+      'compaction' => CompactionOutputItem.fromJson(json),
       _ => throw FormatException('Unknown OutputItem type: $type'),
     };
   }
@@ -44,12 +46,20 @@ class MessageOutputItem extends OutputItem {
   /// Item status.
   final ItemStatus? status;
 
+  /// Labels this assistant message as intermediate commentary or the final
+  /// answer.
+  ///
+  /// Preserve and resend on follow-up requests for compatible models — see
+  /// [MessagePhase] for details. Not used for non-assistant messages.
+  final MessagePhase? phase;
+
   /// Creates a [MessageOutputItem].
   const MessageOutputItem({
     required this.id,
     required this.role,
     required this.content,
     this.status,
+    this.phase,
   });
 
   /// Creates a [MessageOutputItem] from JSON.
@@ -62,6 +72,9 @@ class MessageOutputItem extends OutputItem {
           .toList(),
       status: json['status'] != null
           ? ItemStatus.fromJson(json['status'] as String)
+          : null,
+      phase: json['phase'] != null
+          ? MessagePhase.fromJson(json['phase'] as String)
           : null,
     );
   }
@@ -84,6 +97,7 @@ class MessageOutputItem extends OutputItem {
     'role': role.toJson(),
     'content': content.map((e) => e.toJson()).toList(),
     if (status != null) 'status': status!.toJson(),
+    if (phase != null) 'phase': phase!.toJson(),
   };
 
   @override
@@ -94,14 +108,16 @@ class MessageOutputItem extends OutputItem {
           id == other.id &&
           role == other.role &&
           listsEqual(content, other.content) &&
-          status == other.status;
+          status == other.status &&
+          phase == other.phase;
 
   @override
-  int get hashCode => Object.hash(id, role, Object.hashAll(content), status);
+  int get hashCode =>
+      Object.hash(id, role, Object.hashAll(content), status, phase);
 
   @override
   String toString() =>
-      'MessageOutputItem(id: $id, role: $role, content: $content, status: $status)';
+      'MessageOutputItem(id: $id, role: $role, content: $content, status: $status, phase: $phase)';
 }
 
 /// A function call output item in the response.
@@ -258,4 +274,65 @@ class ReasoningItem extends OutputItem {
   @override
   String toString() =>
       'ReasoningItem(id: $id, content: $content, summary: $summary, encryptedContent: $encryptedContent)';
+}
+
+/// A compaction item produced by the `/responses/compact` endpoint.
+///
+/// Carries the encrypted summary that can be replayed in a new request via
+/// [CompactionItem] to preserve previous turns without resending the full
+/// transcript.
+@immutable
+class CompactionOutputItem extends OutputItem {
+  /// Unique identifier of the compaction item.
+  final String id;
+
+  /// The encrypted content produced by compaction.
+  final String encryptedContent;
+
+  /// The identifier of the actor that created the item.
+  final String? createdBy;
+
+  /// Creates a [CompactionOutputItem].
+  const CompactionOutputItem({
+    required this.id,
+    required this.encryptedContent,
+    this.createdBy,
+  });
+
+  /// Creates a [CompactionOutputItem] from JSON.
+  factory CompactionOutputItem.fromJson(Map<String, dynamic> json) {
+    return CompactionOutputItem(
+      id: json['id'] as String,
+      encryptedContent: json['encrypted_content'] as String,
+      createdBy: json['created_by'] as String?,
+    );
+  }
+
+  /// Converts to a [CompactionItem] for use as input in subsequent requests.
+  CompactionItem toCompactionItem() =>
+      CompactionItem(id: id, encryptedContent: encryptedContent);
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'compaction',
+    'id': id,
+    'encrypted_content': encryptedContent,
+    if (createdBy != null) 'created_by': createdBy,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CompactionOutputItem &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          encryptedContent == other.encryptedContent &&
+          createdBy == other.createdBy;
+
+  @override
+  int get hashCode => Object.hash(id, encryptedContent, createdBy);
+
+  @override
+  String toString() =>
+      'CompactionOutputItem(id: $id, encryptedContent: [${encryptedContent.length} chars], createdBy: $createdBy)';
 }

--- a/packages/open_responses/lib/src/models/items/output_item.dart
+++ b/packages/open_responses/lib/src/models/items/output_item.dart
@@ -1,6 +1,8 @@
 import 'package:meta/meta.dart';
 
 import '../common/equality_helpers.dart';
+import '../content/input_content.dart';
+import '../content/message_content_part.dart';
 import '../content/output_content.dart';
 import '../content/reasoning_summary_content.dart';
 import '../metadata/function_call_status.dart';
@@ -8,6 +10,19 @@ import '../metadata/item_status.dart';
 import '../metadata/message_phase.dart';
 import '../metadata/message_role.dart';
 import 'item.dart';
+
+/// Parses a single content part of a response-side `Message`.
+///
+/// Dispatches to [InputContent] for `input_*` types and to [OutputContent]
+/// for everything else (`output_text`, `reasoning_text`, `summary_text`,
+/// `refusal`).
+MessageContentPart _parseMessageContentPart(Map<String, dynamic> json) {
+  final type = json['type'] as String;
+  if (type.startsWith('input_')) {
+    return InputContent.fromJson(json);
+  }
+  return OutputContent.fromJson(json);
+}
 
 /// Output item from a response.
 ///
@@ -43,7 +58,13 @@ class MessageOutputItem extends OutputItem {
   final MessageRole role;
 
   /// The content of the message.
-  final List<OutputContent> content;
+  ///
+  /// Per the spec's `Message.content` union, response messages may carry both
+  /// [InputContent] parts (e.g. `input_text` for echoed-back user messages in
+  /// stored or compacted history) and [OutputContent] parts (e.g.
+  /// `output_text` for model responses). Use type guards on the leaf types to
+  /// inspect specific content kinds.
+  final List<MessageContentPart> content;
 
   /// Item status.
   final ItemStatus? status;
@@ -70,7 +91,7 @@ class MessageOutputItem extends OutputItem {
       id: json['id'] as String,
       role: MessageRole.fromJson(json['role'] as String),
       content: (json['content'] as List)
-          .map((e) => OutputContent.fromJson(e as Map<String, dynamic>))
+          .map((e) => _parseMessageContentPart(e as Map<String, dynamic>))
           .toList(),
       status: json['status'] != null
           ? ItemStatus.fromJson(json['status'] as String)

--- a/packages/open_responses/lib/src/models/metadata/message_phase.dart
+++ b/packages/open_responses/lib/src/models/metadata/message_phase.dart
@@ -1,0 +1,32 @@
+/// Labels an `assistant` message as intermediate commentary or the final
+/// answer.
+///
+/// For models like `gpt-5.3-codex` and beyond, when sending follow-up
+/// requests, preserve and resend [phase] on all assistant messages. Omitting
+/// it can degrade performance. Not used for user messages.
+enum MessagePhase {
+  /// Unknown phase (fallback for unrecognized values).
+  unknown('unknown'),
+
+  /// Intermediate commentary from the assistant.
+  commentary('commentary'),
+
+  /// The final answer from the assistant.
+  finalAnswer('final_answer');
+
+  /// The JSON value for this phase.
+  final String value;
+
+  const MessagePhase(this.value);
+
+  /// Creates a [MessagePhase] from a JSON value.
+  factory MessagePhase.fromJson(String json) {
+    return MessagePhase.values.firstWhere(
+      (e) => e.value == json,
+      orElse: () => MessagePhase.unknown,
+    );
+  }
+
+  /// Converts to JSON value.
+  String toJson() => value;
+}

--- a/packages/open_responses/lib/src/models/request/compact_response_request.dart
+++ b/packages/open_responses/lib/src/models/request/compact_response_request.dart
@@ -26,8 +26,6 @@ class CompactResponseRequest {
   final String? instructions;
 
   /// ID of a previous response for multi-turn conversation.
-  ///
-  /// Cannot be used in conjunction with `conversation`.
   final String? previousResponseId;
 
   /// A key to use when reading from or writing to the prompt cache.

--- a/packages/open_responses/lib/src/models/request/compact_response_request.dart
+++ b/packages/open_responses/lib/src/models/request/compact_response_request.dart
@@ -1,0 +1,113 @@
+import 'package:meta/meta.dart';
+
+import '../common/copy_with_sentinel.dart';
+import 'create_response_request.dart';
+
+/// Request to compact a response.
+///
+/// Sent to the `POST /responses/compact` endpoint to summarize previous
+/// turns into an opaque compaction item, reducing context size for
+/// follow-up requests.
+@immutable
+class CompactResponseRequest {
+  /// The model to use for compaction.
+  final String model;
+
+  /// The input items to compact.
+  ///
+  /// Can be a [ResponseTextInput] (for simple text) or [ResponseItemsInput]
+  /// (for complex messages).
+  final ResponseInput? input;
+
+  /// System (or developer) message inserted into the model's context.
+  ///
+  /// When used along with [previousResponseId], the instructions from a
+  /// previous response will not be carried over to the next response.
+  final String? instructions;
+
+  /// ID of a previous response for multi-turn conversation.
+  ///
+  /// Cannot be used in conjunction with `conversation`.
+  final String? previousResponseId;
+
+  /// A key to use when reading from or writing to the prompt cache.
+  final String? promptCacheKey;
+
+  /// Creates a [CompactResponseRequest].
+  const CompactResponseRequest({
+    required this.model,
+    this.input,
+    this.instructions,
+    this.previousResponseId,
+    this.promptCacheKey,
+  });
+
+  /// Creates a [CompactResponseRequest] from JSON.
+  factory CompactResponseRequest.fromJson(Map<String, dynamic> json) {
+    return CompactResponseRequest(
+      model: json['model'] as String,
+      input: json['input'] != null
+          ? ResponseInput.fromJson(json['input'] as Object)
+          : null,
+      instructions: json['instructions'] as String?,
+      previousResponseId: json['previous_response_id'] as String?,
+      promptCacheKey: json['prompt_cache_key'] as String?,
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'model': model,
+    if (input != null) 'input': input!.toJson(),
+    if (instructions != null) 'instructions': instructions,
+    if (previousResponseId != null) 'previous_response_id': previousResponseId,
+    if (promptCacheKey != null) 'prompt_cache_key': promptCacheKey,
+  };
+
+  /// Creates a copy with replaced values.
+  CompactResponseRequest copyWith({
+    String? model,
+    Object? input = unsetCopyWithValue,
+    Object? instructions = unsetCopyWithValue,
+    Object? previousResponseId = unsetCopyWithValue,
+    Object? promptCacheKey = unsetCopyWithValue,
+  }) {
+    return CompactResponseRequest(
+      model: model ?? this.model,
+      input: input == unsetCopyWithValue ? this.input : input as ResponseInput?,
+      instructions: instructions == unsetCopyWithValue
+          ? this.instructions
+          : instructions as String?,
+      previousResponseId: previousResponseId == unsetCopyWithValue
+          ? this.previousResponseId
+          : previousResponseId as String?,
+      promptCacheKey: promptCacheKey == unsetCopyWithValue
+          ? this.promptCacheKey
+          : promptCacheKey as String?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CompactResponseRequest &&
+          runtimeType == other.runtimeType &&
+          model == other.model &&
+          input == other.input &&
+          instructions == other.instructions &&
+          previousResponseId == other.previousResponseId &&
+          promptCacheKey == other.promptCacheKey;
+
+  @override
+  int get hashCode => Object.hash(
+    model,
+    input,
+    instructions,
+    previousResponseId,
+    promptCacheKey,
+  );
+
+  @override
+  String toString() =>
+      'CompactResponseRequest(model: $model, input: $input, instructions: $instructions, previousResponseId: $previousResponseId, promptCacheKey: $promptCacheKey)';
+}

--- a/packages/open_responses/lib/src/models/response/compact_resource.dart
+++ b/packages/open_responses/lib/src/models/response/compact_resource.dart
@@ -1,0 +1,97 @@
+import 'package:meta/meta.dart';
+
+import '../common/equality_helpers.dart';
+import '../items/output_item.dart';
+import 'usage.dart';
+
+/// A compacted response resource.
+///
+/// Returned by the `POST /responses/compact` endpoint. Contains the
+/// compacted list of output items and token accounting for the compaction
+/// pass.
+@immutable
+class CompactResource {
+  /// The unique identifier for the compacted response.
+  final String id;
+
+  /// The object type. Always `response.compaction`.
+  final String object;
+
+  /// Unix timestamp (in seconds) when the compacted conversation was
+  /// created.
+  final int createdAt;
+
+  /// The compacted list of output items.
+  final List<OutputItem> output;
+
+  /// Token accounting for the compaction pass, including cached, reasoning,
+  /// and total tokens.
+  final Usage usage;
+
+  /// Creates a [CompactResource].
+  const CompactResource({
+    required this.id,
+    this.object = 'response.compaction',
+    required this.createdAt,
+    required this.output,
+    required this.usage,
+  });
+
+  /// Creates a [CompactResource] from JSON.
+  factory CompactResource.fromJson(Map<String, dynamic> json) {
+    return CompactResource(
+      id: json['id'] as String,
+      object: json['object'] as String? ?? 'response.compaction',
+      createdAt: json['created_at'] as int,
+      output: (json['output'] as List)
+          .map((e) => OutputItem.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      usage: Usage.fromJson(json['usage'] as Map<String, dynamic>),
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'object': object,
+    'created_at': createdAt,
+    'output': output.map((e) => e.toJson()).toList(),
+    'usage': usage.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  CompactResource copyWith({
+    String? id,
+    String? object,
+    int? createdAt,
+    List<OutputItem>? output,
+    Usage? usage,
+  }) {
+    return CompactResource(
+      id: id ?? this.id,
+      object: object ?? this.object,
+      createdAt: createdAt ?? this.createdAt,
+      output: output ?? this.output,
+      usage: usage ?? this.usage,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CompactResource &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          object == other.object &&
+          createdAt == other.createdAt &&
+          listsEqual(output, other.output) &&
+          usage == other.usage;
+
+  @override
+  int get hashCode =>
+      Object.hash(id, object, createdAt, Object.hashAll(output), usage);
+
+  @override
+  String toString() =>
+      'CompactResource(id: $id, object: $object, createdAt: $createdAt, output: ${output.length} items, usage: $usage)';
+}

--- a/packages/open_responses/lib/src/resources/responses_resource.dart
+++ b/packages/open_responses/lib/src/resources/responses_resource.dart
@@ -3,7 +3,9 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 import '../client/response_stream.dart';
+import '../models/request/compact_response_request.dart';
 import '../models/request/create_response_request.dart';
+import '../models/response/compact_resource.dart';
 import '../models/response/response_resource.dart';
 import '../models/streaming/streaming_event.dart';
 import '../utils/sse_parser.dart';
@@ -103,5 +105,31 @@ class ResponsesResource extends ResourceBase with StreamingResource {
     Future<void>? abortTrigger,
   }) {
     return ResponseStream(createStream(request, abortTrigger: abortTrigger));
+  }
+
+  /// Compacts a response.
+  ///
+  /// Sends [request] to `POST /responses/compact` and returns the compacted
+  /// response resource. The optional [abortTrigger] allows canceling the
+  /// request.
+  Future<CompactResource> compact(
+    CompactResponseRequest request, {
+    Future<void>? abortTrigger,
+  }) async {
+    ensureNotClosed?.call();
+
+    final url = requestBuilder.buildUrl('/responses/compact');
+    final headers = requestBuilder.buildHeaders();
+    final httpRequest = http.Request('POST', url)
+      ..headers.addAll(headers)
+      ..body = jsonEncode(request.toJson());
+
+    final response = await interceptorChain.execute(
+      httpRequest,
+      abortTrigger: abortTrigger,
+    );
+    return CompactResource.fromJson(
+      jsonDecode(response.body) as Map<String, dynamic>,
+    );
   }
 }

--- a/packages/open_responses/specs/openapi.json
+++ b/packages/open_responses/specs/openapi.json
@@ -119,6 +119,14 @@
               }
             ]
           },
+          "phase": {
+            "description": "Labels an `assistant` message as intermediate commentary (`commentary`) or the final answer (`final_answer`). For models like `gpt-5.3-codex` and beyond, when sending follow-up requests, preserve and resend phase on all assistant messages. Omitting it can degrade performance. Not used for user messages.",
+            "enum": [
+              "commentary",
+              "final_answer"
+            ],
+            "type": "string"
+          },
           "role": {
             "default": "assistant",
             "description": "The role of the message author. Always `assistant`.",
@@ -152,6 +160,226 @@
           "role",
           "content"
         ],
+        "type": "object"
+      },
+      "CompactResource": {
+        "example": {
+          "created_at": 1764967971,
+          "id": "resp_001",
+          "object": "response.compaction",
+          "output": [
+            {
+              "content": [
+                {
+                  "text": "Create a simple landing page for a dog petting cafe.",
+                  "type": "input_text"
+                }
+              ],
+              "id": "msg_000",
+              "role": "user",
+              "status": "completed",
+              "type": "message"
+            },
+            {
+              "encrypted_content": "gAAAAABpM0Yj-...=",
+              "id": "cmp_001",
+              "type": "compaction"
+            }
+          ],
+          "usage": {
+            "input_tokens": 139,
+            "input_tokens_details": {
+              "cached_tokens": 0
+            },
+            "output_tokens": 438,
+            "output_tokens_details": {
+              "reasoning_tokens": 64
+            },
+            "total_tokens": 577
+          }
+        },
+        "properties": {
+          "created_at": {
+            "description": "Unix timestamp (in seconds) when the compacted conversation was created.",
+            "type": "integer"
+          },
+          "id": {
+            "description": "The unique identifier for the compacted response.",
+            "type": "string"
+          },
+          "object": {
+            "default": "response.compaction",
+            "description": "The object type. Always `response.compaction`.",
+            "enum": [
+              "response.compaction"
+            ],
+            "type": "string"
+          },
+          "output": {
+            "description": "The compacted list of output items.",
+            "items": {
+              "$ref": "#/components/schemas/ItemField"
+            },
+            "type": "array"
+          },
+          "usage": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Usage"
+              },
+              {
+                "description": "Token accounting for the compaction pass, including cached, reasoning, and total tokens."
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "object",
+          "output",
+          "created_at",
+          "usage"
+        ],
+        "title": "The compacted response object",
+        "type": "object"
+      },
+      "CompactResponseMethodPublicBody": {
+        "properties": {
+          "input": {
+            "anyOf": [
+              {
+                "description": "Text, image, or file inputs to the model, used to generate a response",
+                "oneOf": [
+                  {
+                    "description": "A text input to the model, equivalent to a text input with the `user` role.",
+                    "maxLength": 10485760,
+                    "type": "string"
+                  },
+                  {
+                    "description": "A list of one or many input items to the model, containing different content types.",
+                    "items": {
+                      "$ref": "#/components/schemas/ItemParam"
+                    },
+                    "type": "array"
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "instructions": {
+            "anyOf": [
+              {
+                "description": "A system (or developer) message inserted into the model's context.\nWhen used along with `previous_response_id`, the instructions from a previous response will not be carried over to the next response. This makes it simple to swap out system (or developer) messages in new responses.",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "model": {
+            "description": "Model ID used to generate the response, like `gpt-5` or `o3`. OpenAI offers a wide range of models with different capabilities, performance characteristics, and price points. Refer to the [model guide](/docs/models) to browse and compare available models.",
+            "type": "string"
+          },
+          "previous_response_id": {
+            "anyOf": [
+              {
+                "description": "The unique ID of the previous response to the model. Use this to create multi-turn conversations. Learn more about [conversation state](/docs/guides/conversation-state). Cannot be used in conjunction with `conversation`.",
+                "example": "resp_123",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "prompt_cache_key": {
+            "anyOf": [
+              {
+                "description": "A key to use when reading from or writing to the prompt cache.",
+                "maxLength": 64,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "model"
+        ],
+        "type": "object"
+      },
+      "CompactionBody": {
+        "description": "A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).",
+        "properties": {
+          "created_by": {
+            "description": "The identifier of the actor that created the item.",
+            "type": "string"
+          },
+          "encrypted_content": {
+            "description": "The encrypted content that was produced by compaction.",
+            "type": "string"
+          },
+          "id": {
+            "description": "The unique ID of the compaction item.",
+            "type": "string"
+          },
+          "type": {
+            "default": "compaction",
+            "description": "The type of the item. Always `compaction`.",
+            "enum": [
+              "compaction"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "encrypted_content"
+        ],
+        "title": "Compaction item",
+        "type": "object"
+      },
+      "CompactionSummaryItemParam": {
+        "description": "A compaction item generated by the [`v1/responses/compact` API](/docs/api-reference/responses/compact).",
+        "properties": {
+          "encrypted_content": {
+            "description": "The encrypted content of the compaction summary.",
+            "maxLength": 10485760,
+            "type": "string"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "description": "The ID of the compaction item.",
+                "example": "cmp_123",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "type": {
+            "default": "compaction",
+            "description": "The type of the item. Always `compaction`.",
+            "enum": [
+              "compaction"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "encrypted_content"
+        ],
+        "title": "Compaction item",
         "type": "object"
       },
       "CreateResponseBody": {
@@ -1395,6 +1623,9 @@
           },
           {
             "$ref": "#/components/schemas/ReasoningBody"
+          },
+          {
+            "$ref": "#/components/schemas/CompactionBody"
           }
         ]
       },
@@ -1408,6 +1639,9 @@
           },
           {
             "$ref": "#/components/schemas/ReasoningItemParam"
+          },
+          {
+            "$ref": "#/components/schemas/CompactionSummaryItemParam"
           },
           {
             "$ref": "#/components/schemas/UserMessageItemParam"
@@ -1630,6 +1864,14 @@
           },
           "id": {
             "description": "The unique ID of the message.",
+            "type": "string"
+          },
+          "phase": {
+            "description": "Labels an `assistant` message as intermediate commentary (`commentary`) or the final answer (`final_answer`). For models like `gpt-5.3-codex` and beyond, when sending follow-up requests, preserve and resend phase on all assistant messages. Omitting it can degrade performance. Not used for user messages.",
+            "enum": [
+              "commentary",
+              "final_answer"
+            ],
             "type": "string"
           },
           "role": {
@@ -4378,6 +4620,35 @@
         "errorMessage": {
           "$ref": "#/components/schemas/WebSocketErrorEvent"
         }
+      }
+    },
+    "/responses/compact": {
+      "post": {
+        "description": "Compact a conversation. Returns a compacted response object.",
+        "operationId": "compactResponse",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompactResponseMethodPublicBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompactResource"
+                }
+              }
+            },
+            "description": "Success"
+          }
+        },
+        "summary": "Compact a response"
       }
     }
   },

--- a/packages/open_responses/specs/spec_metadata.json
+++ b/packages/open_responses/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "2.3.0",
-      "last_fetched": "2026-04-22T18:51:10.375990Z",
+      "last_fetched": "2026-05-02T07:59:16.747093Z",
       "source_url": "https://www.openresponses.org/openapi/openapi.json",
       "title": "OpenAI API",
       "version_history": []

--- a/packages/open_responses/test/unit/models/compaction_test.dart
+++ b/packages/open_responses/test/unit/models/compaction_test.dart
@@ -1,0 +1,219 @@
+import 'package:open_responses/open_responses.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MessagePhase', () {
+    test('serializes commentary and final_answer values', () {
+      expect(MessagePhase.commentary.toJson(), 'commentary');
+      expect(MessagePhase.finalAnswer.toJson(), 'final_answer');
+    });
+
+    test('parses known values', () {
+      expect(MessagePhase.fromJson('commentary'), MessagePhase.commentary);
+      expect(MessagePhase.fromJson('final_answer'), MessagePhase.finalAnswer);
+    });
+
+    test('falls back to unknown for unrecognized values', () {
+      expect(MessagePhase.fromJson('mystery_phase'), MessagePhase.unknown);
+    });
+  });
+
+  group('AssistantMessageItem.phase', () {
+    test('serializes phase when set', () {
+      final item = MessageItem.assistantText(
+        'Final answer here',
+        id: 'msg_1',
+        phase: MessagePhase.finalAnswer,
+      );
+      final json = item.toJson();
+      expect(json['phase'], 'final_answer');
+    });
+
+    test('omits phase when null', () {
+      final item = MessageItem.assistantText('Some text', id: 'msg_1');
+      expect(item.toJson().containsKey('phase'), isFalse);
+    });
+
+    test('round-trips through JSON', () {
+      final original = MessageItem.assistantText(
+        'Thinking out loud',
+        id: 'msg_2',
+        phase: MessagePhase.commentary,
+      );
+      final restored =
+          MessageItem.fromJson(original.toJson()) as AssistantMessageItem;
+      expect(restored.phase, MessagePhase.commentary);
+    });
+
+    test('copyWith replaces phase', () {
+      final original = MessageItem.assistantText('Hi') as AssistantMessageItem;
+      final modified = original.copyWith(phase: MessagePhase.commentary);
+      expect(modified.phase, MessagePhase.commentary);
+    });
+
+    test('copyWith clears phase with explicit null', () {
+      final original =
+          MessageItem.assistantText('Hi', phase: MessagePhase.finalAnswer)
+              as AssistantMessageItem;
+      final modified = original.copyWith(phase: null);
+      expect(modified.phase, isNull);
+    });
+  });
+
+  group('MessageOutputItem.phase', () {
+    test('round-trips through JSON', () {
+      final json = {
+        'type': 'message',
+        'id': 'msg_1',
+        'role': 'assistant',
+        'content': [
+          {'type': 'output_text', 'text': 'Hello'},
+        ],
+        'phase': 'final_answer',
+      };
+      final item = OutputItem.fromJson(json) as MessageOutputItem;
+      expect(item.phase, MessagePhase.finalAnswer);
+      expect(item.toJson()['phase'], 'final_answer');
+    });
+  });
+
+  group('CompactionItem (input)', () {
+    test('serializes with required fields', () {
+      const item = CompactionItem(
+        id: 'cmp_123',
+        encryptedContent: 'gAAAAAB...',
+      );
+      expect(item.toJson(), {
+        'type': 'compaction',
+        'id': 'cmp_123',
+        'encrypted_content': 'gAAAAAB...',
+      });
+    });
+
+    test('omits id when null', () {
+      const item = CompactionItem(encryptedContent: 'gAAAAAB...');
+      final json = item.toJson();
+      expect(json.containsKey('id'), isFalse);
+      expect(json['type'], 'compaction');
+    });
+
+    test('round-trips via Item.fromJson', () {
+      const original = CompactionItem(id: 'cmp_1', encryptedContent: 'enc');
+      final restored = Item.fromJson(original.toJson());
+      expect(restored, equals(original));
+    });
+
+    test('copyWith clears id with explicit null', () {
+      const original = CompactionItem(id: 'cmp_1', encryptedContent: 'enc');
+      final modified = original.copyWith(id: null);
+      expect(modified.id, isNull);
+    });
+  });
+
+  group('CompactionOutputItem', () {
+    test('parses from JSON', () {
+      final json = {
+        'type': 'compaction',
+        'id': 'cmp_001',
+        'encrypted_content': 'gAAAAABpM0Yj-...',
+      };
+      final item = OutputItem.fromJson(json);
+      expect(item, isA<CompactionOutputItem>());
+      final compaction = item as CompactionOutputItem;
+      expect(compaction.id, 'cmp_001');
+      expect(compaction.encryptedContent, 'gAAAAABpM0Yj-...');
+    });
+
+    test('round-trips through JSON', () {
+      const item = CompactionOutputItem(
+        id: 'cmp_001',
+        encryptedContent: 'enc-data',
+        createdBy: 'system',
+      );
+      expect(OutputItem.fromJson(item.toJson()), equals(item));
+    });
+
+    test('toCompactionItem converts to input variant', () {
+      const item = CompactionOutputItem(id: 'cmp_1', encryptedContent: 'enc');
+      expect(
+        item.toCompactionItem(),
+        const CompactionItem(id: 'cmp_1', encryptedContent: 'enc'),
+      );
+    });
+  });
+
+  group('CompactResource', () {
+    test('parses example payload', () {
+      final json = {
+        'id': 'resp_001',
+        'object': 'response.compaction',
+        'created_at': 1764967971,
+        'output': [
+          {
+            'type': 'message',
+            'id': 'msg_000',
+            'role': 'user',
+            'content': [
+              {'type': 'output_text', 'text': 'Hello'},
+            ],
+            'status': 'completed',
+          },
+          {
+            'type': 'compaction',
+            'id': 'cmp_001',
+            'encrypted_content': 'gAAAAABpM0Yj-...=',
+          },
+        ],
+        'usage': {
+          'input_tokens': 139,
+          'output_tokens': 438,
+          'total_tokens': 577,
+        },
+      };
+      final resource = CompactResource.fromJson(json);
+      expect(resource.id, 'resp_001');
+      expect(resource.object, 'response.compaction');
+      expect(resource.createdAt, 1764967971);
+      expect(resource.output, hasLength(2));
+      expect(resource.output[0], isA<MessageOutputItem>());
+      expect(resource.output[1], isA<CompactionOutputItem>());
+      expect(resource.usage.totalTokens, 577);
+    });
+  });
+
+  group('CompactResponseRequest', () {
+    test('serializes with only required fields', () {
+      const request = CompactResponseRequest(model: 'gpt-5');
+      expect(request.toJson(), {'model': 'gpt-5'});
+    });
+
+    test('serializes with all fields', () {
+      final request = CompactResponseRequest(
+        model: 'gpt-5',
+        input: ResponseInput.text('summarize this'),
+        instructions: 'be concise',
+        previousResponseId: 'resp_prev',
+        promptCacheKey: 'cache-key',
+      );
+      expect(request.toJson(), {
+        'model': 'gpt-5',
+        'input': 'summarize this',
+        'instructions': 'be concise',
+        'previous_response_id': 'resp_prev',
+        'prompt_cache_key': 'cache-key',
+      });
+    });
+
+    test('round-trips through JSON', () {
+      final request = CompactResponseRequest(
+        model: 'gpt-5',
+        input: ResponseInput.items(const [
+          CompactionItem(id: 'cmp_prev', encryptedContent: 'enc'),
+        ]),
+        previousResponseId: 'resp_prev',
+      );
+      final restored = CompactResponseRequest.fromJson(request.toJson());
+      expect(restored, equals(request));
+    });
+  });
+}

--- a/packages/open_responses/test/unit/models/compaction_test.dart
+++ b/packages/open_responses/test/unit/models/compaction_test.dart
@@ -181,6 +181,49 @@ void main() {
     });
   });
 
+  group('FunctionCallOutputResponseItem', () {
+    test('parses from JSON', () {
+      final json = {
+        'type': 'function_call_output',
+        'id': 'fco_001',
+        'call_id': 'call_abc',
+        'output': '{"result":"ok"}',
+        'status': 'completed',
+      };
+      final item = OutputItem.fromJson(json);
+      expect(item, isA<FunctionCallOutputResponseItem>());
+      final fco = item as FunctionCallOutputResponseItem;
+      expect(fco.id, 'fco_001');
+      expect(fco.callId, 'call_abc');
+      expect(fco.output, isA<FunctionCallOutputString>());
+      expect(fco.status, FunctionCallStatus.completed);
+    });
+
+    test('round-trips through JSON', () {
+      const item = FunctionCallOutputResponseItem(
+        id: 'fco_001',
+        callId: 'call_abc',
+        output: FunctionCallOutputString('{"result":"ok"}'),
+        status: FunctionCallStatus.completed,
+      );
+      expect(OutputItem.fromJson(item.toJson()), equals(item));
+    });
+
+    test('toFunctionCallOutputItem converts to input variant', () {
+      const item = FunctionCallOutputResponseItem(
+        id: 'fco_1',
+        callId: 'call_1',
+        output: FunctionCallOutputString('value'),
+        status: FunctionCallStatus.completed,
+      );
+      final input = item.toFunctionCallOutputItem();
+      expect(input.id, 'fco_1');
+      expect(input.callId, 'call_1');
+      expect(input.output, isA<FunctionCallOutputString>());
+      expect(input.status, FunctionCallStatus.completed);
+    });
+  });
+
   group('CompactResponseRequest', () {
     test('serializes with only required fields', () {
       const request = CompactResponseRequest(model: 'gpt-5');

--- a/packages/open_responses/test/unit/models/compaction_test.dart
+++ b/packages/open_responses/test/unit/models/compaction_test.dart
@@ -143,7 +143,9 @@ void main() {
   });
 
   group('CompactResource', () {
-    test('parses example payload', () {
+    test('parses example payload (matches CompactResource spec example)', () {
+      // Matches the OpenAPI example for CompactResource: a user message with
+      // input_text content alongside a compaction output item.
       final json = {
         'id': 'resp_001',
         'object': 'response.compaction',
@@ -154,7 +156,10 @@ void main() {
             'id': 'msg_000',
             'role': 'user',
             'content': [
-              {'type': 'output_text', 'text': 'Hello'},
+              {
+                'type': 'input_text',
+                'text': 'Create a simple landing page for a dog petting cafe.',
+              },
             ],
             'status': 'completed',
           },
@@ -176,8 +181,81 @@ void main() {
       expect(resource.createdAt, 1764967971);
       expect(resource.output, hasLength(2));
       expect(resource.output[0], isA<MessageOutputItem>());
+      final msg = resource.output[0] as MessageOutputItem;
+      expect(msg.content, hasLength(1));
+      expect(msg.content.first, isA<InputTextContent>());
       expect(resource.output[1], isA<CompactionOutputItem>());
       expect(resource.usage.totalTokens, 577);
+    });
+
+    test('round-trips a payload mixing input and output content parts', () {
+      const original = CompactResource(
+        id: 'resp_002',
+        createdAt: 1764967971,
+        output: [
+          MessageOutputItem(
+            id: 'msg_user',
+            role: MessageRole.user,
+            content: [InputTextContent(text: 'Hello')],
+            status: ItemStatus.completed,
+          ),
+          MessageOutputItem(
+            id: 'msg_assistant',
+            role: MessageRole.assistant,
+            content: [OutputTextContent(text: 'Hi there')],
+            status: ItemStatus.completed,
+          ),
+        ],
+        usage: Usage(inputTokens: 1, outputTokens: 1, totalTokens: 2),
+      );
+      expect(CompactResource.fromJson(original.toJson()), equals(original));
+    });
+  });
+
+  group('MessageOutputItem with mixed content', () {
+    test('parses input_text in user-role message', () {
+      final json = {
+        'type': 'message',
+        'id': 'msg_user',
+        'role': 'user',
+        'content': [
+          {'type': 'input_text', 'text': 'Hello'},
+        ],
+        'status': 'completed',
+      };
+      final item = OutputItem.fromJson(json) as MessageOutputItem;
+      expect(item.role, MessageRole.user);
+      expect(item.content.first, isA<InputTextContent>());
+      expect((item.content.first as InputTextContent).text, 'Hello');
+    });
+
+    test('parses input_image in user-role message', () {
+      final json = {
+        'type': 'message',
+        'id': 'msg_user',
+        'role': 'user',
+        'content': [
+          {'type': 'input_image', 'image_url': 'https://example.com/img.png'},
+        ],
+        'status': 'completed',
+      };
+      final item = OutputItem.fromJson(json) as MessageOutputItem;
+      expect(item.content.first, isA<InputImageContent>());
+    });
+
+    test('parses output_text in assistant-role message', () {
+      final json = {
+        'type': 'message',
+        'id': 'msg_asst',
+        'role': 'assistant',
+        'content': [
+          {'type': 'output_text', 'text': 'Hi'},
+        ],
+        'status': 'completed',
+      };
+      final item = OutputItem.fromJson(json) as MessageOutputItem;
+      expect(item.content.first, isA<OutputTextContent>());
+      expect(item.text, 'Hi');
     });
   });
 

--- a/packages/open_responses/test/unit/models/compaction_test.dart
+++ b/packages/open_responses/test/unit/models/compaction_test.dart
@@ -257,6 +257,39 @@ void main() {
       expect(item.content.first, isA<OutputTextContent>());
       expect(item.text, 'Hi');
     });
+
+    test('text getter includes input_text from user messages', () {
+      const item = MessageOutputItem(
+        id: 'msg_user',
+        role: MessageRole.user,
+        content: [InputTextContent(text: 'Hello world')],
+        status: ItemStatus.completed,
+      );
+      expect(item.text, 'Hello world');
+    });
+
+    test('text getter combines input_text and output_text parts', () {
+      const item = MessageOutputItem(
+        id: 'msg_mixed',
+        role: MessageRole.user,
+        content: [
+          InputTextContent(text: 'in '),
+          OutputTextContent(text: 'out'),
+        ],
+        status: ItemStatus.completed,
+      );
+      expect(item.text, 'in out');
+    });
+
+    test('text getter returns null when no text parts exist', () {
+      const item = MessageOutputItem(
+        id: 'msg_image_only',
+        role: MessageRole.user,
+        content: [InputImageContent.url('https://example.com/img.png')],
+        status: ItemStatus.completed,
+      );
+      expect(item.text, isNull);
+    });
   });
 
   group('FunctionCallOutputResponseItem', () {

--- a/packages/open_responses/test/unit/resources/responses_resource_test.dart
+++ b/packages/open_responses/test/unit/resources/responses_resource_test.dart
@@ -612,5 +612,55 @@ void main() {
         );
       });
     });
+
+    group('compact()', () {
+      Map<String, dynamic> compactResponseFixture() => {
+        'id': 'resp_compact_1',
+        'object': 'response.compaction',
+        'created_at': 1764967971,
+        'output': [
+          {
+            'type': 'compaction',
+            'id': 'cmp_001',
+            'encrypted_content': 'gAAAAABpM0Yj-...=',
+          },
+        ],
+        'usage': {
+          'input_tokens': 139,
+          'output_tokens': 438,
+          'total_tokens': 577,
+        },
+      };
+
+      test('sends correct request to /responses/compact endpoint', () async {
+        mockClient.queueJsonResponse(compactResponseFixture());
+
+        await client.responses.compact(
+          const CompactResponseRequest(
+            model: 'gpt-5',
+            previousResponseId: 'resp_prev',
+          ),
+        );
+
+        expect(mockClient.requests, hasLength(1));
+        final request = mockClient.lastRequest!;
+        expect(request.method, 'POST');
+        expect(request.url.path, '/v1/responses/compact');
+      });
+
+      test('returns parsed CompactResource', () async {
+        mockClient.queueJsonResponse(compactResponseFixture());
+
+        final resource = await client.responses.compact(
+          const CompactResponseRequest(model: 'gpt-5'),
+        );
+
+        expect(resource.id, 'resp_compact_1');
+        expect(resource.object, 'response.compaction');
+        expect(resource.output, hasLength(1));
+        expect(resource.output.first, isA<CompactionOutputItem>());
+        expect(resource.usage.totalTokens, 577);
+      });
+    });
   });
 }

--- a/packages/open_responses/test/unit/resources/responses_resource_test.dart
+++ b/packages/open_responses/test/unit/resources/responses_resource_test.dart
@@ -614,11 +614,25 @@ void main() {
     });
 
     group('compact()', () {
+      // Matches the shape of the OpenAPI CompactResource example: a user
+      // message with input_text content alongside the compaction item.
       Map<String, dynamic> compactResponseFixture() => {
         'id': 'resp_compact_1',
         'object': 'response.compaction',
         'created_at': 1764967971,
         'output': [
+          {
+            'type': 'message',
+            'id': 'msg_000',
+            'role': 'user',
+            'status': 'completed',
+            'content': [
+              {
+                'type': 'input_text',
+                'text': 'Create a simple landing page for a dog petting cafe.',
+              },
+            ],
+          },
           {
             'type': 'compaction',
             'id': 'cmp_001',
@@ -648,7 +662,7 @@ void main() {
         expect(request.url.path, '/v1/responses/compact');
       });
 
-      test('returns parsed CompactResource', () async {
+      test('returns parsed CompactResource with mixed output items', () async {
         mockClient.queueJsonResponse(compactResponseFixture());
 
         final resource = await client.responses.compact(
@@ -657,8 +671,12 @@ void main() {
 
         expect(resource.id, 'resp_compact_1');
         expect(resource.object, 'response.compaction');
-        expect(resource.output, hasLength(1));
-        expect(resource.output.first, isA<CompactionOutputItem>());
+        expect(resource.output, hasLength(2));
+        expect(resource.output[0], isA<MessageOutputItem>());
+        final msg = resource.output[0] as MessageOutputItem;
+        expect(msg.role, MessageRole.user);
+        expect(msg.content.first, isA<InputTextContent>());
+        expect(resource.output[1], isA<CompactionOutputItem>());
         expect(resource.usage.totalTokens, 577);
       });
     });


### PR DESCRIPTION
## Summary
- Add `POST /responses/compact` endpoint via `ResponsesResource.compact()` for summarizing prior turns into an opaque compaction item
- Add new `CompactResource`, `CompactResponseRequest`, `CompactionItem` (input variant), and `CompactionOutputItem` (output variant) models
- Add `MessagePhase` enum (`commentary`, `final_answer`) with a new optional `phase` field on `AssistantMessageItem` and `MessageOutputItem` — required for follow-up requests on `gpt-5.3-codex` and similar models
- Add `FunctionCallOutputResponseItem` so `OutputItem` covers all members of the spec's `ItemField` union (fixes a pre-existing `FormatException` on `ResponseResource.output` when the model returned a tool output item in response history)
- Support `input_*` content parts in `MessageOutputItem.content` so echoed-back user messages in stored or compacted history parse correctly (matches the spec's `Message.content` union)

## Details

Tracks OpenResponses spec **v2.3.0** ([openresponses/openresponses#68](https://github.com/openresponses/openresponses/pull/68)).

### Compaction

```dart
// 1. Compact a previous response
final compaction = await client.responses.compact(
  CompactResponseRequest(
    model: 'gpt-5',
    previousResponseId: 'resp_abc123',
  ),
);

// 2. Replay it as input on the next turn
final compactionItem = (compaction.output
        .whereType<CompactionOutputItem>()
        .first)
    .toCompactionItem();

await client.responses.create(
  CreateResponseRequest(
    model: 'gpt-5',
    input: ResponseInput.items([
      compactionItem,
      MessageItem.userText('Continue from where we left off'),
    ]),
  ),
);
```

### Assistant phase

`AssistantMessageItem` and `MessageOutputItem` now carry an optional
`phase` for `commentary` vs `final_answer`. For compatible models the
phase must be preserved across follow-up requests:

```dart
final assistant = MessageItem.assistantText(
  'Final answer here',
  phase: MessagePhase.finalAnswer,
);
```

### `function_call_output` output items

The spec's `ItemField` union (used by both `ResponseResource.output` and
`CompactResource.output`) includes `function_call_output` items —
echoes of previously-submitted function results in stored response
history. `OutputItem` now handles them via `FunctionCallOutputResponseItem`,
which mirrors the input-side `FunctionCallOutputItem` and exposes
`toFunctionCallOutputItem()` for round-tripping.

### `Message.content` union

The spec's response-side `Message.content` union allows both `input_*` and
`output_*` content parts (e.g. an echoed-back user message has
`input_text`). A new `MessageContentPart` marker interface is implemented
by both `InputContent` and `OutputContent`, and `MessageOutputItem.content`
is now typed as `List<MessageContentPart>` with a type-prefix dispatcher
in `fromJson`.

### Implementation notes

- `Item.fromJson` / `OutputItem.fromJson` dispatch handle the new `'compaction'` and `'function_call_output'` discriminators
- `encryptedContent` is redacted to `[N chars]` in `toString()` per the codebase opaque-payload guideline
- `copyWith` uses the `unsetCopyWithValue` sentinel to allow clearing nullable fields (`phase`, `id`)
- Manifest: `CompactionSummaryItemParam` added to the `Item` discriminator mapping; `CompactionBody`, `Message`, and `ItemField` marked as `acknowledged` skips with notes; new `OutputItem:CompactionOutputItem` and `OutputItem:FunctionCallOutputResponseItem` extension entries

## Breaking Changes

- **`MessageOutputItem.content` type changed** from `List<OutputContent>` to `List<MessageContentPart>`. Type guards on leaf classes still work — `content[0] is OutputTextContent` narrows correctly. Callers that declared an intermediate `List<OutputContent>` from `.content` must migrate.

  ```dart
  // Before
  final List<OutputContent> parts = item.content;
  for (final c in parts) {
    if (c is OutputTextContent) print(c.text);
  }

  // After — declare List<MessageContentPart> (or use whereType)
  final List<MessageContentPart> parts = item.content;
  for (final c in parts.whereType<OutputTextContent>()) {
    print(c.text);
  }
  ```

  Direct type checks on leaf classes (`item.content.whereType<OutputTextContent>()`,
  `content[0] is RefusalContent`) continue to work unchanged.

## References

- [openresponses/openresponses#68](https://github.com/openresponses/openresponses/pull/68) — upstream spec PR adding compaction and assistant phase
- [OpenResponses spec v2.3.0](https://www.openresponses.org/) — published spec

## Test Plan

- [x] `dart format` clean
- [x] `dart analyze --fatal-infos` clean
- [x] `dart test test/unit/` — all 432 tests pass (34 new)
- [x] `api_toolkit verify --checks all --scope all` — 0 errors, 0 implementation warnings
- [x] `fromJson`/`toJson` round-trip verified for all new models, including mixed input/output content in `MessageOutputItem`
- [x] `==`/`hashCode` contract verified
- [x] `copyWith` null-clearing semantics verified for nullable fields