### PR TITLE
feat(openai_dart): add prompt_cache_retention to compact endpoint

### DIFF
--- a/packages/openai_dart/.agents/skills/openapi-openai/config/manifest.json
+++ b/packages/openai_dart/.agents/skills/openapi-openai/config/manifest.json
@@ -1186,6 +1186,23 @@
       "schema": "OAuthErrorCode",
       "tags": ["acknowledged"],
       "note": "Orphan schema used only on OAuthError exception in Python SDK. No endpoint or request/response model references it. OAuth error handling not yet in Dart."
+    },
+    "PromptCacheRetentionEnum": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "PromptCacheRetention",
+      "file": "lib/src/models/responses/config/prompt_cache_retention.dart",
+      "schema": "PromptCacheRetentionEnum",
+      "tags": ["acknowledged"],
+      "note": "Spec inconsistency: this named enum uses 'in_memory' (underscore) but the inline ModelResponseProperties.prompt_cache_retention used by chat/responses still uses 'in-memory' (hyphen). The Dart PromptCacheRetention enum maps inMemory -> 'in-memory'; CompactResponseRequest serializes/deserializes 'in_memory' explicitly to bridge the gap. Marked skip to avoid verifier flagging the value mismatch."
+    },
+    "CompactResponseMethodPublicBody": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "CompactResponseRequest",
+      "file": "lib/src/models/responses/compact_response_request.dart",
+      "schema": "CompactResponseMethodPublicBody",
+      "tags": []
     }
   }
 }

--- a/packages/openai_dart/.agents/skills/openapi-openai/config/specs.json
+++ b/packages/openai_dart/.agents/skills/openapi-openai/config/specs.json
@@ -28,7 +28,7 @@
       "local_file": "openapi.json",
       "name": "OpenAI API",
       "requires_auth": false,
-      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai%2Fopenai-7c540cce6eb30401259f4831ea9803b6d88501605d13734f98212cbb3b199e10.yml"
+      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai%2Fopenai-64c6ba619ccbf87e56b4f464230d04401fd78ad924d2606176309d19ca281af5.yml"
     }
   },
   "specs_dir": "packages/openai_dart/specs"

--- a/packages/openai_dart/lib/src/models/responses/compact_response_request.dart
+++ b/packages/openai_dart/lib/src/models/responses/compact_response_request.dart
@@ -1,6 +1,7 @@
 import 'package:meta/meta.dart';
 
 import '../common/copy_with_sentinel.dart';
+import 'config/prompt_cache_retention.dart';
 import 'response_input.dart';
 
 /// Request to compact response conversation state.
@@ -21,6 +22,14 @@ class CompactResponseRequest {
   /// Optional prompt cache key.
   final String? promptCacheKey;
 
+  /// Optional prompt cache retention policy.
+  ///
+  /// The compact endpoint serializes this as `'in_memory'` (underscore) or
+  /// `'24h'`. Note that this differs from the chat/responses surface, which
+  /// uses `'in-memory'` (hyphen) for the same logical value; both spellings
+  /// are accepted on read.
+  final PromptCacheRetention? promptCacheRetention;
+
   /// Creates a [CompactResponseRequest].
   const CompactResponseRequest({
     required this.model,
@@ -28,6 +37,7 @@ class CompactResponseRequest {
     this.previousResponseId,
     this.instructions,
     this.promptCacheKey,
+    this.promptCacheRetention,
   });
 
   /// Creates a [CompactResponseRequest] from JSON.
@@ -40,6 +50,12 @@ class CompactResponseRequest {
       previousResponseId: json['previous_response_id'] as String?,
       instructions: json['instructions'] as String?,
       promptCacheKey: json['prompt_cache_key'] as String?,
+      promptCacheRetention: switch (json['prompt_cache_retention'] as String?) {
+        null => null,
+        'in_memory' || 'in-memory' => PromptCacheRetention.inMemory,
+        '24h' => PromptCacheRetention.h24,
+        _ => PromptCacheRetention.unknown,
+      },
     );
   }
 
@@ -50,6 +66,12 @@ class CompactResponseRequest {
     if (previousResponseId != null) 'previous_response_id': previousResponseId,
     if (instructions != null) 'instructions': instructions,
     if (promptCacheKey != null) 'prompt_cache_key': promptCacheKey,
+    if (promptCacheRetention != null)
+      'prompt_cache_retention': switch (promptCacheRetention!) {
+        PromptCacheRetention.inMemory => 'in_memory',
+        PromptCacheRetention.h24 => '24h',
+        PromptCacheRetention.unknown => 'unknown',
+      },
   };
 
   /// Creates a copy with replaced values.
@@ -61,6 +83,7 @@ class CompactResponseRequest {
     Object? previousResponseId = unsetCopyWithValue,
     Object? instructions = unsetCopyWithValue,
     Object? promptCacheKey = unsetCopyWithValue,
+    Object? promptCacheRetention = unsetCopyWithValue,
   }) {
     return CompactResponseRequest(
       model: model ?? this.model,
@@ -74,6 +97,9 @@ class CompactResponseRequest {
       promptCacheKey: promptCacheKey == unsetCopyWithValue
           ? this.promptCacheKey
           : promptCacheKey as String?,
+      promptCacheRetention: promptCacheRetention == unsetCopyWithValue
+          ? this.promptCacheRetention
+          : promptCacheRetention as PromptCacheRetention?,
     );
   }
 
@@ -86,7 +112,8 @@ class CompactResponseRequest {
           input == other.input &&
           previousResponseId == other.previousResponseId &&
           instructions == other.instructions &&
-          promptCacheKey == other.promptCacheKey;
+          promptCacheKey == other.promptCacheKey &&
+          promptCacheRetention == other.promptCacheRetention;
 
   @override
   int get hashCode => Object.hash(
@@ -95,9 +122,16 @@ class CompactResponseRequest {
     previousResponseId,
     instructions,
     promptCacheKey,
+    promptCacheRetention,
   );
 
   @override
   String toString() =>
-      'CompactResponseRequest(model: $model, previousResponseId: $previousResponseId)';
+      'CompactResponseRequest('
+      'model: $model, '
+      'input: $input, '
+      'previousResponseId: $previousResponseId, '
+      'instructions: $instructions, '
+      'promptCacheKey: $promptCacheKey, '
+      'promptCacheRetention: $promptCacheRetention)';
 }

--- a/packages/openai_dart/specs/openapi.json
+++ b/packages/openai_dart/specs/openapi.json
@@ -4176,8 +4176,6 @@
       },
       "ChatModel": {
         "enum": [
-          "gpt-5.5",
-          "gpt-5.5-2026-04-23",
           "gpt-5.4",
           "gpt-5.4-mini",
           "gpt-5.4-nano",
@@ -5123,6 +5121,17 @@
                 "description": "A key to use when reading from or writing to the prompt cache.",
                 "maxLength": 64,
                 "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "prompt_cache_retention": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PromptCacheRetentionEnum",
+                "description": "How long to retain a prompt cache entry created by this request."
               },
               {
                 "type": "null"
@@ -22997,6 +23006,13 @@
             "type": "null"
           }
         ]
+      },
+      "PromptCacheRetentionEnum": {
+        "enum": [
+          "in_memory",
+          "24h"
+        ],
+        "type": "string"
       },
       "PublicAssignOrganizationGroupRoleBody": {
         "description": "Request payload for assigning a role to a group or user.",

--- a/packages/openai_dart/specs/spec_metadata.json
+++ b/packages/openai_dart/specs/spec_metadata.json
@@ -2,8 +2,8 @@
   "specs": {
     "main": {
       "current_version": "2.3.0",
-      "last_fetched": "2026-04-25T21:03:31.924795Z",
-      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai%2Fopenai-7c540cce6eb30401259f4831ea9803b6d88501605d13734f98212cbb3b199e10.yml",
+      "last_fetched": "2026-05-02T08:00:03.586206Z",
+      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai%2Fopenai-64c6ba619ccbf87e56b4f464230d04401fd78ad924d2606176309d19ca281af5.yml",
       "title": "OpenAI API",
       "version_history": []
     }

--- a/packages/openai_dart/test/unit/models/responses_test.dart
+++ b/packages/openai_dart/test/unit/models/responses_test.dart
@@ -3382,6 +3382,75 @@ void main() {
     });
   });
 
+  group('CompactResponseRequest with promptCacheRetention', () {
+    test('round-trip with inMemory uses in_memory underscore', () {
+      const request = CompactResponseRequest(
+        model: 'gpt-4o',
+        promptCacheRetention: PromptCacheRetention.inMemory,
+      );
+
+      final json = request.toJson();
+      expect(json['prompt_cache_retention'], 'in_memory');
+
+      final restored = CompactResponseRequest.fromJson(json);
+      expect(restored.promptCacheRetention, PromptCacheRetention.inMemory);
+      expect(restored, equals(request));
+    });
+
+    test('round-trip with h24', () {
+      const request = CompactResponseRequest(
+        model: 'gpt-4o',
+        promptCacheRetention: PromptCacheRetention.h24,
+      );
+
+      final json = request.toJson();
+      expect(json['prompt_cache_retention'], '24h');
+
+      final restored = CompactResponseRequest.fromJson(json);
+      expect(restored.promptCacheRetention, PromptCacheRetention.h24);
+      expect(restored, equals(request));
+    });
+
+    test('fromJson accepts legacy hyphenated in-memory', () {
+      final restored = CompactResponseRequest.fromJson(const {
+        'model': 'gpt-4o',
+        'prompt_cache_retention': 'in-memory',
+      });
+      expect(restored.promptCacheRetention, PromptCacheRetention.inMemory);
+    });
+
+    test('fromJson falls back to unknown for unrecognized values', () {
+      final restored = CompactResponseRequest.fromJson(const {
+        'model': 'gpt-4o',
+        'prompt_cache_retention': 'forever',
+      });
+      expect(restored.promptCacheRetention, PromptCacheRetention.unknown);
+    });
+
+    test('copyWith sets promptCacheRetention', () {
+      const request = CompactResponseRequest(model: 'gpt-4o');
+      final updated = request.copyWith(
+        promptCacheRetention: PromptCacheRetention.h24,
+      );
+      expect(updated.promptCacheRetention, PromptCacheRetention.h24);
+    });
+
+    test('copyWith clears promptCacheRetention via null sentinel', () {
+      const request = CompactResponseRequest(
+        model: 'gpt-4o',
+        promptCacheRetention: PromptCacheRetention.inMemory,
+      );
+      final cleared = request.copyWith(promptCacheRetention: null);
+      expect(cleared.promptCacheRetention, isNull);
+    });
+
+    test('toJson omits prompt_cache_retention when null', () {
+      const request = CompactResponseRequest(model: 'gpt-4o');
+      final json = request.toJson();
+      expect(json.containsKey('prompt_cache_retention'), isFalse);
+    });
+  });
+
   group('Response with promptCacheKey and promptCacheRetention', () {
     test('fromJson parses new fields', () {
       final json = {


### PR DESCRIPTION
## Summary
- Adds optional `promptCacheRetention` to `CompactResponseRequest`, exposing the new field on the `/v1/responses/{response_id}/compact` endpoint.
- Reuses the existing `PromptCacheRetention` enum (no second enum); on the compact endpoint, `inMemory` serializes as `'in_memory'` (underscore) per the new named `PromptCacheRetentionEnum` schema, while `fromJson` also accepts the legacy hyphenated `'in-memory'` for forward/backward compatibility.
- Promotes the upstream OpenAI spec to hash `64c6ba619ccbf87e…` and registers the two new schemas (`PromptCacheRetentionEnum`, `CompactResponseMethodPublicBody`) in the manifest.

## Details

The upstream spec introduced a named `PromptCacheRetentionEnum` for the compact endpoint with values `["in_memory", "24h"]`, while the inline `ModelResponseProperties.prompt_cache_retention` used by `Response`/`ChatCompletion` continues to use `["in-memory", "24h"]` (hyphen). Rather than introduce a second Dart enum, this PR keeps a single `PromptCacheRetention` and bridges the wire format inconsistency with explicit per-endpoint switch-based serialization in `CompactResponseRequest`:

```dart
final compact = CompactResponseRequest(
  model: 'gpt-4o',
  promptCacheRetention: PromptCacheRetention.inMemory,
);

// toJson emits the underscore form expected by the compact endpoint:
//   { "model": "gpt-4o", "prompt_cache_retention": "in_memory" }
//
// Chat/responses surfaces continue to emit "in-memory" (hyphen),
// matching the existing schema.
```

`fromJson` accepts both spellings to avoid breaking callers that round-trip recorded payloads, and falls back to `PromptCacheRetention.unknown` for unrecognized server values.

While extending the model, `toString` was also expanded to cover all fields (previously only `model` and `previousResponseId`) to satisfy the toolkit's completeness convention.

The `PromptCacheRetentionEnum` manifest entry is marked `kind: skip` + `acknowledged` with a note explaining the spec/Dart value mismatch, so the verifier doesn't keep flagging it. `CompactResponseMethodPublicBody` is registered as `kind: object`; its remaining info-level note (`model: String` vs spec `ModelIdsCompaction`) mirrors the existing `ChatModel`/`CreateChatCompletionRequest` precedent for raw-string model IDs.

## Test Plan
- [x] `api_toolkit review` — 0 errors, 0 warnings, 0 missing manifest entries
- [x] `api_toolkit verify --checks all --scope all` — 0 errors, 0 warnings (1 expected info on `model` field, matching `ChatModel` precedent)
- [x] `dart analyze .` — clean
- [x] `dart format` — no changes
- [x] `dart test test/unit/` — 1216 passed, 2 skipped, 0 failed
- [x] 7 new unit tests cover round-trip with `inMemory`/`h24`, legacy `'in-memory'` parsing, `unknown` fallback, `copyWith` set/clear via sentinel, and JSON omission when null
- [x] Existing `Response with promptCacheKey and promptCacheRetention` tests still pass (chat/responses serialization unchanged)