### PR TITLE
fix(openai_dart): avoid StateError when non-streaming requests use abortTrigger

### DIFF
--- a/packages/openai_dart/lib/src/client/interceptor_chain.dart
+++ b/packages/openai_dart/lib/src/client/interceptor_chain.dart
@@ -236,18 +236,21 @@ class _AbortableRequestWrapper extends http.BaseRequest
 
   @override
   http.ByteStream finalize() {
-    super.finalize();
+    // Finalize the inner request first so any values it computes during
+    // finalize (e.g. multipart Content-Type boundary, content length) are
+    // available before we mirror them onto this wrapper.
     final stream = _inner.finalize();
 
-    // Synchronize headers and contentLength with the inner request after it
-    // has been finalized. This ensures that any values set during finalize(),
-    // such as multipart Content-Type boundaries and computed content length,
-    // are visible to the HTTP client when sending this wrapper request.
+    // Mirror headers and contentLength from the inner request *before*
+    // finalizing this wrapper. Once super.finalize() runs, the contentLength
+    // setter on http.BaseRequest throws StateError, which previously broke
+    // every non-streaming request that supplied an abortTrigger.
     headers
       ..clear()
       ..addAll(_inner.headers);
     contentLength = _inner.contentLength;
 
+    super.finalize();
     return stream;
   }
 }

--- a/packages/openai_dart/test/unit/client/abort_non_streaming_test.dart
+++ b/packages/openai_dart/test/unit/client/abort_non_streaming_test.dart
@@ -1,0 +1,134 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:openai_dart/openai_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Non-streaming with abortTrigger', () {
+    test(
+      'chat.completions.create with abortTrigger does not throw StateError',
+      () async {
+        // Regression test for https://github.com/davidmigloz/ai_clients_dart/issues/209
+        // The _AbortableRequestWrapper.finalize() previously called
+        // super.finalize() before setting contentLength, which marked the
+        // wrapper as finalized and made the contentLength setter throw
+        // StateError.
+        final mockClient = MockClient((request) async {
+          final body = await _readBody(request);
+          // Ensure body actually flowed through to the transport.
+          expect(body, contains('"messages"'));
+          return http.Response(
+            jsonEncode({
+              'id': 'chat-1',
+              'object': 'chat.completion',
+              'created': 1234567890,
+              'model': 'gpt-4',
+              'choices': [
+                {
+                  'index': 0,
+                  'message': {'role': 'assistant', 'content': 'hi'},
+                  'finish_reason': 'stop',
+                },
+              ],
+              'usage': {
+                'prompt_tokens': 1,
+                'completion_tokens': 1,
+                'total_tokens': 2,
+              },
+            }),
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        });
+
+        final client = OpenAIClient(
+          config: const OpenAIConfig(
+            authProvider: ApiKeyProvider('sk-test-key'),
+            retryPolicy: RetryPolicy(maxRetries: 0),
+          ),
+          httpClient: mockClient,
+        );
+
+        final neverAbort = Completer<void>().future;
+
+        final response = await client.chat.completions.create(
+          ChatCompletionCreateRequest(
+            model: 'gpt-4',
+            messages: [ChatMessage.user('Hello')],
+          ),
+          abortTrigger: neverAbort,
+        );
+
+        expect(response.id, equals('chat-1'));
+
+        client.close();
+      },
+    );
+
+    test(
+      'content-length header reflects body when abortTrigger is set',
+      () async {
+        // The wrapper must mirror the inner request's contentLength so that the
+        // HTTP transport sends the correct Content-Length header.
+        int? observedContentLength;
+        final mockClient = MockClient((request) async {
+          observedContentLength = request.contentLength;
+          return http.Response(
+            jsonEncode({
+              'id': 'chat-2',
+              'object': 'chat.completion',
+              'created': 1,
+              'model': 'gpt-4',
+              'choices': [
+                {
+                  'index': 0,
+                  'message': {'role': 'assistant', 'content': 'ok'},
+                  'finish_reason': 'stop',
+                },
+              ],
+              'usage': {
+                'prompt_tokens': 1,
+                'completion_tokens': 1,
+                'total_tokens': 2,
+              },
+            }),
+            200,
+          );
+        });
+
+        final client = OpenAIClient(
+          config: const OpenAIConfig(
+            authProvider: ApiKeyProvider('sk-test-key'),
+            retryPolicy: RetryPolicy(maxRetries: 0),
+          ),
+          httpClient: mockClient,
+        );
+
+        final neverAbort = Completer<void>().future;
+        await client.chat.completions.create(
+          ChatCompletionCreateRequest(
+            model: 'gpt-4',
+            messages: [ChatMessage.user('Hello world')],
+          ),
+          abortTrigger: neverAbort,
+        );
+
+        expect(observedContentLength, isNotNull);
+        expect(observedContentLength, greaterThan(0));
+
+        client.close();
+      },
+    );
+  });
+}
+
+Future<String> _readBody(http.BaseRequest request) async {
+  if (request is http.Request) {
+    return request.body;
+  }
+  final bytes = await request.finalize().toBytes();
+  return utf8.decode(bytes);
+}


### PR DESCRIPTION
## Summary
- Non-streaming requests that supplied `abortTrigger` (e.g. `chat.completions.create(request, abortTrigger: ...)`) threw `StateError: Bad state: Can't modify a finalized Request` before the HTTP request was even sent.
- Reorder `_AbortableRequestWrapper.finalize()` so the wrapper mirrors the inner request's headers and `contentLength` *before* it is finalized, instead of after.
- Streaming methods went through a different code path and were unaffected.

Fixes #209

## Details

The wrapper used by the abort path extends `http.BaseRequest` and overrides
`finalize()` to delegate to the inner request. The previous implementation
called `super.finalize()` first and then copied state from the inner
request. The `contentLength` setter on `http.BaseRequest` calls
`_checkFinalized()`, so the second assignment threw immediately.

The fix finalizes the inner request first (so any values it computes during
finalize, such as a multipart `Content-Type` boundary, are available),
mirrors them onto the wrapper while it is still mutable, and only then
calls `super.finalize()`. The wrapper still ends in the finalized state
the http client expects when it reads `contentLength` after `send()`.

## Test Plan

- [x] New `test/unit/client/abort_non_streaming_test.dart` reproduces the failure on `chat.completions.create` with a non-completing `abortTrigger` and a `MockClient`, and verifies the transport sees a non-zero `Content-Length`.
- [x] `dart test --reporter=failures-only test/unit/client/` — all client tests pass.
- [x] `dart format` and `dart analyze` clean on touched files.
- [x] `api-toolkit verify --checks all --scope all` reports 0 errors / 0 warnings.