### PR TITLE
fix(openai_dart)!: align FunctionCallStatus values with OpenAI spec

### DIFF
--- a/packages/openai_dart/lib/src/models/responses/config/function_call_status.dart
+++ b/packages/openai_dart/lib/src/models/responses/config/function_call_status.dart
@@ -1,13 +1,20 @@
 /// The status of a function call.
+///
+/// Mirrors the OpenAI `FunctionCallStatus` schema, which only accepts
+/// `in_progress`, `completed`, and `incomplete`. The API rejects any other
+/// value (including `failed`).
 enum FunctionCallStatus {
   /// Unknown status (fallback for unrecognized values).
   unknown('unknown'),
 
+  /// Function call is in progress.
+  inProgress('in_progress'),
+
   /// Function call completed successfully.
   completed('completed'),
 
-  /// Function call failed.
-  failed('failed');
+  /// Function call did not complete (e.g. truncated, refused).
+  incomplete('incomplete');
 
   /// The JSON value for this status.
   final String value;

--- a/packages/openai_dart/test/unit/models/responses/function_call_status_test.dart
+++ b/packages/openai_dart/test/unit/models/responses/function_call_status_test.dart
@@ -1,0 +1,74 @@
+import 'package:openai_dart/openai_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // Regression tests for https://github.com/davidmigloz/ai_clients_dart/issues/208
+  //
+  // The OpenAI spec defines the FunctionCallStatus enum with values
+  // ["in_progress", "completed", "incomplete"]. The Dart enum previously
+  // shipped with ["completed", "failed"], which caused the API to reject
+  // requests built with FunctionCallStatus.failed.
+  group('FunctionCallStatus values match OpenAI spec', () {
+    test('exposes in_progress, completed, incomplete', () {
+      final wireValues = FunctionCallStatus.values
+          .where((v) => v != FunctionCallStatus.unknown)
+          .map((v) => v.toJson())
+          .toSet();
+
+      expect(wireValues, {'in_progress', 'completed', 'incomplete'});
+    });
+
+    test('does not expose failed', () {
+      final names = FunctionCallStatus.values.map((v) => v.name).toSet();
+      expect(names, isNot(contains('failed')));
+    });
+
+    test('round-trip all non-unknown values', () {
+      for (final v in FunctionCallStatus.values.where(
+        (v) => v != FunctionCallStatus.unknown,
+      )) {
+        expect(FunctionCallStatus.fromJson(v.toJson()), v);
+      }
+    });
+
+    test('fromJson falls back to unknown for unrecognized values', () {
+      expect(FunctionCallStatus.fromJson('failed'), FunctionCallStatus.unknown);
+      expect(
+        FunctionCallStatus.fromJson('whatever'),
+        FunctionCallStatus.unknown,
+      );
+    });
+  });
+
+  group('FunctionCallOutputItem with status serializes valid wire value', () {
+    test('serializes incomplete as "incomplete"', () {
+      final item = FunctionCallOutputItem.string(
+        callId: 'call_1',
+        output: 'TOOL_CALL_ERROR: boom',
+        status: FunctionCallStatus.incomplete,
+      );
+
+      expect(item.toJson()['status'], 'incomplete');
+    });
+
+    test('serializes in_progress as "in_progress"', () {
+      final item = FunctionCallOutputItem.string(
+        callId: 'call_1',
+        output: 'partial',
+        status: FunctionCallStatus.inProgress,
+      );
+
+      expect(item.toJson()['status'], 'in_progress');
+    });
+
+    test('serializes completed as "completed"', () {
+      final item = FunctionCallOutputItem.string(
+        callId: 'call_1',
+        output: 'done',
+        status: FunctionCallStatus.completed,
+      );
+
+      expect(item.toJson()['status'], 'completed');
+    });
+  });
+}

--- a/packages/openai_dart/test/unit/models/responses_test.dart
+++ b/packages/openai_dart/test/unit/models/responses_test.dart
@@ -2527,9 +2527,14 @@ void main() {
       );
     });
 
-    test('values are distinct from FunctionCallStatus', () {
+    test('shares wire values with FunctionCallStatus', () {
+      // The OpenAI spec defines FunctionCallStatus and
+      // FunctionCallOutputStatusEnum as separately-named enums with the same
+      // values; both Dart enums should round-trip the same wire strings.
       expect(FunctionCallOutputStatus.inProgress.value, 'in_progress');
       expect(FunctionCallOutputStatus.incomplete.value, 'incomplete');
+      expect(FunctionCallStatus.inProgress.value, 'in_progress');
+      expect(FunctionCallStatus.incomplete.value, 'incomplete');
     });
   });
 


### PR DESCRIPTION
## Summary
- The Dart `FunctionCallStatus` enum shipped with `completed` and `failed`, but the OpenAI `FunctionCallStatus` schema only accepts `in_progress`, `completed`, and `incomplete`. Sending `failed` was rejected by the API: `Invalid value: 'failed'. Supported values are: 'in_progress', 'completed', and 'incomplete'.`.
- Replace the variants with the spec-correct values and document that the two Dart enums (`FunctionCallStatus` and `FunctionCallOutputStatus`) intentionally mirror separately-named spec enums that share the same wire values.

Fixes #208

## Details

The OpenAI spec defines three status enums for function-call schemas
(`FunctionCallStatus`, `FunctionCallItemStatus`, `FunctionCallOutputStatusEnum`),
all with the same values: `in_progress`, `completed`, `incomplete`. The
Dart codebase mirrors the first and third as separate enums for symmetry
with the spec, but `FunctionCallStatus` had been hand-coded with an
incorrect set of variants — it was missing `in_progress` and `incomplete`
and had a non-spec `failed` value that the API always rejects.

This PR brings `FunctionCallStatus` in line with the spec:

```dart
// Before
enum FunctionCallStatus { unknown, completed, failed }

// After
enum FunctionCallStatus { unknown, inProgress, completed, incomplete }
```

The serializer's `unknown` fallback means servers that introduce future
values still parse without throwing.

## Breaking Changes

`FunctionCallStatus.failed` is removed. Any code that referenced it was
already broken at runtime (the API rejected the wire value `'failed'`), so
the practical migration is to send `incomplete` and convey failure detail
in the output payload itself:

```dart
// Before — server rejected this with HTTP 400.
FunctionCallOutputItem.string(
  callId: id,
  output: 'TOOL_CALL_ERROR: \$message',
  status: FunctionCallStatus.failed,
);

// After
FunctionCallOutputItem.string(
  callId: id,
  output: 'TOOL_CALL_ERROR: \$message',
  status: FunctionCallStatus.incomplete,
);
```

`FunctionCallStatus.completed` is unchanged.

## Test Plan

- [x] New `test/unit/models/responses/function_call_status_test.dart` asserts the enum exposes exactly the spec values, no longer exposes `failed`, round-trips, and that `FunctionCallOutputItem` serializes the spec-valid wire strings.
- [x] Updated the existing `FunctionCallOutputStatus` test to assert that both enums share the same wire values (matching the spec's separately-named, value-identical enums).
- [x] `dart test --reporter=failures-only test/unit/` — all unit tests pass.
- [x] `dart format` and `dart analyze` clean on touched files.
- [x] `api-toolkit verify --checks all --scope all` reports 0 errors / 0 warnings.