### PR TITLE
feat(googleai_dart): add file search embeddingModel and downloadMedia

### DIFF
--- a/packages/googleai_dart/.agents/skills/openapi-googleai/config/manifest.json
+++ b/packages/googleai_dart/.agents/skills/openapi-googleai/config/manifest.json
@@ -1565,6 +1565,128 @@
       "tags": [
         "acknowledged"
       ]
+    },
+    "FileSearchStore": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "FileSearchStore",
+      "file": "lib/src/models/files/file_search_store.dart",
+      "schema": "FileSearchStore"
+    },
+    "UsageMetadata": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "UsageMetadata",
+      "file": "lib/src/models/metadata/usage_metadata.dart",
+      "schema": "UsageMetadata"
+    },
+    "DownloadMediaResponse": {
+      "spec": "main",
+      "schema": "DownloadMediaResponse",
+      "kind": "skip",
+      "note": "Wire envelope around GdataMedia for GET /fileSearchStores/{id}/media/{mediaId}. Exposed in Dart as Future<List<int>> downloadMedia() in FileSearchStoresResource. Not modeled in python-genai or js-genai.",
+      "tags": [
+        "acknowledged"
+      ]
+    },
+    "GdataMedia": {
+      "spec": "main",
+      "schema": "GdataMedia",
+      "kind": "skip",
+      "note": "Internal Google Scotty/Bigstore media descriptor; surfaces only inside DownloadMediaResponse. Exposed as raw bytes via FileSearchStoresResource.downloadMedia(). Not modeled in python-genai or js-genai.",
+      "tags": [
+        "acknowledged"
+      ]
+    },
+    "Blobstore2Info": {
+      "spec": "main",
+      "schema": "Blobstore2Info",
+      "kind": "skip",
+      "note": "Internal Scotty/Bigstore type; reachable only through GdataMedia. See GdataMedia entry.",
+      "tags": [
+        "acknowledged"
+      ]
+    },
+    "CompositeMedia": {
+      "spec": "main",
+      "schema": "CompositeMedia",
+      "kind": "skip",
+      "note": "Internal Scotty/Bigstore type; reachable only through GdataMedia. See GdataMedia entry.",
+      "tags": [
+        "acknowledged"
+      ]
+    },
+    "ContentTypeInfo": {
+      "spec": "main",
+      "schema": "ContentTypeInfo",
+      "kind": "skip",
+      "note": "Internal Scotty/Bigstore type; reachable only through GdataMedia. See GdataMedia entry.",
+      "tags": [
+        "acknowledged"
+      ]
+    },
+    "DiffChecksumsResponse": {
+      "spec": "main",
+      "schema": "DiffChecksumsResponse",
+      "kind": "skip",
+      "note": "Internal Scotty/Bigstore type; reachable only through GdataMedia. See GdataMedia entry.",
+      "tags": [
+        "acknowledged"
+      ]
+    },
+    "DiffDownloadResponse": {
+      "spec": "main",
+      "schema": "DiffDownloadResponse",
+      "kind": "skip",
+      "note": "Internal Scotty/Bigstore type; reachable only through GdataMedia. See GdataMedia entry.",
+      "tags": [
+        "acknowledged"
+      ]
+    },
+    "DiffUploadRequest": {
+      "spec": "main",
+      "schema": "DiffUploadRequest",
+      "kind": "skip",
+      "note": "Internal Scotty/Bigstore type; reachable only through GdataMedia. See GdataMedia entry.",
+      "tags": [
+        "acknowledged"
+      ]
+    },
+    "DiffUploadResponse": {
+      "spec": "main",
+      "schema": "DiffUploadResponse",
+      "kind": "skip",
+      "note": "Internal Scotty/Bigstore type; reachable only through GdataMedia. See GdataMedia entry.",
+      "tags": [
+        "acknowledged"
+      ]
+    },
+    "DiffVersionResponse": {
+      "spec": "main",
+      "schema": "DiffVersionResponse",
+      "kind": "skip",
+      "note": "Internal Scotty/Bigstore type; reachable only through GdataMedia. See GdataMedia entry.",
+      "tags": [
+        "acknowledged"
+      ]
+    },
+    "DownloadParameters": {
+      "spec": "main",
+      "schema": "DownloadParameters",
+      "kind": "skip",
+      "note": "Internal Scotty/Bigstore type; reachable only through GdataMedia. See GdataMedia entry.",
+      "tags": [
+        "acknowledged"
+      ]
+    },
+    "ObjectId": {
+      "spec": "main",
+      "schema": "ObjectId",
+      "kind": "skip",
+      "note": "Internal Scotty/Bigstore type; reachable only through GdataMedia and CompositeMedia. See GdataMedia entry.",
+      "tags": [
+        "acknowledged"
+      ]
     }
   }
 }

--- a/packages/googleai_dart/lib/src/models/files/file_search_store.dart
+++ b/packages/googleai_dart/lib/src/models/files/file_search_store.dart
@@ -1,6 +1,9 @@
+import 'package:meta/meta.dart';
+
 import '../copy_with_sentinel.dart';
 
 /// A `FileSearchStore` is a collection of `Document`s.
+@immutable
 class FileSearchStore {
   /// Output only. Immutable. The `FileSearchStore` resource name.
   ///
@@ -39,6 +42,15 @@ class FileSearchStore {
   /// This is the total size of all the documents in the `FileSearchStore`.
   final String? sizeBytes;
 
+  /// Optional. The embedding model to use for the `FileSearchStore`.
+  ///
+  /// The model's resource name. This serves as an ID for the Model to use.
+  /// Format: `models/{model}` — for example, `models/gemini-embedding-2`
+  /// to enable multimodal File Search RAG.
+  ///
+  /// May be `null`. When `null`, the default embedding model is used.
+  final String? embeddingModel;
+
   /// Creates a [FileSearchStore].
   const FileSearchStore({
     this.name,
@@ -49,6 +61,7 @@ class FileSearchStore {
     this.pendingDocumentsCount,
     this.failedDocumentsCount,
     this.sizeBytes,
+    this.embeddingModel,
   });
 
   /// Creates a [FileSearchStore] from JSON.
@@ -66,6 +79,7 @@ class FileSearchStore {
         pendingDocumentsCount: json['pendingDocumentsCount'] as String?,
         failedDocumentsCount: json['failedDocumentsCount'] as String?,
         sizeBytes: json['sizeBytes'] as String?,
+        embeddingModel: json['embeddingModel'] as String?,
       );
 
   /// Converts to JSON.
@@ -81,6 +95,7 @@ class FileSearchStore {
     if (failedDocumentsCount != null)
       'failedDocumentsCount': failedDocumentsCount,
     if (sizeBytes != null) 'sizeBytes': sizeBytes,
+    if (embeddingModel != null) 'embeddingModel': embeddingModel,
   };
 
   /// Creates a copy with replaced values.
@@ -93,6 +108,7 @@ class FileSearchStore {
     Object? pendingDocumentsCount = unsetCopyWithValue,
     Object? failedDocumentsCount = unsetCopyWithValue,
     Object? sizeBytes = unsetCopyWithValue,
+    Object? embeddingModel = unsetCopyWithValue,
   }) {
     return FileSearchStore(
       name: name == unsetCopyWithValue ? this.name : name as String?,
@@ -117,10 +133,43 @@ class FileSearchStore {
       sizeBytes: sizeBytes == unsetCopyWithValue
           ? this.sizeBytes
           : sizeBytes as String?,
+      embeddingModel: embeddingModel == unsetCopyWithValue
+          ? this.embeddingModel
+          : embeddingModel as String?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is FileSearchStore &&
+        other.name == name &&
+        other.displayName == displayName &&
+        other.createTime == createTime &&
+        other.updateTime == updateTime &&
+        other.activeDocumentsCount == activeDocumentsCount &&
+        other.pendingDocumentsCount == pendingDocumentsCount &&
+        other.failedDocumentsCount == failedDocumentsCount &&
+        other.sizeBytes == sizeBytes &&
+        other.embeddingModel == embeddingModel;
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(
+      name,
+      displayName,
+      createTime,
+      updateTime,
+      activeDocumentsCount,
+      pendingDocumentsCount,
+      failedDocumentsCount,
+      sizeBytes,
+      embeddingModel,
     );
   }
 
   @override
   String toString() =>
-      'FileSearchStore(name: $name, displayName: $displayName, createTime: $createTime, updateTime: $updateTime, activeDocumentsCount: $activeDocumentsCount, pendingDocumentsCount: $pendingDocumentsCount, failedDocumentsCount: $failedDocumentsCount, sizeBytes: $sizeBytes)';
+      'FileSearchStore(name: $name, displayName: $displayName, createTime: $createTime, updateTime: $updateTime, activeDocumentsCount: $activeDocumentsCount, pendingDocumentsCount: $pendingDocumentsCount, failedDocumentsCount: $failedDocumentsCount, sizeBytes: $sizeBytes, embeddingModel: $embeddingModel)';
 }

--- a/packages/googleai_dart/lib/src/models/metadata/modality_token_count.dart
+++ b/packages/googleai_dart/lib/src/models/metadata/modality_token_count.dart
@@ -1,6 +1,9 @@
+import 'package:meta/meta.dart';
+
 import '../copy_with_sentinel.dart';
 
 /// Represents token counting info for a single modality.
+@immutable
 class ModalityTokenCount {
   /// The modality associated with this token count.
   final String? modality;
@@ -38,4 +41,19 @@ class ModalityTokenCount {
           : tokenCount as int?,
     );
   }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ModalityTokenCount &&
+        other.modality == modality &&
+        other.tokenCount == tokenCount;
+  }
+
+  @override
+  int get hashCode => Object.hash(modality, tokenCount);
+
+  @override
+  String toString() =>
+      'ModalityTokenCount(modality: $modality, tokenCount: $tokenCount)';
 }

--- a/packages/googleai_dart/lib/src/models/metadata/usage_metadata.dart
+++ b/packages/googleai_dart/lib/src/models/metadata/usage_metadata.dart
@@ -230,9 +230,12 @@ class UsageMetadata {
       'cachedContentTokenCount: $cachedContentTokenCount, '
       'thoughtsTokenCount: $thoughtsTokenCount, '
       'toolUsePromptTokenCount: $toolUsePromptTokenCount, '
-      'cacheTokensDetails: ${cacheTokensDetails?.length} items, '
-      'candidatesTokensDetails: ${candidatesTokensDetails?.length} items, '
-      'promptTokensDetails: ${promptTokensDetails?.length} items, '
-      'toolUsePromptTokensDetails: ${toolUsePromptTokensDetails?.length} items, '
+      'cacheTokensDetails: ${_summarize(cacheTokensDetails)}, '
+      'candidatesTokensDetails: ${_summarize(candidatesTokensDetails)}, '
+      'promptTokensDetails: ${_summarize(promptTokensDetails)}, '
+      'toolUsePromptTokensDetails: ${_summarize(toolUsePromptTokensDetails)}, '
       'serviceTier: $serviceTier)';
 }
+
+String _summarize(List<Object?>? list) =>
+    list == null ? 'null' : '${list.length} items';

--- a/packages/googleai_dart/lib/src/models/metadata/usage_metadata.dart
+++ b/packages/googleai_dart/lib/src/models/metadata/usage_metadata.dart
@@ -1,18 +1,65 @@
+import 'package:collection/collection.dart';
+import 'package:meta/meta.dart';
+
+import '../common/service_tier.dart';
 import '../copy_with_sentinel.dart';
+import 'modality_token_count.dart';
 
 /// Token usage metadata for the request/response.
+@immutable
 class UsageMetadata {
   /// Number of tokens in the prompt.
+  ///
+  /// When `cachedContent` is set, this is still the total effective prompt
+  /// size meaning it includes the number of tokens in the cached content.
   final int? promptTokenCount;
 
-  /// Number of tokens in the response(s).
+  /// Total number of tokens across all generated response candidates.
   final int? candidatesTokenCount;
 
-  /// Total token count.
+  /// Total token count for the generation request
+  /// (prompt + thoughts + response candidates).
   final int? totalTokenCount;
 
-  /// Number of cached tokens in the prompt.
+  /// Number of tokens in the cached part of the prompt (the cached content).
   final int? cachedContentTokenCount;
+
+  /// Output only. Number of tokens of thoughts for thinking models.
+  ///
+  /// May be `null` for models that do not produce thoughts.
+  final int? thoughtsTokenCount;
+
+  /// Output only. Number of tokens present in tool-use prompt(s).
+  ///
+  /// May be `null` when no tool-use prompt was processed.
+  final int? toolUsePromptTokenCount;
+
+  /// Output only. List of modalities of the cached content in the request
+  /// input.
+  ///
+  /// May be `null` when no cached content was supplied.
+  final List<ModalityTokenCount>? cacheTokensDetails;
+
+  /// Output only. List of modalities that were returned in the response.
+  ///
+  /// May be `null` when no candidates were returned.
+  final List<ModalityTokenCount>? candidatesTokensDetails;
+
+  /// Output only. List of modalities that were processed in the request input.
+  ///
+  /// May be `null` when no prompt modality breakdown is available.
+  final List<ModalityTokenCount>? promptTokensDetails;
+
+  /// Output only. List of modalities that were processed for tool-use request
+  /// inputs.
+  ///
+  /// May be `null` when no tool-use breakdown is available.
+  final List<ModalityTokenCount>? toolUsePromptTokensDetails;
+
+  /// Output only. Service tier of the request.
+  ///
+  /// May be `null` when the API did not report a service tier.
+  final ServiceTier? serviceTier;
 
   /// Creates a [UsageMetadata].
   const UsageMetadata({
@@ -20,6 +67,13 @@ class UsageMetadata {
     this.candidatesTokenCount,
     this.totalTokenCount,
     this.cachedContentTokenCount,
+    this.thoughtsTokenCount,
+    this.toolUsePromptTokenCount,
+    this.cacheTokensDetails,
+    this.candidatesTokensDetails,
+    this.promptTokensDetails,
+    this.toolUsePromptTokensDetails,
+    this.serviceTier,
   });
 
   /// Creates a [UsageMetadata] from JSON.
@@ -28,6 +82,23 @@ class UsageMetadata {
     candidatesTokenCount: json['candidatesTokenCount'] as int?,
     totalTokenCount: json['totalTokenCount'] as int?,
     cachedContentTokenCount: json['cachedContentTokenCount'] as int?,
+    thoughtsTokenCount: json['thoughtsTokenCount'] as int?,
+    toolUsePromptTokenCount: json['toolUsePromptTokenCount'] as int?,
+    cacheTokensDetails: (json['cacheTokensDetails'] as List?)
+        ?.map((e) => ModalityTokenCount.fromJson(e as Map<String, dynamic>))
+        .toList(),
+    candidatesTokensDetails: (json['candidatesTokensDetails'] as List?)
+        ?.map((e) => ModalityTokenCount.fromJson(e as Map<String, dynamic>))
+        .toList(),
+    promptTokensDetails: (json['promptTokensDetails'] as List?)
+        ?.map((e) => ModalityTokenCount.fromJson(e as Map<String, dynamic>))
+        .toList(),
+    toolUsePromptTokensDetails: (json['toolUsePromptTokensDetails'] as List?)
+        ?.map((e) => ModalityTokenCount.fromJson(e as Map<String, dynamic>))
+        .toList(),
+    serviceTier: json['serviceTier'] != null
+        ? serviceTierFromString(json['serviceTier'] as String?)
+        : null,
   );
 
   /// Converts to JSON.
@@ -38,6 +109,25 @@ class UsageMetadata {
     if (totalTokenCount != null) 'totalTokenCount': totalTokenCount,
     if (cachedContentTokenCount != null)
       'cachedContentTokenCount': cachedContentTokenCount,
+    if (thoughtsTokenCount != null) 'thoughtsTokenCount': thoughtsTokenCount,
+    if (toolUsePromptTokenCount != null)
+      'toolUsePromptTokenCount': toolUsePromptTokenCount,
+    if (cacheTokensDetails != null)
+      'cacheTokensDetails': cacheTokensDetails!.map((e) => e.toJson()).toList(),
+    if (candidatesTokensDetails != null)
+      'candidatesTokensDetails': candidatesTokensDetails!
+          .map((e) => e.toJson())
+          .toList(),
+    if (promptTokensDetails != null)
+      'promptTokensDetails': promptTokensDetails!
+          .map((e) => e.toJson())
+          .toList(),
+    if (toolUsePromptTokensDetails != null)
+      'toolUsePromptTokensDetails': toolUsePromptTokensDetails!
+          .map((e) => e.toJson())
+          .toList(),
+    if (serviceTier != null && serviceTier != ServiceTier.unspecified)
+      'serviceTier': serviceTierToString(serviceTier!),
   };
 
   /// Creates a copy with replaced values.
@@ -46,6 +136,13 @@ class UsageMetadata {
     Object? candidatesTokenCount = unsetCopyWithValue,
     Object? totalTokenCount = unsetCopyWithValue,
     Object? cachedContentTokenCount = unsetCopyWithValue,
+    Object? thoughtsTokenCount = unsetCopyWithValue,
+    Object? toolUsePromptTokenCount = unsetCopyWithValue,
+    Object? cacheTokensDetails = unsetCopyWithValue,
+    Object? candidatesTokensDetails = unsetCopyWithValue,
+    Object? promptTokensDetails = unsetCopyWithValue,
+    Object? toolUsePromptTokensDetails = unsetCopyWithValue,
+    Object? serviceTier = unsetCopyWithValue,
   }) {
     return UsageMetadata(
       promptTokenCount: promptTokenCount == unsetCopyWithValue
@@ -60,6 +157,82 @@ class UsageMetadata {
       cachedContentTokenCount: cachedContentTokenCount == unsetCopyWithValue
           ? this.cachedContentTokenCount
           : cachedContentTokenCount as int?,
+      thoughtsTokenCount: thoughtsTokenCount == unsetCopyWithValue
+          ? this.thoughtsTokenCount
+          : thoughtsTokenCount as int?,
+      toolUsePromptTokenCount: toolUsePromptTokenCount == unsetCopyWithValue
+          ? this.toolUsePromptTokenCount
+          : toolUsePromptTokenCount as int?,
+      cacheTokensDetails: cacheTokensDetails == unsetCopyWithValue
+          ? this.cacheTokensDetails
+          : cacheTokensDetails as List<ModalityTokenCount>?,
+      candidatesTokensDetails: candidatesTokensDetails == unsetCopyWithValue
+          ? this.candidatesTokensDetails
+          : candidatesTokensDetails as List<ModalityTokenCount>?,
+      promptTokensDetails: promptTokensDetails == unsetCopyWithValue
+          ? this.promptTokensDetails
+          : promptTokensDetails as List<ModalityTokenCount>?,
+      toolUsePromptTokensDetails:
+          toolUsePromptTokensDetails == unsetCopyWithValue
+          ? this.toolUsePromptTokensDetails
+          : toolUsePromptTokensDetails as List<ModalityTokenCount>?,
+      serviceTier: serviceTier == unsetCopyWithValue
+          ? this.serviceTier
+          : serviceTier as ServiceTier?,
     );
   }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    const listEq = ListEquality<ModalityTokenCount>();
+    return other is UsageMetadata &&
+        other.promptTokenCount == promptTokenCount &&
+        other.candidatesTokenCount == candidatesTokenCount &&
+        other.totalTokenCount == totalTokenCount &&
+        other.cachedContentTokenCount == cachedContentTokenCount &&
+        other.thoughtsTokenCount == thoughtsTokenCount &&
+        other.toolUsePromptTokenCount == toolUsePromptTokenCount &&
+        listEq.equals(other.cacheTokensDetails, cacheTokensDetails) &&
+        listEq.equals(other.candidatesTokensDetails, candidatesTokensDetails) &&
+        listEq.equals(other.promptTokensDetails, promptTokensDetails) &&
+        listEq.equals(
+          other.toolUsePromptTokensDetails,
+          toolUsePromptTokensDetails,
+        ) &&
+        other.serviceTier == serviceTier;
+  }
+
+  @override
+  int get hashCode {
+    const listEq = ListEquality<ModalityTokenCount>();
+    return Object.hash(
+      promptTokenCount,
+      candidatesTokenCount,
+      totalTokenCount,
+      cachedContentTokenCount,
+      thoughtsTokenCount,
+      toolUsePromptTokenCount,
+      listEq.hash(cacheTokensDetails),
+      listEq.hash(candidatesTokensDetails),
+      listEq.hash(promptTokensDetails),
+      listEq.hash(toolUsePromptTokensDetails),
+      serviceTier,
+    );
+  }
+
+  @override
+  String toString() =>
+      'UsageMetadata('
+      'promptTokenCount: $promptTokenCount, '
+      'candidatesTokenCount: $candidatesTokenCount, '
+      'totalTokenCount: $totalTokenCount, '
+      'cachedContentTokenCount: $cachedContentTokenCount, '
+      'thoughtsTokenCount: $thoughtsTokenCount, '
+      'toolUsePromptTokenCount: $toolUsePromptTokenCount, '
+      'cacheTokensDetails: ${cacheTokensDetails?.length} items, '
+      'candidatesTokensDetails: ${candidatesTokensDetails?.length} items, '
+      'promptTokensDetails: ${promptTokensDetails?.length} items, '
+      'toolUsePromptTokensDetails: ${toolUsePromptTokensDetails?.length} items, '
+      'serviceTier: $serviceTier)';
 }

--- a/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_io.dart
+++ b/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_io.dart
@@ -476,6 +476,34 @@ class FileSearchStoresResource extends ResourceBase {
     await interceptorChain.execute(httpRequest);
   }
 
+  /// Downloads the raw media bytes for a chunk in a file search store.
+  ///
+  /// The [fileSearchStoreName] is the resource name of the store
+  /// (e.g., `fileSearchStores/my-store-123`). [mediaId] identifies the media
+  /// within that store.
+  ///
+  /// Returns the raw byte payload.
+  ///
+  /// GET /v1beta/{fileSearchStoreName}/media/{mediaId}
+  Future<List<int>> downloadMedia({
+    required String fileSearchStoreName,
+    required String mediaId,
+  }) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl(
+      '/{version}/$fileSearchStoreName/media/$mediaId',
+    );
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('GET', url)..headers.addAll(headers);
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    return response.bodyBytes;
+  }
+
   /// Maps HTTP errors for streaming (mirrors ErrorInterceptor logic).
   GoogleAIException _mapHttpErrorForStreaming(http.Response response) {
     final statusCode = response.statusCode;

--- a/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_io.dart
+++ b/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_io.dart
@@ -482,9 +482,10 @@ class FileSearchStoresResource extends ResourceBase {
   /// (e.g., `fileSearchStores/my-store-123`). [mediaId] identifies the media
   /// within that store.
   ///
-  /// Returns the raw byte payload.
+  /// Returns the raw byte payload. The request sends `alt=media` so the
+  /// server returns the media bytes directly rather than a JSON envelope.
   ///
-  /// GET /v1beta/{fileSearchStoreName}/media/{mediaId}
+  /// GET /v1beta/{fileSearchStoreName}/media/{mediaId}?alt=media
   Future<List<int>> downloadMedia({
     required String fileSearchStoreName,
     required String mediaId,
@@ -493,6 +494,7 @@ class FileSearchStoresResource extends ResourceBase {
 
     final url = requestBuilder.buildUrl(
       '/{version}/$fileSearchStoreName/media/$mediaId',
+      queryParams: const {'alt': 'media'},
     );
 
     final headers = requestBuilder.buildHeaders();

--- a/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_stub.dart
+++ b/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_stub.dart
@@ -288,9 +288,10 @@ class FileSearchStoresResource extends ResourceBase {
   /// (e.g., `fileSearchStores/my-store-123`). [mediaId] identifies the media
   /// within that store.
   ///
-  /// Returns the raw byte payload.
+  /// Returns the raw byte payload. The request sends `alt=media` so the
+  /// server returns the media bytes directly rather than a JSON envelope.
   ///
-  /// GET /v1beta/{fileSearchStoreName}/media/{mediaId}
+  /// GET /v1beta/{fileSearchStoreName}/media/{mediaId}?alt=media
   Future<List<int>> downloadMedia({
     required String fileSearchStoreName,
     required String mediaId,
@@ -299,6 +300,7 @@ class FileSearchStoresResource extends ResourceBase {
 
     final url = requestBuilder.buildUrl(
       '/{version}/$fileSearchStoreName/media/$mediaId',
+      queryParams: const {'alt': 'media'},
     );
 
     final headers = requestBuilder.buildHeaders();

--- a/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_stub.dart
+++ b/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_stub.dart
@@ -281,4 +281,32 @@ class FileSearchStoresResource extends ResourceBase {
 
     await interceptorChain.execute(httpRequest);
   }
+
+  /// Downloads the raw media bytes for a chunk in a file search store.
+  ///
+  /// The [fileSearchStoreName] is the resource name of the store
+  /// (e.g., `fileSearchStores/my-store-123`). [mediaId] identifies the media
+  /// within that store.
+  ///
+  /// Returns the raw byte payload.
+  ///
+  /// GET /v1beta/{fileSearchStoreName}/media/{mediaId}
+  Future<List<int>> downloadMedia({
+    required String fileSearchStoreName,
+    required String mediaId,
+  }) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl(
+      '/{version}/$fileSearchStoreName/media/$mediaId',
+    );
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('GET', url)..headers.addAll(headers);
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    return response.bodyBytes;
+  }
 }

--- a/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_web.dart
+++ b/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_web.dart
@@ -416,6 +416,34 @@ class FileSearchStoresResource extends ResourceBase {
     await interceptorChain.execute(httpRequest);
   }
 
+  /// Downloads the raw media bytes for a chunk in a file search store.
+  ///
+  /// The [fileSearchStoreName] is the resource name of the store
+  /// (e.g., `fileSearchStores/my-store-123`). [mediaId] identifies the media
+  /// within that store.
+  ///
+  /// Returns the raw byte payload.
+  ///
+  /// GET /v1beta/{fileSearchStoreName}/media/{mediaId}
+  Future<List<int>> downloadMedia({
+    required String fileSearchStoreName,
+    required String mediaId,
+  }) async {
+    _validateGoogleAIOnly();
+
+    final url = requestBuilder.buildUrl(
+      '/{version}/$fileSearchStoreName/media/$mediaId',
+    );
+
+    final headers = requestBuilder.buildHeaders();
+
+    final httpRequest = http.Request('GET', url)..headers.addAll(headers);
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    return response.bodyBytes;
+  }
+
   /// Maps HTTP errors for streaming (mirrors ErrorInterceptor logic).
   GoogleAIException _mapHttpErrorForStreaming(http.Response response) {
     final statusCode = response.statusCode;

--- a/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_web.dart
+++ b/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_web.dart
@@ -422,9 +422,10 @@ class FileSearchStoresResource extends ResourceBase {
   /// (e.g., `fileSearchStores/my-store-123`). [mediaId] identifies the media
   /// within that store.
   ///
-  /// Returns the raw byte payload.
+  /// Returns the raw byte payload. The request sends `alt=media` so the
+  /// server returns the media bytes directly rather than a JSON envelope.
   ///
-  /// GET /v1beta/{fileSearchStoreName}/media/{mediaId}
+  /// GET /v1beta/{fileSearchStoreName}/media/{mediaId}?alt=media
   Future<List<int>> downloadMedia({
     required String fileSearchStoreName,
     required String mediaId,
@@ -433,6 +434,7 @@ class FileSearchStoresResource extends ResourceBase {
 
     final url = requestBuilder.buildUrl(
       '/{version}/$fileSearchStoreName/media/$mediaId',
+      queryParams: const {'alt': 'media'},
     );
 
     final headers = requestBuilder.buildHeaders();

--- a/packages/googleai_dart/specs/openapi.json
+++ b/packages/googleai_dart/specs/openapi.json
@@ -342,6 +342,45 @@
         },
         "type": "object"
       },
+      "Blobstore2Info": {
+        "description": "Information to read/write to blobstore2.",
+        "properties": {
+          "blobGeneration": {
+            "description": "The blob generation id.",
+            "format": "int64",
+            "type": "string"
+          },
+          "blobId": {
+            "description": "The blob id, e.g., /blobstore/prod/playground/scotty",
+            "type": "string"
+          },
+          "downloadExternalReadToken": {
+            "description": "A serialized External Read Token passed from Bigstore -> Scotty for a GCS\ndownload. This field must never be consumed outside of Bigstore, and is not\napplicable to non-GCS media uploads.",
+            "format": "byte",
+            "type": "string"
+          },
+          "downloadReadHandle": {
+            "description": "Read handle passed from Bigstore -> Scotty for a GCS download.\nThis is a signed, serialized blobstore2.ReadHandle proto which must never\nbe set outside of Bigstore, and is not applicable to non-GCS media\ndownloads.",
+            "format": "byte",
+            "type": "string"
+          },
+          "readToken": {
+            "description": "The blob read token. Needed to read blobs that have not been\nreplicated. Might not be available until the final call.",
+            "type": "string"
+          },
+          "uploadFragmentListCreationInfo": {
+            "description": "A serialized Object Fragment List Creation Info passed from Bigstore ->\nScotty for a GCS upload. This field must never be consumed outside of\nBigstore, and is not applicable to non-GCS media uploads.",
+            "format": "byte",
+            "type": "string"
+          },
+          "uploadMetadataContainer": {
+            "description": "Metadata passed from Blobstore -> Scotty for a new GCS upload.\nThis is a signed, serialized blobstore2.BlobMetadataContainer proto which\nmust never be consumed outside of Bigstore, and is not applicable to\nnon-GCS media uploads.",
+            "format": "byte",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "CachedContent": {
         "description": "Content that has been preprocessed and can be used in subsequent request\nto GenerativeService.\n\nCached content can be only used with model it was created for.",
         "properties": {
@@ -674,6 +713,88 @@
         ],
         "type": "object"
       },
+      "CompositeMedia": {
+        "description": "A sequence of media data references representing composite data.\nIntroduced to support Bigstore composite objects. For details, visit\nhttp://go/bigstore-composites.",
+        "properties": {
+          "blobRef": {
+            "deprecated": true,
+            "description": "Blobstore v1 reference, set if reference_type is BLOBSTORE_REF\nThis should be the byte representation of a blobstore.BlobRef.\nSince Blobstore is deprecating v1, use blobstore2_info instead.\nFor now, any v2 blob will also be represented in this field as\nv1 BlobRef.",
+            "format": "byte",
+            "type": "string"
+          },
+          "blobstore2Info": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Blobstore2Info"
+              }
+            ],
+            "description": "Blobstore v2 info, set if reference_type is BLOBSTORE_REF and it refers\nto a v2 blob."
+          },
+          "cosmoBinaryReference": {
+            "description": "A binary data reference for a media download. Serves as a\ntechnology-agnostic binary reference in some Google infrastructure.\nThis value is a serialized storage_cosmo.BinaryReference proto. Storing\nit as bytes is a hack to get around the fact that the cosmo proto\n(as well as others it includes) doesn't support JavaScript. This\nprevents us from including the actual type of this field.",
+            "format": "byte",
+            "type": "string"
+          },
+          "crc32cHash": {
+            "description": "crc32.c hash for the payload.",
+            "format": "int64",
+            "maximum": 4294967295,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "inline": {
+            "description": "Media data, set if reference_type is INLINE",
+            "format": "byte",
+            "type": "string"
+          },
+          "length": {
+            "description": "Size of the data, in bytes",
+            "format": "int64",
+            "type": "string"
+          },
+          "md5Hash": {
+            "description": "MD5 hash for the payload.",
+            "format": "byte",
+            "type": "string"
+          },
+          "objectId": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ObjectId"
+              }
+            ],
+            "description": "Reference to a TI Blob, set if reference_type is BIGSTORE_REF."
+          },
+          "path": {
+            "description": "Path to the data, set if reference_type is PATH",
+            "type": "string"
+          },
+          "referenceType": {
+            "description": "Describes what the field reference contains.",
+            "enum": [
+              "PATH",
+              "BLOB_REF",
+              "INLINE",
+              "BIGSTORE_REF",
+              "COSMO_BINARY_REFERENCE"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Reference contains a GFS path or a local path.",
+              "Reference points to a blobstore object. This could be either\na v1 blob_ref or a v2 blobstore2_info. Clients should check\nblobstore2_info first, since v1 is being deprecated.",
+              "Data is included into this proto buffer",
+              "Reference points to a bigstore object",
+              "Indicates the data is stored in cosmo_binary_reference."
+            ]
+          },
+          "sha1Hash": {
+            "description": "SHA-1 hash for the payload.",
+            "format": "byte",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "ComputerUse": {
         "description": "Computer Use tool type.",
         "properties": {
@@ -805,6 +926,41 @@
               "Content was blocked by safety settings.",
               "Content was blocked, but the reason is uncategorized."
             ]
+          }
+        },
+        "type": "object"
+      },
+      "ContentTypeInfo": {
+        "description": "Detailed Content-Type information from Scotty. The Content-Type of the media\nwill typically be filled in by the header or Scotty's best_guess, but this\nextended information provides the backend with more information so that it\ncan make a better decision if needed. This is only used on media upload\nrequests from Scotty.",
+        "properties": {
+          "bestGuess": {
+            "description": "Scotty's best guess of what the content type of the file is.",
+            "type": "string"
+          },
+          "fromBytes": {
+            "description": "The content type of the file derived by looking at specific\nbytes (i.e. \"magic bytes\") of the actual file.",
+            "type": "string"
+          },
+          "fromFileName": {
+            "description": "The content type of the file derived from the file extension of\nthe original file name used by the client.",
+            "type": "string"
+          },
+          "fromFusionId": {
+            "description": "The content type of the file detected by Fusion ID. go/fusionid",
+            "type": "string"
+          },
+          "fromHeader": {
+            "description": "The content type of the file as specified in the request headers,\nmultipart headers, or RUPIO start request.",
+            "type": "string"
+          },
+          "fromUrlPath": {
+            "description": "The content type of the file derived from the file extension of the\nURL path.  The URL path is assumed to represent a file name (which\nis typically only true for agents that are providing a REST API).",
+            "type": "string"
+          },
+          "fusionIdDetectionMetadata": {
+            "description": "Metadata information from Fusion ID detection. Serialized\nFusionIdDetectionMetadata proto. Only set if from_fusion_id is set.",
+            "format": "byte",
+            "type": "string"
           }
         },
         "type": "object"
@@ -1106,6 +1262,115 @@
         },
         "type": "object"
       },
+      "DiffChecksumsResponse": {
+        "description": "Backend response for a Diff get checksums response.\nFor details on the Scotty Diff protocol,\nvisit http://go/scotty-diff-protocol.",
+        "properties": {
+          "checksumsLocation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CompositeMedia"
+              }
+            ],
+            "description": "Exactly one of these fields must be populated.\n\nIf checksums_location is filled, the server will return the corresponding\ncontents to the user.  If object_location is filled, the server will\ncalculate the checksums based on the content there and return that to the\nuser.\nFor details on the format of the checksums,\nsee http://go/scotty-diff-protocol."
+          },
+          "chunkSizeBytes": {
+            "description": "The chunk size of checksums.  Must be a multiple of 256KB.",
+            "format": "int64",
+            "type": "string"
+          },
+          "objectLocation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CompositeMedia"
+              }
+            ],
+            "description": "If set, calculate the checksums based on the contents and return them to\nthe caller."
+          },
+          "objectSizeBytes": {
+            "description": "The total size of the server object.",
+            "format": "int64",
+            "type": "string"
+          },
+          "objectVersion": {
+            "description": "The object version of the object the checksums are being returned for.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "DiffDownloadResponse": {
+        "description": "Backend response for a Diff download response.\nFor details on the Scotty Diff protocol,\nvisit http://go/scotty-diff-protocol.",
+        "properties": {
+          "objectLocation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CompositeMedia"
+              }
+            ],
+            "description": "The original object location."
+          }
+        },
+        "type": "object"
+      },
+      "DiffUploadRequest": {
+        "description": "A Diff upload request.\nFor details on the Scotty Diff protocol,\nvisit http://go/scotty-diff-protocol.",
+        "properties": {
+          "checksumsInfo": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CompositeMedia"
+              }
+            ],
+            "description": "The location of the checksums for the new object.\nAgents must clone the object located here, as the upload server will\ndelete the contents once a response is received.\nFor details on the format of the checksums,\nsee http://go/scotty-diff-protocol."
+          },
+          "objectInfo": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CompositeMedia"
+              }
+            ],
+            "description": "The location of the new object.\nAgents must clone the object located here, as the upload server will\ndelete the contents once a response is received."
+          },
+          "objectVersion": {
+            "description": "The object version of the object that is the base version the incoming\ndiff script will be applied to.\nThis field will always be filled in.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "DiffUploadResponse": {
+        "description": "Backend response for a Diff upload request.\nFor details on the Scotty Diff protocol,\nvisit http://go/scotty-diff-protocol.",
+        "properties": {
+          "objectVersion": {
+            "description": "The object version of the object at the server. Must be included in the\nend notification response.\nThe version in the end notification response must correspond to the new\nversion of the object that is now stored at the server, after the upload.",
+            "type": "string"
+          },
+          "originalObject": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/CompositeMedia"
+              }
+            ],
+            "description": "The location of the original file for a diff upload request. Must be\nfilled in if responding to an upload start notification."
+          }
+        },
+        "type": "object"
+      },
+      "DiffVersionResponse": {
+        "description": "Backend response for a Diff get version response.\nFor details on the Scotty Diff protocol,\nvisit http://go/scotty-diff-protocol.",
+        "properties": {
+          "objectSizeBytes": {
+            "description": "The total size of the server object.",
+            "format": "int64",
+            "type": "string"
+          },
+          "objectVersion": {
+            "description": "The version of the object stored at the server.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "Document": {
         "description": "A `Document` is a collection of `Chunk`s.",
         "properties": {
@@ -1171,6 +1436,35 @@
       },
       "DownloadFileResponse": {
         "description": "Response for `DownloadFile`.",
+        "type": "object"
+      },
+      "DownloadMediaResponse": {
+        "description": "Response for DownloadMedia.",
+        "properties": {
+          "blob": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/GdataMedia"
+              }
+            ],
+            "description": "Output only. The blob data.",
+            "readOnly": true
+          }
+        },
+        "type": "object"
+      },
+      "DownloadParameters": {
+        "description": "Parameters specific to media downloads.",
+        "properties": {
+          "allowGzipCompression": {
+            "description": "A boolean to be returned in the response to Scotty. Allows/disallows gzip\nencoding of the payload content when the server thinks it's\nadvantageous (hence, does not guarantee compression) which allows\nScotty to GZip the response to the client.",
+            "type": "boolean"
+          },
+          "ignoreRange": {
+            "description": "Determining whether or not Apiary should skip the inclusion\nof any Content-Range header on its response to Scotty.",
+            "type": "boolean"
+          }
+        },
         "type": "object"
       },
       "DynamicRetrievalConfig": {
@@ -1737,6 +2031,10 @@
             "description": "Optional. The human-readable display name for the `FileSearchStore`. The display name\nmust be no more than 512 characters in length, including spaces. Example:\n\"Docs on Semantic Retriever\"",
             "type": "string"
           },
+          "embeddingModel": {
+            "description": "Optional. The embedding model to use for the `FileSearchStore`.\nThe model's resource name. This serves as an ID for the Model to use.\nFormat: `models/{model}`.\nIf not specified, the default embedding model will be used.",
+            "type": "string"
+          },
           "failedDocumentsCount": {
             "description": "Output only. The number of documents in the `FileSearchStore` that have failed\nprocessing.",
             "format": "int64",
@@ -1957,6 +2255,218 @@
               }
             ],
             "description": "Inline media bytes."
+          }
+        },
+        "type": "object"
+      },
+      "GdataMedia": {
+        "description": "A reference to data stored on the filesystem, on GFS or in blobstore.",
+        "properties": {
+          "algorithm": {
+            "deprecated": true,
+            "description": "Deprecated, use one of explicit hash type fields instead.\nAlgorithm used for calculating the hash.\nAs of 2011/01/21, \"MD5\" is the only possible value for this field.\nNew values may be added at any time.",
+            "type": "string"
+          },
+          "bigstoreObjectRef": {
+            "deprecated": true,
+            "description": "Use object_id instead.",
+            "format": "byte",
+            "type": "string"
+          },
+          "blobRef": {
+            "deprecated": true,
+            "description": "Blobstore v1 reference, set if reference_type is BLOBSTORE_REF\nThis should be the byte representation of a blobstore.BlobRef.\nSince Blobstore is deprecating v1, use blobstore2_info instead.\nFor now, any v2 blob will also be represented in this field as\nv1 BlobRef.",
+            "format": "byte",
+            "type": "string"
+          },
+          "blobstore2Info": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Blobstore2Info"
+              }
+            ],
+            "description": "Blobstore v2 info, set if reference_type is BLOBSTORE_REF and it refers\nto a v2 blob."
+          },
+          "compositeMedia": {
+            "description": "A composite media composed of one or more media objects, set if\nreference_type is COMPOSITE_MEDIA. The media length field must be set\nto the sum of the lengths of all composite media objects.\n\nNote: All composite media must have length specified.",
+            "items": {
+              "$ref": "#/components/schemas/CompositeMedia"
+            },
+            "type": "array"
+          },
+          "contentType": {
+            "description": "MIME type of the data",
+            "type": "string"
+          },
+          "contentTypeInfo": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ContentTypeInfo"
+              }
+            ],
+            "description": "Extended content type information provided for Scotty uploads."
+          },
+          "cosmoBinaryReference": {
+            "description": "A binary data reference for a media download. Serves as a\ntechnology-agnostic binary reference in some Google infrastructure.\nThis value is a serialized storage_cosmo.BinaryReference proto. Storing\nit as bytes is a hack to get around the fact that the cosmo proto\n(as well as others it includes) doesn't support JavaScript. This\nprevents us from including the actual type of this field.",
+            "format": "byte",
+            "type": "string"
+          },
+          "crc32cHash": {
+            "description": "For Scotty Uploads:\nScotty-provided hashes for uploads\n\nFor Scotty Downloads:\n(WARNING: DO NOT USE WITHOUT PERMISSION FROM THE SCOTTY TEAM.)\nA Hash provided by the agent to be used to verify the data being\ndownloaded. Currently only supported for inline payloads.\nFurther, only crc32c_hash is currently supported.",
+            "format": "int64",
+            "maximum": 4294967295,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "diffChecksumsResponse": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DiffChecksumsResponse"
+              }
+            ],
+            "description": "Set if reference_type is DIFF_CHECKSUMS_RESPONSE."
+          },
+          "diffDownloadResponse": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DiffDownloadResponse"
+              }
+            ],
+            "description": "Set if reference_type is DIFF_DOWNLOAD_RESPONSE."
+          },
+          "diffUploadRequest": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DiffUploadRequest"
+              }
+            ],
+            "description": "Set if reference_type is DIFF_UPLOAD_REQUEST."
+          },
+          "diffUploadResponse": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DiffUploadResponse"
+              }
+            ],
+            "description": "Set if reference_type is DIFF_UPLOAD_RESPONSE."
+          },
+          "diffVersionResponse": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DiffVersionResponse"
+              }
+            ],
+            "description": "Set if reference_type is DIFF_VERSION_RESPONSE."
+          },
+          "downloadParameters": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/DownloadParameters"
+              }
+            ],
+            "description": "Parameters for a media download."
+          },
+          "filename": {
+            "description": "Original file name",
+            "type": "string"
+          },
+          "hash": {
+            "deprecated": true,
+            "description": "Deprecated, use one of explicit hash type fields instead.\nThese two hash related fields will only be populated on Scotty based media\nuploads and will contain the content of the hash group in the\nNotificationRequest:\nhttp://cs/#google3/blobstore2/api/scotty/service/proto/upload_listener.proto&q=class:Hash\nHex encoded hash value of the uploaded media.",
+            "type": "string"
+          },
+          "hashVerified": {
+            "description": "For Scotty uploads only. If a user sends a hash code and the backend has\nrequested that Scotty verify the upload against the client hash,\nScotty will perform the check on behalf of the backend and will reject it\nif the hashes don't match. This is set to true if Scotty performed\nthis verification.",
+            "type": "boolean"
+          },
+          "inline": {
+            "description": "Media data, set if reference_type is INLINE",
+            "format": "byte",
+            "type": "string"
+          },
+          "isPotentialRetry": {
+            "description": "|is_potential_retry| is set false only when Scotty is\ncertain that it has not sent the request before. When a client resumes\nan upload, this field must be set true in agent calls, because Scotty\ncannot be certain that it has never sent the request before due\nto potential failure in the session state persistence.",
+            "type": "boolean"
+          },
+          "length": {
+            "description": "Size of the data, in bytes",
+            "format": "int64",
+            "type": "string"
+          },
+          "md5Hash": {
+            "description": "Scotty-provided MD5 hash for an upload.",
+            "format": "byte",
+            "type": "string"
+          },
+          "mediaId": {
+            "description": "Media id to forward to the operation GetMedia.\nCan be set if reference_type is GET_MEDIA.",
+            "format": "byte",
+            "type": "string"
+          },
+          "objectId": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ObjectId"
+              }
+            ],
+            "description": "Reference to a TI Blob, set if reference_type is BIGSTORE_REF."
+          },
+          "path": {
+            "description": "Path to the data, set if reference_type is PATH",
+            "type": "string"
+          },
+          "referenceType": {
+            "description": "Describes what the field reference contains.",
+            "enum": [
+              "PATH",
+              "BLOB_REF",
+              "INLINE",
+              "GET_MEDIA",
+              "COMPOSITE_MEDIA",
+              "BIGSTORE_REF",
+              "DIFF_VERSION_RESPONSE",
+              "DIFF_CHECKSUMS_RESPONSE",
+              "DIFF_DOWNLOAD_RESPONSE",
+              "DIFF_UPLOAD_REQUEST",
+              "DIFF_UPLOAD_RESPONSE",
+              "COSMO_BINARY_REFERENCE",
+              "ARBITRARY_BYTES"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Reference contains a GFS path or a local path.",
+              "Reference points to a blobstore object. This could be either\na v1 blob_ref or a v2 blobstore2_info. Clients should check\nblobstore2_info first, since v1 is being deprecated.",
+              "Data is included into this proto buffer",
+              "Data should be accessed from the current service\nusing the operation GetMedia.",
+              "The content for this media object is stored across\nmultiple partial media objects under the\ncomposite_media field.",
+              "Reference points to a bigstore object",
+              "Indicates the data is stored in diff_version_response.",
+              "Indicates the data is stored in diff_checksums_response.",
+              "Indicates the data is stored in diff_download_response.",
+              "Indicates the data is stored in diff_upload_request.",
+              "Indicates the data is stored in diff_upload_response.",
+              "Indicates the data is stored in cosmo_binary_reference.",
+              "Informs Scotty to generate a response payload with the size specified\nin the length field. The contents of the payload are generated by\nScotty and are undefined. This is useful for testing download speeds\nbetween the user and Scotty without involving a real payload source.\n\nNote: range is not supported when using arbitrary_bytes."
+            ]
+          },
+          "sha1Hash": {
+            "description": "Scotty-provided SHA1 hash for an upload.",
+            "format": "byte",
+            "type": "string"
+          },
+          "sha256Hash": {
+            "description": "Scotty-provided SHA256 hash for an upload.",
+            "format": "byte",
+            "type": "string"
+          },
+          "timestamp": {
+            "description": "Time at which the media data was last updated,\nin milliseconds since UNIX epoch",
+            "format": "uint64",
+            "type": "string"
+          },
+          "token": {
+            "description": "A unique fingerprint/version id for the media data",
+            "type": "string"
           }
         },
         "type": "object"
@@ -3912,6 +4422,25 @@
         ],
         "type": "object"
       },
+      "ObjectId": {
+        "description": "This is a copy of the tech.blob.ObjectId proto, which could not\nbe used directly here due to transitive closure issues with\nJavaScript support; see http://b/8801763.",
+        "properties": {
+          "bucketName": {
+            "description": "The name of the bucket to which this object belongs.",
+            "type": "string"
+          },
+          "generation": {
+            "description": "Generation of the object. Generations are monotonically increasing\nacross writes, allowing them to be be compared to determine which\ngeneration is newer. If this is omitted in a request, then you are\nrequesting the live object.\nSee http://go/bigstore-versions",
+            "format": "int64",
+            "type": "string"
+          },
+          "objectName": {
+            "description": "The name of the object.",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "Operation": {
         "allOf": [
           {
@@ -4905,7 +5434,7 @@
             "type": "integer"
           },
           "thinkingLevel": {
-            "description": "Optional. Controls the maximum depth of the model's internal reasoning process before\nit produces a response. If not specified, the default is HIGH. Recommended\nfor Gemini 3 or later models. Use with earlier models results in an error.",
+            "description": "Optional. Controls the maximum depth of the model's internal reasoning process before\nit produces a response. The default value is model-dependent. Refer to the\n[Thinking levels\nguide](https://ai.google.dev/gemini-api/docs/thinking#thinking-levels) for\nmore details. Recommended for Gemini 3 or later models. Use with earlier\nmodels results in an error.",
             "enum": [
               "THINKING_LEVEL_UNSPECIFIED",
               "MINIMAL",
@@ -5520,6 +6049,15 @@
             "readOnly": true,
             "type": "array"
           },
+          "serviceTier": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ServiceTier"
+              }
+            ],
+            "description": "Output only. Service tier of the request.",
+            "readOnly": true
+          },
           "thoughtsTokenCount": {
             "description": "Output only. Number of tokens of thoughts for thinking models.",
             "format": "int32",
@@ -5541,7 +6079,7 @@
             "type": "array"
           },
           "totalTokenCount": {
-            "description": "Total token count for the generation request (prompt + response\ncandidates).",
+            "description": "Total token count for the generation request (prompt + thoughts +\nresponse candidates).",
             "format": "int32",
             "type": "integer"
           }
@@ -5689,7 +6227,7 @@
     "description": "The Gemini API allows developers to build generative AI applications using Gemini models. Gemini is our most capable model, built from the ground up to be multimodal. It can generalize and seamlessly understand, operate across, and combine different types of information including language, images, audio, video, and code. You can use the Gemini API for use cases like reasoning across text and images, content generation, dialogue agents, summarization and classification systems, and more.",
     "title": "Gemini API",
     "version": "v1beta",
-    "x-google-revision": "20260501"
+    "x-google-revision": "20260506"
   },
   "openapi": "3.0.3",
   "paths": {
@@ -7007,6 +7545,62 @@
           "generativelanguage"
         ]
       }
+    },
+    "/v1beta/fileSearchStores/{fileSearchStoresId}/media/{mediaId}": {
+      "get": {
+        "description": "Downloads media from a `FileSearchStore`.",
+        "operationId": "DownloadMedia",
+        "parameters": [
+          {
+            "description": "Part of `name`. Required. The resource name of the media to download.\nExample: `fileSearchStores/abc-123/media/blob123`",
+            "in": "path",
+            "name": "fileSearchStoresId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Part of `name`. See documentation of `fileSearchStoresId`.",
+            "in": "path",
+            "name": "mediaId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadMediaResponse"
+                }
+              }
+            },
+            "description": "Successful operation"
+          }
+        },
+        "security": [],
+        "tags": [
+          "generativelanguage"
+        ]
+      },
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/alt"
+        },
+        {
+          "$ref": "#/components/parameters/callback"
+        },
+        {
+          "$ref": "#/components/parameters/prettyPrint"
+        },
+        {
+          "$ref": "#/components/parameters/_.xgafv"
+        }
+      ]
     },
     "/v1beta/fileSearchStores/{fileSearchStoresId}/upload/operations/{operationsId}": {
       "get": {

--- a/packages/googleai_dart/specs/spec_metadata.json
+++ b/packages/googleai_dart/specs/spec_metadata.json
@@ -2,14 +2,14 @@
   "specs": {
     "interactions": {
       "current_version": "v1beta",
-      "last_fetched": "2026-04-22T18:45:26.530625Z",
+      "last_fetched": "2026-05-06T16:25:43.341974Z",
       "source_url": "https://ai.google.dev/static/api/interactions.openapi.json",
       "title": "Gemini API",
       "version_history": []
     },
     "main": {
       "current_version": "v1beta",
-      "last_fetched": "2026-05-02T07:56:30.790985Z",
+      "last_fetched": "2026-05-06T16:25:42.194568Z",
       "source_url": "https://generativelanguage.googleapis.com/$discovery/OPENAPI3_0?version=v1beta",
       "title": "Gemini API",
       "version_history": []

--- a/packages/googleai_dart/test/unit/models/files/file_search_store_test.dart
+++ b/packages/googleai_dart/test/unit/models/files/file_search_store_test.dart
@@ -14,6 +14,7 @@ void main() {
           'pendingDocumentsCount': '2',
           'failedDocumentsCount': '1',
           'sizeBytes': '1048576',
+          'embeddingModel': 'models/gemini-embedding-2',
         };
 
         final store = FileSearchStore.fromJson(json);
@@ -26,6 +27,7 @@ void main() {
         expect(store.pendingDocumentsCount, '2');
         expect(store.failedDocumentsCount, '1');
         expect(store.sizeBytes, '1048576');
+        expect(store.embeddingModel, 'models/gemini-embedding-2');
       });
 
       test('creates FileSearchStore with minimal fields', () {
@@ -41,6 +43,7 @@ void main() {
         expect(store.pendingDocumentsCount, isNull);
         expect(store.failedDocumentsCount, isNull);
         expect(store.sizeBytes, isNull);
+        expect(store.embeddingModel, isNull);
       });
     });
 
@@ -77,6 +80,18 @@ void main() {
         expect(json['name'], 'fileSearchStores/test-123');
         expect(json.containsKey('displayName'), false);
         expect(json.containsKey('activeDocumentsCount'), false);
+        expect(json.containsKey('embeddingModel'), false);
+      });
+
+      test('emits embeddingModel when set', () {
+        const store = FileSearchStore(
+          name: 'fileSearchStores/multimodal',
+          embeddingModel: 'models/gemini-embedding-2',
+        );
+
+        final json = store.toJson();
+
+        expect(json['embeddingModel'], 'models/gemini-embedding-2');
       });
     });
 
@@ -90,19 +105,13 @@ void main() {
         pendingDocumentsCount: '1',
         failedDocumentsCount: '0',
         sizeBytes: '512000',
+        embeddingModel: 'models/gemini-embedding-2',
       );
 
       final json = original.toJson();
       final restored = FileSearchStore.fromJson(json);
 
-      expect(restored.name, original.name);
-      expect(restored.displayName, original.displayName);
-      expect(restored.createTime, original.createTime);
-      expect(restored.updateTime, original.updateTime);
-      expect(restored.activeDocumentsCount, original.activeDocumentsCount);
-      expect(restored.pendingDocumentsCount, original.pendingDocumentsCount);
-      expect(restored.failedDocumentsCount, original.failedDocumentsCount);
-      expect(restored.sizeBytes, original.sizeBytes);
+      expect(restored, original);
     });
 
     group('copyWith', () {
@@ -127,19 +136,32 @@ void main() {
         const original = FileSearchStore(
           name: 'fileSearchStores/test',
           displayName: 'Test',
+          embeddingModel: 'models/gemini-embedding-2',
         );
 
-        final copy = original.copyWith(displayName: null);
+        final copy = original.copyWith(displayName: null, embeddingModel: null);
 
         expect(copy.name, 'fileSearchStores/test');
         expect(copy.displayName, isNull);
+        expect(copy.embeddingModel, isNull);
+      });
+
+      test('updates embeddingModel', () {
+        const original = FileSearchStore(name: 'fileSearchStores/x');
+
+        final copy = original.copyWith(
+          embeddingModel: 'models/gemini-embedding-2',
+        );
+
+        expect(copy.embeddingModel, 'models/gemini-embedding-2');
       });
     });
 
-    test('toString includes all fields', () {
+    test('toString includes embeddingModel', () {
       const store = FileSearchStore(
         name: 'fileSearchStores/test-456',
         displayName: 'Test Display',
+        embeddingModel: 'models/gemini-embedding-2',
       );
 
       final str = store.toString();
@@ -147,6 +169,38 @@ void main() {
       expect(str, contains('FileSearchStore('));
       expect(str, contains('name: fileSearchStores/test-456'));
       expect(str, contains('displayName: Test Display'));
+      expect(str, contains('embeddingModel: models/gemini-embedding-2'));
+    });
+
+    group('equality', () {
+      test('two instances with the same fields are equal', () {
+        const a = FileSearchStore(
+          name: 'fileSearchStores/eq',
+          displayName: 'Eq',
+          embeddingModel: 'models/gemini-embedding-2',
+        );
+        const b = FileSearchStore(
+          name: 'fileSearchStores/eq',
+          displayName: 'Eq',
+          embeddingModel: 'models/gemini-embedding-2',
+        );
+
+        expect(a, b);
+        expect(a.hashCode, b.hashCode);
+      });
+
+      test('differing embeddingModel makes instances unequal', () {
+        const a = FileSearchStore(
+          name: 'fileSearchStores/eq',
+          embeddingModel: 'models/gemini-embedding-2',
+        );
+        const b = FileSearchStore(
+          name: 'fileSearchStores/eq',
+          embeddingModel: 'models/text-embedding-004',
+        );
+
+        expect(a, isNot(b));
+      });
     });
   });
 }

--- a/packages/googleai_dart/test/unit/models/metadata/usage_metadata_test.dart
+++ b/packages/googleai_dart/test/unit/models/metadata/usage_metadata_test.dart
@@ -193,6 +193,26 @@ void main() {
       expect(str, contains('serviceTier: ServiceTier.flex'));
     });
 
+    test('toString renders absent lists as "null", not "null items"', () {
+      const usage = UsageMetadata(promptTokenCount: 1);
+
+      final str = usage.toString();
+
+      expect(str, contains('cacheTokensDetails: null'));
+      expect(str, isNot(contains('cacheTokensDetails: null items')));
+      expect(str, contains('candidatesTokensDetails: null'));
+      expect(str, contains('promptTokensDetails: null'));
+      expect(str, contains('toolUsePromptTokensDetails: null'));
+    });
+
+    test('toString renders empty lists as "0 items"', () {
+      const usage = UsageMetadata(cacheTokensDetails: []);
+
+      final str = usage.toString();
+
+      expect(str, contains('cacheTokensDetails: 0 items'));
+    });
+
     group('equality', () {
       test('instances with identical lists are equal', () {
         const a = UsageMetadata(

--- a/packages/googleai_dart/test/unit/models/metadata/usage_metadata_test.dart
+++ b/packages/googleai_dart/test/unit/models/metadata/usage_metadata_test.dart
@@ -1,0 +1,238 @@
+import 'package:googleai_dart/src/models/common/service_tier.dart';
+import 'package:googleai_dart/src/models/metadata/modality_token_count.dart';
+import 'package:googleai_dart/src/models/metadata/usage_metadata.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('UsageMetadata', () {
+    group('fromJson', () {
+      test('parses every spec field', () {
+        final json = {
+          'promptTokenCount': 12,
+          'candidatesTokenCount': 34,
+          'totalTokenCount': 78,
+          'cachedContentTokenCount': 4,
+          'thoughtsTokenCount': 5,
+          'toolUsePromptTokenCount': 6,
+          'cacheTokensDetails': [
+            {'modality': 'TEXT', 'tokenCount': 4},
+          ],
+          'candidatesTokensDetails': [
+            {'modality': 'TEXT', 'tokenCount': 30},
+            {'modality': 'IMAGE', 'tokenCount': 4},
+          ],
+          'promptTokensDetails': [
+            {'modality': 'TEXT', 'tokenCount': 12},
+          ],
+          'toolUsePromptTokensDetails': [
+            {'modality': 'TEXT', 'tokenCount': 6},
+          ],
+          'serviceTier': 'priority',
+        };
+
+        final usage = UsageMetadata.fromJson(json);
+
+        expect(usage.promptTokenCount, 12);
+        expect(usage.candidatesTokenCount, 34);
+        expect(usage.totalTokenCount, 78);
+        expect(usage.cachedContentTokenCount, 4);
+        expect(usage.thoughtsTokenCount, 5);
+        expect(usage.toolUsePromptTokenCount, 6);
+        expect(usage.cacheTokensDetails, hasLength(1));
+        expect(usage.candidatesTokensDetails, hasLength(2));
+        expect(usage.promptTokensDetails, hasLength(1));
+        expect(usage.toolUsePromptTokensDetails, hasLength(1));
+        expect(usage.serviceTier, ServiceTier.priority);
+      });
+
+      test('returns null for absent serviceTier and lists', () {
+        final usage = UsageMetadata.fromJson(const <String, dynamic>{});
+
+        expect(usage.serviceTier, isNull);
+        expect(usage.thoughtsTokenCount, isNull);
+        expect(usage.toolUsePromptTokenCount, isNull);
+        expect(usage.cacheTokensDetails, isNull);
+        expect(usage.candidatesTokensDetails, isNull);
+        expect(usage.promptTokensDetails, isNull);
+        expect(usage.toolUsePromptTokensDetails, isNull);
+      });
+    });
+
+    group('toJson', () {
+      test('omits keys that are null', () {
+        const usage = UsageMetadata(promptTokenCount: 1);
+
+        final json = usage.toJson();
+
+        expect(json['promptTokenCount'], 1);
+        expect(json.containsKey('serviceTier'), false);
+        expect(json.containsKey('thoughtsTokenCount'), false);
+        expect(json.containsKey('cacheTokensDetails'), false);
+      });
+
+      test('omits serviceTier when set to ServiceTier.unspecified', () {
+        const usage = UsageMetadata(serviceTier: ServiceTier.unspecified);
+
+        final json = usage.toJson();
+
+        expect(json.containsKey('serviceTier'), false);
+      });
+
+      test('emits serviceTier when set to a real tier', () {
+        const usage = UsageMetadata(serviceTier: ServiceTier.flex);
+
+        final json = usage.toJson();
+
+        expect(json['serviceTier'], 'flex');
+      });
+
+      test('serializes list fields as JSON arrays', () {
+        const usage = UsageMetadata(
+          cacheTokensDetails: [
+            ModalityTokenCount(modality: 'TEXT', tokenCount: 4),
+          ],
+          candidatesTokensDetails: [
+            ModalityTokenCount(modality: 'TEXT', tokenCount: 30),
+          ],
+        );
+
+        final json = usage.toJson();
+
+        expect(json['cacheTokensDetails'], isA<List<dynamic>>());
+        expect((json['cacheTokensDetails'] as List).first, {
+          'modality': 'TEXT',
+          'tokenCount': 4,
+        });
+        expect(json['candidatesTokensDetails'], isA<List<dynamic>>());
+      });
+    });
+
+    test('round-trip preserves equality across all fields', () {
+      const original = UsageMetadata(
+        promptTokenCount: 12,
+        candidatesTokenCount: 34,
+        totalTokenCount: 78,
+        cachedContentTokenCount: 4,
+        thoughtsTokenCount: 5,
+        toolUsePromptTokenCount: 6,
+        cacheTokensDetails: [
+          ModalityTokenCount(modality: 'TEXT', tokenCount: 4),
+        ],
+        candidatesTokensDetails: [
+          ModalityTokenCount(modality: 'TEXT', tokenCount: 30),
+          ModalityTokenCount(modality: 'IMAGE', tokenCount: 4),
+        ],
+        promptTokensDetails: [
+          ModalityTokenCount(modality: 'TEXT', tokenCount: 12),
+        ],
+        toolUsePromptTokensDetails: [
+          ModalityTokenCount(modality: 'TEXT', tokenCount: 6),
+        ],
+        serviceTier: ServiceTier.priority,
+      );
+
+      final restored = UsageMetadata.fromJson(original.toJson());
+
+      expect(restored, original);
+      expect(restored.hashCode, original.hashCode);
+    });
+
+    group('copyWith', () {
+      test('updates a scalar field', () {
+        const original = UsageMetadata(promptTokenCount: 1);
+
+        final copy = original.copyWith(promptTokenCount: 99);
+
+        expect(copy.promptTokenCount, 99);
+      });
+
+      test('clears a nullable scalar back to null', () {
+        const original = UsageMetadata(thoughtsTokenCount: 5);
+
+        final copy = original.copyWith(thoughtsTokenCount: null);
+
+        expect(copy.thoughtsTokenCount, isNull);
+      });
+
+      test('clears a nullable list back to null', () {
+        const original = UsageMetadata(
+          cacheTokensDetails: [
+            ModalityTokenCount(modality: 'TEXT', tokenCount: 1),
+          ],
+        );
+
+        final copy = original.copyWith(cacheTokensDetails: null);
+
+        expect(copy.cacheTokensDetails, isNull);
+      });
+
+      test('updates serviceTier', () {
+        const original = UsageMetadata();
+
+        final copy = original.copyWith(serviceTier: ServiceTier.standard);
+
+        expect(copy.serviceTier, ServiceTier.standard);
+      });
+    });
+
+    test('toString summarizes list lengths', () {
+      const usage = UsageMetadata(
+        promptTokenCount: 1,
+        cacheTokensDetails: [
+          ModalityTokenCount(modality: 'TEXT', tokenCount: 1),
+          ModalityTokenCount(modality: 'IMAGE', tokenCount: 2),
+        ],
+        serviceTier: ServiceTier.flex,
+      );
+
+      final str = usage.toString();
+
+      expect(str, contains('UsageMetadata('));
+      expect(str, contains('promptTokenCount: 1'));
+      expect(str, contains('cacheTokensDetails: 2 items'));
+      expect(str, contains('serviceTier: ServiceTier.flex'));
+    });
+
+    group('equality', () {
+      test('instances with identical lists are equal', () {
+        const a = UsageMetadata(
+          promptTokenCount: 5,
+          cacheTokensDetails: [
+            ModalityTokenCount(modality: 'TEXT', tokenCount: 4),
+          ],
+        );
+        const b = UsageMetadata(
+          promptTokenCount: 5,
+          cacheTokensDetails: [
+            ModalityTokenCount(modality: 'TEXT', tokenCount: 4),
+          ],
+        );
+
+        expect(a, b);
+        expect(a.hashCode, b.hashCode);
+      });
+
+      test('instances with different list contents are not equal', () {
+        const a = UsageMetadata(
+          cacheTokensDetails: [
+            ModalityTokenCount(modality: 'TEXT', tokenCount: 4),
+          ],
+        );
+        const b = UsageMetadata(
+          cacheTokensDetails: [
+            ModalityTokenCount(modality: 'TEXT', tokenCount: 5),
+          ],
+        );
+
+        expect(a, isNot(b));
+      });
+
+      test('instances with different serviceTier are not equal', () {
+        const a = UsageMetadata(serviceTier: ServiceTier.standard);
+        const b = UsageMetadata(serviceTier: ServiceTier.priority);
+
+        expect(a, isNot(b));
+      });
+    });
+  });
+}

--- a/packages/googleai_dart/test/unit/resources/file_search_stores/file_search_stores_resource_test.dart
+++ b/packages/googleai_dart/test/unit/resources/file_search_stores/file_search_stores_resource_test.dart
@@ -80,6 +80,9 @@ void main() {
           req.url.path,
           '/v1beta/fileSearchStores/my-store-123/media/media-abc-456',
         );
+        // alt=media is required so the server returns raw bytes rather than
+        // a JSON DownloadMediaResponse envelope.
+        expect(req.url.queryParameters['alt'], 'media');
       },
     );
 

--- a/packages/googleai_dart/test/unit/resources/file_search_stores/file_search_stores_resource_test.dart
+++ b/packages/googleai_dart/test/unit/resources/file_search_stores/file_search_stores_resource_test.dart
@@ -1,0 +1,111 @@
+import 'dart:async';
+
+import 'package:googleai_dart/src/auth/auth_provider.dart';
+import 'package:googleai_dart/src/client/config.dart';
+import 'package:googleai_dart/src/client/interceptor_chain.dart';
+import 'package:googleai_dart/src/client/request_builder.dart';
+import 'package:googleai_dart/src/resources/file_search_stores/file_search_stores_resource.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class _MockHttpClient extends Mock implements http.Client {}
+
+http.StreamedResponse _bytesResponse(List<int> bytes, {int status = 200}) {
+  return http.StreamedResponse(
+    Stream.value(bytes),
+    status,
+    headers: {
+      'content-type': 'application/octet-stream',
+      'content-length': '${bytes.length}',
+    },
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      http.Request('GET', Uri.parse('https://example.com')),
+    );
+  });
+
+  group('FileSearchStoresResource.downloadMedia', () {
+    late _MockHttpClient mockHttpClient;
+    late FileSearchStoresResource resource;
+    final capturedRequests = <http.BaseRequest>[];
+
+    setUp(() {
+      mockHttpClient = _MockHttpClient();
+      capturedRequests.clear();
+
+      const config = GoogleAIConfig(
+        baseUrl: 'https://generativelanguage.googleapis.com',
+        authProvider: ApiKeyProvider('test-key'),
+      );
+      resource = FileSearchStoresResource(
+        config: config,
+        httpClient: mockHttpClient,
+        interceptorChain: InterceptorChain(
+          interceptors: const [],
+          httpClient: mockHttpClient,
+        ),
+        requestBuilder: const RequestBuilder(config: config),
+      );
+    });
+
+    test(
+      'issues GET to /v1beta/{store}/media/{mediaId} and returns bytes',
+      () async {
+        final payload = List<int>.generate(64, (i) => i % 256);
+
+        when(() => mockHttpClient.send(any())).thenAnswer((invocation) async {
+          capturedRequests.add(
+            invocation.positionalArguments.first as http.BaseRequest,
+          );
+          return _bytesResponse(payload);
+        });
+
+        final bytes = await resource.downloadMedia(
+          fileSearchStoreName: 'fileSearchStores/my-store-123',
+          mediaId: 'media-abc-456',
+        );
+
+        expect(bytes, equals(payload));
+
+        expect(capturedRequests, hasLength(1));
+        final req = capturedRequests.single;
+        expect(req.method, 'GET');
+        expect(req.url.host, 'generativelanguage.googleapis.com');
+        expect(
+          req.url.path,
+          '/v1beta/fileSearchStores/my-store-123/media/media-abc-456',
+        );
+      },
+    );
+
+    test('throws UnsupportedError when configured for Vertex AI', () async {
+      const config = GoogleAIConfig(
+        baseUrl: 'https://us-central1-aiplatform.googleapis.com',
+        apiMode: ApiMode.vertexAI,
+        authProvider: ApiKeyProvider('test-key'),
+      );
+      final vertexResource = FileSearchStoresResource(
+        config: config,
+        httpClient: mockHttpClient,
+        interceptorChain: InterceptorChain(
+          interceptors: const [],
+          httpClient: mockHttpClient,
+        ),
+        requestBuilder: const RequestBuilder(config: config),
+      );
+
+      await expectLater(
+        vertexResource.downloadMedia(
+          fileSearchStoreName: 'fileSearchStores/x',
+          mediaId: 'm',
+        ),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Update `googleai_dart` to the latest Gemini OpenAPI v1beta spec.
- Enable File Search multimodal RAG: `FileSearchStore` now exposes `embeddingModel`, so callers can opt into `models/gemini-embedding-2`.
- Add `FileSearchStoresResource.downloadMedia({fileSearchStoreName, mediaId})` returning raw bytes for the new `GET /v1beta/{store}/media/{mediaId}` endpoint.
- Add `serviceTier` on `UsageMetadata` and backfill 6 long-missing spec fields (`thoughtsTokenCount`, `toolUsePromptTokenCount`, and the four `*TokensDetails` lists).

## Details

### File Search multimodal RAG (`FileSearchStore.embeddingModel`)

The spec adds an optional `embeddingModel` resource-name field on `FileSearchStore`. Selecting `models/gemini-embedding-2` enables the multimodal RAG capability described in Google's announcement (text + images, custom metadata filters, page-level citations). Existing stores without this field continue to use the default embedding model.

```dart
final store = await client.fileSearchStores.create(displayName: 'Multimodal docs');
final updated = store.copyWith(embeddingModel: 'models/gemini-embedding-2');
```

### `downloadMedia` for chunk-level retrieval

The new `GET /v1beta/{store}/media/{mediaId}` endpoint is exposed as a raw-bytes Dart method modelled on the existing `files.download()`:

```dart
final bytes = await client.fileSearchStores.downloadMedia(
  fileSearchStoreName: 'fileSearchStores/my-store-id',
  mediaId: 'media-abc-123',
);
```

The wire response wraps the bytes in a deeply-nested `DownloadMediaResponse` → `GdataMedia` envelope of internal Google Scotty/Bigstore protocol types (`Blobstore2Info`, `CompositeMedia`, `ContentTypeInfo`, the `Diff*` family, `DownloadParameters`, `ObjectId`). Neither `python-genai` nor `js-genai` expose those, and they would force consumers to navigate Google-internal protocol enums (`PATH`, `BLOB_REF`, `INLINE`, `BIGSTORE_REF`, `COSMO_BINARY_REFERENCE`, etc.). They are registered as `kind: "skip"` with `tags: ["acknowledged"]` in the manifest, with notes pointing back to `downloadMedia()`.

### `UsageMetadata` brought into spec parity

The strict spec diff is `serviceTier`. While in the file, the 6 long-missing spec fields were backfilled so consumers stop silently dropping data:

| Field | Type |
| --- | --- |
| `serviceTier` | `ServiceTier?` |
| `thoughtsTokenCount` | `int?` |
| `toolUsePromptTokenCount` | `int?` |
| `cacheTokensDetails` | `List<ModalityTokenCount>?` |
| `candidatesTokensDetails` | `List<ModalityTokenCount>?` |
| `promptTokensDetails` | `List<ModalityTokenCount>?` |
| `toolUsePromptTokensDetails` | `List<ModalityTokenCount>?` |

`serviceTier` is omitted from `toJson` when `null` or `ServiceTier.unspecified` to mirror the existing pattern in `interactions/interaction.dart`.

### Equality contract

`FileSearchStore`, `UsageMetadata`, and `ModalityTokenCount` previously had no `==` / `hashCode`. Adding fields without those would have left a known checklist gap, and `==` on `UsageMetadata` containers would have failed list-element equality without `ModalityTokenCount` getting the same treatment. All three are now `@immutable` with proper `==` / `hashCode` (using `package:collection`'s `ListEquality` for the four list fields on `UsageMetadata`).

### Webhooks deferral

The user-flagged webhooks announcement (`/v1/webhooks/*`) is **not** in any published OpenAPI spec — verified across v1beta (our `main`), v1, v1alpha, the static interactions URL, and the static `webhooks.openapi.json` URL (404). `python-genai` hand-codes the surface in `_interactions/resources/webhooks.py`. Deferred until Google publishes a spec we already fetch.

### Toolkit verification

Both specs pass `review` with 0 missing entries and 0 changed types. `verify --checks all --scope all` reports 0 errors in any file this PR touches. The 4 pre-existing implementation errors on `EmbedContentRequest.model` already existed on `main` and are out of scope.

## References

- [Expanded Gemini API File Search and multimodal RAG](https://blog.google/innovation-and-ai/technology/developers-tools/expanded-gemini-api-file-search-multimodal-rag/) — announcement that motivates `embeddingModel`.
- [Gemini API webhooks documentation](https://ai.google.dev/gemini-api/docs/webhooks) — reviewed; deferred (not yet in any OpenAPI spec).

## Test Plan

- [x] `dart format --show=none --summary=line .` — clean
- [x] `dart fix --apply` — nothing to fix
- [x] `dart analyze --fatal-infos .` — clean
- [x] `dart test --reporter=failures-only test/unit/` — 1445 passed, 7 skipped (env-bound)
- [x] `api_toolkit.py review --spec-name main` and `--spec-name interactions` — 0 errors, 0 missing entries
- [x] `api_toolkit.py verify --spec-name main --checks all --scope all` — 0 new errors in touched files
- [x] `api_toolkit.py verify --spec-name interactions --checks all --scope all` — 0 errors
- [x] `FileSearchStore.embeddingModel` round-trip, `copyWith`, `toString`, `==`/`hashCode` covered
- [x] `UsageMetadata` round-trip, `serviceTier` omit-on-`unspecified`, `copyWith` clear, list equality covered
- [x] `downloadMedia` request URL/method/auth headers and response bytes covered
- [ ] Manual smoke test of `downloadMedia` against a live API key (requires maintainer)