### PR TITLE
feat(openai_dart)!: migrate Realtime API to GA shape

### DIFF
--- a/packages/openai_dart/.agents/skills/openapi-openai/config/specs.json
+++ b/packages/openai_dart/.agents/skills/openapi-openai/config/specs.json
@@ -28,7 +28,7 @@
       "local_file": "openapi.json",
       "name": "OpenAI API",
       "requires_auth": false,
-      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai%2Fopenai-64c6ba619ccbf87e56b4f464230d04401fd78ad924d2606176309d19ca281af5.yml"
+      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-371f497afe4d6070f6e252e5febbe8f453c7058a8dff0c26a01b4d88442a4ac2.yml"
     }
   },
   "specs_dir": "packages/openai_dart/specs"

--- a/packages/openai_dart/README.md
+++ b/packages/openai_dart/README.md
@@ -447,9 +447,12 @@ final client = OpenAIClient.fromEnvironment();
 
 // Connect to a realtime session via WebSocket
 final session = await client.realtime.connect(
-  model: 'gpt-realtime-1.5',
-  config: const realtime.SessionUpdateConfig(
-    voice: realtime.RealtimeVoice.alloy,
+  model: 'gpt-realtime-2',
+  config: const realtime.RealtimeSessionCreateRequest(
+    model: 'gpt-realtime-2',
+    audio: realtime.RealtimeAudioConfig(
+      output: realtime.RealtimeAudioConfigOutput(voice: 'alloy'),
+    ),
     instructions: 'You are a helpful assistant.',
   ),
 );
@@ -498,8 +501,10 @@ final sdpAnswer = await client.realtimeSessions.calls.create(
   realtime.RealtimeCallCreateRequest(
     sdp: offer.sdp!,
     session: const realtime.RealtimeSessionCreateRequest(
-      model: 'gpt-realtime-1.5',
-      voice: realtime.RealtimeVoice.alloy,
+      model: 'gpt-realtime-2',
+      audio: realtime.RealtimeAudioConfig(
+        output: realtime.RealtimeAudioConfigOutput(voice: 'alloy'),
+      ),
     ),
   ),
 );

--- a/packages/openai_dart/README.md
+++ b/packages/openai_dart/README.md
@@ -457,8 +457,9 @@ final session = await client.realtime.connect(
   ),
 );
 
-// Send a request and process events until the response is complete
-session.createResponse();
+// Send a user text message and process events until the response is complete.
+// (Use `session.appendAudioBytes(rawPcmBytes)` to stream raw audio instead.)
+session.sendUserMessage('Say hello and nothing else.');
 
 await for (final event in session.events) {
   switch (event) {
@@ -514,7 +515,18 @@ await pc.setRemoteDescription(RTCSessionDescription(sdpAnswer, 'answer'));
 
 // Call management operations (callId is obtained from your SIP/telephony layer)
 const callId = 'call_xxx';
-await client.realtimeSessions.calls.accept(callId);
+
+// Accept the call (optionally override the session configuration on accept).
+await client.realtimeSessions.calls.accept(
+  callId,
+  request: const realtime.RealtimeSessionCreateRequest(
+    model: 'gpt-realtime-2',
+    audio: realtime.RealtimeAudioConfig(
+      output: realtime.RealtimeAudioConfigOutput(voice: 'alloy'),
+    ),
+    instructions: 'Greet the caller in English.',
+  ),
+);
 await client.realtimeSessions.calls.hangup(callId);
 await client.realtimeSessions.calls.refer(
   callId,

--- a/packages/openai_dart/example/realtime_example.dart
+++ b/packages/openai_dart/example/realtime_example.dart
@@ -52,12 +52,23 @@ Future<void> main() async {
       }
     }
 
-    // --- Ephemeral client secret (for web/frontend clients) ---
+    // --- Ephemeral client secret (for WebRTC / signed URLs) ---
     print('\n=== Ephemeral Client Secret ===\n');
 
-    // On web platforms, browsers cannot set custom headers on WebSocket
-    // connections. Call createClientSecret() to obtain an ephemeral key,
-    // then pass it to your frontend to connect directly.
+    // Generates a short-lived (`ek_…`) credential for use with the
+    // Realtime API. Use cases:
+    //   • WebRTC SDP exchange (`realtimeSessions.calls.create(...)`) —
+    //     the SDK uses the secret server-side; the browser only sees
+    //     the SDP answer.
+    //   • Server-side WebSocket sessions where you'd rather not pass
+    //     the main API key around (the secret has narrower scope and a
+    //     ~10-minute lifetime).
+    //
+    // Note: browser WebSocket connections cannot use this secret as a
+    // bearer token because the WebSocket API doesn't allow custom
+    // Authorization headers. For browser realtime, prefer WebRTC (see
+    // the WebRTC section below) or proxy the WebSocket through a
+    // server.
     final secretResponse = await client.realtimeSessions.createClientSecret(
       const realtime.RealtimeClientSecretCreateRequest(
         session: realtime.RealtimeSessionCreateRequest(
@@ -77,8 +88,6 @@ Future<void> main() async {
     print('Session ID: ${secretResponse.session.id}');
     print('Client secret: ${secretResponse.value}');
     print('Expires at: ${secretResponse.expiresAt}');
-    // Use secretResponse.value as the Bearer token when connecting from a
-    // browser WebSocket client.
 
     // --- WebRTC: Create call with SDP exchange ---
     print('\n=== WebRTC: SDP Exchange ===\n');

--- a/packages/openai_dart/example/realtime_example.dart
+++ b/packages/openai_dart/example/realtime_example.dart
@@ -141,7 +141,7 @@ Future<void> main() async {
     // --- Transcription session ---
     print('\n=== Transcription Session ===\n');
 
-    // Transcription sessions are created via the GA client-secrets endpoint
+    // Transcription sessions are created via the client-secrets endpoint
     // with `type: 'transcription'`.
     final transcriptionSecret = await client.realtimeSessions
         .createClientSecret(

--- a/packages/openai_dart/example/realtime_example.dart
+++ b/packages/openai_dart/example/realtime_example.dart
@@ -31,8 +31,9 @@ Future<void> main() async {
       ),
     );
 
-    // Listen for events using await for to process them until done
-    ws.createResponse();
+    // Send a user text message and process events until the response is
+    // complete. Use `ws.appendAudioBytes(rawPcmBytes)` to stream audio.
+    ws.sendUserMessage('Say hello and nothing else.');
 
     await for (final event in ws.events) {
       switch (event) {
@@ -116,9 +117,20 @@ Future<void> main() async {
     // These operations require a valid call ID from a previous call
     const callId = 'call_example_id';
 
-    // Accept an incoming SIP call
+    // Accept an incoming SIP call (optionally override the session
+    // configuration on accept).
     // await client.realtimeSessions.calls.accept(callId);
-    print('accept(callId) - Accept an incoming call');
+    // await client.realtimeSessions.calls.accept(
+    //   callId,
+    //   request: const realtime.RealtimeSessionCreateRequest(
+    //     model: 'gpt-realtime-2',
+    //     audio: realtime.RealtimeAudioConfig(
+    //       output: realtime.RealtimeAudioConfigOutput(voice: 'alloy'),
+    //     ),
+    //     instructions: 'Greet the caller in English.',
+    //   ),
+    // );
+    print('accept(callId, {request}) - Accept an incoming call');
 
     // Hang up an active call
     // await client.realtimeSessions.calls.hangup(callId);

--- a/packages/openai_dart/example/realtime_example.dart
+++ b/packages/openai_dart/example/realtime_example.dart
@@ -21,9 +21,12 @@ Future<void> main() async {
     // Connect to a realtime session via WebSocket using the main API key.
     // This is suitable for server-side (Dart VM) usage.
     final ws = await client.realtime.connect(
-      model: 'gpt-realtime-1.5',
-      config: const realtime.SessionUpdateConfig(
-        voice: realtime.RealtimeVoice.alloy,
+      model: 'gpt-realtime-2',
+      config: const realtime.RealtimeSessionCreateRequest(
+        model: 'gpt-realtime-2',
+        audio: realtime.RealtimeAudioConfig(
+          output: realtime.RealtimeAudioConfigOutput(voice: 'alloy'),
+        ),
         instructions: 'You are a helpful assistant.',
       ),
     );
@@ -52,24 +55,29 @@ Future<void> main() async {
     print('\n=== Ephemeral Client Secret ===\n');
 
     // On web platforms, browsers cannot set custom headers on WebSocket
-    // connections. Use realtimeSessions.create() to obtain an ephemeral
-    // client secret, then pass it to your frontend to connect directly.
-    final session = await client.realtimeSessions.create(
-      const realtime.RealtimeSessionCreateRequest(
-        model: 'gpt-realtime-1.5',
-        voice: realtime.RealtimeVoice.alloy,
-        instructions: 'You are a helpful assistant.',
-        turnDetection: realtime.TurnDetection(
-          type: realtime.TurnDetectionType.serverVad,
+    // connections. Call createClientSecret() to obtain an ephemeral key,
+    // then pass it to your frontend to connect directly.
+    final secretResponse = await client.realtimeSessions.createClientSecret(
+      const realtime.RealtimeClientSecretCreateRequest(
+        session: realtime.RealtimeSessionCreateRequest(
+          model: 'gpt-realtime-2',
+          audio: realtime.RealtimeAudioConfig(
+            input: realtime.RealtimeAudioConfigInput(
+              turnDetection:
+                  realtime.RealtimeAudioInputTurnDetection.serverVad(),
+            ),
+            output: realtime.RealtimeAudioConfigOutput(voice: 'alloy'),
+          ),
+          instructions: 'You are a helpful assistant.',
         ),
       ),
     );
 
-    print('Session ID: ${session.id}');
-    print('Client secret: ${session.clientSecret?.value}');
-    print('Expires at: ${session.clientSecret?.expiresAt}');
-    // Use session.clientSecret.value as the Bearer token when connecting
-    // from a browser WebSocket client.
+    print('Session ID: ${secretResponse.session.id}');
+    print('Client secret: ${secretResponse.value}');
+    print('Expires at: ${secretResponse.expiresAt}');
+    // Use secretResponse.value as the Bearer token when connecting from a
+    // browser WebSocket client.
 
     // --- WebRTC: Create call with SDP exchange ---
     print('\n=== WebRTC: SDP Exchange ===\n');
@@ -88,8 +96,10 @@ Future<void> main() async {
     //   realtime.RealtimeCallCreateRequest(
     //     sdp: offer.sdp!,
     //     session: realtime.RealtimeSessionCreateRequest(
-    //       model: 'gpt-realtime-1.5',
-    //       voice: realtime.RealtimeVoice.alloy,
+    //       model: 'gpt-realtime-2',
+    //       audio: realtime.RealtimeAudioConfig(
+    //         output: realtime.RealtimeAudioConfigOutput(voice: 'alloy'),
+    //       ),
     //     ),
     //   ),
     // );
@@ -131,20 +141,53 @@ Future<void> main() async {
     // --- Transcription session ---
     print('\n=== Transcription Session ===\n');
 
-    final transcriptionSession = await client.realtimeSessions
-        .createTranscription(
-          const realtime.RealtimeTranscriptionSessionCreateRequest(
-            inputAudioFormat: realtime.RealtimeAudioFormat.pcm16,
-            inputAudioTranscription: realtime.InputAudioTranscription(
-              model: 'whisper-1',
-            ),
-            turnDetection: realtime.TurnDetection(
-              type: realtime.TurnDetectionType.serverVad,
+    // Transcription sessions are created via the GA client-secrets endpoint
+    // with `type: 'transcription'`.
+    final transcriptionSecret = await client.realtimeSessions
+        .createClientSecret(
+          const realtime.RealtimeClientSecretCreateRequest(
+            session: realtime.RealtimeSessionCreateRequest(
+              model: 'gpt-realtime-2',
+              type: 'transcription',
+              audio: realtime.RealtimeAudioConfig(
+                input: realtime.RealtimeAudioConfigInput(
+                  format: realtime.AudioPcm(rate: 24000),
+                  transcription: realtime.InputAudioTranscription(
+                    model: 'gpt-realtime-whisper',
+                    delay: realtime.AudioTranscriptionDelay.high,
+                  ),
+                ),
+              ),
             ),
           ),
         );
 
-    print('Client secret: ${transcriptionSession.clientSecret.value}');
+    print('Transcription session ID: ${transcriptionSecret.session.id}');
+
+    // --- Translation session (new in v6) ---
+    print('\n=== Translation Session ===\n');
+
+    final translationSecret = await client.realtimeSessions.translations
+        .createClientSecret(
+          const realtime.RealtimeTranslationClientSecretCreateRequest(
+            session: realtime.RealtimeTranslationSessionCreateRequest(
+              model: 'gpt-realtime-translate',
+              audio: realtime.RealtimeTranslationSessionAudio(
+                input: realtime.RealtimeTranslationSessionAudioInput(
+                  transcription: realtime.RealtimeTranslationInputTranscription(
+                    model: 'gpt-realtime-whisper',
+                  ),
+                ),
+                output: realtime.RealtimeTranslationSessionAudioOutput(
+                  language: 'es',
+                ),
+              ),
+            ),
+          ),
+        );
+
+    print('Translation secret: ${translationSecret.value}');
+    print('Translation session: ${translationSecret.session.id}');
 
     print('\nDone!');
   } on OpenAIException catch (e) {

--- a/packages/openai_dart/example/realtime_example.dart
+++ b/packages/openai_dart/example/realtime_example.dart
@@ -153,15 +153,15 @@ Future<void> main() async {
     // --- Transcription session ---
     print('\n=== Transcription Session ===\n');
 
-    // Transcription sessions are created via the client-secrets endpoint
-    // with `type: 'transcription'`.
+    // Transcription sessions use the dedicated
+    // `createTranscriptionClientSecret(...)` helper, which posts to the
+    // shared `/realtime/client_secrets` endpoint with the transcription
+    // session shape (no top-level `model`).
     final transcriptionSecret = await client.realtimeSessions
-        .createClientSecret(
-          const realtime.RealtimeClientSecretCreateRequest(
-            session: realtime.RealtimeSessionCreateRequest(
-              model: 'gpt-realtime-2',
-              type: 'transcription',
-              audio: realtime.RealtimeAudioConfig(
+        .createTranscriptionClientSecret(
+          const realtime.RealtimeTranscriptionClientSecretCreateRequest(
+            session: realtime.RealtimeTranscriptionSessionCreateRequest(
+              audio: realtime.RealtimeTranscriptionSessionAudio(
                 input: realtime.RealtimeAudioConfigInput(
                   format: realtime.AudioPcm(rate: 24000),
                   transcription: realtime.InputAudioTranscription(

--- a/packages/openai_dart/lib/src/client/openai_client.dart
+++ b/packages/openai_dart/lib/src/client/openai_client.dart
@@ -630,7 +630,7 @@ class OpenAIClient {
   ///
   /// ```dart
   /// final session = await client.realtime.connect(
-  ///   model: 'gpt-realtime-1.5',
+  ///   model: 'gpt-realtime-2',
   /// );
   ///
   /// session.events.listen((event) {
@@ -653,22 +653,26 @@ class OpenAIClient {
 
   /// Real-time sessions API resource (HTTP).
   ///
-  /// Use this to create realtime sessions, client secrets, and manage
-  /// WebRTC calls via HTTP endpoints.
+  /// Use this to create realtime client secrets and manage WebRTC calls and
+  /// translation sessions via HTTP endpoints.
   ///
   /// ## Example
   ///
   /// ```dart
-  /// // Create a session with ephemeral key
-  /// final session = await client.realtimeSessions.create(
-  ///   RealtimeSessionCreateRequest(
-  ///     model: 'gpt-realtime-1.5',
-  ///     voice: RealtimeVoice.alloy,
+  /// // Create a session with an ephemeral client secret.
+  /// final response = await client.realtimeSessions.createClientSecret(
+  ///   RealtimeClientSecretCreateRequest(
+  ///     session: RealtimeSessionCreateRequest(
+  ///       model: 'gpt-realtime-2',
+  ///       audio: RealtimeAudioConfig(
+  ///         output: RealtimeAudioConfigOutput(voice: 'alloy'),
+  ///       ),
+  ///     ),
   ///   ),
   /// );
   ///
-  /// // Use the client secret for WebSocket authentication
-  /// print('Client secret: ${session.clientSecret.value}');
+  /// // Use the client secret for WebSocket authentication.
+  /// print('Client secret: ${response.value}');
   /// ```
   RealtimeSessionsResource get realtimeSessions =>
       _realtimeSessions ??= RealtimeSessionsResource(

--- a/packages/openai_dart/lib/src/models/realtime/realtime.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime.dart
@@ -1,10 +1,18 @@
 /// Realtime API models for WebSocket-based audio conversations.
 library;
 
+export 'realtime_audio_config.dart';
+export 'realtime_audio_formats.dart';
+export 'realtime_audio_input_turn_detection.dart';
 export 'realtime_call.dart';
 export 'realtime_client_secret.dart';
 export 'realtime_enums.dart';
 export 'realtime_event.dart';
+export 'realtime_reasoning.dart';
 export 'realtime_session.dart';
 export 'realtime_session_create.dart';
+export 'realtime_tracing_config.dart';
 export 'realtime_transcription_session.dart';
+export 'realtime_translation_event.dart';
+export 'realtime_translation_session.dart';
+export 'realtime_truncation.dart';

--- a/packages/openai_dart/lib/src/models/realtime/realtime_audio_config.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_audio_config.dart
@@ -89,7 +89,7 @@ class InputAudioTranscription {
   /// Optional delay knob.
   ///
   /// Higher values trade latency for accuracy. Only supported with
-  /// `gpt-realtime-whisper` in GA Realtime sessions.
+  /// `gpt-realtime-whisper` in Realtime sessions.
   final AudioTranscriptionDelay? delay;
 
   /// ISO-639-1 language hint, e.g. `'en'`.
@@ -155,7 +155,7 @@ class InputAudioTranscription {
 // RealtimeAudioConfigInput
 // =============================================================================
 
-/// Input audio configuration for a GA Realtime session.
+/// Input audio configuration for a Realtime session.
 @immutable
 class RealtimeAudioConfigInput {
   /// Creates a [RealtimeAudioConfigInput].
@@ -258,7 +258,7 @@ class RealtimeAudioConfigInput {
 // RealtimeAudioConfigOutput
 // =============================================================================
 
-/// Output audio configuration for a GA Realtime session.
+/// Output audio configuration for a Realtime session.
 @immutable
 class RealtimeAudioConfigOutput {
   /// Creates a [RealtimeAudioConfigOutput].
@@ -331,12 +331,11 @@ class RealtimeAudioConfigOutput {
 // RealtimeAudioConfig
 // =============================================================================
 
-/// Audio configuration for a GA Realtime session.
+/// Audio configuration for a Realtime session.
 ///
-/// Replaces the Beta-shape top-level audio fields (`voice`, `inputAudioFormat`,
-/// `outputAudioFormat`, `inputAudioTranscription`, `turnDetection`,
-/// `inputAudioNoiseReduction`) with a nested `audio.input.*` /
-/// `audio.output.*` structure that matches the GA Stainless schema.
+/// Groups input audio settings (`format`, `transcription`, `turn_detection`,
+/// `noise_reduction`) and output audio settings (`format`, `voice`, `speed`)
+/// under a single nested object on the session payload.
 @immutable
 class RealtimeAudioConfig {
   /// Creates a [RealtimeAudioConfig].

--- a/packages/openai_dart/lib/src/models/realtime/realtime_audio_config.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_audio_config.dart
@@ -156,6 +156,23 @@ class InputAudioTranscription {
 // =============================================================================
 
 /// Input audio configuration for a Realtime session.
+///
+/// **Tri-state serialization for `noise_reduction`, `transcription`,
+/// `turn_detection`** — these fields have three distinct meanings on
+/// `session.update`:
+///
+/// - **Field omitted from the request** → server keeps the current value
+///   (don't change). This is the default when the typed field is `null`.
+/// - **Field present with value** → server sets/replaces the configuration.
+/// - **Field present with explicit JSON `null`** → server *disables* the
+///   feature (clears any prior configuration).
+///
+/// To send the third form (explicit JSON null), pass the matching
+/// `clearNoiseReduction` / `clearTranscription` / `clearTurnDetection`
+/// flag as `true`. The flags are ignored when the corresponding typed
+/// field is also non-null (the value wins). Roundtrip preserves the
+/// distinction: a wire payload with `"noise_reduction": null` parses
+/// back as `clearNoiseReduction: true`.
 @immutable
 class RealtimeAudioConfigInput {
   /// Creates a [RealtimeAudioConfigInput].
@@ -164,6 +181,9 @@ class RealtimeAudioConfigInput {
     this.noiseReduction,
     this.transcription,
     this.turnDetection,
+    this.clearNoiseReduction = false,
+    this.clearTranscription = false,
+    this.clearTurnDetection = false,
   });
 
   /// Creates from JSON.
@@ -189,6 +209,13 @@ class RealtimeAudioConfigInput {
               json['turn_detection'] as Map<String, dynamic>,
             )
           : null,
+      clearNoiseReduction:
+          json.containsKey('noise_reduction') &&
+          json['noise_reduction'] == null,
+      clearTranscription:
+          json.containsKey('transcription') && json['transcription'] == null,
+      clearTurnDetection:
+          json.containsKey('turn_detection') && json['turn_detection'] == null,
     );
   }
 
@@ -204,21 +231,50 @@ class RealtimeAudioConfigInput {
   /// Turn-detection configuration.
   final RealtimeAudioInputTurnDetection? turnDetection;
 
+  /// When `true`, emit `"noise_reduction": null` on the wire to ask the
+  /// server to disable noise reduction (only relevant on
+  /// `session.update`). Has no effect when [noiseReduction] is non-null.
+  final bool clearNoiseReduction;
+
+  /// When `true`, emit `"transcription": null` on the wire to ask the
+  /// server to disable transcription. Has no effect when [transcription]
+  /// is non-null.
+  final bool clearTranscription;
+
+  /// When `true`, emit `"turn_detection": null` on the wire to ask the
+  /// server to disable turn detection. Has no effect when
+  /// [turnDetection] is non-null.
+  final bool clearTurnDetection;
+
   /// Converts to JSON.
   Map<String, dynamic> toJson() => {
     if (format != null) 'format': format!.toJson(),
-    if (noiseReduction != null) 'noise_reduction': noiseReduction!.toJson(),
-    if (transcription != null) 'transcription': transcription!.toJson(),
-    if (turnDetection != null) 'turn_detection': turnDetection!.toJson(),
+    if (noiseReduction != null)
+      'noise_reduction': noiseReduction!.toJson()
+    else if (clearNoiseReduction)
+      'noise_reduction': null,
+    if (transcription != null)
+      'transcription': transcription!.toJson()
+    else if (clearTranscription)
+      'transcription': null,
+    if (turnDetection != null)
+      'turn_detection': turnDetection!.toJson()
+    else if (clearTurnDetection)
+      'turn_detection': null,
   };
 
   /// Returns a copy of this [RealtimeAudioConfigInput] with the given fields
-  /// replaced. Pass `null` for any field to clear the existing value.
+  /// replaced. Pass `null` for any nullable field to clear the in-memory
+  /// value (use the `clear*` flags to send explicit JSON null over the
+  /// wire).
   RealtimeAudioConfigInput copyWith({
     Object? format = unsetCopyWithValue,
     Object? noiseReduction = unsetCopyWithValue,
     Object? transcription = unsetCopyWithValue,
     Object? turnDetection = unsetCopyWithValue,
+    bool? clearNoiseReduction,
+    bool? clearTranscription,
+    bool? clearTurnDetection,
   }) => RealtimeAudioConfigInput(
     format: identical(format, unsetCopyWithValue)
         ? this.format
@@ -232,6 +288,9 @@ class RealtimeAudioConfigInput {
     turnDetection: identical(turnDetection, unsetCopyWithValue)
         ? this.turnDetection
         : turnDetection as RealtimeAudioInputTurnDetection?,
+    clearNoiseReduction: clearNoiseReduction ?? this.clearNoiseReduction,
+    clearTranscription: clearTranscription ?? this.clearTranscription,
+    clearTurnDetection: clearTurnDetection ?? this.clearTurnDetection,
   );
 
   @override
@@ -242,16 +301,29 @@ class RealtimeAudioConfigInput {
           format == other.format &&
           noiseReduction == other.noiseReduction &&
           transcription == other.transcription &&
-          turnDetection == other.turnDetection;
+          turnDetection == other.turnDetection &&
+          clearNoiseReduction == other.clearNoiseReduction &&
+          clearTranscription == other.clearTranscription &&
+          clearTurnDetection == other.clearTurnDetection;
 
   @override
-  int get hashCode =>
-      Object.hash(format, noiseReduction, transcription, turnDetection);
+  int get hashCode => Object.hash(
+    format,
+    noiseReduction,
+    transcription,
+    turnDetection,
+    clearNoiseReduction,
+    clearTranscription,
+    clearTurnDetection,
+  );
 
   @override
   String toString() =>
       'RealtimeAudioConfigInput(format: $format, noiseReduction: $noiseReduction, '
-      'transcription: $transcription, turnDetection: $turnDetection)';
+      'transcription: $transcription, turnDetection: $turnDetection, '
+      'clearNoiseReduction: $clearNoiseReduction, '
+      'clearTranscription: $clearTranscription, '
+      'clearTurnDetection: $clearTurnDetection)';
 }
 
 // =============================================================================

--- a/packages/openai_dart/lib/src/models/realtime/realtime_audio_config.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_audio_config.dart
@@ -1,0 +1,400 @@
+import 'package:meta/meta.dart';
+
+import '../common/copy_with_sentinel.dart';
+import 'realtime_audio_formats.dart';
+import 'realtime_audio_input_turn_detection.dart';
+import 'realtime_enums.dart';
+
+// =============================================================================
+// AudioInputNoiseReduction
+// =============================================================================
+
+/// Noise reduction configuration for the input audio buffer.
+///
+/// `null` (the field omitted) disables noise reduction.
+@immutable
+class AudioInputNoiseReduction {
+  /// Creates an [AudioInputNoiseReduction].
+  const AudioInputNoiseReduction({this.type});
+
+  /// Creates from JSON.
+  factory AudioInputNoiseReduction.fromJson(Map<String, dynamic> json) {
+    return AudioInputNoiseReduction(
+      type: json['type'] != null
+          ? NoiseReductionType.fromJson(json['type'] as String)
+          : null,
+    );
+  }
+
+  /// The noise-reduction profile.
+  final NoiseReductionType? type;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {if (type != null) 'type': type!.toJson()};
+
+  /// Returns a copy of this [AudioInputNoiseReduction] with the given fields
+  /// replaced. Pass `null` for [type] to clear the existing value.
+  AudioInputNoiseReduction copyWith({Object? type = unsetCopyWithValue}) =>
+      AudioInputNoiseReduction(
+        type: identical(type, unsetCopyWithValue)
+            ? this.type
+            : type as NoiseReductionType?,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AudioInputNoiseReduction &&
+          runtimeType == other.runtimeType &&
+          type == other.type;
+
+  @override
+  int get hashCode => type.hashCode;
+
+  @override
+  String toString() => 'AudioInputNoiseReduction(type: $type)';
+}
+
+// =============================================================================
+// InputAudioTranscription
+// =============================================================================
+
+/// Configuration for input audio transcription.
+///
+/// Transcription runs asynchronously through the Whisper or GPT-realtime
+/// transcription pipeline and is treated as guidance about the input audio
+/// content rather than precisely what the model heard.
+@immutable
+class InputAudioTranscription {
+  /// Creates an [InputAudioTranscription].
+  const InputAudioTranscription({
+    this.delay,
+    this.language,
+    this.model,
+    this.prompt,
+  });
+
+  /// Creates from JSON.
+  factory InputAudioTranscription.fromJson(Map<String, dynamic> json) {
+    return InputAudioTranscription(
+      delay: json['delay'] != null
+          ? AudioTranscriptionDelay.fromJson(json['delay'] as String)
+          : null,
+      language: json['language'] as String?,
+      model: json['model'] as String?,
+      prompt: json['prompt'] as String?,
+    );
+  }
+
+  /// Optional delay knob.
+  ///
+  /// Higher values trade latency for accuracy. Only supported with
+  /// `gpt-realtime-whisper` in GA Realtime sessions.
+  final AudioTranscriptionDelay? delay;
+
+  /// ISO-639-1 language hint, e.g. `'en'`.
+  final String? language;
+
+  /// Transcription model identifier (e.g. `'whisper-1'`,
+  /// `'gpt-realtime-whisper'`).
+  final String? model;
+
+  /// Optional free-text prompt to guide the transcription.
+  ///
+  /// Not supported with `gpt-realtime-whisper`.
+  final String? prompt;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (delay != null) 'delay': delay!.toJson(),
+    if (language != null) 'language': language,
+    if (model != null) 'model': model,
+    if (prompt != null) 'prompt': prompt,
+  };
+
+  /// Returns a copy of this [InputAudioTranscription] with the given fields
+  /// replaced. Pass `null` for any field to clear the existing value.
+  InputAudioTranscription copyWith({
+    Object? delay = unsetCopyWithValue,
+    Object? language = unsetCopyWithValue,
+    Object? model = unsetCopyWithValue,
+    Object? prompt = unsetCopyWithValue,
+  }) => InputAudioTranscription(
+    delay: identical(delay, unsetCopyWithValue)
+        ? this.delay
+        : delay as AudioTranscriptionDelay?,
+    language: identical(language, unsetCopyWithValue)
+        ? this.language
+        : language as String?,
+    model: identical(model, unsetCopyWithValue) ? this.model : model as String?,
+    prompt: identical(prompt, unsetCopyWithValue)
+        ? this.prompt
+        : prompt as String?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is InputAudioTranscription &&
+          runtimeType == other.runtimeType &&
+          delay == other.delay &&
+          language == other.language &&
+          model == other.model &&
+          prompt == other.prompt;
+
+  @override
+  int get hashCode => Object.hash(delay, language, model, prompt);
+
+  @override
+  String toString() =>
+      'InputAudioTranscription(delay: $delay, language: $language, '
+      'model: $model, prompt: $prompt)';
+}
+
+// =============================================================================
+// RealtimeAudioConfigInput
+// =============================================================================
+
+/// Input audio configuration for a GA Realtime session.
+@immutable
+class RealtimeAudioConfigInput {
+  /// Creates a [RealtimeAudioConfigInput].
+  const RealtimeAudioConfigInput({
+    this.format,
+    this.noiseReduction,
+    this.transcription,
+    this.turnDetection,
+  });
+
+  /// Creates from JSON.
+  factory RealtimeAudioConfigInput.fromJson(Map<String, dynamic> json) {
+    return RealtimeAudioConfigInput(
+      format: json['format'] != null
+          ? RealtimeAudioFormats.fromJson(
+              json['format'] as Map<String, dynamic>,
+            )
+          : null,
+      noiseReduction: json['noise_reduction'] != null
+          ? AudioInputNoiseReduction.fromJson(
+              json['noise_reduction'] as Map<String, dynamic>,
+            )
+          : null,
+      transcription: json['transcription'] != null
+          ? InputAudioTranscription.fromJson(
+              json['transcription'] as Map<String, dynamic>,
+            )
+          : null,
+      turnDetection: json['turn_detection'] != null
+          ? RealtimeAudioInputTurnDetection.fromJson(
+              json['turn_detection'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+
+  /// Input audio format.
+  final RealtimeAudioFormats? format;
+
+  /// Noise-reduction configuration.
+  final AudioInputNoiseReduction? noiseReduction;
+
+  /// Transcription configuration.
+  final InputAudioTranscription? transcription;
+
+  /// Turn-detection configuration.
+  final RealtimeAudioInputTurnDetection? turnDetection;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (format != null) 'format': format!.toJson(),
+    if (noiseReduction != null) 'noise_reduction': noiseReduction!.toJson(),
+    if (transcription != null) 'transcription': transcription!.toJson(),
+    if (turnDetection != null) 'turn_detection': turnDetection!.toJson(),
+  };
+
+  /// Returns a copy of this [RealtimeAudioConfigInput] with the given fields
+  /// replaced. Pass `null` for any field to clear the existing value.
+  RealtimeAudioConfigInput copyWith({
+    Object? format = unsetCopyWithValue,
+    Object? noiseReduction = unsetCopyWithValue,
+    Object? transcription = unsetCopyWithValue,
+    Object? turnDetection = unsetCopyWithValue,
+  }) => RealtimeAudioConfigInput(
+    format: identical(format, unsetCopyWithValue)
+        ? this.format
+        : format as RealtimeAudioFormats?,
+    noiseReduction: identical(noiseReduction, unsetCopyWithValue)
+        ? this.noiseReduction
+        : noiseReduction as AudioInputNoiseReduction?,
+    transcription: identical(transcription, unsetCopyWithValue)
+        ? this.transcription
+        : transcription as InputAudioTranscription?,
+    turnDetection: identical(turnDetection, unsetCopyWithValue)
+        ? this.turnDetection
+        : turnDetection as RealtimeAudioInputTurnDetection?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeAudioConfigInput &&
+          runtimeType == other.runtimeType &&
+          format == other.format &&
+          noiseReduction == other.noiseReduction &&
+          transcription == other.transcription &&
+          turnDetection == other.turnDetection;
+
+  @override
+  int get hashCode =>
+      Object.hash(format, noiseReduction, transcription, turnDetection);
+
+  @override
+  String toString() =>
+      'RealtimeAudioConfigInput(format: $format, noiseReduction: $noiseReduction, '
+      'transcription: $transcription, turnDetection: $turnDetection)';
+}
+
+// =============================================================================
+// RealtimeAudioConfigOutput
+// =============================================================================
+
+/// Output audio configuration for a GA Realtime session.
+@immutable
+class RealtimeAudioConfigOutput {
+  /// Creates a [RealtimeAudioConfigOutput].
+  const RealtimeAudioConfigOutput({this.format, this.voice, this.speed});
+
+  /// Creates from JSON.
+  factory RealtimeAudioConfigOutput.fromJson(Map<String, dynamic> json) {
+    return RealtimeAudioConfigOutput(
+      format: json['format'] != null
+          ? RealtimeAudioFormats.fromJson(
+              json['format'] as Map<String, dynamic>,
+            )
+          : null,
+      voice: json['voice'] as String?,
+      speed: (json['speed'] as num?)?.toDouble(),
+    );
+  }
+
+  /// Output audio format.
+  final RealtimeAudioFormats? format;
+
+  /// Voice identifier or custom voice name (e.g. `'alloy'`, `'cedar'`).
+  ///
+  /// Modeled as an open `String` to match the spec's `VoiceIdsOrCustomVoice`
+  /// union (built-in voices + custom strings).
+  final String? voice;
+
+  /// Speech speed multiplier (0.25–1.5; default `1.0`).
+  final double? speed;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (format != null) 'format': format!.toJson(),
+    if (voice != null) 'voice': voice,
+    if (speed != null) 'speed': speed,
+  };
+
+  /// Returns a copy of this [RealtimeAudioConfigOutput] with the given fields
+  /// replaced. Pass `null` for any field to clear the existing value.
+  RealtimeAudioConfigOutput copyWith({
+    Object? format = unsetCopyWithValue,
+    Object? voice = unsetCopyWithValue,
+    Object? speed = unsetCopyWithValue,
+  }) => RealtimeAudioConfigOutput(
+    format: identical(format, unsetCopyWithValue)
+        ? this.format
+        : format as RealtimeAudioFormats?,
+    voice: identical(voice, unsetCopyWithValue) ? this.voice : voice as String?,
+    speed: identical(speed, unsetCopyWithValue) ? this.speed : speed as double?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeAudioConfigOutput &&
+          runtimeType == other.runtimeType &&
+          format == other.format &&
+          voice == other.voice &&
+          speed == other.speed;
+
+  @override
+  int get hashCode => Object.hash(format, voice, speed);
+
+  @override
+  String toString() =>
+      'RealtimeAudioConfigOutput(format: $format, voice: $voice, speed: $speed)';
+}
+
+// =============================================================================
+// RealtimeAudioConfig
+// =============================================================================
+
+/// Audio configuration for a GA Realtime session.
+///
+/// Replaces the Beta-shape top-level audio fields (`voice`, `inputAudioFormat`,
+/// `outputAudioFormat`, `inputAudioTranscription`, `turnDetection`,
+/// `inputAudioNoiseReduction`) with a nested `audio.input.*` /
+/// `audio.output.*` structure that matches the GA Stainless schema.
+@immutable
+class RealtimeAudioConfig {
+  /// Creates a [RealtimeAudioConfig].
+  const RealtimeAudioConfig({this.input, this.output});
+
+  /// Creates from JSON.
+  factory RealtimeAudioConfig.fromJson(Map<String, dynamic> json) {
+    return RealtimeAudioConfig(
+      input: json['input'] != null
+          ? RealtimeAudioConfigInput.fromJson(
+              json['input'] as Map<String, dynamic>,
+            )
+          : null,
+      output: json['output'] != null
+          ? RealtimeAudioConfigOutput.fromJson(
+              json['output'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+
+  /// Input audio configuration.
+  final RealtimeAudioConfigInput? input;
+
+  /// Output audio configuration.
+  final RealtimeAudioConfigOutput? output;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (input != null) 'input': input!.toJson(),
+    if (output != null) 'output': output!.toJson(),
+  };
+
+  /// Returns a copy of this [RealtimeAudioConfig] with the given fields
+  /// replaced. Pass `null` for any field to clear the existing value.
+  RealtimeAudioConfig copyWith({
+    Object? input = unsetCopyWithValue,
+    Object? output = unsetCopyWithValue,
+  }) => RealtimeAudioConfig(
+    input: identical(input, unsetCopyWithValue)
+        ? this.input
+        : input as RealtimeAudioConfigInput?,
+    output: identical(output, unsetCopyWithValue)
+        ? this.output
+        : output as RealtimeAudioConfigOutput?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeAudioConfig &&
+          runtimeType == other.runtimeType &&
+          input == other.input &&
+          output == other.output;
+
+  @override
+  int get hashCode => Object.hash(input, output);
+
+  @override
+  String toString() => 'RealtimeAudioConfig(input: $input, output: $output)';
+}

--- a/packages/openai_dart/lib/src/models/realtime/realtime_audio_formats.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_audio_formats.dart
@@ -7,7 +7,7 @@ import '../common/equality_helpers.dart';
 // RealtimeAudioFormats
 // =============================================================================
 
-/// Audio format for GA Realtime sessions.
+/// Audio format for Realtime sessions.
 ///
 /// A discriminated union (`type`) of three concrete formats:
 ///

--- a/packages/openai_dart/lib/src/models/realtime/realtime_audio_formats.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_audio_formats.dart
@@ -1,0 +1,219 @@
+import 'package:meta/meta.dart';
+
+import '../common/copy_with_sentinel.dart';
+import '../common/equality_helpers.dart';
+
+// =============================================================================
+// RealtimeAudioFormats
+// =============================================================================
+
+/// Audio format for GA Realtime sessions.
+///
+/// A discriminated union (`type`) of three concrete formats:
+///
+/// - [AudioPcm] — `audio/pcm`, 24 kHz signed 16-bit PCM (`rate: 24000`).
+/// - [AudioPcmu] — `audio/pcmu`, G.711 μ-law.
+/// - [AudioPcma] — `audio/pcma`, G.711 A-law.
+///
+/// An [UnknownRealtimeAudioFormats] fallback preserves the original payload
+/// for any unrecognised discriminator so that future server additions do not
+/// break existing clients.
+///
+/// ## Example
+///
+/// ```dart
+/// const format = RealtimeAudioFormats.pcm(rate: 24000);
+/// const ulaw = RealtimeAudioFormats.pcmu();
+/// ```
+sealed class RealtimeAudioFormats {
+  const RealtimeAudioFormats();
+
+  /// Creates a 24 kHz PCM audio format.
+  const factory RealtimeAudioFormats.pcm({int? rate}) = AudioPcm;
+
+  /// Creates a G.711 μ-law audio format.
+  const factory RealtimeAudioFormats.pcmu() = AudioPcmu;
+
+  /// Creates a G.711 A-law audio format.
+  const factory RealtimeAudioFormats.pcma() = AudioPcma;
+
+  /// Creates from JSON.
+  ///
+  /// Returns an [UnknownRealtimeAudioFormats] for unrecognised `type` values
+  /// rather than throwing — the raw payload is preserved on round-trip.
+  factory RealtimeAudioFormats.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    return switch (type) {
+      'audio/pcm' => AudioPcm.fromJson(json),
+      'audio/pcmu' => AudioPcmu.fromJson(json),
+      'audio/pcma' => AudioPcma.fromJson(json),
+      _ => UnknownRealtimeAudioFormats(Map<String, dynamic>.from(json)),
+    };
+  }
+
+  /// The audio format discriminator.
+  String get type;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson();
+}
+
+/// 24 kHz signed 16-bit PCM audio format.
+///
+/// `type == "audio/pcm"`. Only `rate: 24000` is currently supported by the API.
+@immutable
+class AudioPcm extends RealtimeAudioFormats {
+  /// Creates an [AudioPcm].
+  const AudioPcm({this.rate});
+
+  /// Creates from JSON.
+  factory AudioPcm.fromJson(Map<String, dynamic> json) {
+    if (json['type'] != 'audio/pcm') {
+      throw FormatException(
+        'AudioPcm.fromJson expected type "audio/pcm", got ${json['type']}',
+      );
+    }
+    return AudioPcm(rate: json['rate'] as int?);
+  }
+
+  /// Sample rate. Always `24000` when present.
+  final int? rate;
+
+  @override
+  String get type => 'audio/pcm';
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (rate != null) 'rate': rate,
+  };
+
+  /// Returns a copy of this [AudioPcm] with the given fields replaced.
+  ///
+  /// Pass `null` for [rate] to clear the existing value.
+  AudioPcm copyWith({Object? rate = unsetCopyWithValue}) => AudioPcm(
+    rate: identical(rate, unsetCopyWithValue) ? this.rate : rate as int?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AudioPcm &&
+          runtimeType == other.runtimeType &&
+          rate == other.rate;
+
+  @override
+  int get hashCode => rate.hashCode;
+
+  @override
+  String toString() => 'AudioPcm(rate: $rate)';
+}
+
+/// G.711 μ-law audio format.
+///
+/// `type == "audio/pcmu"`.
+@immutable
+class AudioPcmu extends RealtimeAudioFormats {
+  /// Creates an [AudioPcmu].
+  const AudioPcmu();
+
+  /// Creates from JSON.
+  factory AudioPcmu.fromJson(Map<String, dynamic> json) {
+    if (json['type'] != 'audio/pcmu') {
+      throw FormatException(
+        'AudioPcmu.fromJson expected type "audio/pcmu", got ${json['type']}',
+      );
+    }
+    return const AudioPcmu();
+  }
+
+  @override
+  String get type => 'audio/pcmu';
+
+  @override
+  Map<String, dynamic> toJson() => {'type': type};
+
+  /// Returns a copy of this [AudioPcmu]. No fields to replace.
+  AudioPcmu copyWith() => const AudioPcmu();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AudioPcmu && runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => type.hashCode;
+
+  @override
+  String toString() => 'AudioPcmu()';
+}
+
+/// G.711 A-law audio format.
+///
+/// `type == "audio/pcma"`.
+@immutable
+class AudioPcma extends RealtimeAudioFormats {
+  /// Creates an [AudioPcma].
+  const AudioPcma();
+
+  /// Creates from JSON.
+  factory AudioPcma.fromJson(Map<String, dynamic> json) {
+    if (json['type'] != 'audio/pcma') {
+      throw FormatException(
+        'AudioPcma.fromJson expected type "audio/pcma", got ${json['type']}',
+      );
+    }
+    return const AudioPcma();
+  }
+
+  @override
+  String get type => 'audio/pcma';
+
+  @override
+  Map<String, dynamic> toJson() => {'type': type};
+
+  /// Returns a copy of this [AudioPcma]. No fields to replace.
+  AudioPcma copyWith() => const AudioPcma();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AudioPcma && runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => type.hashCode;
+
+  @override
+  String toString() => 'AudioPcma()';
+}
+
+/// Forward-compatible fallback for unknown [RealtimeAudioFormats] discriminators.
+///
+/// Preserves the raw JSON payload so the value can round-trip without loss.
+@immutable
+class UnknownRealtimeAudioFormats extends RealtimeAudioFormats {
+  /// Creates an [UnknownRealtimeAudioFormats] from the raw JSON payload.
+  const UnknownRealtimeAudioFormats(this.json);
+
+  /// The raw JSON map preserved verbatim.
+  final Map<String, dynamic> json;
+
+  @override
+  String get type => json['type'] as String? ?? '';
+
+  @override
+  Map<String, dynamic> toJson() => Map<String, dynamic>.from(json);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnknownRealtimeAudioFormats &&
+          runtimeType == other.runtimeType &&
+          mapsDeepEqual(json, other.json);
+
+  @override
+  int get hashCode => mapDeepHashCode(json);
+
+  @override
+  String toString() => 'UnknownRealtimeAudioFormats(type: $type)';
+}

--- a/packages/openai_dart/lib/src/models/realtime/realtime_audio_input_turn_detection.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_audio_input_turn_detection.dart
@@ -51,7 +51,7 @@ enum SemanticVadEagerness {
 // RealtimeAudioInputTurnDetection
 // =============================================================================
 
-/// Turn detection configuration for GA Realtime sessions.
+/// Turn detection configuration for Realtime sessions.
 ///
 /// A discriminated union covering the two supported strategies:
 ///

--- a/packages/openai_dart/lib/src/models/realtime/realtime_audio_input_turn_detection.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_audio_input_turn_detection.dart
@@ -1,0 +1,347 @@
+import 'package:meta/meta.dart';
+
+import '../common/copy_with_sentinel.dart';
+
+// =============================================================================
+// SemanticVadEagerness
+// =============================================================================
+
+/// Eagerness levels for `semantic_vad` turn detection.
+///
+/// Determines how aggressively the model decides the user has finished
+/// speaking. `low`/`medium`/`high` cap the detection timeout at 8s/4s/2s
+/// respectively; `auto` is the default and behaves like `medium`.
+///
+/// Unknown values from `fromJson` throw `FormatException`, matching the
+/// existing convention.
+enum SemanticVadEagerness {
+  /// Wait longer (up to 8s) before deciding the user has finished speaking.
+  low._('low'),
+
+  /// Default cadence (~4s timeout). Equivalent to `auto`.
+  medium._('medium'),
+
+  /// Respond more eagerly (up to 2s timeout).
+  high._('high'),
+
+  /// Auto (server default; equivalent to medium).
+  auto._('auto');
+
+  const SemanticVadEagerness._(this._value);
+
+  /// Creates from JSON string. Throws `FormatException` for unknown values.
+  factory SemanticVadEagerness.fromJson(String json) {
+    return values.firstWhere(
+      (e) => e._value == json,
+      orElse: () =>
+          throw FormatException('Unknown SemanticVadEagerness: $json'),
+    );
+  }
+
+  final String _value;
+
+  /// Converts to JSON string.
+  String toJson() => _value;
+
+  @override
+  String toString() => _value;
+}
+
+// =============================================================================
+// RealtimeAudioInputTurnDetection
+// =============================================================================
+
+/// Turn detection configuration for GA Realtime sessions.
+///
+/// A discriminated union covering the two supported strategies:
+///
+/// - [ServerVad] — server-side voice activity detection that flips on/off
+///   based on audio volume.
+/// - [SemanticVad] — turn detection that uses a model to predict when the
+///   speaker has finished.
+///
+/// An [UnknownRealtimeAudioInputTurnDetection] fallback preserves any
+/// unrecognised payload so future server additions do not break existing
+/// clients.
+sealed class RealtimeAudioInputTurnDetection {
+  const RealtimeAudioInputTurnDetection();
+
+  /// Server VAD turn detection.
+  const factory RealtimeAudioInputTurnDetection.serverVad({
+    bool? createResponse,
+    int? idleTimeoutMs,
+    bool? interruptResponse,
+    int? prefixPaddingMs,
+    int? silenceDurationMs,
+    double? threshold,
+  }) = ServerVad;
+
+  /// Semantic VAD turn detection.
+  const factory RealtimeAudioInputTurnDetection.semanticVad({
+    bool? createResponse,
+    SemanticVadEagerness? eagerness,
+    bool? interruptResponse,
+  }) = SemanticVad;
+
+  /// Creates from JSON.
+  factory RealtimeAudioInputTurnDetection.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    return switch (type) {
+      'server_vad' => ServerVad.fromJson(json),
+      'semantic_vad' => SemanticVad.fromJson(json),
+      _ => UnknownRealtimeAudioInputTurnDetection(
+        Map<String, dynamic>.from(json),
+      ),
+    };
+  }
+
+  /// The discriminator value.
+  String get type;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson();
+}
+
+/// Server-side voice activity detection.
+@immutable
+class ServerVad extends RealtimeAudioInputTurnDetection {
+  /// Creates a [ServerVad].
+  const ServerVad({
+    this.createResponse,
+    this.idleTimeoutMs,
+    this.interruptResponse,
+    this.prefixPaddingMs,
+    this.silenceDurationMs,
+    this.threshold,
+  });
+
+  /// Creates from JSON.
+  factory ServerVad.fromJson(Map<String, dynamic> json) {
+    if (json['type'] != 'server_vad') {
+      throw FormatException(
+        'ServerVad.fromJson expected type "server_vad", got ${json['type']}',
+      );
+    }
+    return ServerVad(
+      createResponse: json['create_response'] as bool?,
+      idleTimeoutMs: json['idle_timeout_ms'] as int?,
+      interruptResponse: json['interrupt_response'] as bool?,
+      prefixPaddingMs: json['prefix_padding_ms'] as int?,
+      silenceDurationMs: json['silence_duration_ms'] as int?,
+      threshold: (json['threshold'] as num?)?.toDouble(),
+    );
+  }
+
+  /// Whether to automatically generate a response on VAD stop.
+  final bool? createResponse;
+
+  /// Idle timeout in milliseconds (5000–30000) that triggers a model response.
+  final int? idleTimeoutMs;
+
+  /// Whether to interrupt an in-progress response on VAD start.
+  final bool? interruptResponse;
+
+  /// Audio padding before detected speech (ms). Default 300.
+  final int? prefixPaddingMs;
+
+  /// Silence duration to detect speech end (ms). Default 500.
+  final int? silenceDurationMs;
+
+  /// Activation threshold (0.0–1.0). Default 0.5.
+  final double? threshold;
+
+  @override
+  String get type => 'server_vad';
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (createResponse != null) 'create_response': createResponse,
+    if (idleTimeoutMs != null) 'idle_timeout_ms': idleTimeoutMs,
+    if (interruptResponse != null) 'interrupt_response': interruptResponse,
+    if (prefixPaddingMs != null) 'prefix_padding_ms': prefixPaddingMs,
+    if (silenceDurationMs != null) 'silence_duration_ms': silenceDurationMs,
+    if (threshold != null) 'threshold': threshold,
+  };
+
+  /// Returns a copy with the given fields replaced.
+  ///
+  /// Pass `null` for any field to clear the existing value.
+  ServerVad copyWith({
+    Object? createResponse = unsetCopyWithValue,
+    Object? idleTimeoutMs = unsetCopyWithValue,
+    Object? interruptResponse = unsetCopyWithValue,
+    Object? prefixPaddingMs = unsetCopyWithValue,
+    Object? silenceDurationMs = unsetCopyWithValue,
+    Object? threshold = unsetCopyWithValue,
+  }) => ServerVad(
+    createResponse: identical(createResponse, unsetCopyWithValue)
+        ? this.createResponse
+        : createResponse as bool?,
+    idleTimeoutMs: identical(idleTimeoutMs, unsetCopyWithValue)
+        ? this.idleTimeoutMs
+        : idleTimeoutMs as int?,
+    interruptResponse: identical(interruptResponse, unsetCopyWithValue)
+        ? this.interruptResponse
+        : interruptResponse as bool?,
+    prefixPaddingMs: identical(prefixPaddingMs, unsetCopyWithValue)
+        ? this.prefixPaddingMs
+        : prefixPaddingMs as int?,
+    silenceDurationMs: identical(silenceDurationMs, unsetCopyWithValue)
+        ? this.silenceDurationMs
+        : silenceDurationMs as int?,
+    threshold: identical(threshold, unsetCopyWithValue)
+        ? this.threshold
+        : threshold as double?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ServerVad &&
+          runtimeType == other.runtimeType &&
+          createResponse == other.createResponse &&
+          idleTimeoutMs == other.idleTimeoutMs &&
+          interruptResponse == other.interruptResponse &&
+          prefixPaddingMs == other.prefixPaddingMs &&
+          silenceDurationMs == other.silenceDurationMs &&
+          threshold == other.threshold;
+
+  @override
+  int get hashCode => Object.hash(
+    createResponse,
+    idleTimeoutMs,
+    interruptResponse,
+    prefixPaddingMs,
+    silenceDurationMs,
+    threshold,
+  );
+
+  @override
+  String toString() =>
+      'ServerVad(createResponse: $createResponse, idleTimeoutMs: $idleTimeoutMs, '
+      'interruptResponse: $interruptResponse, prefixPaddingMs: $prefixPaddingMs, '
+      'silenceDurationMs: $silenceDurationMs, threshold: $threshold)';
+}
+
+/// Semantic VAD turn detection.
+@immutable
+class SemanticVad extends RealtimeAudioInputTurnDetection {
+  /// Creates a [SemanticVad].
+  const SemanticVad({
+    this.createResponse,
+    this.eagerness,
+    this.interruptResponse,
+  });
+
+  /// Creates from JSON.
+  factory SemanticVad.fromJson(Map<String, dynamic> json) {
+    if (json['type'] != 'semantic_vad') {
+      throw FormatException(
+        'SemanticVad.fromJson expected type "semantic_vad", got ${json['type']}',
+      );
+    }
+    return SemanticVad(
+      createResponse: json['create_response'] as bool?,
+      eagerness: json['eagerness'] != null
+          ? SemanticVadEagerness.fromJson(json['eagerness'] as String)
+          : null,
+      interruptResponse: json['interrupt_response'] as bool?,
+    );
+  }
+
+  /// Whether to automatically generate a response on VAD stop.
+  final bool? createResponse;
+
+  /// Eagerness controlling the timeout used to decide the speaker is done.
+  final SemanticVadEagerness? eagerness;
+
+  /// Whether to interrupt an in-progress response on VAD start.
+  final bool? interruptResponse;
+
+  @override
+  String get type => 'semantic_vad';
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (createResponse != null) 'create_response': createResponse,
+    if (eagerness != null) 'eagerness': eagerness!.toJson(),
+    if (interruptResponse != null) 'interrupt_response': interruptResponse,
+  };
+
+  /// Returns a copy with the given fields replaced.
+  ///
+  /// Pass `null` for any field to clear the existing value.
+  SemanticVad copyWith({
+    Object? createResponse = unsetCopyWithValue,
+    Object? eagerness = unsetCopyWithValue,
+    Object? interruptResponse = unsetCopyWithValue,
+  }) => SemanticVad(
+    createResponse: identical(createResponse, unsetCopyWithValue)
+        ? this.createResponse
+        : createResponse as bool?,
+    eagerness: identical(eagerness, unsetCopyWithValue)
+        ? this.eagerness
+        : eagerness as SemanticVadEagerness?,
+    interruptResponse: identical(interruptResponse, unsetCopyWithValue)
+        ? this.interruptResponse
+        : interruptResponse as bool?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SemanticVad &&
+          runtimeType == other.runtimeType &&
+          createResponse == other.createResponse &&
+          eagerness == other.eagerness &&
+          interruptResponse == other.interruptResponse;
+
+  @override
+  int get hashCode => Object.hash(createResponse, eagerness, interruptResponse);
+
+  @override
+  String toString() =>
+      'SemanticVad(createResponse: $createResponse, eagerness: $eagerness, '
+      'interruptResponse: $interruptResponse)';
+}
+
+/// Forward-compatible fallback for unknown turn-detection variants.
+@immutable
+class UnknownRealtimeAudioInputTurnDetection
+    extends RealtimeAudioInputTurnDetection {
+  /// Creates from the raw payload.
+  const UnknownRealtimeAudioInputTurnDetection(this.json);
+
+  /// The raw JSON map preserved verbatim.
+  final Map<String, dynamic> json;
+
+  @override
+  String get type => json['type'] as String? ?? '';
+
+  @override
+  Map<String, dynamic> toJson() => Map<String, dynamic>.from(json);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnknownRealtimeAudioInputTurnDetection &&
+          runtimeType == other.runtimeType &&
+          _mapsEqual(json, other.json);
+
+  @override
+  int get hashCode => Object.hashAllUnordered(json.entries);
+
+  @override
+  String toString() => 'UnknownRealtimeAudioInputTurnDetection(type: $type)';
+}
+
+bool _mapsEqual(Map<String, dynamic> a, Map<String, dynamic> b) {
+  if (identical(a, b)) return true;
+  if (a.length != b.length) return false;
+  for (final key in a.keys) {
+    if (!b.containsKey(key) || a[key] != b[key]) return false;
+  }
+  return true;
+}

--- a/packages/openai_dart/lib/src/models/realtime/realtime_audio_input_turn_detection.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_audio_input_turn_detection.dart
@@ -1,6 +1,7 @@
 import 'package:meta/meta.dart';
 
 import '../common/copy_with_sentinel.dart';
+import '../common/equality_helpers.dart';
 
 // =============================================================================
 // SemanticVadEagerness
@@ -328,20 +329,11 @@ class UnknownRealtimeAudioInputTurnDetection
       identical(this, other) ||
       other is UnknownRealtimeAudioInputTurnDetection &&
           runtimeType == other.runtimeType &&
-          _mapsEqual(json, other.json);
+          mapsDeepEqual(json, other.json);
 
   @override
-  int get hashCode => Object.hashAllUnordered(json.entries);
+  int get hashCode => mapDeepHashCode(json);
 
   @override
   String toString() => 'UnknownRealtimeAudioInputTurnDetection(type: $type)';
-}
-
-bool _mapsEqual(Map<String, dynamic> a, Map<String, dynamic> b) {
-  if (identical(a, b)) return true;
-  if (a.length != b.length) return false;
-  for (final key in a.keys) {
-    if (!b.containsKey(key) || a[key] != b[key]) return false;
-  }
-  return true;
 }

--- a/packages/openai_dart/lib/src/models/realtime/realtime_call.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_call.dart
@@ -18,8 +18,10 @@ import 'realtime_session_create.dart';
 ///   RealtimeCallCreateRequest(
 ///     sdp: sdpOffer,
 ///     session: RealtimeSessionCreateRequest(
-///       model: 'gpt-realtime-1.5',
-///       voice: RealtimeVoice.alloy,
+///       model: 'gpt-realtime-2',
+///       audio: RealtimeAudioConfig(
+///         output: RealtimeAudioConfigOutput(voice: 'alloy'),
+///       ),
 ///     ),
 ///   ),
 /// );

--- a/packages/openai_dart/lib/src/models/realtime/realtime_client_secret.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_client_secret.dart
@@ -1,6 +1,7 @@
 import 'package:meta/meta.dart';
 
 import 'realtime_session_create.dart';
+import 'realtime_transcription_session.dart';
 
 // =============================================================================
 // ExpiresAfter
@@ -62,8 +63,10 @@ class ExpiresAfter {
 ///   RealtimeClientSecretCreateRequest(
 ///     expiresAfter: ExpiresAfter(anchor: 'created_at', seconds: 3600),
 ///     session: RealtimeSessionCreateRequest(
-///       model: 'gpt-realtime-1.5',
-///       voice: RealtimeVoice.alloy,
+///       model: 'gpt-realtime-2',
+///       audio: RealtimeAudioConfig(
+///         output: RealtimeAudioConfigOutput(voice: 'alloy'),
+///       ),
 ///     ),
 ///   ),
 /// );
@@ -99,10 +102,20 @@ class RealtimeClientSecretCreateRequest {
   final RealtimeSessionCreateRequest session;
 
   /// Converts to JSON.
-  Map<String, dynamic> toJson() => {
-    if (expiresAfter != null) 'expires_after': expiresAfter!.toJson(),
-    'session': session.toJson(),
-  };
+  ///
+  /// The `/realtime/client_secrets` endpoint requires a `type` discriminator
+  /// on the embedded session (`'realtime'` vs `'transcription'`). If the
+  /// caller didn't set it explicitly, default it to `'realtime'` here so the
+  /// bare `/realtime/sessions` payload (which rejects `type`) stays
+  /// untouched.
+  Map<String, dynamic> toJson() {
+    final sessionJson = session.toJson();
+    sessionJson['type'] ??= 'realtime';
+    return {
+      if (expiresAfter != null) 'expires_after': expiresAfter!.toJson(),
+      'session': sessionJson,
+    };
+  }
 
   @override
   bool operator ==(Object other) =>
@@ -115,6 +128,77 @@ class RealtimeClientSecretCreateRequest {
 
   @override
   String toString() => 'RealtimeClientSecretCreateRequest(...)';
+}
+
+// =============================================================================
+// RealtimeTranscriptionClientSecretCreateRequest
+// =============================================================================
+
+/// Request for creating a client secret for a **transcription** session.
+///
+/// Posts to `POST /realtime/client_secrets`. The session payload uses the
+/// transcription-specific shape (no `model` field, audio limited to inputs).
+/// Realtime sessions use [RealtimeClientSecretCreateRequest] instead.
+@immutable
+class RealtimeTranscriptionClientSecretCreateRequest {
+  /// Creates a [RealtimeTranscriptionClientSecretCreateRequest].
+  const RealtimeTranscriptionClientSecretCreateRequest({
+    required this.session,
+    this.expiresAfter,
+  });
+
+  /// Creates from JSON.
+  factory RealtimeTranscriptionClientSecretCreateRequest.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    if (json['session'] == null) {
+      throw const FormatException(
+        'RealtimeTranscriptionClientSecretCreateRequest.fromJson missing '
+        'required "session" field',
+      );
+    }
+    return RealtimeTranscriptionClientSecretCreateRequest(
+      session: RealtimeTranscriptionSessionCreateRequest.fromJson(
+        json['session'] as Map<String, dynamic>,
+      ),
+      expiresAfter: json['expires_after'] != null
+          ? ExpiresAfter.fromJson(json['expires_after'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+
+  /// Transcription session configuration.
+  final RealtimeTranscriptionSessionCreateRequest session;
+
+  /// Optional client-secret expiration.
+  final ExpiresAfter? expiresAfter;
+
+  /// Converts to JSON, injecting `'type': 'transcription'` on the embedded
+  /// session if the caller didn't set it explicitly.
+  Map<String, dynamic> toJson() {
+    final sessionJson = session.toJson();
+    sessionJson['type'] ??= 'transcription';
+    return {
+      if (expiresAfter != null) 'expires_after': expiresAfter!.toJson(),
+      'session': sessionJson,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranscriptionClientSecretCreateRequest &&
+          runtimeType == other.runtimeType &&
+          session == other.session &&
+          expiresAfter == other.expiresAfter;
+
+  @override
+  int get hashCode => Object.hash(session, expiresAfter);
+
+  @override
+  String toString() =>
+      'RealtimeTranscriptionClientSecretCreateRequest(session: $session, '
+      'expiresAfter: $expiresAfter)';
 }
 
 // =============================================================================

--- a/packages/openai_dart/lib/src/models/realtime/realtime_client_secret.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_client_secret.dart
@@ -121,13 +121,17 @@ class RealtimeClientSecretCreateRequest {
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is RealtimeClientSecretCreateRequest &&
-          runtimeType == other.runtimeType;
+          runtimeType == other.runtimeType &&
+          expiresAfter == other.expiresAfter &&
+          session == other.session;
 
   @override
-  int get hashCode => session.hashCode;
+  int get hashCode => Object.hash(expiresAfter, session);
 
   @override
-  String toString() => 'RealtimeClientSecretCreateRequest(...)';
+  String toString() =>
+      'RealtimeClientSecretCreateRequest(expiresAfter: $expiresAfter, '
+      'session: $session)';
 }
 
 // =============================================================================
@@ -249,12 +253,15 @@ class RealtimeClientSecretCreateResponse {
       identical(this, other) ||
       other is RealtimeClientSecretCreateResponse &&
           runtimeType == other.runtimeType &&
-          value == other.value;
+          value == other.value &&
+          expiresAt == other.expiresAt &&
+          session == other.session;
 
   @override
-  int get hashCode => value.hashCode;
+  int get hashCode => Object.hash(value, expiresAt, session);
 
   @override
   String toString() =>
-      'RealtimeClientSecretCreateResponse(expiresAt: $expiresAt)';
+      'RealtimeClientSecretCreateResponse(expiresAt: $expiresAt, '
+      'session: $session)';
 }

--- a/packages/openai_dart/lib/src/models/realtime/realtime_enums.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_enums.dart
@@ -1,45 +1,31 @@
 import 'package:meta/meta.dart';
 
 // =============================================================================
-// RealtimeVoice
+// NoiseReductionType
 // =============================================================================
 
-/// Voice options for realtime audio output.
+/// Noise reduction profile for the input audio buffer.
 ///
-/// These are the available voices for generating audio responses
-/// in realtime sessions.
-enum RealtimeVoice {
-  /// Alloy voice.
-  alloy._('alloy'),
+/// `near_field` is for close-talking microphones such as headphones;
+/// `far_field` is for far-field microphones such as conference-room mics or
+/// laptops.
+///
+/// Unknown values from `fromJson` throw `FormatException`, matching the
+/// existing convention used by other realtime enums.
+enum NoiseReductionType {
+  /// Close-talking microphone profile.
+  nearField._('near_field'),
 
-  /// Ash voice.
-  ash._('ash'),
+  /// Far-field microphone profile.
+  farField._('far_field');
 
-  /// Ballad voice.
-  ballad._('ballad'),
+  const NoiseReductionType._(this._value);
 
-  /// Coral voice.
-  coral._('coral'),
-
-  /// Echo voice.
-  echo._('echo'),
-
-  /// Sage voice.
-  sage._('sage'),
-
-  /// Shimmer voice.
-  shimmer._('shimmer'),
-
-  /// Verse voice.
-  verse._('verse');
-
-  const RealtimeVoice._(this._value);
-
-  /// Creates from JSON string.
-  factory RealtimeVoice.fromJson(String json) {
+  /// Creates from JSON string. Throws `FormatException` for unknown values.
+  factory NoiseReductionType.fromJson(String json) {
     return values.firstWhere(
       (e) => e._value == json,
-      orElse: () => throw FormatException('Unknown RealtimeVoice: $json'),
+      orElse: () => throw FormatException('Unknown NoiseReductionType: $json'),
     );
   }
 
@@ -53,62 +39,40 @@ enum RealtimeVoice {
 }
 
 // =============================================================================
-// RealtimeAudioFormat
+// AudioTranscriptionDelay
 // =============================================================================
 
-/// Audio format for realtime sessions.
+/// Transcription latency-vs-accuracy delay knob.
 ///
-/// Specifies the encoding format for audio input and output.
-enum RealtimeAudioFormat {
-  /// 16-bit PCM audio.
-  pcm16._('pcm16'),
+/// Higher values trade latency for accuracy. Only supported with
+/// `gpt-realtime-whisper` in GA Realtime sessions.
+///
+/// Unknown values from `fromJson` throw `FormatException`, matching the
+/// existing convention used by other realtime enums.
+enum AudioTranscriptionDelay {
+  /// Lowest latency, lowest accuracy.
+  minimal._('minimal'),
 
-  /// G.711 μ-law audio.
-  g711Ulaw._('g711_ulaw'),
+  /// Low transcription delay.
+  low._('low'),
 
-  /// G.711 A-law audio.
-  g711Alaw._('g711_alaw');
+  /// Medium transcription delay.
+  medium._('medium'),
 
-  const RealtimeAudioFormat._(this._value);
+  /// High transcription delay.
+  high._('high'),
 
-  /// Creates from JSON string.
-  factory RealtimeAudioFormat.fromJson(String json) {
+  /// Highest latency, highest accuracy.
+  xhigh._('xhigh');
+
+  const AudioTranscriptionDelay._(this._value);
+
+  /// Creates from JSON string. Throws `FormatException` for unknown values.
+  factory AudioTranscriptionDelay.fromJson(String json) {
     return values.firstWhere(
       (e) => e._value == json,
-      orElse: () => throw FormatException('Unknown RealtimeAudioFormat: $json'),
-    );
-  }
-
-  final String _value;
-
-  /// Converts to JSON string.
-  String toJson() => _value;
-
-  @override
-  String toString() => _value;
-}
-
-// =============================================================================
-// TurnDetectionType
-// =============================================================================
-
-/// Turn detection type for realtime sessions.
-///
-/// Determines how the server detects when the user has finished speaking.
-enum TurnDetectionType {
-  /// Server-side voice activity detection.
-  serverVad._('server_vad'),
-
-  /// No automatic turn detection.
-  none._('none');
-
-  const TurnDetectionType._(this._value);
-
-  /// Creates from JSON string.
-  factory TurnDetectionType.fromJson(String json) {
-    return values.firstWhere(
-      (e) => e._value == json,
-      orElse: () => throw FormatException('Unknown TurnDetectionType: $json'),
+      orElse: () =>
+          throw FormatException('Unknown AudioTranscriptionDelay: $json'),
     );
   }
 

--- a/packages/openai_dart/lib/src/models/realtime/realtime_enums.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_enums.dart
@@ -45,7 +45,7 @@ enum NoiseReductionType {
 /// Transcription latency-vs-accuracy delay knob.
 ///
 /// Higher values trade latency for accuracy. Only supported with
-/// `gpt-realtime-whisper` in GA Realtime sessions.
+/// `gpt-realtime-whisper` in Realtime sessions.
 ///
 /// Unknown values from `fromJson` throw `FormatException`, matching the
 /// existing convention used by other realtime enums.

--- a/packages/openai_dart/lib/src/models/realtime/realtime_event.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_event.dart
@@ -5,116 +5,115 @@ import 'realtime_session.dart';
 /// Base class for all realtime events.
 ///
 /// Events are sent and received over the WebSocket connection.
+///
+/// **Wire names**: a few server events have multiple historical names
+/// (e.g., `response.text.delta` and `response.output_text.delta`,
+/// `response.audio.delta` and `response.output_audio.delta`,
+/// `response.audio_transcript.delta` and `response.output_audio_transcript.delta`).
+/// `fromJson` accepts either spelling and dispatches to the same Dart
+/// class. Unrecognised event types fall through to
+/// [UnknownRealtimeEvent] rather than throwing, so future server
+/// additions don't break existing clients.
 sealed class RealtimeEvent {
   /// Creates a [RealtimeEvent] from JSON.
+  ///
+  /// Unknown `type` values yield an [UnknownRealtimeEvent] preserving the
+  /// raw payload — never throws on unrecognised discriminators.
   factory RealtimeEvent.fromJson(Map<String, dynamic> json) {
-    final type = json['type'] as String;
+    final type = json['type'] as String?;
+    if (type == null) {
+      return UnknownRealtimeEvent(Map<String, dynamic>.from(json));
+    }
+    return switch (type) {
+      // Session events
+      'session.created' => SessionCreatedEvent.fromJson(json),
+      'session.updated' => SessionUpdatedEvent.fromJson(json),
 
-    // Session events
-    if (type == 'session.created') {
-      return SessionCreatedEvent.fromJson(json);
-    }
-    if (type == 'session.updated') {
-      return SessionUpdatedEvent.fromJson(json);
-    }
+      // Conversation events
+      'conversation.created' => ConversationCreatedEvent.fromJson(json),
+      'conversation.item.added' => ConversationItemAddedEvent.fromJson(json),
+      'conversation.item.created' => ConversationItemCreatedEvent.fromJson(
+        json,
+      ),
+      'conversation.item.deleted' => ConversationItemDeletedEvent.fromJson(
+        json,
+      ),
+      'conversation.item.truncated' => ConversationItemTruncatedEvent.fromJson(
+        json,
+      ),
 
-    // Conversation events
-    if (type == 'conversation.created') {
-      return ConversationCreatedEvent.fromJson(json);
-    }
-    if (type == 'conversation.item.created') {
-      return ConversationItemCreatedEvent.fromJson(json);
-    }
-    if (type == 'conversation.item.deleted') {
-      return ConversationItemDeletedEvent.fromJson(json);
-    }
-    if (type == 'conversation.item.truncated') {
-      return ConversationItemTruncatedEvent.fromJson(json);
-    }
+      // Input audio transcription events
+      'conversation.item.input_audio_transcription.delta' =>
+        InputAudioTranscriptionDeltaEvent.fromJson(json),
+      'conversation.item.input_audio_transcription.completed' =>
+        InputAudioTranscriptionCompletedEvent.fromJson(json),
+      'conversation.item.input_audio_transcription.failed' =>
+        InputAudioTranscriptionFailedEvent.fromJson(json),
+      'conversation.item.input_audio_transcription.segment' =>
+        InputAudioTranscriptionSegmentEvent.fromJson(json),
 
-    // Input audio transcription events
-    if (type == 'conversation.item.input_audio_transcription.delta') {
-      return InputAudioTranscriptionDeltaEvent.fromJson(json);
-    }
-    if (type == 'conversation.item.input_audio_transcription.completed') {
-      return InputAudioTranscriptionCompletedEvent.fromJson(json);
-    }
-    if (type == 'conversation.item.input_audio_transcription.failed') {
-      return InputAudioTranscriptionFailedEvent.fromJson(json);
-    }
-    if (type == 'conversation.item.input_audio_transcription.segment') {
-      return InputAudioTranscriptionSegmentEvent.fromJson(json);
-    }
+      // Input audio buffer events
+      'input_audio_buffer.committed' => InputAudioBufferCommittedEvent.fromJson(
+        json,
+      ),
+      'input_audio_buffer.cleared' => InputAudioBufferClearedEvent.fromJson(
+        json,
+      ),
+      'input_audio_buffer.speech_started' =>
+        InputAudioBufferSpeechStartedEvent.fromJson(json),
+      'input_audio_buffer.speech_stopped' =>
+        InputAudioBufferSpeechStoppedEvent.fromJson(json),
 
-    // Input audio events
-    if (type == 'input_audio_buffer.committed') {
-      return InputAudioBufferCommittedEvent.fromJson(json);
-    }
-    if (type == 'input_audio_buffer.cleared') {
-      return InputAudioBufferClearedEvent.fromJson(json);
-    }
-    if (type == 'input_audio_buffer.speech_started') {
-      return InputAudioBufferSpeechStartedEvent.fromJson(json);
-    }
-    if (type == 'input_audio_buffer.speech_stopped') {
-      return InputAudioBufferSpeechStoppedEvent.fromJson(json);
-    }
+      // Response events
+      'response.created' => ResponseCreatedEvent.fromJson(json),
+      'response.done' => ResponseDoneEvent.fromJson(json),
+      'response.output_item.added' => ResponseOutputItemAddedEvent.fromJson(
+        json,
+      ),
+      'response.output_item.done' => ResponseOutputItemDoneEvent.fromJson(json),
+      'response.content_part.added' => ResponseContentPartAddedEvent.fromJson(
+        json,
+      ),
+      'response.content_part.done' => ResponseContentPartDoneEvent.fromJson(
+        json,
+      ),
 
-    // Response events
-    if (type == 'response.created') {
-      return ResponseCreatedEvent.fromJson(json);
-    }
-    if (type == 'response.done') {
-      return ResponseDoneEvent.fromJson(json);
-    }
-    if (type == 'response.output_item.added') {
-      return ResponseOutputItemAddedEvent.fromJson(json);
-    }
-    if (type == 'response.output_item.done') {
-      return ResponseOutputItemDoneEvent.fromJson(json);
-    }
-    if (type == 'response.content_part.added') {
-      return ResponseContentPartAddedEvent.fromJson(json);
-    }
-    if (type == 'response.content_part.done') {
-      return ResponseContentPartDoneEvent.fromJson(json);
-    }
-    if (type == 'response.text.delta') {
-      return ResponseTextDeltaEvent.fromJson(json);
-    }
-    if (type == 'response.text.done') {
-      return ResponseTextDoneEvent.fromJson(json);
-    }
-    if (type == 'response.audio_transcript.delta') {
-      return ResponseAudioTranscriptDeltaEvent.fromJson(json);
-    }
-    if (type == 'response.audio_transcript.done') {
-      return ResponseAudioTranscriptDoneEvent.fromJson(json);
-    }
-    if (type == 'response.audio.delta') {
-      return ResponseAudioDeltaEvent.fromJson(json);
-    }
-    if (type == 'response.audio.done') {
-      return ResponseAudioDoneEvent.fromJson(json);
-    }
-    if (type == 'response.function_call_arguments.delta') {
-      return ResponseFunctionCallArgumentsDeltaEvent.fromJson(json);
-    }
-    if (type == 'response.function_call_arguments.done') {
-      return ResponseFunctionCallArgumentsDoneEvent.fromJson(json);
-    }
+      // Text delta/done — accept either historical wire name.
+      'response.text.delta' ||
+      'response.output_text.delta' => ResponseTextDeltaEvent.fromJson(json),
+      'response.text.done' ||
+      'response.output_text.done' => ResponseTextDoneEvent.fromJson(json),
 
-    // Rate limit event
-    if (type == 'rate_limits.updated') {
-      return RateLimitsUpdatedEvent.fromJson(json);
-    }
+      // Audio transcript delta/done — accept either historical wire name.
+      'response.audio_transcript.delta' ||
+      'response.output_audio_transcript.delta' =>
+        ResponseAudioTranscriptDeltaEvent.fromJson(json),
+      'response.audio_transcript.done' ||
+      'response.output_audio_transcript.done' =>
+        ResponseAudioTranscriptDoneEvent.fromJson(json),
 
-    // Error event
-    if (type == 'error') {
-      return ErrorEvent.fromJson(json);
-    }
+      // Audio delta/done — accept either historical wire name.
+      'response.audio.delta' ||
+      'response.output_audio.delta' => ResponseAudioDeltaEvent.fromJson(json),
+      'response.audio.done' ||
+      'response.output_audio.done' => ResponseAudioDoneEvent.fromJson(json),
 
-    throw FormatException('Unknown realtime event type: $type');
+      'response.function_call_arguments.delta' =>
+        ResponseFunctionCallArgumentsDeltaEvent.fromJson(json),
+      'response.function_call_arguments.done' =>
+        ResponseFunctionCallArgumentsDoneEvent.fromJson(json),
+
+      // Rate limit + error events.
+      'rate_limits.updated' => RateLimitsUpdatedEvent.fromJson(json),
+      'error' => ErrorEvent.fromJson(json),
+
+      // Forward-compat: any event we don't model individually
+      // (`conversation.item.done`, `output_audio_buffer.*`,
+      // `mcp_list_tools.*`, `response.mcp_call.*`,
+      // `transcription_session.updated`, `input_audio_buffer.timeout_triggered`,
+      // …) is surfaced as [UnknownRealtimeEvent] preserving the raw JSON.
+      _ => UnknownRealtimeEvent(Map<String, dynamic>.from(json)),
+    };
   }
 
   /// The event type.
@@ -125,6 +124,52 @@ sealed class RealtimeEvent {
 
   /// Converts to JSON.
   Map<String, dynamic> toJson();
+}
+
+/// Forward-compatible fallback for [RealtimeEvent] discriminators that this
+/// client doesn't model individually.
+///
+/// Surfaces unrecognised wire `type` values without throwing so future
+/// server additions or out-of-band frames don't break the event stream.
+/// The raw JSON is preserved verbatim and round-trips through [toJson].
+@immutable
+class UnknownRealtimeEvent implements RealtimeEvent {
+  /// Creates an [UnknownRealtimeEvent] from the raw JSON payload.
+  const UnknownRealtimeEvent(this.json);
+
+  /// The raw JSON map preserved verbatim.
+  final Map<String, dynamic> json;
+
+  @override
+  String get type => (json['type'] as String?) ?? '';
+
+  @override
+  String? get eventId => json['event_id'] as String?;
+
+  @override
+  Map<String, dynamic> toJson() => Map<String, dynamic>.from(json);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnknownRealtimeEvent &&
+          runtimeType == other.runtimeType &&
+          _mapsEqual(json, other.json);
+
+  @override
+  int get hashCode => Object.hashAllUnordered(json.entries);
+
+  @override
+  String toString() => 'UnknownRealtimeEvent(type: $type)';
+}
+
+bool _mapsEqual(Map<String, dynamic> a, Map<String, dynamic> b) {
+  if (identical(a, b)) return true;
+  if (a.length != b.length) return false;
+  for (final key in a.keys) {
+    if (!b.containsKey(key) || a[key] != b[key]) return false;
+  }
+  return true;
 }
 
 /// Session created event.
@@ -317,6 +362,65 @@ class ConversationItemCreatedEvent implements RealtimeEvent {
 
   @override
   String toString() => 'ConversationItemCreatedEvent(eventId: $eventId)';
+}
+
+/// Conversation item added event.
+///
+/// The server emits `conversation.item.added` when a new item is appended
+/// to the conversation (e.g., immediately after the client sends
+/// `conversation.item.create`). For most flows this is the primary
+/// item-creation signal; `conversation.item.created` is emitted for
+/// `item_reference` lookup paths in some flows.
+@immutable
+class ConversationItemAddedEvent implements RealtimeEvent {
+  /// Creates a [ConversationItemAddedEvent].
+  const ConversationItemAddedEvent({
+    required this.eventId,
+    this.previousItemId,
+    required this.item,
+  });
+
+  /// Creates a [ConversationItemAddedEvent] from JSON.
+  factory ConversationItemAddedEvent.fromJson(Map<String, dynamic> json) {
+    return ConversationItemAddedEvent(
+      eventId: json['event_id'] as String,
+      previousItemId: json['previous_item_id'] as String?,
+      item: Map<String, dynamic>.from(json['item'] as Map),
+    );
+  }
+
+  @override
+  String get type => 'conversation.item.added';
+
+  @override
+  final String eventId;
+
+  /// The ID of the previous item, if any.
+  final String? previousItemId;
+
+  /// The newly added item.
+  final Map<String, dynamic> item;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'event_id': eventId,
+    if (previousItemId != null) 'previous_item_id': previousItemId,
+    'item': item,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ConversationItemAddedEvent &&
+          runtimeType == other.runtimeType &&
+          eventId == other.eventId;
+
+  @override
+  int get hashCode => eventId.hashCode;
+
+  @override
+  String toString() => 'ConversationItemAddedEvent(eventId: $eventId)';
 }
 
 /// Conversation item deleted event.

--- a/packages/openai_dart/lib/src/models/realtime/realtime_event.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_event.dart
@@ -1,5 +1,6 @@
 import 'package:meta/meta.dart';
 
+import '../common/equality_helpers.dart';
 import 'realtime_session.dart';
 
 /// Base class for all realtime events.
@@ -154,22 +155,13 @@ class UnknownRealtimeEvent implements RealtimeEvent {
       identical(this, other) ||
       other is UnknownRealtimeEvent &&
           runtimeType == other.runtimeType &&
-          _mapsEqual(json, other.json);
+          mapsDeepEqual(json, other.json);
 
   @override
-  int get hashCode => Object.hashAllUnordered(json.entries);
+  int get hashCode => mapDeepHashCode(json);
 
   @override
   String toString() => 'UnknownRealtimeEvent(type: $type)';
-}
-
-bool _mapsEqual(Map<String, dynamic> a, Map<String, dynamic> b) {
-  if (identical(a, b)) return true;
-  if (a.length != b.length) return false;
-  for (final key in a.keys) {
-    if (!b.containsKey(key) || a[key] != b[key]) return false;
-  }
-  return true;
 }
 
 /// Session created event.
@@ -317,7 +309,7 @@ class ConversationItemCreatedEvent implements RealtimeEvent {
   /// Creates a [ConversationItemCreatedEvent].
   const ConversationItemCreatedEvent({
     required this.eventId,
-    required this.previousItemId,
+    this.previousItemId,
     required this.item,
   });
 
@@ -2034,13 +2026,18 @@ class RateLimit {
       identical(this, other) ||
       other is RateLimit &&
           runtimeType == other.runtimeType &&
-          name == other.name;
+          name == other.name &&
+          limit == other.limit &&
+          remaining == other.remaining &&
+          resetSeconds == other.resetSeconds;
 
   @override
-  int get hashCode => name.hashCode;
+  int get hashCode => Object.hash(name, limit, remaining, resetSeconds);
 
   @override
-  String toString() => 'RateLimit(name: $name, remaining: $remaining)';
+  String toString() =>
+      'RateLimit(name: $name, limit: $limit, remaining: $remaining, '
+      'resetSeconds: $resetSeconds)';
 }
 
 /// An error event.
@@ -2139,11 +2136,17 @@ class RealtimeError {
       identical(this, other) ||
       other is RealtimeError &&
           runtimeType == other.runtimeType &&
-          code == other.code;
+          type == other.type &&
+          code == other.code &&
+          message == other.message &&
+          param == other.param &&
+          eventId == other.eventId;
 
   @override
-  int get hashCode => code.hashCode;
+  int get hashCode => Object.hash(type, code, message, param, eventId);
 
   @override
-  String toString() => 'RealtimeError(code: $code, message: $message)';
+  String toString() =>
+      'RealtimeError(type: $type, code: $code, message: $message, '
+      'param: $param, eventId: $eventId)';
 }

--- a/packages/openai_dart/lib/src/models/realtime/realtime_reasoning.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_reasoning.dart
@@ -1,0 +1,102 @@
+import 'package:meta/meta.dart';
+
+import '../common/copy_with_sentinel.dart';
+
+// =============================================================================
+// RealtimeReasoningEffort
+// =============================================================================
+
+/// Reasoning effort levels for reasoning-capable Realtime models.
+///
+/// Constrains the amount of reasoning the model performs before responding,
+/// trading latency for quality. Currently applies only to reasoning Realtime
+/// models such as `gpt-realtime-2`.
+///
+/// Unknown values from `fromJson` throw `FormatException`, matching the
+/// package's existing enum convention.
+enum RealtimeReasoningEffort {
+  /// Minimal reasoning. Lowest latency.
+  minimal._('minimal'),
+
+  /// Low reasoning effort.
+  low._('low'),
+
+  /// Medium reasoning effort.
+  medium._('medium'),
+
+  /// High reasoning effort.
+  high._('high'),
+
+  /// Extra-high reasoning effort.
+  xhigh._('xhigh');
+
+  const RealtimeReasoningEffort._(this._value);
+
+  /// Creates from JSON string. Throws `FormatException` for unknown values.
+  factory RealtimeReasoningEffort.fromJson(String json) {
+    return values.firstWhere(
+      (e) => e._value == json,
+      orElse: () =>
+          throw FormatException('Unknown RealtimeReasoningEffort: $json'),
+    );
+  }
+
+  final String _value;
+
+  /// Converts to JSON string.
+  String toJson() => _value;
+
+  @override
+  String toString() => _value;
+}
+
+// =============================================================================
+// RealtimeReasoning
+// =============================================================================
+
+/// Configuration for reasoning-capable Realtime models such as `gpt-realtime-2`.
+@immutable
+class RealtimeReasoning {
+  /// Creates a [RealtimeReasoning].
+  const RealtimeReasoning({this.effort});
+
+  /// Creates a [RealtimeReasoning] from JSON.
+  factory RealtimeReasoning.fromJson(Map<String, dynamic> json) {
+    return RealtimeReasoning(
+      effort: json['effort'] != null
+          ? RealtimeReasoningEffort.fromJson(json['effort'] as String)
+          : null,
+    );
+  }
+
+  /// The reasoning effort level. `null` means use the model default.
+  final RealtimeReasoningEffort? effort;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (effort != null) 'effort': effort!.toJson(),
+  };
+
+  /// Returns a copy of this [RealtimeReasoning] with the given fields replaced.
+  ///
+  /// Pass `null` for [effort] to clear the existing value.
+  RealtimeReasoning copyWith({Object? effort = unsetCopyWithValue}) =>
+      RealtimeReasoning(
+        effort: identical(effort, unsetCopyWithValue)
+            ? this.effort
+            : effort as RealtimeReasoningEffort?,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeReasoning &&
+          runtimeType == other.runtimeType &&
+          effort == other.effort;
+
+  @override
+  int get hashCode => effort.hashCode;
+
+  @override
+  String toString() => 'RealtimeReasoning(effort: $effort)';
+}

--- a/packages/openai_dart/lib/src/models/realtime/realtime_session.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_session.dart
@@ -1,362 +1,17 @@
 import 'package:meta/meta.dart';
 
 import '../common/auto_or_value.dart';
+import '../common/copy_with_sentinel.dart';
+import '../common/equality_helpers.dart';
+import 'realtime_audio_config.dart';
 import 'realtime_enums.dart';
+import 'realtime_reasoning.dart';
+import 'realtime_tracing_config.dart';
+import 'realtime_truncation.dart';
 
-/// Configuration for a realtime session.
-///
-/// The Realtime API enables real-time audio conversations with the model
-/// using WebSockets.
-@immutable
-class RealtimeSession {
-  /// Creates a [RealtimeSession].
-  const RealtimeSession({
-    required this.id,
-    required this.object,
-    required this.model,
-    this.modalities,
-    this.instructions,
-    this.voice,
-    this.inputAudioFormat,
-    this.outputAudioFormat,
-    this.inputAudioTranscription,
-    this.turnDetection,
-    this.tools,
-    this.toolChoice,
-    this.temperature,
-    this.maxResponseOutputTokens,
-  });
-
-  /// Creates a [RealtimeSession] from JSON.
-  factory RealtimeSession.fromJson(Map<String, dynamic> json) {
-    return RealtimeSession(
-      id: json['id'] as String,
-      object: json['object'] as String,
-      model: json['model'] as String,
-      modalities: (json['modalities'] as List<dynamic>?)?.cast<String>(),
-      instructions: json['instructions'] as String?,
-      voice: json['voice'] != null
-          ? RealtimeVoice.fromJson(json['voice'] as String)
-          : null,
-      inputAudioFormat: json['input_audio_format'] != null
-          ? RealtimeAudioFormat.fromJson(json['input_audio_format'] as String)
-          : null,
-      outputAudioFormat: json['output_audio_format'] != null
-          ? RealtimeAudioFormat.fromJson(json['output_audio_format'] as String)
-          : null,
-      inputAudioTranscription: json['input_audio_transcription'] != null
-          ? InputAudioTranscription.fromJson(
-              json['input_audio_transcription'] as Map<String, dynamic>,
-            )
-          : null,
-      turnDetection: json['turn_detection'] != null
-          ? TurnDetection.fromJson(
-              json['turn_detection'] as Map<String, dynamic>,
-            )
-          : null,
-      tools: (json['tools'] as List<dynamic>?)
-          ?.map((e) => RealtimeTool.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      toolChoice: json['tool_choice'] != null
-          ? RealtimeToolChoice.fromJson(json['tool_choice'] as Object)
-          : null,
-      temperature: (json['temperature'] as num?)?.toDouble(),
-      maxResponseOutputTokens: json['max_response_output_tokens'] != null
-          ? InfOrInt.fromJson(json['max_response_output_tokens'] as Object)
-          : null,
-    );
-  }
-
-  /// The session identifier.
-  final String id;
-
-  /// The object type (always "realtime.session").
-  final String object;
-
-  /// The model to use.
-  final String model;
-
-  /// The modalities enabled (e.g., ["text", "audio"]).
-  final List<String>? modalities;
-
-  /// System instructions for the model.
-  final String? instructions;
-
-  /// The voice to use for audio output.
-  final RealtimeVoice? voice;
-
-  /// Input audio format.
-  final RealtimeAudioFormat? inputAudioFormat;
-
-  /// Output audio format.
-  final RealtimeAudioFormat? outputAudioFormat;
-
-  /// Configuration for input audio transcription.
-  final InputAudioTranscription? inputAudioTranscription;
-
-  /// Turn detection configuration.
-  final TurnDetection? turnDetection;
-
-  /// Tools available to the model.
-  final List<RealtimeTool>? tools;
-
-  /// Tool choice setting.
-  final RealtimeToolChoice? toolChoice;
-
-  /// Sampling temperature.
-  final double? temperature;
-
-  /// Maximum output tokens ("inf" or a specific integer).
-  final InfOrInt? maxResponseOutputTokens;
-
-  /// Converts to JSON.
-  Map<String, dynamic> toJson() => {
-    'id': id,
-    'object': object,
-    'model': model,
-    if (modalities != null) 'modalities': modalities,
-    if (instructions != null) 'instructions': instructions,
-    if (voice != null) 'voice': voice!.toJson(),
-    if (inputAudioFormat != null)
-      'input_audio_format': inputAudioFormat!.toJson(),
-    if (outputAudioFormat != null)
-      'output_audio_format': outputAudioFormat!.toJson(),
-    if (inputAudioTranscription != null)
-      'input_audio_transcription': inputAudioTranscription!.toJson(),
-    if (turnDetection != null) 'turn_detection': turnDetection!.toJson(),
-    if (tools != null) 'tools': tools!.map((t) => t.toJson()).toList(),
-    if (toolChoice != null) 'tool_choice': toolChoice!.toJson(),
-    if (temperature != null) 'temperature': temperature,
-    if (maxResponseOutputTokens != null)
-      'max_response_output_tokens': maxResponseOutputTokens!.toJson(),
-  };
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is RealtimeSession &&
-          runtimeType == other.runtimeType &&
-          id == other.id;
-
-  @override
-  int get hashCode => id.hashCode;
-
-  @override
-  String toString() => 'RealtimeSession(id: $id, model: $model)';
-}
-
-/// Configuration for updating a session.
-@immutable
-class SessionUpdateConfig {
-  /// Creates a [SessionUpdateConfig].
-  const SessionUpdateConfig({
-    this.modalities,
-    this.instructions,
-    this.voice,
-    this.inputAudioFormat,
-    this.outputAudioFormat,
-    this.inputAudioTranscription,
-    this.turnDetection,
-    this.tools,
-    this.toolChoice,
-    this.temperature,
-    this.maxResponseOutputTokens,
-  });
-
-  /// Creates a [SessionUpdateConfig] from JSON.
-  factory SessionUpdateConfig.fromJson(Map<String, dynamic> json) {
-    return SessionUpdateConfig(
-      modalities: (json['modalities'] as List<dynamic>?)?.cast<String>(),
-      instructions: json['instructions'] as String?,
-      voice: json['voice'] != null
-          ? RealtimeVoice.fromJson(json['voice'] as String)
-          : null,
-      inputAudioFormat: json['input_audio_format'] != null
-          ? RealtimeAudioFormat.fromJson(json['input_audio_format'] as String)
-          : null,
-      outputAudioFormat: json['output_audio_format'] != null
-          ? RealtimeAudioFormat.fromJson(json['output_audio_format'] as String)
-          : null,
-      inputAudioTranscription: json['input_audio_transcription'] != null
-          ? InputAudioTranscription.fromJson(
-              json['input_audio_transcription'] as Map<String, dynamic>,
-            )
-          : null,
-      turnDetection: json['turn_detection'] != null
-          ? TurnDetection.fromJson(
-              json['turn_detection'] as Map<String, dynamic>,
-            )
-          : null,
-      tools: (json['tools'] as List<dynamic>?)
-          ?.map((e) => RealtimeTool.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      toolChoice: json['tool_choice'] != null
-          ? RealtimeToolChoice.fromJson(json['tool_choice'] as Object)
-          : null,
-      temperature: (json['temperature'] as num?)?.toDouble(),
-      maxResponseOutputTokens: json['max_response_output_tokens'] != null
-          ? InfOrInt.fromJson(json['max_response_output_tokens'] as Object)
-          : null,
-    );
-  }
-
-  /// The modalities to enable.
-  final List<String>? modalities;
-
-  /// System instructions.
-  final String? instructions;
-
-  /// The voice to use.
-  final RealtimeVoice? voice;
-
-  /// Input audio format.
-  final RealtimeAudioFormat? inputAudioFormat;
-
-  /// Output audio format.
-  final RealtimeAudioFormat? outputAudioFormat;
-
-  /// Input audio transcription config.
-  final InputAudioTranscription? inputAudioTranscription;
-
-  /// Turn detection config.
-  final TurnDetection? turnDetection;
-
-  /// Available tools.
-  final List<RealtimeTool>? tools;
-
-  /// Tool choice setting.
-  final RealtimeToolChoice? toolChoice;
-
-  /// Sampling temperature.
-  final double? temperature;
-
-  /// Maximum output tokens ("inf" or a specific integer).
-  final InfOrInt? maxResponseOutputTokens;
-
-  /// Converts to JSON.
-  Map<String, dynamic> toJson() => {
-    if (modalities != null) 'modalities': modalities,
-    if (instructions != null) 'instructions': instructions,
-    if (voice != null) 'voice': voice!.toJson(),
-    if (inputAudioFormat != null)
-      'input_audio_format': inputAudioFormat!.toJson(),
-    if (outputAudioFormat != null)
-      'output_audio_format': outputAudioFormat!.toJson(),
-    if (inputAudioTranscription != null)
-      'input_audio_transcription': inputAudioTranscription!.toJson(),
-    if (turnDetection != null) 'turn_detection': turnDetection!.toJson(),
-    if (tools != null) 'tools': tools!.map((t) => t.toJson()).toList(),
-    if (toolChoice != null) 'tool_choice': toolChoice!.toJson(),
-    if (temperature != null) 'temperature': temperature,
-    if (maxResponseOutputTokens != null)
-      'max_response_output_tokens': maxResponseOutputTokens!.toJson(),
-  };
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is SessionUpdateConfig && runtimeType == other.runtimeType;
-
-  @override
-  int get hashCode => Object.hash(modalities, voice, temperature);
-
-  @override
-  String toString() => 'SessionUpdateConfig(...)';
-}
-
-/// Input audio transcription configuration.
-@immutable
-class InputAudioTranscription {
-  /// Creates an [InputAudioTranscription].
-  const InputAudioTranscription({this.model});
-
-  /// Creates an [InputAudioTranscription] from JSON.
-  factory InputAudioTranscription.fromJson(Map<String, dynamic> json) {
-    return InputAudioTranscription(model: json['model'] as String?);
-  }
-
-  /// The transcription model (e.g., "whisper-1").
-  final String? model;
-
-  /// Converts to JSON.
-  Map<String, dynamic> toJson() => {if (model != null) 'model': model};
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is InputAudioTranscription &&
-          runtimeType == other.runtimeType &&
-          model == other.model;
-
-  @override
-  int get hashCode => model.hashCode;
-
-  @override
-  String toString() => 'InputAudioTranscription(model: $model)';
-}
-
-/// Turn detection configuration.
-@immutable
-class TurnDetection {
-  /// Creates a [TurnDetection].
-  const TurnDetection({
-    this.type,
-    this.threshold,
-    this.prefixPaddingMs,
-    this.silenceDurationMs,
-    this.createResponse,
-  });
-
-  /// Creates a [TurnDetection] from JSON.
-  factory TurnDetection.fromJson(Map<String, dynamic> json) {
-    return TurnDetection(
-      type: json['type'] != null
-          ? TurnDetectionType.fromJson(json['type'] as String)
-          : null,
-      threshold: (json['threshold'] as num?)?.toDouble(),
-      prefixPaddingMs: json['prefix_padding_ms'] as int?,
-      silenceDurationMs: json['silence_duration_ms'] as int?,
-      createResponse: json['create_response'] as bool?,
-    );
-  }
-
-  /// The type of turn detection.
-  final TurnDetectionType? type;
-
-  /// Voice activity detection threshold (0.0 to 1.0).
-  final double? threshold;
-
-  /// Audio to include before speech starts (ms).
-  final int? prefixPaddingMs;
-
-  /// Duration of silence to detect end of speech (ms).
-  final int? silenceDurationMs;
-
-  /// Whether to automatically create a response.
-  final bool? createResponse;
-
-  /// Converts to JSON.
-  Map<String, dynamic> toJson() => {
-    if (type != null) 'type': type!.toJson(),
-    if (threshold != null) 'threshold': threshold,
-    if (prefixPaddingMs != null) 'prefix_padding_ms': prefixPaddingMs,
-    if (silenceDurationMs != null) 'silence_duration_ms': silenceDurationMs,
-    if (createResponse != null) 'create_response': createResponse,
-  };
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is TurnDetection &&
-          runtimeType == other.runtimeType &&
-          type == other.type;
-
-  @override
-  int get hashCode => type.hashCode;
-
-  @override
-  String toString() => 'TurnDetection(type: $type)';
-}
+// =============================================================================
+// RealtimeTool
+// =============================================================================
 
 /// A tool for realtime sessions.
 @immutable
@@ -399,16 +54,326 @@ class RealtimeTool {
     if (parameters != null) 'parameters': parameters,
   };
 
+  /// Returns a copy with the given fields replaced.
+  ///
+  /// Pass `null` for [description] or [parameters] to clear the existing value.
+  RealtimeTool copyWith({
+    String? type,
+    String? name,
+    Object? description = unsetCopyWithValue,
+    Object? parameters = unsetCopyWithValue,
+  }) => RealtimeTool(
+    type: type ?? this.type,
+    name: name ?? this.name,
+    description: identical(description, unsetCopyWithValue)
+        ? this.description
+        : description as String?,
+    parameters: identical(parameters, unsetCopyWithValue)
+        ? this.parameters
+        : parameters as Map<String, dynamic>?,
+  );
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is RealtimeTool &&
           runtimeType == other.runtimeType &&
-          name == other.name;
+          type == other.type &&
+          name == other.name &&
+          description == other.description &&
+          mapsDeepEqual(parameters, other.parameters);
 
   @override
-  int get hashCode => name.hashCode;
+  int get hashCode =>
+      Object.hash(type, name, description, mapDeepHashCode(parameters));
 
   @override
-  String toString() => 'RealtimeTool(name: $name)';
+  String toString() =>
+      'RealtimeTool(type: $type, name: $name, description: $description, '
+      'parameters: $parameters)';
+}
+
+// =============================================================================
+// RealtimeSession
+// =============================================================================
+
+/// Configuration for a GA Realtime session.
+///
+/// The Realtime API enables real-time audio conversations with the model
+/// using WebSockets.
+///
+/// This is the **GA-shape** session: audio configuration is nested under
+/// [audio] (`audio.input.*` / `audio.output.*`), `outputModalities` replaces
+/// the legacy `modalities` field, and `maxOutputTokens` replaces
+/// `maxResponseOutputTokens`.
+///
+/// Note: the `prompt` field from the spec is intentionally not modelled in
+/// this PR — the spec helper schema `Prompt` has no Dart class yet. Tracked
+/// as a follow-up for prompt-template support.
+// TODO(prompt-support): expose `prompt: Prompt?` once the `Prompt` schema
+// has a Dart model.
+@immutable
+class RealtimeSession {
+  /// Creates a [RealtimeSession].
+  const RealtimeSession({
+    required this.id,
+    required this.object,
+    required this.type,
+    required this.model,
+    required this.expiresAt,
+    this.audio,
+    this.outputModalities,
+    this.instructions,
+    this.tools,
+    this.toolChoice,
+    this.temperature,
+    this.maxOutputTokens,
+    this.parallelToolCalls,
+    this.reasoning,
+    this.tracing,
+    this.truncation,
+    this.include,
+  });
+
+  /// Creates a [RealtimeSession] from JSON.
+  ///
+  /// `id`, `object`, `type`, `model`, and `expires_at` are documented as
+  /// required by the spec, but the live API has been observed to omit them
+  /// transiently (e.g., on early WebSocket `session.created` payloads
+  /// before the session is fully provisioned). To stay forward- and
+  /// backward-compatible, missing values default rather than throw.
+  factory RealtimeSession.fromJson(Map<String, dynamic> json) {
+    return RealtimeSession(
+      id: (json['id'] as String?) ?? '',
+      object: (json['object'] as String?) ?? 'realtime.session',
+      type: (json['type'] as String?) ?? 'realtime',
+      model: (json['model'] as String?) ?? '',
+      expiresAt: (json['expires_at'] as int?) ?? 0,
+      audio: json['audio'] != null
+          ? RealtimeAudioConfig.fromJson(json['audio'] as Map<String, dynamic>)
+          : null,
+      outputModalities: (json['output_modalities'] as List<dynamic>?)
+          ?.cast<String>(),
+      instructions: json['instructions'] as String?,
+      tools: (json['tools'] as List<dynamic>?)
+          ?.map((e) => RealtimeTool.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      toolChoice: json['tool_choice'] != null
+          ? RealtimeToolChoice.fromJson(json['tool_choice'] as Object)
+          : null,
+      temperature: (json['temperature'] as num?)?.toDouble(),
+      maxOutputTokens: json['max_output_tokens'] != null
+          ? InfOrInt.fromJson(json['max_output_tokens'] as Object)
+          : null,
+      parallelToolCalls: json['parallel_tool_calls'] as bool?,
+      reasoning: json['reasoning'] != null
+          ? RealtimeReasoning.fromJson(
+              json['reasoning'] as Map<String, dynamic>,
+            )
+          : null,
+      tracing: json['tracing'] != null
+          ? RealtimeTracingConfig.fromJson(json['tracing'] as Object)
+          : null,
+      truncation: json['truncation'] != null
+          ? RealtimeTruncation.fromJson(json['truncation'] as Object)
+          : null,
+      include: (json['include'] as List<dynamic>?)?.cast<String>(),
+    );
+  }
+
+  /// The session identifier (`sess_…`).
+  final String id;
+
+  /// The object type (always `'realtime.session'`).
+  final String object;
+
+  /// The session type (always `'realtime'` for realtime sessions).
+  final String type;
+
+  /// The model identifier.
+  final String model;
+
+  /// Expiration timestamp (Unix epoch seconds).
+  final int expiresAt;
+
+  /// Nested audio configuration.
+  final RealtimeAudioConfig? audio;
+
+  /// Output modalities (e.g. `['text', 'audio']`). Defaults to `['audio']`.
+  ///
+  /// Replaces the Beta-shape `modalities` field.
+  final List<String>? outputModalities;
+
+  /// System instructions.
+  final String? instructions;
+
+  /// Tools available to the model.
+  final List<RealtimeTool>? tools;
+
+  /// Tool choice setting.
+  final RealtimeToolChoice? toolChoice;
+
+  /// Sampling temperature.
+  final double? temperature;
+
+  /// Maximum output tokens (`'inf'` or a specific integer).
+  ///
+  /// Replaces the Beta-shape `maxResponseOutputTokens` field.
+  final InfOrInt? maxOutputTokens;
+
+  /// Whether the model may call multiple tools in parallel. Only supported by
+  /// reasoning Realtime models such as `gpt-realtime-2`.
+  final bool? parallelToolCalls;
+
+  /// Reasoning configuration. Only supported by reasoning models.
+  final RealtimeReasoning? reasoning;
+
+  /// Tracing configuration.
+  final RealtimeTracingConfig? tracing;
+
+  /// Truncation configuration.
+  final RealtimeTruncation? truncation;
+
+  /// Additional fields to include in server outputs (e.g.
+  /// `'item.input_audio_transcription.logprobs'`).
+  final List<String>? include;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'object': object,
+    'type': type,
+    'model': model,
+    'expires_at': expiresAt,
+    if (audio != null) 'audio': audio!.toJson(),
+    if (outputModalities != null) 'output_modalities': outputModalities,
+    if (instructions != null) 'instructions': instructions,
+    if (tools != null) 'tools': tools!.map((t) => t.toJson()).toList(),
+    if (toolChoice != null) 'tool_choice': toolChoice!.toJson(),
+    if (temperature != null) 'temperature': temperature,
+    if (maxOutputTokens != null) 'max_output_tokens': maxOutputTokens!.toJson(),
+    if (parallelToolCalls != null) 'parallel_tool_calls': parallelToolCalls,
+    if (reasoning != null) 'reasoning': reasoning!.toJson(),
+    if (tracing != null) 'tracing': tracing!.toJson(),
+    if (truncation != null) 'truncation': truncation!.toJson(),
+    if (include != null) 'include': include,
+  };
+
+  /// Returns a copy of this [RealtimeSession] with the given fields replaced.
+  ///
+  /// Pass `null` for any nullable field to clear the existing value.
+  RealtimeSession copyWith({
+    String? id,
+    String? object,
+    String? type,
+    String? model,
+    int? expiresAt,
+    Object? audio = unsetCopyWithValue,
+    Object? outputModalities = unsetCopyWithValue,
+    Object? instructions = unsetCopyWithValue,
+    Object? tools = unsetCopyWithValue,
+    Object? toolChoice = unsetCopyWithValue,
+    Object? temperature = unsetCopyWithValue,
+    Object? maxOutputTokens = unsetCopyWithValue,
+    Object? parallelToolCalls = unsetCopyWithValue,
+    Object? reasoning = unsetCopyWithValue,
+    Object? tracing = unsetCopyWithValue,
+    Object? truncation = unsetCopyWithValue,
+    Object? include = unsetCopyWithValue,
+  }) => RealtimeSession(
+    id: id ?? this.id,
+    object: object ?? this.object,
+    type: type ?? this.type,
+    model: model ?? this.model,
+    expiresAt: expiresAt ?? this.expiresAt,
+    audio: identical(audio, unsetCopyWithValue)
+        ? this.audio
+        : audio as RealtimeAudioConfig?,
+    outputModalities: identical(outputModalities, unsetCopyWithValue)
+        ? this.outputModalities
+        : outputModalities as List<String>?,
+    instructions: identical(instructions, unsetCopyWithValue)
+        ? this.instructions
+        : instructions as String?,
+    tools: identical(tools, unsetCopyWithValue)
+        ? this.tools
+        : tools as List<RealtimeTool>?,
+    toolChoice: identical(toolChoice, unsetCopyWithValue)
+        ? this.toolChoice
+        : toolChoice as RealtimeToolChoice?,
+    temperature: identical(temperature, unsetCopyWithValue)
+        ? this.temperature
+        : temperature as double?,
+    maxOutputTokens: identical(maxOutputTokens, unsetCopyWithValue)
+        ? this.maxOutputTokens
+        : maxOutputTokens as InfOrInt?,
+    parallelToolCalls: identical(parallelToolCalls, unsetCopyWithValue)
+        ? this.parallelToolCalls
+        : parallelToolCalls as bool?,
+    reasoning: identical(reasoning, unsetCopyWithValue)
+        ? this.reasoning
+        : reasoning as RealtimeReasoning?,
+    tracing: identical(tracing, unsetCopyWithValue)
+        ? this.tracing
+        : tracing as RealtimeTracingConfig?,
+    truncation: identical(truncation, unsetCopyWithValue)
+        ? this.truncation
+        : truncation as RealtimeTruncation?,
+    include: identical(include, unsetCopyWithValue)
+        ? this.include
+        : include as List<String>?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeSession &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          object == other.object &&
+          type == other.type &&
+          model == other.model &&
+          expiresAt == other.expiresAt &&
+          audio == other.audio &&
+          listsEqual(outputModalities, other.outputModalities) &&
+          instructions == other.instructions &&
+          listsEqual(tools, other.tools) &&
+          toolChoice == other.toolChoice &&
+          temperature == other.temperature &&
+          maxOutputTokens == other.maxOutputTokens &&
+          parallelToolCalls == other.parallelToolCalls &&
+          reasoning == other.reasoning &&
+          tracing == other.tracing &&
+          truncation == other.truncation &&
+          listsEqual(include, other.include);
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    object,
+    type,
+    model,
+    expiresAt,
+    audio,
+    listHash(outputModalities),
+    instructions,
+    listHash(tools),
+    toolChoice,
+    temperature,
+    maxOutputTokens,
+    parallelToolCalls,
+    reasoning,
+    tracing,
+    truncation,
+    listHash(include),
+  );
+
+  @override
+  String toString() =>
+      'RealtimeSession(id: $id, model: $model, expiresAt: $expiresAt, '
+      'audio: $audio, outputModalities: $outputModalities, '
+      'instructions: $instructions, tools: $tools, toolChoice: $toolChoice, '
+      'temperature: $temperature, maxOutputTokens: $maxOutputTokens, '
+      'parallelToolCalls: $parallelToolCalls, reasoning: $reasoning, '
+      'tracing: $tracing, truncation: $truncation, include: $include)';
 }

--- a/packages/openai_dart/lib/src/models/realtime/realtime_session.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_session.dart
@@ -114,11 +114,11 @@ class RealtimeTool {
 class RealtimeSession {
   /// Creates a [RealtimeSession].
   const RealtimeSession({
-    required this.id,
-    required this.object,
-    required this.type,
-    required this.model,
-    required this.expiresAt,
+    this.id,
+    this.object,
+    this.type,
+    this.model,
+    this.expiresAt,
     this.audio,
     this.outputModalities,
     this.instructions,
@@ -134,18 +134,17 @@ class RealtimeSession {
 
   /// Creates a [RealtimeSession] from JSON.
   ///
-  /// `id`, `object`, `type`, `model`, and `expires_at` are documented as
-  /// required by the spec, but the live API has been observed to omit them
-  /// transiently (e.g., on early WebSocket `session.created` payloads
-  /// before the session is fully provisioned). To stay forward- and
-  /// backward-compatible, missing values default rather than throw.
+  /// All fields are optional per the spec — server payloads include
+  /// the relevant subset for the session shape (realtime vs.
+  /// transcription) and partial frames omit metadata that hasn't been
+  /// resolved yet.
   factory RealtimeSession.fromJson(Map<String, dynamic> json) {
     return RealtimeSession(
-      id: (json['id'] as String?) ?? '',
-      object: (json['object'] as String?) ?? 'realtime.session',
-      type: (json['type'] as String?) ?? 'realtime',
-      model: (json['model'] as String?) ?? '',
-      expiresAt: (json['expires_at'] as int?) ?? 0,
+      id: json['id'] as String?,
+      object: json['object'] as String?,
+      type: json['type'] as String?,
+      model: json['model'] as String?,
+      expiresAt: json['expires_at'] as int?,
       audio: json['audio'] != null
           ? RealtimeAudioConfig.fromJson(json['audio'] as Map<String, dynamic>)
           : null,
@@ -177,20 +176,23 @@ class RealtimeSession {
     );
   }
 
-  /// The session identifier (`sess_…`).
-  final String id;
+  /// The session identifier (`sess_…`). Optional on partial frames.
+  final String? id;
 
-  /// The object type (always `'realtime.session'`).
-  final String object;
+  /// The object type (e.g. `'realtime.session'`). Optional on partial frames.
+  final String? object;
 
-  /// The session type (always `'realtime'` for realtime sessions).
-  final String type;
+  /// The session type (`'realtime'` or `'transcription'`). Optional on
+  /// partial frames.
+  final String? type;
 
-  /// The model identifier.
-  final String model;
+  /// The model identifier. Always present for realtime sessions; omitted
+  /// for transcription sessions (which don't carry a top-level model).
+  final String? model;
 
-  /// Expiration timestamp (Unix epoch seconds).
-  final int expiresAt;
+  /// Expiration timestamp (Unix epoch seconds). May be `null` on partial
+  /// frames before the session is fully provisioned.
+  final int? expiresAt;
 
   /// Nested audio configuration.
   final RealtimeAudioConfig? audio;
@@ -230,11 +232,11 @@ class RealtimeSession {
 
   /// Converts to JSON.
   Map<String, dynamic> toJson() => {
-    'id': id,
-    'object': object,
-    'type': type,
-    'model': model,
-    'expires_at': expiresAt,
+    if (id != null) 'id': id,
+    if (object != null) 'object': object,
+    if (type != null) 'type': type,
+    if (model != null) 'model': model,
+    if (expiresAt != null) 'expires_at': expiresAt,
     if (audio != null) 'audio': audio!.toJson(),
     if (outputModalities != null) 'output_modalities': outputModalities,
     if (instructions != null) 'instructions': instructions,
@@ -252,11 +254,11 @@ class RealtimeSession {
   ///
   /// Pass `null` for any nullable field to clear the existing value.
   RealtimeSession copyWith({
-    String? id,
-    String? object,
-    String? type,
-    String? model,
-    int? expiresAt,
+    Object? id = unsetCopyWithValue,
+    Object? object = unsetCopyWithValue,
+    Object? type = unsetCopyWithValue,
+    Object? model = unsetCopyWithValue,
+    Object? expiresAt = unsetCopyWithValue,
     Object? audio = unsetCopyWithValue,
     Object? outputModalities = unsetCopyWithValue,
     Object? instructions = unsetCopyWithValue,
@@ -269,11 +271,15 @@ class RealtimeSession {
     Object? truncation = unsetCopyWithValue,
     Object? include = unsetCopyWithValue,
   }) => RealtimeSession(
-    id: id ?? this.id,
-    object: object ?? this.object,
-    type: type ?? this.type,
-    model: model ?? this.model,
-    expiresAt: expiresAt ?? this.expiresAt,
+    id: identical(id, unsetCopyWithValue) ? this.id : id as String?,
+    object: identical(object, unsetCopyWithValue)
+        ? this.object
+        : object as String?,
+    type: identical(type, unsetCopyWithValue) ? this.type : type as String?,
+    model: identical(model, unsetCopyWithValue) ? this.model : model as String?,
+    expiresAt: identical(expiresAt, unsetCopyWithValue)
+        ? this.expiresAt
+        : expiresAt as int?,
     audio: identical(audio, unsetCopyWithValue)
         ? this.audio
         : audio as RealtimeAudioConfig?,

--- a/packages/openai_dart/lib/src/models/realtime/realtime_session.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_session.dart
@@ -97,15 +97,13 @@ class RealtimeTool {
 // RealtimeSession
 // =============================================================================
 
-/// Configuration for a GA Realtime session.
+/// Configuration for a Realtime session.
 ///
 /// The Realtime API enables real-time audio conversations with the model
-/// using WebSockets.
-///
-/// This is the **GA-shape** session: audio configuration is nested under
-/// [audio] (`audio.input.*` / `audio.output.*`), `outputModalities` replaces
-/// the legacy `modalities` field, and `maxOutputTokens` replaces
-/// `maxResponseOutputTokens`.
+/// using WebSockets. Audio configuration is nested under [audio]
+/// (`audio.input.*` / `audio.output.*`), output modalities are configured
+/// via [outputModalities], and the maximum output token cap is set on
+/// [maxOutputTokens].
 ///
 /// Note: the `prompt` field from the spec is intentionally not modelled in
 /// this PR — the spec helper schema `Prompt` has no Dart class yet. Tracked
@@ -126,7 +124,6 @@ class RealtimeSession {
     this.instructions,
     this.tools,
     this.toolChoice,
-    this.temperature,
     this.maxOutputTokens,
     this.parallelToolCalls,
     this.reasoning,
@@ -161,7 +158,6 @@ class RealtimeSession {
       toolChoice: json['tool_choice'] != null
           ? RealtimeToolChoice.fromJson(json['tool_choice'] as Object)
           : null,
-      temperature: (json['temperature'] as num?)?.toDouble(),
       maxOutputTokens: json['max_output_tokens'] != null
           ? InfOrInt.fromJson(json['max_output_tokens'] as Object)
           : null,
@@ -199,9 +195,8 @@ class RealtimeSession {
   /// Nested audio configuration.
   final RealtimeAudioConfig? audio;
 
-  /// Output modalities (e.g. `['text', 'audio']`). Defaults to `['audio']`.
-  ///
-  /// Replaces the Beta-shape `modalities` field.
+  /// Output modalities (e.g. `['audio']` or `['text']`). Defaults to
+  /// `['audio']`. The server only accepts a single modality at a time.
   final List<String>? outputModalities;
 
   /// System instructions.
@@ -213,12 +208,7 @@ class RealtimeSession {
   /// Tool choice setting.
   final RealtimeToolChoice? toolChoice;
 
-  /// Sampling temperature.
-  final double? temperature;
-
   /// Maximum output tokens (`'inf'` or a specific integer).
-  ///
-  /// Replaces the Beta-shape `maxResponseOutputTokens` field.
   final InfOrInt? maxOutputTokens;
 
   /// Whether the model may call multiple tools in parallel. Only supported by
@@ -250,7 +240,6 @@ class RealtimeSession {
     if (instructions != null) 'instructions': instructions,
     if (tools != null) 'tools': tools!.map((t) => t.toJson()).toList(),
     if (toolChoice != null) 'tool_choice': toolChoice!.toJson(),
-    if (temperature != null) 'temperature': temperature,
     if (maxOutputTokens != null) 'max_output_tokens': maxOutputTokens!.toJson(),
     if (parallelToolCalls != null) 'parallel_tool_calls': parallelToolCalls,
     if (reasoning != null) 'reasoning': reasoning!.toJson(),
@@ -273,7 +262,6 @@ class RealtimeSession {
     Object? instructions = unsetCopyWithValue,
     Object? tools = unsetCopyWithValue,
     Object? toolChoice = unsetCopyWithValue,
-    Object? temperature = unsetCopyWithValue,
     Object? maxOutputTokens = unsetCopyWithValue,
     Object? parallelToolCalls = unsetCopyWithValue,
     Object? reasoning = unsetCopyWithValue,
@@ -301,9 +289,6 @@ class RealtimeSession {
     toolChoice: identical(toolChoice, unsetCopyWithValue)
         ? this.toolChoice
         : toolChoice as RealtimeToolChoice?,
-    temperature: identical(temperature, unsetCopyWithValue)
-        ? this.temperature
-        : temperature as double?,
     maxOutputTokens: identical(maxOutputTokens, unsetCopyWithValue)
         ? this.maxOutputTokens
         : maxOutputTokens as InfOrInt?,
@@ -339,7 +324,6 @@ class RealtimeSession {
           instructions == other.instructions &&
           listsEqual(tools, other.tools) &&
           toolChoice == other.toolChoice &&
-          temperature == other.temperature &&
           maxOutputTokens == other.maxOutputTokens &&
           parallelToolCalls == other.parallelToolCalls &&
           reasoning == other.reasoning &&
@@ -359,7 +343,6 @@ class RealtimeSession {
     instructions,
     listHash(tools),
     toolChoice,
-    temperature,
     maxOutputTokens,
     parallelToolCalls,
     reasoning,
@@ -373,7 +356,7 @@ class RealtimeSession {
       'RealtimeSession(id: $id, model: $model, expiresAt: $expiresAt, '
       'audio: $audio, outputModalities: $outputModalities, '
       'instructions: $instructions, tools: $tools, toolChoice: $toolChoice, '
-      'temperature: $temperature, maxOutputTokens: $maxOutputTokens, '
+      'maxOutputTokens: $maxOutputTokens, '
       'parallelToolCalls: $parallelToolCalls, reasoning: $reasoning, '
       'tracing: $tracing, truncation: $truncation, include: $include)';
 }

--- a/packages/openai_dart/lib/src/models/realtime/realtime_session_create.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_session_create.dart
@@ -1,166 +1,79 @@
 import 'package:meta/meta.dart';
 
 import '../common/auto_or_value.dart';
+import '../common/copy_with_sentinel.dart';
+import '../common/equality_helpers.dart';
+import 'realtime_audio_config.dart';
 import 'realtime_enums.dart';
+import 'realtime_reasoning.dart';
 import 'realtime_session.dart';
-
-// =============================================================================
-// ClientSecret
-// =============================================================================
-
-/// An ephemeral client secret for realtime API authentication.
-///
-/// Client secrets are short-lived tokens that can be used to authenticate
-/// WebSocket connections without exposing your main API key.
-@immutable
-class ClientSecret {
-  /// Creates a [ClientSecret].
-  const ClientSecret({required this.value, required this.expiresAt});
-
-  /// Creates a [ClientSecret] from JSON.
-  factory ClientSecret.fromJson(Map<String, dynamic> json) {
-    return ClientSecret(
-      value: json['value'] as String,
-      expiresAt: json['expires_at'] as int,
-    );
-  }
-
-  /// The client secret value (starts with "ek_").
-  final String value;
-
-  /// Unix timestamp when the secret expires.
-  final int expiresAt;
-
-  /// Converts to JSON.
-  Map<String, dynamic> toJson() => {'value': value, 'expires_at': expiresAt};
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is ClientSecret &&
-          runtimeType == other.runtimeType &&
-          value == other.value;
-
-  @override
-  int get hashCode => value.hashCode;
-
-  @override
-  String toString() => 'ClientSecret(expiresAt: $expiresAt)';
-}
-
-// =============================================================================
-// NoiseReductionConfig
-// =============================================================================
-
-/// Configuration for input audio noise reduction.
-@immutable
-class NoiseReductionConfig {
-  /// Creates a [NoiseReductionConfig].
-  const NoiseReductionConfig({this.type});
-
-  /// Creates a [NoiseReductionConfig] from JSON.
-  factory NoiseReductionConfig.fromJson(Map<String, dynamic> json) {
-    return NoiseReductionConfig(type: json['type'] as String?);
-  }
-
-  /// The noise reduction type (e.g., "near_field", "far_field").
-  final String? type;
-
-  /// Converts to JSON.
-  Map<String, dynamic> toJson() => {if (type != null) 'type': type};
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is NoiseReductionConfig &&
-          runtimeType == other.runtimeType &&
-          type == other.type;
-
-  @override
-  int get hashCode => type.hashCode;
-
-  @override
-  String toString() => 'NoiseReductionConfig(type: $type)';
-}
+import 'realtime_tracing_config.dart';
+import 'realtime_truncation.dart';
 
 // =============================================================================
 // RealtimeSessionCreateRequest
 // =============================================================================
 
-/// Request for creating a realtime session via HTTP.
+/// Request for creating a GA Realtime session via HTTP.
 ///
-/// This endpoint creates an ephemeral API key that can be used to
-/// authenticate a WebSocket connection to the Realtime API.
+/// This endpoint creates an ephemeral API key that can be used to authenticate
+/// a WebSocket connection to the Realtime API.
 ///
 /// ## Example
 ///
 /// ```dart
 /// final response = await client.realtimeSessions.create(
 ///   RealtimeSessionCreateRequest(
-///     model: 'gpt-realtime-1.5',
-///     voice: RealtimeVoice.alloy,
+///     model: 'gpt-realtime-2',
+///     audio: RealtimeAudioConfig(
+///       output: RealtimeAudioConfigOutput(voice: 'alloy'),
+///     ),
 ///     instructions: 'You are a helpful assistant.',
+///     reasoning: RealtimeReasoning(effort: RealtimeReasoningEffort.minimal),
 ///   ),
 /// );
-///
-/// // Use the client secret for WebSocket auth
-/// print('Client secret: ${response.clientSecret.value}');
 /// ```
 @immutable
 class RealtimeSessionCreateRequest {
   /// Creates a [RealtimeSessionCreateRequest].
   ///
-  /// The [type] field is used as a discriminator when the API needs to
-  /// distinguish between realtime and transcription sessions (e.g., when
-  /// creating client secrets). Set to `"realtime"` for realtime sessions.
+  /// The [type] field is the session-type discriminator (`'realtime'` for
+  /// realtime sessions). Set this when the API needs to distinguish between
+  /// realtime and transcription sessions, such as when creating client
+  /// secrets.
   const RealtimeSessionCreateRequest({
-    this.type,
     required this.model,
-    this.modalities,
+    this.type,
+    this.audio,
+    this.outputModalities,
     this.instructions,
-    this.voice,
-    this.inputAudioFormat,
-    this.outputAudioFormat,
-    this.inputAudioTranscription,
-    this.turnDetection,
-    this.inputAudioNoiseReduction,
     this.tools,
     this.toolChoice,
     this.temperature,
-    this.maxResponseOutputTokens,
+    this.maxOutputTokens,
+    this.parallelToolCalls,
+    this.reasoning,
+    this.tracing,
+    this.truncation,
+    this.include,
   });
 
   /// Creates a [RealtimeSessionCreateRequest] from JSON.
   factory RealtimeSessionCreateRequest.fromJson(Map<String, dynamic> json) {
+    if (json['model'] == null) {
+      throw const FormatException(
+        'RealtimeSessionCreateRequest.fromJson missing required "model" field',
+      );
+    }
     return RealtimeSessionCreateRequest(
-      type: json['type'] as String?,
       model: json['model'] as String,
-      modalities: (json['modalities'] as List<dynamic>?)?.cast<String>(),
+      type: json['type'] as String?,
+      audio: json['audio'] != null
+          ? RealtimeAudioConfig.fromJson(json['audio'] as Map<String, dynamic>)
+          : null,
+      outputModalities: (json['output_modalities'] as List<dynamic>?)
+          ?.cast<String>(),
       instructions: json['instructions'] as String?,
-      voice: json['voice'] != null
-          ? RealtimeVoice.fromJson(json['voice'] as String)
-          : null,
-      inputAudioFormat: json['input_audio_format'] != null
-          ? RealtimeAudioFormat.fromJson(json['input_audio_format'] as String)
-          : null,
-      outputAudioFormat: json['output_audio_format'] != null
-          ? RealtimeAudioFormat.fromJson(json['output_audio_format'] as String)
-          : null,
-      inputAudioTranscription: json['input_audio_transcription'] != null
-          ? InputAudioTranscription.fromJson(
-              json['input_audio_transcription'] as Map<String, dynamic>,
-            )
-          : null,
-      turnDetection: json['turn_detection'] != null
-          ? TurnDetection.fromJson(
-              json['turn_detection'] as Map<String, dynamic>,
-            )
-          : null,
-      inputAudioNoiseReduction: json['input_audio_noise_reduction'] != null
-          ? NoiseReductionConfig.fromJson(
-              json['input_audio_noise_reduction'] as Map<String, dynamic>,
-            )
-          : null,
       tools: (json['tools'] as List<dynamic>?)
           ?.map((e) => RealtimeTool.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -168,211 +81,43 @@ class RealtimeSessionCreateRequest {
           ? RealtimeToolChoice.fromJson(json['tool_choice'] as Object)
           : null,
       temperature: (json['temperature'] as num?)?.toDouble(),
-      maxResponseOutputTokens: json['max_response_output_tokens'] != null
-          ? InfOrInt.fromJson(json['max_response_output_tokens'] as Object)
+      maxOutputTokens: json['max_output_tokens'] != null
+          ? InfOrInt.fromJson(json['max_output_tokens'] as Object)
           : null,
+      parallelToolCalls: json['parallel_tool_calls'] as bool?,
+      reasoning: json['reasoning'] != null
+          ? RealtimeReasoning.fromJson(
+              json['reasoning'] as Map<String, dynamic>,
+            )
+          : null,
+      tracing: json['tracing'] != null
+          ? RealtimeTracingConfig.fromJson(json['tracing'] as Object)
+          : null,
+      truncation: json['truncation'] != null
+          ? RealtimeTruncation.fromJson(json['truncation'] as Object)
+          : null,
+      include: (json['include'] as List<dynamic>?)?.cast<String>(),
     );
   }
 
   /// The session type discriminator.
   ///
-  /// This field is used by the API to distinguish between realtime sessions
-  /// and transcription sessions when creating client secrets. Set to `"realtime"`
-  /// for realtime sessions. Only needed for certain endpoints like client secrets.
+  /// Used by the API to distinguish between realtime sessions and
+  /// transcription sessions when creating client secrets. Set to
+  /// `'realtime'` for realtime sessions.
   final String? type;
 
-  /// The model to use (required for HTTP, e.g., 'gpt-realtime-1.5').
+  /// The model identifier (required).
   final String model;
 
-  /// The modalities enabled (e.g., ["text", "audio"]).
-  final List<String>? modalities;
+  /// Nested audio configuration.
+  final RealtimeAudioConfig? audio;
 
-  /// System instructions for the model.
+  /// Output modalities.
+  final List<String>? outputModalities;
+
+  /// System instructions.
   final String? instructions;
-
-  /// The voice to use for audio output.
-  final RealtimeVoice? voice;
-
-  /// Input audio format.
-  final RealtimeAudioFormat? inputAudioFormat;
-
-  /// Output audio format.
-  final RealtimeAudioFormat? outputAudioFormat;
-
-  /// Configuration for input audio transcription.
-  final InputAudioTranscription? inputAudioTranscription;
-
-  /// Turn detection configuration.
-  final TurnDetection? turnDetection;
-
-  /// Input audio noise reduction configuration.
-  final NoiseReductionConfig? inputAudioNoiseReduction;
-
-  /// Tools available to the model.
-  final List<RealtimeTool>? tools;
-
-  /// Tool choice setting.
-  final RealtimeToolChoice? toolChoice;
-
-  /// Sampling temperature (0.6-1.2).
-  final double? temperature;
-
-  /// Maximum output tokens ("inf" or a specific integer).
-  final InfOrInt? maxResponseOutputTokens;
-
-  /// Converts to JSON.
-  Map<String, dynamic> toJson() => {
-    if (type != null) 'type': type,
-    'model': model,
-    if (modalities != null) 'modalities': modalities,
-    if (instructions != null) 'instructions': instructions,
-    if (voice != null) 'voice': voice!.toJson(),
-    if (inputAudioFormat != null)
-      'input_audio_format': inputAudioFormat!.toJson(),
-    if (outputAudioFormat != null)
-      'output_audio_format': outputAudioFormat!.toJson(),
-    if (inputAudioTranscription != null)
-      'input_audio_transcription': inputAudioTranscription!.toJson(),
-    if (turnDetection != null) 'turn_detection': turnDetection!.toJson(),
-    if (inputAudioNoiseReduction != null)
-      'input_audio_noise_reduction': inputAudioNoiseReduction!.toJson(),
-    if (tools != null) 'tools': tools!.map((t) => t.toJson()).toList(),
-    if (toolChoice != null) 'tool_choice': toolChoice!.toJson(),
-    if (temperature != null) 'temperature': temperature,
-    if (maxResponseOutputTokens != null)
-      'max_response_output_tokens': maxResponseOutputTokens!.toJson(),
-  };
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is RealtimeSessionCreateRequest &&
-          runtimeType == other.runtimeType &&
-          model == other.model;
-
-  @override
-  int get hashCode => model.hashCode;
-
-  @override
-  String toString() => 'RealtimeSessionCreateRequest(model: $model)';
-}
-
-// =============================================================================
-// RealtimeSessionCreateResponse
-// =============================================================================
-
-/// Response from creating a realtime session via HTTP.
-///
-/// Contains the session configuration and an ephemeral client secret
-/// for authenticating WebSocket connections.
-@immutable
-class RealtimeSessionCreateResponse {
-  /// Creates a [RealtimeSessionCreateResponse].
-  const RealtimeSessionCreateResponse({
-    required this.id,
-    required this.object,
-    required this.model,
-    this.clientSecret,
-    this.modalities,
-    this.instructions,
-    this.voice,
-    this.inputAudioFormat,
-    this.outputAudioFormat,
-    this.inputAudioTranscription,
-    this.turnDetection,
-    this.inputAudioNoiseReduction,
-    this.tools,
-    this.toolChoice,
-    this.temperature,
-    this.maxResponseOutputTokens,
-  });
-
-  /// Creates a [RealtimeSessionCreateResponse] from JSON.
-  factory RealtimeSessionCreateResponse.fromJson(Map<String, dynamic> json) {
-    return RealtimeSessionCreateResponse(
-      id: json['id'] as String,
-      object: json['object'] as String,
-      model: json['model'] as String,
-      clientSecret: json['client_secret'] != null
-          ? ClientSecret.fromJson(json['client_secret'] as Map<String, dynamic>)
-          : null,
-      modalities: (json['modalities'] as List<dynamic>?)?.cast<String>(),
-      instructions: json['instructions'] as String?,
-      voice: json['voice'] != null
-          ? RealtimeVoice.fromJson(json['voice'] as String)
-          : null,
-      inputAudioFormat: json['input_audio_format'] != null
-          ? RealtimeAudioFormat.fromJson(json['input_audio_format'] as String)
-          : null,
-      outputAudioFormat: json['output_audio_format'] != null
-          ? RealtimeAudioFormat.fromJson(json['output_audio_format'] as String)
-          : null,
-      inputAudioTranscription: json['input_audio_transcription'] != null
-          ? InputAudioTranscription.fromJson(
-              json['input_audio_transcription'] as Map<String, dynamic>,
-            )
-          : null,
-      turnDetection: json['turn_detection'] != null
-          ? TurnDetection.fromJson(
-              json['turn_detection'] as Map<String, dynamic>,
-            )
-          : null,
-      inputAudioNoiseReduction: json['input_audio_noise_reduction'] != null
-          ? NoiseReductionConfig.fromJson(
-              json['input_audio_noise_reduction'] as Map<String, dynamic>,
-            )
-          : null,
-      tools: (json['tools'] as List<dynamic>?)
-          ?.map((e) => RealtimeTool.fromJson(e as Map<String, dynamic>))
-          .toList(),
-      toolChoice: json['tool_choice'] != null
-          ? RealtimeToolChoice.fromJson(json['tool_choice'] as Object)
-          : null,
-      temperature: (json['temperature'] as num?)?.toDouble(),
-      maxResponseOutputTokens: json['max_response_output_tokens'] != null
-          ? InfOrInt.fromJson(json['max_response_output_tokens'] as Object)
-          : null,
-    );
-  }
-
-  /// The session identifier.
-  final String id;
-
-  /// The object type (always "realtime.session").
-  final String object;
-
-  /// The model to use.
-  final String model;
-
-  /// The ephemeral client secret for WebSocket authentication.
-  ///
-  /// This field is present when the session is created via the HTTP endpoint,
-  /// but may be null when the session is returned as part of another response.
-  final ClientSecret? clientSecret;
-
-  /// The modalities enabled (e.g., ["text", "audio"]).
-  final List<String>? modalities;
-
-  /// System instructions for the model.
-  final String? instructions;
-
-  /// The voice to use for audio output.
-  final RealtimeVoice? voice;
-
-  /// Input audio format.
-  final RealtimeAudioFormat? inputAudioFormat;
-
-  /// Output audio format.
-  final RealtimeAudioFormat? outputAudioFormat;
-
-  /// Configuration for input audio transcription.
-  final InputAudioTranscription? inputAudioTranscription;
-
-  /// Turn detection configuration.
-  final TurnDetection? turnDetection;
-
-  /// Input audio noise reduction configuration.
-  final NoiseReductionConfig? inputAudioNoiseReduction;
 
   /// Tools available to the model.
   final List<RealtimeTool>? tools;
@@ -383,44 +128,414 @@ class RealtimeSessionCreateResponse {
   /// Sampling temperature.
   final double? temperature;
 
-  /// Maximum output tokens ("inf" or a specific integer).
-  final InfOrInt? maxResponseOutputTokens;
+  /// Maximum output tokens (`'inf'` or a specific integer).
+  final InfOrInt? maxOutputTokens;
+
+  /// Whether the model may call multiple tools in parallel.
+  final bool? parallelToolCalls;
+
+  /// Reasoning configuration.
+  final RealtimeReasoning? reasoning;
+
+  /// Tracing configuration.
+  final RealtimeTracingConfig? tracing;
+
+  /// Truncation configuration.
+  final RealtimeTruncation? truncation;
+
+  /// Additional fields to include in server outputs.
+  final List<String>? include;
+
+  /// Converts to JSON.
+  ///
+  /// `type` is only emitted when explicitly set. The bare `/realtime/sessions`
+  /// endpoint rejects unknown parameters; the `/realtime/client_secrets`
+  /// wrapper injects `'type': 'realtime'` itself when it serializes the
+  /// embedded session.
+  Map<String, dynamic> toJson() => {
+    if (type != null) 'type': type,
+    'model': model,
+    if (audio != null) 'audio': audio!.toJson(),
+    if (outputModalities != null) 'output_modalities': outputModalities,
+    if (instructions != null) 'instructions': instructions,
+    if (tools != null) 'tools': tools!.map((t) => t.toJson()).toList(),
+    if (toolChoice != null) 'tool_choice': toolChoice!.toJson(),
+    if (temperature != null) 'temperature': temperature,
+    if (maxOutputTokens != null) 'max_output_tokens': maxOutputTokens!.toJson(),
+    if (parallelToolCalls != null) 'parallel_tool_calls': parallelToolCalls,
+    if (reasoning != null) 'reasoning': reasoning!.toJson(),
+    if (tracing != null) 'tracing': tracing!.toJson(),
+    if (truncation != null) 'truncation': truncation!.toJson(),
+    if (include != null) 'include': include,
+  };
+
+  /// Returns a copy of this [RealtimeSessionCreateRequest] with the given
+  /// fields replaced. Pass `null` for any nullable field to clear the
+  /// existing value.
+  RealtimeSessionCreateRequest copyWith({
+    String? model,
+    Object? type = unsetCopyWithValue,
+    Object? audio = unsetCopyWithValue,
+    Object? outputModalities = unsetCopyWithValue,
+    Object? instructions = unsetCopyWithValue,
+    Object? tools = unsetCopyWithValue,
+    Object? toolChoice = unsetCopyWithValue,
+    Object? temperature = unsetCopyWithValue,
+    Object? maxOutputTokens = unsetCopyWithValue,
+    Object? parallelToolCalls = unsetCopyWithValue,
+    Object? reasoning = unsetCopyWithValue,
+    Object? tracing = unsetCopyWithValue,
+    Object? truncation = unsetCopyWithValue,
+    Object? include = unsetCopyWithValue,
+  }) => RealtimeSessionCreateRequest(
+    model: model ?? this.model,
+    type: identical(type, unsetCopyWithValue) ? this.type : type as String?,
+    audio: identical(audio, unsetCopyWithValue)
+        ? this.audio
+        : audio as RealtimeAudioConfig?,
+    outputModalities: identical(outputModalities, unsetCopyWithValue)
+        ? this.outputModalities
+        : outputModalities as List<String>?,
+    instructions: identical(instructions, unsetCopyWithValue)
+        ? this.instructions
+        : instructions as String?,
+    tools: identical(tools, unsetCopyWithValue)
+        ? this.tools
+        : tools as List<RealtimeTool>?,
+    toolChoice: identical(toolChoice, unsetCopyWithValue)
+        ? this.toolChoice
+        : toolChoice as RealtimeToolChoice?,
+    temperature: identical(temperature, unsetCopyWithValue)
+        ? this.temperature
+        : temperature as double?,
+    maxOutputTokens: identical(maxOutputTokens, unsetCopyWithValue)
+        ? this.maxOutputTokens
+        : maxOutputTokens as InfOrInt?,
+    parallelToolCalls: identical(parallelToolCalls, unsetCopyWithValue)
+        ? this.parallelToolCalls
+        : parallelToolCalls as bool?,
+    reasoning: identical(reasoning, unsetCopyWithValue)
+        ? this.reasoning
+        : reasoning as RealtimeReasoning?,
+    tracing: identical(tracing, unsetCopyWithValue)
+        ? this.tracing
+        : tracing as RealtimeTracingConfig?,
+    truncation: identical(truncation, unsetCopyWithValue)
+        ? this.truncation
+        : truncation as RealtimeTruncation?,
+    include: identical(include, unsetCopyWithValue)
+        ? this.include
+        : include as List<String>?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeSessionCreateRequest &&
+          runtimeType == other.runtimeType &&
+          model == other.model &&
+          type == other.type &&
+          audio == other.audio &&
+          listsEqual(outputModalities, other.outputModalities) &&
+          instructions == other.instructions &&
+          listsEqual(tools, other.tools) &&
+          toolChoice == other.toolChoice &&
+          temperature == other.temperature &&
+          maxOutputTokens == other.maxOutputTokens &&
+          parallelToolCalls == other.parallelToolCalls &&
+          reasoning == other.reasoning &&
+          tracing == other.tracing &&
+          truncation == other.truncation &&
+          listsEqual(include, other.include);
+
+  @override
+  int get hashCode => Object.hash(
+    model,
+    type,
+    audio,
+    listHash(outputModalities),
+    instructions,
+    listHash(tools),
+    toolChoice,
+    temperature,
+    maxOutputTokens,
+    parallelToolCalls,
+    reasoning,
+    tracing,
+    truncation,
+    listHash(include),
+  );
+
+  @override
+  String toString() =>
+      'RealtimeSessionCreateRequest(model: $model, type: $type, audio: $audio, '
+      'outputModalities: $outputModalities, instructions: $instructions, '
+      'tools: $tools, toolChoice: $toolChoice, temperature: $temperature, '
+      'maxOutputTokens: $maxOutputTokens, parallelToolCalls: $parallelToolCalls, '
+      'reasoning: $reasoning, tracing: $tracing, truncation: $truncation, '
+      'include: $include)';
+}
+
+// =============================================================================
+// RealtimeSessionCreateResponse
+// =============================================================================
+
+/// Response from creating a GA Realtime session via HTTP.
+///
+/// Contains the session configuration. Note that the GA shape no longer nests
+/// the client secret inside this response — the `/realtime/client_secrets`
+/// endpoint returns a [RealtimeClientSecretCreateResponse] wrapping this
+/// [RealtimeSessionCreateResponse] alongside the secret.
+@immutable
+class RealtimeSessionCreateResponse {
+  /// Creates a [RealtimeSessionCreateResponse].
+  const RealtimeSessionCreateResponse({
+    required this.id,
+    required this.object,
+    required this.type,
+    required this.model,
+    required this.expiresAt,
+    this.audio,
+    this.outputModalities,
+    this.instructions,
+    this.tools,
+    this.toolChoice,
+    this.temperature,
+    this.maxOutputTokens,
+    this.parallelToolCalls,
+    this.reasoning,
+    this.tracing,
+    this.truncation,
+    this.include,
+  });
+
+  /// Creates a [RealtimeSessionCreateResponse] from JSON.
+  ///
+  /// Spec-required fields (`id`, `object`, `type`, `model`, `expires_at`)
+  /// are defaulted rather than required to stay tolerant of partial server
+  /// payloads (e.g., on early `session.created` frames).
+  factory RealtimeSessionCreateResponse.fromJson(Map<String, dynamic> json) {
+    return RealtimeSessionCreateResponse(
+      id: (json['id'] as String?) ?? '',
+      object: (json['object'] as String?) ?? 'realtime.session',
+      type: (json['type'] as String?) ?? 'realtime',
+      model: (json['model'] as String?) ?? '',
+      expiresAt: (json['expires_at'] as int?) ?? 0,
+      audio: json['audio'] != null
+          ? RealtimeAudioConfig.fromJson(json['audio'] as Map<String, dynamic>)
+          : null,
+      outputModalities: (json['output_modalities'] as List<dynamic>?)
+          ?.cast<String>(),
+      instructions: json['instructions'] as String?,
+      tools: (json['tools'] as List<dynamic>?)
+          ?.map((e) => RealtimeTool.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      toolChoice: json['tool_choice'] != null
+          ? RealtimeToolChoice.fromJson(json['tool_choice'] as Object)
+          : null,
+      temperature: (json['temperature'] as num?)?.toDouble(),
+      maxOutputTokens: json['max_output_tokens'] != null
+          ? InfOrInt.fromJson(json['max_output_tokens'] as Object)
+          : null,
+      parallelToolCalls: json['parallel_tool_calls'] as bool?,
+      reasoning: json['reasoning'] != null
+          ? RealtimeReasoning.fromJson(
+              json['reasoning'] as Map<String, dynamic>,
+            )
+          : null,
+      tracing: json['tracing'] != null
+          ? RealtimeTracingConfig.fromJson(json['tracing'] as Object)
+          : null,
+      truncation: json['truncation'] != null
+          ? RealtimeTruncation.fromJson(json['truncation'] as Object)
+          : null,
+      include: (json['include'] as List<dynamic>?)?.cast<String>(),
+    );
+  }
+
+  /// The session identifier.
+  final String id;
+
+  /// The object type (always `'realtime.session'`).
+  final String object;
+
+  /// The session type (always `'realtime'`).
+  final String type;
+
+  /// The model identifier.
+  final String model;
+
+  /// Expiration timestamp (Unix epoch seconds).
+  final int expiresAt;
+
+  /// Nested audio configuration.
+  final RealtimeAudioConfig? audio;
+
+  /// Output modalities.
+  final List<String>? outputModalities;
+
+  /// System instructions.
+  final String? instructions;
+
+  /// Tools available to the model.
+  final List<RealtimeTool>? tools;
+
+  /// Tool choice setting.
+  final RealtimeToolChoice? toolChoice;
+
+  /// Sampling temperature.
+  final double? temperature;
+
+  /// Maximum output tokens.
+  final InfOrInt? maxOutputTokens;
+
+  /// Whether the model may call multiple tools in parallel.
+  final bool? parallelToolCalls;
+
+  /// Reasoning configuration.
+  final RealtimeReasoning? reasoning;
+
+  /// Tracing configuration.
+  final RealtimeTracingConfig? tracing;
+
+  /// Truncation configuration.
+  final RealtimeTruncation? truncation;
+
+  /// Additional fields to include in server outputs.
+  final List<String>? include;
 
   /// Converts to JSON.
   Map<String, dynamic> toJson() => {
     'id': id,
     'object': object,
+    'type': type,
     'model': model,
-    if (clientSecret != null) 'client_secret': clientSecret!.toJson(),
-    if (modalities != null) 'modalities': modalities,
+    'expires_at': expiresAt,
+    if (audio != null) 'audio': audio!.toJson(),
+    if (outputModalities != null) 'output_modalities': outputModalities,
     if (instructions != null) 'instructions': instructions,
-    if (voice != null) 'voice': voice!.toJson(),
-    if (inputAudioFormat != null)
-      'input_audio_format': inputAudioFormat!.toJson(),
-    if (outputAudioFormat != null)
-      'output_audio_format': outputAudioFormat!.toJson(),
-    if (inputAudioTranscription != null)
-      'input_audio_transcription': inputAudioTranscription!.toJson(),
-    if (turnDetection != null) 'turn_detection': turnDetection!.toJson(),
-    if (inputAudioNoiseReduction != null)
-      'input_audio_noise_reduction': inputAudioNoiseReduction!.toJson(),
     if (tools != null) 'tools': tools!.map((t) => t.toJson()).toList(),
     if (toolChoice != null) 'tool_choice': toolChoice!.toJson(),
     if (temperature != null) 'temperature': temperature,
-    if (maxResponseOutputTokens != null)
-      'max_response_output_tokens': maxResponseOutputTokens!.toJson(),
+    if (maxOutputTokens != null) 'max_output_tokens': maxOutputTokens!.toJson(),
+    if (parallelToolCalls != null) 'parallel_tool_calls': parallelToolCalls,
+    if (reasoning != null) 'reasoning': reasoning!.toJson(),
+    if (tracing != null) 'tracing': tracing!.toJson(),
+    if (truncation != null) 'truncation': truncation!.toJson(),
+    if (include != null) 'include': include,
   };
+
+  /// Returns a copy of this [RealtimeSessionCreateResponse] with the given
+  /// fields replaced. Pass `null` for any nullable field to clear the
+  /// existing value.
+  RealtimeSessionCreateResponse copyWith({
+    String? id,
+    String? object,
+    String? type,
+    String? model,
+    int? expiresAt,
+    Object? audio = unsetCopyWithValue,
+    Object? outputModalities = unsetCopyWithValue,
+    Object? instructions = unsetCopyWithValue,
+    Object? tools = unsetCopyWithValue,
+    Object? toolChoice = unsetCopyWithValue,
+    Object? temperature = unsetCopyWithValue,
+    Object? maxOutputTokens = unsetCopyWithValue,
+    Object? parallelToolCalls = unsetCopyWithValue,
+    Object? reasoning = unsetCopyWithValue,
+    Object? tracing = unsetCopyWithValue,
+    Object? truncation = unsetCopyWithValue,
+    Object? include = unsetCopyWithValue,
+  }) => RealtimeSessionCreateResponse(
+    id: id ?? this.id,
+    object: object ?? this.object,
+    type: type ?? this.type,
+    model: model ?? this.model,
+    expiresAt: expiresAt ?? this.expiresAt,
+    audio: identical(audio, unsetCopyWithValue)
+        ? this.audio
+        : audio as RealtimeAudioConfig?,
+    outputModalities: identical(outputModalities, unsetCopyWithValue)
+        ? this.outputModalities
+        : outputModalities as List<String>?,
+    instructions: identical(instructions, unsetCopyWithValue)
+        ? this.instructions
+        : instructions as String?,
+    tools: identical(tools, unsetCopyWithValue)
+        ? this.tools
+        : tools as List<RealtimeTool>?,
+    toolChoice: identical(toolChoice, unsetCopyWithValue)
+        ? this.toolChoice
+        : toolChoice as RealtimeToolChoice?,
+    temperature: identical(temperature, unsetCopyWithValue)
+        ? this.temperature
+        : temperature as double?,
+    maxOutputTokens: identical(maxOutputTokens, unsetCopyWithValue)
+        ? this.maxOutputTokens
+        : maxOutputTokens as InfOrInt?,
+    parallelToolCalls: identical(parallelToolCalls, unsetCopyWithValue)
+        ? this.parallelToolCalls
+        : parallelToolCalls as bool?,
+    reasoning: identical(reasoning, unsetCopyWithValue)
+        ? this.reasoning
+        : reasoning as RealtimeReasoning?,
+    tracing: identical(tracing, unsetCopyWithValue)
+        ? this.tracing
+        : tracing as RealtimeTracingConfig?,
+    truncation: identical(truncation, unsetCopyWithValue)
+        ? this.truncation
+        : truncation as RealtimeTruncation?,
+    include: identical(include, unsetCopyWithValue)
+        ? this.include
+        : include as List<String>?,
+  );
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is RealtimeSessionCreateResponse &&
           runtimeType == other.runtimeType &&
-          id == other.id;
+          id == other.id &&
+          object == other.object &&
+          type == other.type &&
+          model == other.model &&
+          expiresAt == other.expiresAt &&
+          audio == other.audio &&
+          listsEqual(outputModalities, other.outputModalities) &&
+          instructions == other.instructions &&
+          listsEqual(tools, other.tools) &&
+          toolChoice == other.toolChoice &&
+          temperature == other.temperature &&
+          maxOutputTokens == other.maxOutputTokens &&
+          parallelToolCalls == other.parallelToolCalls &&
+          reasoning == other.reasoning &&
+          tracing == other.tracing &&
+          truncation == other.truncation &&
+          listsEqual(include, other.include);
 
   @override
-  int get hashCode => id.hashCode;
+  int get hashCode => Object.hash(
+    id,
+    object,
+    type,
+    model,
+    expiresAt,
+    audio,
+    listHash(outputModalities),
+    instructions,
+    listHash(tools),
+    toolChoice,
+    temperature,
+    maxOutputTokens,
+    parallelToolCalls,
+    reasoning,
+    tracing,
+    truncation,
+    listHash(include),
+  );
 
   @override
-  String toString() => 'RealtimeSessionCreateResponse(id: $id, model: $model)';
+  String toString() =>
+      'RealtimeSessionCreateResponse(id: $id, model: $model, '
+      'expiresAt: $expiresAt, audio: $audio)';
 }

--- a/packages/openai_dart/lib/src/models/realtime/realtime_session_create.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_session_create.dart
@@ -284,8 +284,8 @@ class RealtimeSessionCreateResponse {
     required this.id,
     required this.object,
     required this.type,
-    required this.model,
-    required this.expiresAt,
+    this.model,
+    this.expiresAt,
     this.audio,
     this.outputModalities,
     this.instructions,
@@ -301,16 +301,24 @@ class RealtimeSessionCreateResponse {
 
   /// Creates a [RealtimeSessionCreateResponse] from JSON.
   ///
-  /// Spec-required fields (`id`, `object`, `type`, `model`, `expires_at`)
-  /// are defaulted rather than required to stay tolerant of partial server
-  /// payloads (e.g., on early `session.created` frames).
+  /// Throws [FormatException] when any spec-required field (`id`,
+  /// `object`, `type`) is missing. `model` and `expires_at` are
+  /// optional per the spec — transcription session responses don't
+  /// carry a top-level `model`, and partial frames may omit
+  /// `expires_at`.
   factory RealtimeSessionCreateResponse.fromJson(Map<String, dynamic> json) {
+    if (json['id'] == null || json['object'] == null || json['type'] == null) {
+      throw const FormatException(
+        'RealtimeSessionCreateResponse.fromJson missing one or more required '
+        'fields (id, object, type)',
+      );
+    }
     return RealtimeSessionCreateResponse(
-      id: (json['id'] as String?) ?? '',
-      object: (json['object'] as String?) ?? 'realtime.session',
-      type: (json['type'] as String?) ?? 'realtime',
-      model: (json['model'] as String?) ?? '',
-      expiresAt: (json['expires_at'] as int?) ?? 0,
+      id: json['id'] as String,
+      object: json['object'] as String,
+      type: json['type'] as String,
+      model: json['model'] as String?,
+      expiresAt: json['expires_at'] as int?,
       audio: json['audio'] != null
           ? RealtimeAudioConfig.fromJson(json['audio'] as Map<String, dynamic>)
           : null,
@@ -345,17 +353,21 @@ class RealtimeSessionCreateResponse {
   /// The session identifier.
   final String id;
 
-  /// The object type (always `'realtime.session'`).
+  /// The object type (e.g. `'realtime.session'` /
+  /// `'realtime.transcription_session'`).
   final String object;
 
-  /// The session type (always `'realtime'`).
+  /// The session type (`'realtime'` or `'transcription'`).
   final String type;
 
-  /// The model identifier.
-  final String model;
+  /// The model identifier. Always present for realtime sessions; omitted
+  /// from transcription session responses (which carry the model on the
+  /// nested `audio.input.transcription` instead).
+  final String? model;
 
-  /// Expiration timestamp (Unix epoch seconds).
-  final int expiresAt;
+  /// Expiration timestamp (Unix epoch seconds). May be `null` on partial
+  /// or transient frames.
+  final int? expiresAt;
 
   /// Nested audio configuration.
   final RealtimeAudioConfig? audio;
@@ -395,8 +407,8 @@ class RealtimeSessionCreateResponse {
     'id': id,
     'object': object,
     'type': type,
-    'model': model,
-    'expires_at': expiresAt,
+    if (model != null) 'model': model,
+    if (expiresAt != null) 'expires_at': expiresAt,
     if (audio != null) 'audio': audio!.toJson(),
     if (outputModalities != null) 'output_modalities': outputModalities,
     if (instructions != null) 'instructions': instructions,
@@ -417,8 +429,8 @@ class RealtimeSessionCreateResponse {
     String? id,
     String? object,
     String? type,
-    String? model,
-    int? expiresAt,
+    Object? model = unsetCopyWithValue,
+    Object? expiresAt = unsetCopyWithValue,
     Object? audio = unsetCopyWithValue,
     Object? outputModalities = unsetCopyWithValue,
     Object? instructions = unsetCopyWithValue,
@@ -434,8 +446,10 @@ class RealtimeSessionCreateResponse {
     id: id ?? this.id,
     object: object ?? this.object,
     type: type ?? this.type,
-    model: model ?? this.model,
-    expiresAt: expiresAt ?? this.expiresAt,
+    model: identical(model, unsetCopyWithValue) ? this.model : model as String?,
+    expiresAt: identical(expiresAt, unsetCopyWithValue)
+        ? this.expiresAt
+        : expiresAt as int?,
     audio: identical(audio, unsetCopyWithValue)
         ? this.audio
         : audio as RealtimeAudioConfig?,

--- a/packages/openai_dart/lib/src/models/realtime/realtime_session_create.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_session_create.dart
@@ -14,22 +14,25 @@ import 'realtime_truncation.dart';
 // RealtimeSessionCreateRequest
 // =============================================================================
 
-/// Request for creating a GA Realtime session via HTTP.
+/// Realtime session configuration.
 ///
-/// This endpoint creates an ephemeral API key that can be used to authenticate
-/// a WebSocket connection to the Realtime API.
+/// Used as the embedded `session` in [RealtimeClientSecretCreateRequest]
+/// when calling `client.realtimeSessions.createClientSecret(...)` and as the
+/// payload of the `session.update` WebSocket event.
 ///
 /// ## Example
 ///
 /// ```dart
-/// final response = await client.realtimeSessions.create(
-///   RealtimeSessionCreateRequest(
-///     model: 'gpt-realtime-2',
-///     audio: RealtimeAudioConfig(
-///       output: RealtimeAudioConfigOutput(voice: 'alloy'),
+/// final response = await client.realtimeSessions.createClientSecret(
+///   RealtimeClientSecretCreateRequest(
+///     session: RealtimeSessionCreateRequest(
+///       model: 'gpt-realtime-2',
+///       audio: RealtimeAudioConfig(
+///         output: RealtimeAudioConfigOutput(voice: 'alloy'),
+///       ),
+///       instructions: 'You are a helpful assistant.',
+///       reasoning: RealtimeReasoning(effort: RealtimeReasoningEffort.minimal),
 ///     ),
-///     instructions: 'You are a helpful assistant.',
-///     reasoning: RealtimeReasoning(effort: RealtimeReasoningEffort.minimal),
 ///   ),
 /// );
 /// ```
@@ -49,7 +52,6 @@ class RealtimeSessionCreateRequest {
     this.instructions,
     this.tools,
     this.toolChoice,
-    this.temperature,
     this.maxOutputTokens,
     this.parallelToolCalls,
     this.reasoning,
@@ -80,7 +82,6 @@ class RealtimeSessionCreateRequest {
       toolChoice: json['tool_choice'] != null
           ? RealtimeToolChoice.fromJson(json['tool_choice'] as Object)
           : null,
-      temperature: (json['temperature'] as num?)?.toDouble(),
       maxOutputTokens: json['max_output_tokens'] != null
           ? InfOrInt.fromJson(json['max_output_tokens'] as Object)
           : null,
@@ -125,9 +126,6 @@ class RealtimeSessionCreateRequest {
   /// Tool choice setting.
   final RealtimeToolChoice? toolChoice;
 
-  /// Sampling temperature.
-  final double? temperature;
-
   /// Maximum output tokens (`'inf'` or a specific integer).
   final InfOrInt? maxOutputTokens;
 
@@ -160,7 +158,6 @@ class RealtimeSessionCreateRequest {
     if (instructions != null) 'instructions': instructions,
     if (tools != null) 'tools': tools!.map((t) => t.toJson()).toList(),
     if (toolChoice != null) 'tool_choice': toolChoice!.toJson(),
-    if (temperature != null) 'temperature': temperature,
     if (maxOutputTokens != null) 'max_output_tokens': maxOutputTokens!.toJson(),
     if (parallelToolCalls != null) 'parallel_tool_calls': parallelToolCalls,
     if (reasoning != null) 'reasoning': reasoning!.toJson(),
@@ -180,7 +177,6 @@ class RealtimeSessionCreateRequest {
     Object? instructions = unsetCopyWithValue,
     Object? tools = unsetCopyWithValue,
     Object? toolChoice = unsetCopyWithValue,
-    Object? temperature = unsetCopyWithValue,
     Object? maxOutputTokens = unsetCopyWithValue,
     Object? parallelToolCalls = unsetCopyWithValue,
     Object? reasoning = unsetCopyWithValue,
@@ -205,9 +201,6 @@ class RealtimeSessionCreateRequest {
     toolChoice: identical(toolChoice, unsetCopyWithValue)
         ? this.toolChoice
         : toolChoice as RealtimeToolChoice?,
-    temperature: identical(temperature, unsetCopyWithValue)
-        ? this.temperature
-        : temperature as double?,
     maxOutputTokens: identical(maxOutputTokens, unsetCopyWithValue)
         ? this.maxOutputTokens
         : maxOutputTokens as InfOrInt?,
@@ -240,7 +233,6 @@ class RealtimeSessionCreateRequest {
           instructions == other.instructions &&
           listsEqual(tools, other.tools) &&
           toolChoice == other.toolChoice &&
-          temperature == other.temperature &&
           maxOutputTokens == other.maxOutputTokens &&
           parallelToolCalls == other.parallelToolCalls &&
           reasoning == other.reasoning &&
@@ -257,7 +249,6 @@ class RealtimeSessionCreateRequest {
     instructions,
     listHash(tools),
     toolChoice,
-    temperature,
     maxOutputTokens,
     parallelToolCalls,
     reasoning,
@@ -270,7 +261,7 @@ class RealtimeSessionCreateRequest {
   String toString() =>
       'RealtimeSessionCreateRequest(model: $model, type: $type, audio: $audio, '
       'outputModalities: $outputModalities, instructions: $instructions, '
-      'tools: $tools, toolChoice: $toolChoice, temperature: $temperature, '
+      'tools: $tools, toolChoice: $toolChoice, '
       'maxOutputTokens: $maxOutputTokens, parallelToolCalls: $parallelToolCalls, '
       'reasoning: $reasoning, tracing: $tracing, truncation: $truncation, '
       'include: $include)';
@@ -280,11 +271,11 @@ class RealtimeSessionCreateRequest {
 // RealtimeSessionCreateResponse
 // =============================================================================
 
-/// Response from creating a GA Realtime session via HTTP.
+/// Response from creating a Realtime session via HTTP.
 ///
-/// Contains the session configuration. Note that the GA shape no longer nests
-/// the client secret inside this response — the `/realtime/client_secrets`
-/// endpoint returns a [RealtimeClientSecretCreateResponse] wrapping this
+/// Contains the session configuration. The client secret is **not** nested
+/// on this response — the `/realtime/client_secrets` endpoint returns a
+/// [RealtimeClientSecretCreateResponse] wrapping this
 /// [RealtimeSessionCreateResponse] alongside the secret.
 @immutable
 class RealtimeSessionCreateResponse {
@@ -300,7 +291,6 @@ class RealtimeSessionCreateResponse {
     this.instructions,
     this.tools,
     this.toolChoice,
-    this.temperature,
     this.maxOutputTokens,
     this.parallelToolCalls,
     this.reasoning,
@@ -333,7 +323,6 @@ class RealtimeSessionCreateResponse {
       toolChoice: json['tool_choice'] != null
           ? RealtimeToolChoice.fromJson(json['tool_choice'] as Object)
           : null,
-      temperature: (json['temperature'] as num?)?.toDouble(),
       maxOutputTokens: json['max_output_tokens'] != null
           ? InfOrInt.fromJson(json['max_output_tokens'] as Object)
           : null,
@@ -383,9 +372,6 @@ class RealtimeSessionCreateResponse {
   /// Tool choice setting.
   final RealtimeToolChoice? toolChoice;
 
-  /// Sampling temperature.
-  final double? temperature;
-
   /// Maximum output tokens.
   final InfOrInt? maxOutputTokens;
 
@@ -416,7 +402,6 @@ class RealtimeSessionCreateResponse {
     if (instructions != null) 'instructions': instructions,
     if (tools != null) 'tools': tools!.map((t) => t.toJson()).toList(),
     if (toolChoice != null) 'tool_choice': toolChoice!.toJson(),
-    if (temperature != null) 'temperature': temperature,
     if (maxOutputTokens != null) 'max_output_tokens': maxOutputTokens!.toJson(),
     if (parallelToolCalls != null) 'parallel_tool_calls': parallelToolCalls,
     if (reasoning != null) 'reasoning': reasoning!.toJson(),
@@ -439,7 +424,6 @@ class RealtimeSessionCreateResponse {
     Object? instructions = unsetCopyWithValue,
     Object? tools = unsetCopyWithValue,
     Object? toolChoice = unsetCopyWithValue,
-    Object? temperature = unsetCopyWithValue,
     Object? maxOutputTokens = unsetCopyWithValue,
     Object? parallelToolCalls = unsetCopyWithValue,
     Object? reasoning = unsetCopyWithValue,
@@ -467,9 +451,6 @@ class RealtimeSessionCreateResponse {
     toolChoice: identical(toolChoice, unsetCopyWithValue)
         ? this.toolChoice
         : toolChoice as RealtimeToolChoice?,
-    temperature: identical(temperature, unsetCopyWithValue)
-        ? this.temperature
-        : temperature as double?,
     maxOutputTokens: identical(maxOutputTokens, unsetCopyWithValue)
         ? this.maxOutputTokens
         : maxOutputTokens as InfOrInt?,
@@ -505,7 +486,6 @@ class RealtimeSessionCreateResponse {
           instructions == other.instructions &&
           listsEqual(tools, other.tools) &&
           toolChoice == other.toolChoice &&
-          temperature == other.temperature &&
           maxOutputTokens == other.maxOutputTokens &&
           parallelToolCalls == other.parallelToolCalls &&
           reasoning == other.reasoning &&
@@ -525,7 +505,6 @@ class RealtimeSessionCreateResponse {
     instructions,
     listHash(tools),
     toolChoice,
-    temperature,
     maxOutputTokens,
     parallelToolCalls,
     reasoning,

--- a/packages/openai_dart/lib/src/models/realtime/realtime_tracing_config.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_tracing_config.dart
@@ -7,7 +7,7 @@ import '../common/equality_helpers.dart';
 // RealtimeTracingConfig
 // =============================================================================
 
-/// Tracing configuration for GA Realtime sessions.
+/// Tracing configuration for Realtime sessions.
 ///
 /// A discriminated union covering:
 ///

--- a/packages/openai_dart/lib/src/models/realtime/realtime_tracing_config.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_tracing_config.dart
@@ -1,0 +1,170 @@
+import 'package:meta/meta.dart';
+
+import '../common/copy_with_sentinel.dart';
+import '../common/equality_helpers.dart';
+
+// =============================================================================
+// RealtimeTracingConfig
+// =============================================================================
+
+/// Tracing configuration for GA Realtime sessions.
+///
+/// A discriminated union covering:
+///
+/// - [TracingAuto] — the bare string `"auto"`, enabling tracing with default
+///   values.
+/// - [TracingConfiguration] — an object with optional `group_id`, `metadata`,
+///   and `workflow_name` for granular tracing control.
+///
+/// An [UnknownRealtimeTracingConfig] fallback preserves any unrecognised
+/// payload so future server additions do not break existing clients.
+sealed class RealtimeTracingConfig {
+  const RealtimeTracingConfig();
+
+  /// Auto tracing.
+  const factory RealtimeTracingConfig.auto() = TracingAuto;
+
+  /// Granular tracing configuration.
+  const factory RealtimeTracingConfig.configuration({
+    String? groupId,
+    Map<String, dynamic>? metadata,
+    String? workflowName,
+  }) = TracingConfiguration;
+
+  /// Creates from JSON.
+  ///
+  /// Accepts the bare string `"auto"` or an object with optional fields.
+  factory RealtimeTracingConfig.fromJson(Object json) {
+    if (json == 'auto') return const TracingAuto();
+    if (json is Map<String, dynamic>) {
+      return TracingConfiguration.fromJson(json);
+    }
+    return UnknownRealtimeTracingConfig({'value': json});
+  }
+
+  /// Converts to JSON. Returns either the string `"auto"` or a `Map`.
+  Object toJson();
+}
+
+/// `auto` tracing strategy.
+@immutable
+class TracingAuto extends RealtimeTracingConfig {
+  /// Creates a [TracingAuto].
+  const TracingAuto();
+
+  @override
+  Object toJson() => 'auto';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TracingAuto && runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => 'auto'.hashCode;
+
+  @override
+  String toString() => 'RealtimeTracingConfig.auto()';
+}
+
+/// Granular tracing configuration.
+@immutable
+class TracingConfiguration extends RealtimeTracingConfig {
+  /// Creates a [TracingConfiguration].
+  const TracingConfiguration({this.groupId, this.metadata, this.workflowName});
+
+  /// Creates from JSON.
+  factory TracingConfiguration.fromJson(Map<String, dynamic> json) {
+    return TracingConfiguration(
+      groupId: json['group_id'] as String?,
+      metadata: json['metadata'] != null
+          ? Map<String, dynamic>.from(json['metadata'] as Map)
+          : null,
+      workflowName: json['workflow_name'] as String?,
+    );
+  }
+
+  /// Optional group identifier for filtering in the Traces Dashboard.
+  final String? groupId;
+
+  /// Optional arbitrary metadata.
+  final Map<String, dynamic>? metadata;
+
+  /// Optional workflow name.
+  final String? workflowName;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    if (groupId != null) 'group_id': groupId,
+    if (metadata != null) 'metadata': metadata,
+    if (workflowName != null) 'workflow_name': workflowName,
+  };
+
+  /// Returns a copy of this [TracingConfiguration] with the given fields replaced.
+  ///
+  /// Pass `null` for any field to clear the existing value.
+  TracingConfiguration copyWith({
+    Object? groupId = unsetCopyWithValue,
+    Object? metadata = unsetCopyWithValue,
+    Object? workflowName = unsetCopyWithValue,
+  }) => TracingConfiguration(
+    groupId: identical(groupId, unsetCopyWithValue)
+        ? this.groupId
+        : groupId as String?,
+    metadata: identical(metadata, unsetCopyWithValue)
+        ? this.metadata
+        : metadata as Map<String, dynamic>?,
+    workflowName: identical(workflowName, unsetCopyWithValue)
+        ? this.workflowName
+        : workflowName as String?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TracingConfiguration &&
+          runtimeType == other.runtimeType &&
+          groupId == other.groupId &&
+          mapsDeepEqual(metadata, other.metadata) &&
+          workflowName == other.workflowName;
+
+  @override
+  int get hashCode =>
+      Object.hash(groupId, mapDeepHashCode(metadata), workflowName);
+
+  @override
+  String toString() =>
+      'TracingConfiguration(groupId: $groupId, metadata: $metadata, '
+      'workflowName: $workflowName)';
+}
+
+/// Forward-compatible fallback for unknown [RealtimeTracingConfig] payloads.
+@immutable
+class UnknownRealtimeTracingConfig extends RealtimeTracingConfig {
+  /// Creates an [UnknownRealtimeTracingConfig] from the raw payload.
+  const UnknownRealtimeTracingConfig(this.json);
+
+  /// The raw JSON map preserved verbatim.
+  final Map<String, dynamic> json;
+
+  @override
+  Object toJson() {
+    if (json.length == 1 && json.containsKey('value')) {
+      return json['value'] as Object;
+    }
+    return Map<String, dynamic>.from(json);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnknownRealtimeTracingConfig &&
+          runtimeType == other.runtimeType &&
+          mapsDeepEqual(json, other.json);
+
+  @override
+  int get hashCode => mapDeepHashCode(json);
+
+  @override
+  String toString() => 'UnknownRealtimeTracingConfig($json)';
+}

--- a/packages/openai_dart/lib/src/models/realtime/realtime_transcription_session.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_transcription_session.dart
@@ -1,38 +1,100 @@
 import 'package:meta/meta.dart';
 
-import 'realtime_enums.dart';
-import 'realtime_session.dart';
-import 'realtime_session_create.dart';
+import '../common/copy_with_sentinel.dart';
+import '../common/equality_helpers.dart';
+import 'realtime_audio_config.dart';
+
+// =============================================================================
+// RealtimeTranscriptionSessionAudio
+// =============================================================================
+
+/// Audio configuration block for a GA transcription session.
+///
+/// Mirrors the Python SDK `realtime_transcription_session_audio` shape.
+@immutable
+class RealtimeTranscriptionSessionAudio {
+  /// Creates a [RealtimeTranscriptionSessionAudio].
+  const RealtimeTranscriptionSessionAudio({this.input});
+
+  /// Creates from JSON.
+  factory RealtimeTranscriptionSessionAudio.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return RealtimeTranscriptionSessionAudio(
+      input: json['input'] != null
+          ? RealtimeAudioConfigInput.fromJson(
+              json['input'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+
+  /// Input audio configuration. Transcription sessions only have inputs.
+  final RealtimeAudioConfigInput? input;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (input != null) 'input': input!.toJson(),
+  };
+
+  /// Returns a copy with the given fields replaced.
+  ///
+  /// Pass `null` for [input] to clear the existing value.
+  RealtimeTranscriptionSessionAudio copyWith({
+    Object? input = unsetCopyWithValue,
+  }) => RealtimeTranscriptionSessionAudio(
+    input: identical(input, unsetCopyWithValue)
+        ? this.input
+        : input as RealtimeAudioConfigInput?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranscriptionSessionAudio &&
+          runtimeType == other.runtimeType &&
+          input == other.input;
+
+  @override
+  int get hashCode => input.hashCode;
+
+  @override
+  String toString() => 'RealtimeTranscriptionSessionAudio(input: $input)';
+}
 
 // =============================================================================
 // RealtimeTranscriptionSessionCreateRequest
 // =============================================================================
 
-/// Request for creating a realtime transcription session via HTTP.
+/// Request for creating a GA Realtime transcription session via HTTP.
 ///
-/// Transcription sessions are optimized for audio-to-text scenarios
-/// without generating audio responses.
+/// Transcription sessions are optimized for audio-to-text scenarios without
+/// generating audio responses.
 ///
 /// ## Example
 ///
 /// ```dart
 /// final response = await client.realtimeSessions.createTranscription(
 ///   RealtimeTranscriptionSessionCreateRequest(
-///     inputAudioFormat: RealtimeAudioFormat.pcm16,
-///     inputAudioTranscription: InputAudioTranscription(model: 'whisper-1'),
+///     audio: RealtimeTranscriptionSessionAudio(
+///       input: RealtimeAudioConfigInput(
+///         transcription: InputAudioTranscription(model: 'whisper-1'),
+///       ),
+///     ),
 ///   ),
 /// );
-///
-/// print('Client secret: ${response.clientSecret.value}');
 /// ```
 @immutable
 class RealtimeTranscriptionSessionCreateRequest {
   /// Creates a [RealtimeTranscriptionSessionCreateRequest].
+  ///
+  /// [type] is the session-type discriminator (`'transcription'` for
+  /// transcription sessions). Set this when the API needs to distinguish
+  /// session types, e.g. when creating client secrets.
   const RealtimeTranscriptionSessionCreateRequest({
-    this.inputAudioFormat,
-    this.inputAudioTranscription,
-    this.turnDetection,
-    this.inputAudioNoiseReduction,
+    this.type,
+    this.audio,
+    this.include,
   });
 
   /// Creates a [RealtimeTranscriptionSessionCreateRequest] from JSON.
@@ -40,155 +102,190 @@ class RealtimeTranscriptionSessionCreateRequest {
     Map<String, dynamic> json,
   ) {
     return RealtimeTranscriptionSessionCreateRequest(
-      inputAudioFormat: json['input_audio_format'] != null
-          ? RealtimeAudioFormat.fromJson(json['input_audio_format'] as String)
-          : null,
-      inputAudioTranscription: json['input_audio_transcription'] != null
-          ? InputAudioTranscription.fromJson(
-              json['input_audio_transcription'] as Map<String, dynamic>,
+      type: json['type'] as String?,
+      audio: json['audio'] != null
+          ? RealtimeTranscriptionSessionAudio.fromJson(
+              json['audio'] as Map<String, dynamic>,
             )
           : null,
-      turnDetection: json['turn_detection'] != null
-          ? TurnDetection.fromJson(
-              json['turn_detection'] as Map<String, dynamic>,
-            )
-          : null,
-      inputAudioNoiseReduction: json['input_audio_noise_reduction'] != null
-          ? NoiseReductionConfig.fromJson(
-              json['input_audio_noise_reduction'] as Map<String, dynamic>,
-            )
-          : null,
+      include: (json['include'] as List<dynamic>?)?.cast<String>(),
     );
   }
 
-  /// Input audio format.
-  final RealtimeAudioFormat? inputAudioFormat;
+  /// The session type discriminator. Defaults to `'transcription'` on the
+  /// wire if omitted.
+  final String? type;
 
-  /// Configuration for input audio transcription.
-  final InputAudioTranscription? inputAudioTranscription;
+  /// Audio configuration.
+  final RealtimeTranscriptionSessionAudio? audio;
 
-  /// Turn detection configuration.
-  final TurnDetection? turnDetection;
-
-  /// Input audio noise reduction configuration.
-  final NoiseReductionConfig? inputAudioNoiseReduction;
+  /// Additional fields to include in server outputs.
+  final List<String>? include;
 
   /// Converts to JSON.
+  ///
+  /// `type` is only emitted when explicitly set. The bare
+  /// `/realtime/transcription_sessions` endpoint rejects unknown parameters;
+  /// the `/realtime/client_secrets` wrapper injects
+  /// `'type': 'transcription'` itself when serializing the embedded session.
   Map<String, dynamic> toJson() => {
-    if (inputAudioFormat != null)
-      'input_audio_format': inputAudioFormat!.toJson(),
-    if (inputAudioTranscription != null)
-      'input_audio_transcription': inputAudioTranscription!.toJson(),
-    if (turnDetection != null) 'turn_detection': turnDetection!.toJson(),
-    if (inputAudioNoiseReduction != null)
-      'input_audio_noise_reduction': inputAudioNoiseReduction!.toJson(),
+    if (type != null) 'type': type,
+    if (audio != null) 'audio': audio!.toJson(),
+    if (include != null) 'include': include,
   };
+
+  /// Returns a copy with the given fields replaced.
+  ///
+  /// Pass `null` for any nullable field to clear the existing value.
+  RealtimeTranscriptionSessionCreateRequest copyWith({
+    Object? type = unsetCopyWithValue,
+    Object? audio = unsetCopyWithValue,
+    Object? include = unsetCopyWithValue,
+  }) => RealtimeTranscriptionSessionCreateRequest(
+    type: identical(type, unsetCopyWithValue) ? this.type : type as String?,
+    audio: identical(audio, unsetCopyWithValue)
+        ? this.audio
+        : audio as RealtimeTranscriptionSessionAudio?,
+    include: identical(include, unsetCopyWithValue)
+        ? this.include
+        : include as List<String>?,
+  );
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is RealtimeTranscriptionSessionCreateRequest &&
-          runtimeType == other.runtimeType;
+          runtimeType == other.runtimeType &&
+          type == other.type &&
+          audio == other.audio &&
+          listsEqual(include, other.include);
 
   @override
-  int get hashCode => Object.hash(inputAudioFormat, inputAudioTranscription);
+  int get hashCode => Object.hash(type, audio, listHash(include));
 
   @override
-  String toString() => 'RealtimeTranscriptionSessionCreateRequest(...)';
+  String toString() =>
+      'RealtimeTranscriptionSessionCreateRequest(type: $type, audio: $audio, '
+      'include: $include)';
 }
 
 // =============================================================================
 // RealtimeTranscriptionSessionCreateResponse
 // =============================================================================
 
-/// Response from creating a realtime transcription session via HTTP.
+/// Response from creating a GA Realtime transcription session.
 ///
-/// Contains the session configuration and an ephemeral client secret
-/// for authenticating WebSocket connections.
+/// Note: the GA shape no longer includes `client_secret` on the inner session
+/// object; callers must read the secret from the wrapper response of the
+/// `/realtime/client_secrets` endpoint.
 @immutable
 class RealtimeTranscriptionSessionCreateResponse {
   /// Creates a [RealtimeTranscriptionSessionCreateResponse].
   const RealtimeTranscriptionSessionCreateResponse({
-    required this.clientSecret,
-    this.modalities,
-    this.inputAudioFormat,
-    this.inputAudioTranscription,
-    this.turnDetection,
-    this.inputAudioNoiseReduction,
+    required this.id,
+    required this.object,
+    required this.type,
+    required this.expiresAt,
+    this.audio,
+    this.include,
   });
 
   /// Creates a [RealtimeTranscriptionSessionCreateResponse] from JSON.
   factory RealtimeTranscriptionSessionCreateResponse.fromJson(
     Map<String, dynamic> json,
   ) {
+    if (json['id'] == null ||
+        json['object'] == null ||
+        json['type'] == null ||
+        json['expires_at'] == null) {
+      throw const FormatException(
+        'RealtimeTranscriptionSessionCreateResponse.fromJson missing one or more '
+        'required fields (id, object, type, expires_at)',
+      );
+    }
     return RealtimeTranscriptionSessionCreateResponse(
-      clientSecret: ClientSecret.fromJson(
-        json['client_secret'] as Map<String, dynamic>,
-      ),
-      modalities: (json['modalities'] as List<dynamic>?)?.cast<String>(),
-      inputAudioFormat: json['input_audio_format'] != null
-          ? RealtimeAudioFormat.fromJson(json['input_audio_format'] as String)
-          : null,
-      inputAudioTranscription: json['input_audio_transcription'] != null
-          ? InputAudioTranscription.fromJson(
-              json['input_audio_transcription'] as Map<String, dynamic>,
+      id: json['id'] as String,
+      object: json['object'] as String,
+      type: json['type'] as String,
+      expiresAt: json['expires_at'] as int,
+      audio: json['audio'] != null
+          ? RealtimeTranscriptionSessionAudio.fromJson(
+              json['audio'] as Map<String, dynamic>,
             )
           : null,
-      turnDetection: json['turn_detection'] != null
-          ? TurnDetection.fromJson(
-              json['turn_detection'] as Map<String, dynamic>,
-            )
-          : null,
-      inputAudioNoiseReduction: json['input_audio_noise_reduction'] != null
-          ? NoiseReductionConfig.fromJson(
-              json['input_audio_noise_reduction'] as Map<String, dynamic>,
-            )
-          : null,
+      include: (json['include'] as List<dynamic>?)?.cast<String>(),
     );
   }
 
-  /// The ephemeral client secret for WebSocket authentication.
-  final ClientSecret clientSecret;
+  /// The session identifier (`sess_…`).
+  final String id;
 
-  /// The modalities enabled.
-  final List<String>? modalities;
+  /// The object type (`'realtime.transcription_session'`).
+  final String object;
 
-  /// Input audio format.
-  final RealtimeAudioFormat? inputAudioFormat;
+  /// The session type (always `'transcription'`).
+  final String type;
 
-  /// Configuration for input audio transcription.
-  final InputAudioTranscription? inputAudioTranscription;
+  /// Expiration timestamp (Unix epoch seconds).
+  final int expiresAt;
 
-  /// Turn detection configuration.
-  final TurnDetection? turnDetection;
+  /// Audio configuration.
+  final RealtimeTranscriptionSessionAudio? audio;
 
-  /// Input audio noise reduction configuration.
-  final NoiseReductionConfig? inputAudioNoiseReduction;
+  /// Fields included in server outputs.
+  final List<String>? include;
 
   /// Converts to JSON.
   Map<String, dynamic> toJson() => {
-    'client_secret': clientSecret.toJson(),
-    if (modalities != null) 'modalities': modalities,
-    if (inputAudioFormat != null)
-      'input_audio_format': inputAudioFormat!.toJson(),
-    if (inputAudioTranscription != null)
-      'input_audio_transcription': inputAudioTranscription!.toJson(),
-    if (turnDetection != null) 'turn_detection': turnDetection!.toJson(),
-    if (inputAudioNoiseReduction != null)
-      'input_audio_noise_reduction': inputAudioNoiseReduction!.toJson(),
+    'id': id,
+    'object': object,
+    'type': type,
+    'expires_at': expiresAt,
+    if (audio != null) 'audio': audio!.toJson(),
+    if (include != null) 'include': include,
   };
+
+  /// Returns a copy with the given fields replaced.
+  ///
+  /// Pass `null` for any nullable field to clear the existing value.
+  RealtimeTranscriptionSessionCreateResponse copyWith({
+    String? id,
+    String? object,
+    String? type,
+    int? expiresAt,
+    Object? audio = unsetCopyWithValue,
+    Object? include = unsetCopyWithValue,
+  }) => RealtimeTranscriptionSessionCreateResponse(
+    id: id ?? this.id,
+    object: object ?? this.object,
+    type: type ?? this.type,
+    expiresAt: expiresAt ?? this.expiresAt,
+    audio: identical(audio, unsetCopyWithValue)
+        ? this.audio
+        : audio as RealtimeTranscriptionSessionAudio?,
+    include: identical(include, unsetCopyWithValue)
+        ? this.include
+        : include as List<String>?,
+  );
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is RealtimeTranscriptionSessionCreateResponse &&
           runtimeType == other.runtimeType &&
-          clientSecret == other.clientSecret;
+          id == other.id &&
+          object == other.object &&
+          type == other.type &&
+          expiresAt == other.expiresAt &&
+          audio == other.audio &&
+          listsEqual(include, other.include);
 
   @override
-  int get hashCode => clientSecret.hashCode;
+  int get hashCode =>
+      Object.hash(id, object, type, expiresAt, audio, listHash(include));
 
   @override
   String toString() =>
-      'RealtimeTranscriptionSessionCreateResponse(clientSecret: ${clientSecret.value.substring(0, 10)}...)';
+      'RealtimeTranscriptionSessionCreateResponse(id: $id, expiresAt: $expiresAt, '
+      'audio: $audio)';
 }

--- a/packages/openai_dart/lib/src/models/realtime/realtime_transcription_session.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_transcription_session.dart
@@ -74,11 +74,14 @@ class RealtimeTranscriptionSessionAudio {
 /// ## Example
 ///
 /// ```dart
-/// final response = await client.realtimeSessions.createTranscription(
-///   RealtimeTranscriptionSessionCreateRequest(
-///     audio: RealtimeTranscriptionSessionAudio(
-///       input: RealtimeAudioConfigInput(
-///         transcription: InputAudioTranscription(model: 'whisper-1'),
+/// final response =
+///     await client.realtimeSessions.createTranscriptionClientSecret(
+///   RealtimeTranscriptionClientSecretCreateRequest(
+///     session: RealtimeTranscriptionSessionCreateRequest(
+///       audio: RealtimeTranscriptionSessionAudio(
+///         input: RealtimeAudioConfigInput(
+///           transcription: InputAudioTranscription(model: 'whisper-1'),
+///         ),
 ///       ),
 ///     ),
 ///   ),

--- a/packages/openai_dart/lib/src/models/realtime/realtime_transcription_session.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_transcription_session.dart
@@ -8,7 +8,7 @@ import 'realtime_audio_config.dart';
 // RealtimeTranscriptionSessionAudio
 // =============================================================================
 
-/// Audio configuration block for a GA transcription session.
+/// Audio configuration block for a transcription session.
 ///
 /// Mirrors the Python SDK `realtime_transcription_session_audio` shape.
 @immutable
@@ -66,7 +66,7 @@ class RealtimeTranscriptionSessionAudio {
 // RealtimeTranscriptionSessionCreateRequest
 // =============================================================================
 
-/// Request for creating a GA Realtime transcription session via HTTP.
+/// Request for creating a Realtime transcription session via HTTP.
 ///
 /// Transcription sessions are optimized for audio-to-text scenarios without
 /// generating audio responses.
@@ -173,9 +173,9 @@ class RealtimeTranscriptionSessionCreateRequest {
 // RealtimeTranscriptionSessionCreateResponse
 // =============================================================================
 
-/// Response from creating a GA Realtime transcription session.
+/// Response from creating a Realtime transcription session.
 ///
-/// Note: the GA shape no longer includes `client_secret` on the inner session
+/// Note: the response does not include `client_secret` on the inner session
 /// object; callers must read the secret from the wrapper response of the
 /// `/realtime/client_secrets` endpoint.
 @immutable

--- a/packages/openai_dart/lib/src/models/realtime/realtime_translation_event.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_translation_event.dart
@@ -1,0 +1,881 @@
+import 'package:meta/meta.dart';
+
+import '../common/equality_helpers.dart';
+import 'realtime_translation_session.dart';
+
+// =============================================================================
+// RealtimeTranslationClientEvent (sealed)
+// =============================================================================
+
+/// A client → server event for a Realtime translation session.
+///
+/// Discriminated by `type`:
+///
+/// - [RealtimeTranslationSessionUpdateEvent] — `session.update`
+/// - [RealtimeTranslationInputAudioBufferAppendEvent] — `session.input_audio_buffer.append`
+/// - [RealtimeTranslationSessionCloseEvent] — `session.close`
+///
+/// Unknown discriminators are surfaced as
+/// [UnknownRealtimeTranslationClientEvent], preserving the raw payload.
+sealed class RealtimeTranslationClientEvent {
+  const RealtimeTranslationClientEvent();
+
+  /// Creates from JSON.
+  factory RealtimeTranslationClientEvent.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    return switch (type) {
+      'session.update' => RealtimeTranslationSessionUpdateEvent.fromJson(json),
+      'session.input_audio_buffer.append' =>
+        RealtimeTranslationInputAudioBufferAppendEvent.fromJson(json),
+      'session.close' => RealtimeTranslationSessionCloseEvent.fromJson(json),
+      _ => UnknownRealtimeTranslationClientEvent(
+        Map<String, dynamic>.from(json),
+      ),
+    };
+  }
+
+  /// The discriminator value.
+  String get type;
+
+  /// Optional client-generated event id.
+  String? get eventId;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson();
+}
+
+/// Send to update the translation session configuration.
+@immutable
+class RealtimeTranslationSessionUpdateEvent
+    extends RealtimeTranslationClientEvent {
+  /// Creates a [RealtimeTranslationSessionUpdateEvent].
+  const RealtimeTranslationSessionUpdateEvent({
+    required this.session,
+    this.eventId,
+  });
+
+  /// Creates from JSON.
+  factory RealtimeTranslationSessionUpdateEvent.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    if (json['type'] != 'session.update') {
+      throw FormatException(
+        'RealtimeTranslationSessionUpdateEvent.fromJson expected type '
+        '"session.update", got ${json['type']}',
+      );
+    }
+    if (json['session'] == null) {
+      throw const FormatException(
+        'RealtimeTranslationSessionUpdateEvent.fromJson missing required '
+        '"session" field',
+      );
+    }
+    return RealtimeTranslationSessionUpdateEvent(
+      session: RealtimeTranslationSessionUpdateRequest.fromJson(
+        json['session'] as Map<String, dynamic>,
+      ),
+      eventId: json['event_id'] as String?,
+    );
+  }
+
+  /// Translation session fields to update. The session `type` and `model` are
+  /// set at creation and cannot be changed via `session.update`.
+  final RealtimeTranslationSessionUpdateRequest session;
+
+  @override
+  final String? eventId;
+
+  @override
+  String get type => 'session.update';
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'session': session.toJson(),
+    if (eventId != null) 'event_id': eventId,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationSessionUpdateEvent &&
+          runtimeType == other.runtimeType &&
+          session == other.session &&
+          eventId == other.eventId;
+
+  @override
+  int get hashCode => Object.hash(session, eventId);
+
+  @override
+  String toString() =>
+      'RealtimeTranslationSessionUpdateEvent(eventId: $eventId, session: $session)';
+}
+
+/// Append base64-encoded audio bytes to the translation input buffer.
+///
+/// WebSocket translation sessions accept base64-encoded 24 kHz PCM16 mono
+/// little-endian raw audio bytes. Note: this base64 is the **raw audio bytes
+/// from the client**, *not* a request-factory data URL — the OpenAI-specific
+/// `data:<mediaType>;base64,<data>` rule does not apply.
+@immutable
+class RealtimeTranslationInputAudioBufferAppendEvent
+    extends RealtimeTranslationClientEvent {
+  /// Creates a [RealtimeTranslationInputAudioBufferAppendEvent].
+  const RealtimeTranslationInputAudioBufferAppendEvent({
+    required this.audio,
+    this.eventId,
+  });
+
+  /// Creates from JSON.
+  factory RealtimeTranslationInputAudioBufferAppendEvent.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    if (json['type'] != 'session.input_audio_buffer.append') {
+      throw FormatException(
+        'RealtimeTranslationInputAudioBufferAppendEvent.fromJson expected type '
+        '"session.input_audio_buffer.append", got ${json['type']}',
+      );
+    }
+    if (json['audio'] == null) {
+      throw const FormatException(
+        'RealtimeTranslationInputAudioBufferAppendEvent.fromJson missing '
+        'required "audio" field',
+      );
+    }
+    return RealtimeTranslationInputAudioBufferAppendEvent(
+      audio: json['audio'] as String,
+      eventId: json['event_id'] as String?,
+    );
+  }
+
+  /// Base64-encoded 24 kHz PCM16 mono raw audio bytes.
+  final String audio;
+
+  @override
+  final String? eventId;
+
+  @override
+  String get type => 'session.input_audio_buffer.append';
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'audio': audio,
+    if (eventId != null) 'event_id': eventId,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationInputAudioBufferAppendEvent &&
+          runtimeType == other.runtimeType &&
+          audio == other.audio &&
+          eventId == other.eventId;
+
+  @override
+  int get hashCode => Object.hash(audio, eventId);
+
+  @override
+  String toString() =>
+      'RealtimeTranslationInputAudioBufferAppendEvent(eventId: $eventId, '
+      'audio: <${audio.length} chars>)';
+}
+
+/// Gracefully close a translation session.
+@immutable
+class RealtimeTranslationSessionCloseEvent
+    extends RealtimeTranslationClientEvent {
+  /// Creates a [RealtimeTranslationSessionCloseEvent].
+  const RealtimeTranslationSessionCloseEvent({this.eventId});
+
+  /// Creates from JSON.
+  factory RealtimeTranslationSessionCloseEvent.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    if (json['type'] != 'session.close') {
+      throw FormatException(
+        'RealtimeTranslationSessionCloseEvent.fromJson expected type '
+        '"session.close", got ${json['type']}',
+      );
+    }
+    return RealtimeTranslationSessionCloseEvent(
+      eventId: json['event_id'] as String?,
+    );
+  }
+
+  @override
+  final String? eventId;
+
+  @override
+  String get type => 'session.close';
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (eventId != null) 'event_id': eventId,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationSessionCloseEvent &&
+          runtimeType == other.runtimeType &&
+          eventId == other.eventId;
+
+  @override
+  int get hashCode => eventId.hashCode;
+
+  @override
+  String toString() =>
+      'RealtimeTranslationSessionCloseEvent(eventId: $eventId)';
+}
+
+/// Forward-compatible fallback for unknown translation client events.
+@immutable
+class UnknownRealtimeTranslationClientEvent
+    extends RealtimeTranslationClientEvent {
+  /// Creates from raw JSON.
+  const UnknownRealtimeTranslationClientEvent(this.json);
+
+  /// The raw JSON map preserved verbatim.
+  final Map<String, dynamic> json;
+
+  @override
+  String get type => json['type'] as String? ?? '';
+
+  @override
+  String? get eventId => json['event_id'] as String?;
+
+  @override
+  Map<String, dynamic> toJson() => Map<String, dynamic>.from(json);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnknownRealtimeTranslationClientEvent &&
+          runtimeType == other.runtimeType &&
+          mapsDeepEqual(json, other.json);
+
+  @override
+  int get hashCode => mapDeepHashCode(json);
+
+  @override
+  String toString() => 'UnknownRealtimeTranslationClientEvent(type: $type)';
+}
+
+// =============================================================================
+// RealtimeTranslationServerEvent (sealed)
+// =============================================================================
+
+/// A server → client event for a Realtime translation session.
+///
+/// Discriminated by `type`:
+///
+/// - [RealtimeTranslationErrorEvent] — `error` (shared with the regular
+///   Realtime API)
+/// - [RealtimeTranslationSessionCreatedEvent] — `session.created`
+/// - [RealtimeTranslationSessionUpdatedEvent] — `session.updated`
+/// - [RealtimeTranslationSessionClosedEvent] — `session.closed`
+/// - [RealtimeTranslationInputTranscriptDeltaEvent] —
+///   `session.input_transcript.delta`
+/// - [RealtimeTranslationOutputTranscriptDeltaEvent] —
+///   `session.output_transcript.delta`
+/// - [RealtimeTranslationOutputAudioDeltaEvent] —
+///   `session.output_audio.delta`
+///
+/// Unknown discriminators are surfaced as
+/// [UnknownRealtimeTranslationServerEvent], preserving the raw payload.
+sealed class RealtimeTranslationServerEvent {
+  const RealtimeTranslationServerEvent();
+
+  /// Creates from JSON.
+  factory RealtimeTranslationServerEvent.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    return switch (type) {
+      'error' => RealtimeTranslationErrorEvent.fromJson(json),
+      'session.created' => RealtimeTranslationSessionCreatedEvent.fromJson(
+        json,
+      ),
+      'session.updated' => RealtimeTranslationSessionUpdatedEvent.fromJson(
+        json,
+      ),
+      'session.closed' => RealtimeTranslationSessionClosedEvent.fromJson(json),
+      'session.input_transcript.delta' =>
+        RealtimeTranslationInputTranscriptDeltaEvent.fromJson(json),
+      'session.output_transcript.delta' =>
+        RealtimeTranslationOutputTranscriptDeltaEvent.fromJson(json),
+      'session.output_audio.delta' =>
+        RealtimeTranslationOutputAudioDeltaEvent.fromJson(json),
+      _ => UnknownRealtimeTranslationServerEvent(
+        Map<String, dynamic>.from(json),
+      ),
+    };
+  }
+
+  /// The discriminator value.
+  String get type;
+
+  /// The server-generated event id.
+  String get eventId;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson();
+}
+
+// -----------------------------------------------------------------------------
+// RealtimeTranslationError
+// -----------------------------------------------------------------------------
+
+/// The `error` payload nested inside [RealtimeTranslationErrorEvent].
+@immutable
+class RealtimeTranslationError {
+  /// Creates a [RealtimeTranslationError].
+  const RealtimeTranslationError({
+    required this.type,
+    required this.message,
+    this.code,
+    this.eventId,
+    this.param,
+  });
+
+  /// Creates from JSON.
+  factory RealtimeTranslationError.fromJson(Map<String, dynamic> json) {
+    return RealtimeTranslationError(
+      type: json['type'] as String,
+      message: json['message'] as String,
+      code: json['code'] as String?,
+      eventId: json['event_id'] as String?,
+      param: json['param'] as String?,
+    );
+  }
+
+  /// Error category (e.g. `'invalid_request_error'`, `'server_error'`).
+  final String type;
+
+  /// Human-readable error message.
+  final String message;
+
+  /// Optional machine-readable error code.
+  final String? code;
+
+  /// Optional event id of the originating client event.
+  final String? eventId;
+
+  /// Optional related parameter name.
+  final String? param;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'message': message,
+    if (code != null) 'code': code,
+    if (eventId != null) 'event_id': eventId,
+    if (param != null) 'param': param,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationError &&
+          runtimeType == other.runtimeType &&
+          type == other.type &&
+          message == other.message &&
+          code == other.code &&
+          eventId == other.eventId &&
+          param == other.param;
+
+  @override
+  int get hashCode => Object.hash(type, message, code, eventId, param);
+
+  @override
+  String toString() =>
+      'RealtimeTranslationError(type: $type, message: $message)';
+}
+
+/// Returned when an error occurs in a translation session.
+@immutable
+class RealtimeTranslationErrorEvent extends RealtimeTranslationServerEvent {
+  /// Creates a [RealtimeTranslationErrorEvent].
+  const RealtimeTranslationErrorEvent({
+    required this.eventId,
+    required this.error,
+  });
+
+  /// Creates from JSON.
+  factory RealtimeTranslationErrorEvent.fromJson(Map<String, dynamic> json) {
+    if (json['type'] != 'error') {
+      throw FormatException(
+        'RealtimeTranslationErrorEvent.fromJson expected type "error", got '
+        '${json['type']}',
+      );
+    }
+    return RealtimeTranslationErrorEvent(
+      eventId: json['event_id'] as String,
+      error: RealtimeTranslationError.fromJson(
+        json['error'] as Map<String, dynamic>,
+      ),
+    );
+  }
+
+  @override
+  final String eventId;
+
+  /// Error payload.
+  final RealtimeTranslationError error;
+
+  @override
+  String get type => 'error';
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'event_id': eventId,
+    'error': error.toJson(),
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationErrorEvent &&
+          runtimeType == other.runtimeType &&
+          eventId == other.eventId &&
+          error == other.error;
+
+  @override
+  int get hashCode => Object.hash(eventId, error);
+
+  @override
+  String toString() =>
+      'RealtimeTranslationErrorEvent(eventId: $eventId, error: $error)';
+}
+
+// -----------------------------------------------------------------------------
+// session.created / session.updated / session.closed
+// -----------------------------------------------------------------------------
+
+/// Returned when a translation session is created.
+@immutable
+class RealtimeTranslationSessionCreatedEvent
+    extends RealtimeTranslationServerEvent {
+  /// Creates a [RealtimeTranslationSessionCreatedEvent].
+  const RealtimeTranslationSessionCreatedEvent({
+    required this.eventId,
+    required this.session,
+  });
+
+  /// Creates from JSON.
+  factory RealtimeTranslationSessionCreatedEvent.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    if (json['type'] != 'session.created') {
+      throw FormatException(
+        'RealtimeTranslationSessionCreatedEvent.fromJson expected type '
+        '"session.created", got ${json['type']}',
+      );
+    }
+    return RealtimeTranslationSessionCreatedEvent(
+      eventId: json['event_id'] as String,
+      session: RealtimeTranslationSession.fromJson(
+        json['session'] as Map<String, dynamic>,
+      ),
+    );
+  }
+
+  @override
+  final String eventId;
+
+  /// The created translation session.
+  final RealtimeTranslationSession session;
+
+  @override
+  String get type => 'session.created';
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'event_id': eventId,
+    'session': session.toJson(),
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationSessionCreatedEvent &&
+          runtimeType == other.runtimeType &&
+          eventId == other.eventId &&
+          session == other.session;
+
+  @override
+  int get hashCode => Object.hash(eventId, session);
+
+  @override
+  String toString() =>
+      'RealtimeTranslationSessionCreatedEvent(eventId: $eventId, session: $session)';
+}
+
+/// Returned when a translation session is updated.
+@immutable
+class RealtimeTranslationSessionUpdatedEvent
+    extends RealtimeTranslationServerEvent {
+  /// Creates a [RealtimeTranslationSessionUpdatedEvent].
+  const RealtimeTranslationSessionUpdatedEvent({
+    required this.eventId,
+    required this.session,
+  });
+
+  /// Creates from JSON.
+  factory RealtimeTranslationSessionUpdatedEvent.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    if (json['type'] != 'session.updated') {
+      throw FormatException(
+        'RealtimeTranslationSessionUpdatedEvent.fromJson expected type '
+        '"session.updated", got ${json['type']}',
+      );
+    }
+    return RealtimeTranslationSessionUpdatedEvent(
+      eventId: json['event_id'] as String,
+      session: RealtimeTranslationSession.fromJson(
+        json['session'] as Map<String, dynamic>,
+      ),
+    );
+  }
+
+  @override
+  final String eventId;
+
+  /// The updated translation session.
+  final RealtimeTranslationSession session;
+
+  @override
+  String get type => 'session.updated';
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'event_id': eventId,
+    'session': session.toJson(),
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationSessionUpdatedEvent &&
+          runtimeType == other.runtimeType &&
+          eventId == other.eventId &&
+          session == other.session;
+
+  @override
+  int get hashCode => Object.hash(eventId, session);
+
+  @override
+  String toString() =>
+      'RealtimeTranslationSessionUpdatedEvent(eventId: $eventId, session: $session)';
+}
+
+/// Returned when a translation session is closed.
+@immutable
+class RealtimeTranslationSessionClosedEvent
+    extends RealtimeTranslationServerEvent {
+  /// Creates a [RealtimeTranslationSessionClosedEvent].
+  const RealtimeTranslationSessionClosedEvent({required this.eventId});
+
+  /// Creates from JSON.
+  factory RealtimeTranslationSessionClosedEvent.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    if (json['type'] != 'session.closed') {
+      throw FormatException(
+        'RealtimeTranslationSessionClosedEvent.fromJson expected type '
+        '"session.closed", got ${json['type']}',
+      );
+    }
+    return RealtimeTranslationSessionClosedEvent(
+      eventId: json['event_id'] as String,
+    );
+  }
+
+  @override
+  final String eventId;
+
+  @override
+  String get type => 'session.closed';
+
+  @override
+  Map<String, dynamic> toJson() => {'type': type, 'event_id': eventId};
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationSessionClosedEvent &&
+          runtimeType == other.runtimeType &&
+          eventId == other.eventId;
+
+  @override
+  int get hashCode => eventId.hashCode;
+
+  @override
+  String toString() =>
+      'RealtimeTranslationSessionClosedEvent(eventId: $eventId)';
+}
+
+// -----------------------------------------------------------------------------
+// transcript / audio deltas
+// -----------------------------------------------------------------------------
+
+/// Source-language transcript delta.
+@immutable
+class RealtimeTranslationInputTranscriptDeltaEvent
+    extends RealtimeTranslationServerEvent {
+  /// Creates a [RealtimeTranslationInputTranscriptDeltaEvent].
+  const RealtimeTranslationInputTranscriptDeltaEvent({
+    required this.eventId,
+    required this.delta,
+    this.elapsedMs,
+  });
+
+  /// Creates from JSON.
+  factory RealtimeTranslationInputTranscriptDeltaEvent.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    if (json['type'] != 'session.input_transcript.delta') {
+      throw FormatException(
+        'RealtimeTranslationInputTranscriptDeltaEvent.fromJson expected type '
+        '"session.input_transcript.delta", got ${json['type']}',
+      );
+    }
+    return RealtimeTranslationInputTranscriptDeltaEvent(
+      eventId: json['event_id'] as String,
+      delta: json['delta'] as String,
+      elapsedMs: json['elapsed_ms'] as int?,
+    );
+  }
+
+  @override
+  final String eventId;
+
+  /// Append-only source-language transcript fragment.
+  final String delta;
+
+  /// Optional alignment-frame timing in 200 ms increments.
+  final int? elapsedMs;
+
+  @override
+  String get type => 'session.input_transcript.delta';
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'event_id': eventId,
+    'delta': delta,
+    if (elapsedMs != null) 'elapsed_ms': elapsedMs,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationInputTranscriptDeltaEvent &&
+          runtimeType == other.runtimeType &&
+          eventId == other.eventId &&
+          delta == other.delta &&
+          elapsedMs == other.elapsedMs;
+
+  @override
+  int get hashCode => Object.hash(eventId, delta, elapsedMs);
+
+  @override
+  String toString() =>
+      'RealtimeTranslationInputTranscriptDeltaEvent(eventId: $eventId, '
+      'delta: $delta, elapsedMs: $elapsedMs)';
+}
+
+/// Translated transcript delta.
+@immutable
+class RealtimeTranslationOutputTranscriptDeltaEvent
+    extends RealtimeTranslationServerEvent {
+  /// Creates a [RealtimeTranslationOutputTranscriptDeltaEvent].
+  const RealtimeTranslationOutputTranscriptDeltaEvent({
+    required this.eventId,
+    required this.delta,
+    this.elapsedMs,
+  });
+
+  /// Creates from JSON.
+  factory RealtimeTranslationOutputTranscriptDeltaEvent.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    if (json['type'] != 'session.output_transcript.delta') {
+      throw FormatException(
+        'RealtimeTranslationOutputTranscriptDeltaEvent.fromJson expected type '
+        '"session.output_transcript.delta", got ${json['type']}',
+      );
+    }
+    return RealtimeTranslationOutputTranscriptDeltaEvent(
+      eventId: json['event_id'] as String,
+      delta: json['delta'] as String,
+      elapsedMs: json['elapsed_ms'] as int?,
+    );
+  }
+
+  @override
+  final String eventId;
+
+  /// Append-only translated transcript fragment.
+  final String delta;
+
+  /// Optional alignment-frame timing in 200 ms increments.
+  final int? elapsedMs;
+
+  @override
+  String get type => 'session.output_transcript.delta';
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'event_id': eventId,
+    'delta': delta,
+    if (elapsedMs != null) 'elapsed_ms': elapsedMs,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationOutputTranscriptDeltaEvent &&
+          runtimeType == other.runtimeType &&
+          eventId == other.eventId &&
+          delta == other.delta &&
+          elapsedMs == other.elapsedMs;
+
+  @override
+  int get hashCode => Object.hash(eventId, delta, elapsedMs);
+
+  @override
+  String toString() =>
+      'RealtimeTranslationOutputTranscriptDeltaEvent(eventId: $eventId, '
+      'delta: $delta, elapsedMs: $elapsedMs)';
+}
+
+/// Translated output-audio delta (200 ms PCM16 frames).
+///
+/// `delta` is a base64-encoded **server-emitted** audio fragment. This is not
+/// a request-factory base64 input, so the OpenAI-specific data-URL convention
+/// does not apply here.
+@immutable
+class RealtimeTranslationOutputAudioDeltaEvent
+    extends RealtimeTranslationServerEvent {
+  /// Creates a [RealtimeTranslationOutputAudioDeltaEvent].
+  const RealtimeTranslationOutputAudioDeltaEvent({
+    required this.eventId,
+    required this.delta,
+    this.format,
+    this.sampleRate,
+    this.channels,
+    this.elapsedMs,
+  });
+
+  /// Creates from JSON.
+  factory RealtimeTranslationOutputAudioDeltaEvent.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    if (json['type'] != 'session.output_audio.delta') {
+      throw FormatException(
+        'RealtimeTranslationOutputAudioDeltaEvent.fromJson expected type '
+        '"session.output_audio.delta", got ${json['type']}',
+      );
+    }
+    return RealtimeTranslationOutputAudioDeltaEvent(
+      eventId: json['event_id'] as String,
+      delta: json['delta'] as String,
+      format: json['format'] as String?,
+      sampleRate: json['sample_rate'] as int?,
+      channels: json['channels'] as int?,
+      elapsedMs: json['elapsed_ms'] as int?,
+    );
+  }
+
+  @override
+  final String eventId;
+
+  /// Base64-encoded translated audio data (server-emitted PCM16).
+  final String delta;
+
+  /// Audio encoding for [delta]. Currently always `'pcm16'`.
+  final String? format;
+
+  /// Sample rate of the audio delta. Defaults to 24000.
+  final int? sampleRate;
+
+  /// Number of audio channels. Defaults to 1.
+  final int? channels;
+
+  /// Optional alignment-frame timing.
+  final int? elapsedMs;
+
+  @override
+  String get type => 'session.output_audio.delta';
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'event_id': eventId,
+    'delta': delta,
+    if (format != null) 'format': format,
+    if (sampleRate != null) 'sample_rate': sampleRate,
+    if (channels != null) 'channels': channels,
+    if (elapsedMs != null) 'elapsed_ms': elapsedMs,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationOutputAudioDeltaEvent &&
+          runtimeType == other.runtimeType &&
+          eventId == other.eventId &&
+          delta == other.delta &&
+          format == other.format &&
+          sampleRate == other.sampleRate &&
+          channels == other.channels &&
+          elapsedMs == other.elapsedMs;
+
+  @override
+  int get hashCode =>
+      Object.hash(eventId, delta, format, sampleRate, channels, elapsedMs);
+
+  @override
+  String toString() =>
+      'RealtimeTranslationOutputAudioDeltaEvent(eventId: $eventId, '
+      'delta: <${delta.length} chars>, sampleRate: $sampleRate, channels: $channels)';
+}
+
+/// Forward-compatible fallback for unknown translation server events.
+@immutable
+class UnknownRealtimeTranslationServerEvent
+    extends RealtimeTranslationServerEvent {
+  /// Creates from raw JSON.
+  const UnknownRealtimeTranslationServerEvent(this.json);
+
+  /// The raw JSON map preserved verbatim.
+  final Map<String, dynamic> json;
+
+  @override
+  String get type => json['type'] as String? ?? '';
+
+  @override
+  String get eventId => (json['event_id'] as String?) ?? '';
+
+  @override
+  Map<String, dynamic> toJson() => Map<String, dynamic>.from(json);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnknownRealtimeTranslationServerEvent &&
+          runtimeType == other.runtimeType &&
+          mapsDeepEqual(json, other.json);
+
+  @override
+  int get hashCode => mapDeepHashCode(json);
+
+  @override
+  String toString() => 'UnknownRealtimeTranslationServerEvent(type: $type)';
+}

--- a/packages/openai_dart/lib/src/models/realtime/realtime_translation_session.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_translation_session.dart
@@ -1,0 +1,710 @@
+import 'package:meta/meta.dart';
+
+import '../common/copy_with_sentinel.dart';
+import 'realtime_audio_config.dart';
+import 'realtime_client_secret.dart' show ExpiresAfter;
+import 'realtime_enums.dart';
+
+// =============================================================================
+// RealtimeTranslationInputTranscription
+// =============================================================================
+
+/// Optional source-language transcription for a translation session.
+///
+/// When configured, the server emits `session.input_transcript.delta` events.
+/// Translation itself still runs from the input audio stream regardless.
+@immutable
+class RealtimeTranslationInputTranscription {
+  /// Creates a [RealtimeTranslationInputTranscription].
+  const RealtimeTranslationInputTranscription({required this.model});
+
+  /// Creates from JSON.
+  factory RealtimeTranslationInputTranscription.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    if (json['model'] == null) {
+      throw const FormatException(
+        'RealtimeTranslationInputTranscription.fromJson missing required "model" field',
+      );
+    }
+    return RealtimeTranslationInputTranscription(
+      model: json['model'] as String,
+    );
+  }
+
+  /// Transcription model id (e.g. `'gpt-realtime-whisper'`).
+  final String model;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {'model': model};
+
+  /// Returns a copy with the given fields replaced.
+  RealtimeTranslationInputTranscription copyWith({String? model}) =>
+      RealtimeTranslationInputTranscription(model: model ?? this.model);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationInputTranscription &&
+          runtimeType == other.runtimeType &&
+          model == other.model;
+
+  @override
+  int get hashCode => model.hashCode;
+
+  @override
+  String toString() => 'RealtimeTranslationInputTranscription(model: $model)';
+}
+
+// =============================================================================
+// RealtimeTranslationNoiseReduction
+// =============================================================================
+
+/// Noise reduction configuration for a translation session.
+///
+/// Distinct from [AudioInputNoiseReduction]: the spec requires `type` and the
+/// field can be set to `null` on the wrapper to disable filtering.
+@immutable
+class RealtimeTranslationNoiseReduction {
+  /// Creates a [RealtimeTranslationNoiseReduction].
+  const RealtimeTranslationNoiseReduction({required this.type});
+
+  /// Creates from JSON.
+  factory RealtimeTranslationNoiseReduction.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    if (json['type'] == null) {
+      throw const FormatException(
+        'RealtimeTranslationNoiseReduction.fromJson missing required "type" field',
+      );
+    }
+    return RealtimeTranslationNoiseReduction(
+      type: NoiseReductionType.fromJson(json['type'] as String),
+    );
+  }
+
+  /// The noise-reduction profile.
+  final NoiseReductionType type;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {'type': type.toJson()};
+
+  /// Returns a copy with the given fields replaced.
+  RealtimeTranslationNoiseReduction copyWith({NoiseReductionType? type}) =>
+      RealtimeTranslationNoiseReduction(type: type ?? this.type);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationNoiseReduction &&
+          runtimeType == other.runtimeType &&
+          type == other.type;
+
+  @override
+  int get hashCode => type.hashCode;
+
+  @override
+  String toString() => 'RealtimeTranslationNoiseReduction(type: $type)';
+}
+
+// =============================================================================
+// RealtimeTranslationSessionAudioInput
+// =============================================================================
+
+/// Input audio configuration for a translation session.
+@immutable
+class RealtimeTranslationSessionAudioInput {
+  /// Creates a [RealtimeTranslationSessionAudioInput].
+  const RealtimeTranslationSessionAudioInput({
+    this.transcription,
+    this.noiseReduction,
+  });
+
+  /// Creates from JSON.
+  factory RealtimeTranslationSessionAudioInput.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return RealtimeTranslationSessionAudioInput(
+      transcription: json['transcription'] != null
+          ? RealtimeTranslationInputTranscription.fromJson(
+              json['transcription'] as Map<String, dynamic>,
+            )
+          : null,
+      noiseReduction: json['noise_reduction'] != null
+          ? RealtimeTranslationNoiseReduction.fromJson(
+              json['noise_reduction'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+
+  /// Source-language transcription configuration.
+  final RealtimeTranslationInputTranscription? transcription;
+
+  /// Noise reduction configuration. `null` disables noise reduction.
+  final RealtimeTranslationNoiseReduction? noiseReduction;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (transcription != null) 'transcription': transcription!.toJson(),
+    if (noiseReduction != null) 'noise_reduction': noiseReduction!.toJson(),
+  };
+
+  /// Returns a copy of this with the given fields replaced.
+  ///
+  /// Pass `null` for any field to clear the existing value.
+  RealtimeTranslationSessionAudioInput copyWith({
+    Object? transcription = unsetCopyWithValue,
+    Object? noiseReduction = unsetCopyWithValue,
+  }) => RealtimeTranslationSessionAudioInput(
+    transcription: identical(transcription, unsetCopyWithValue)
+        ? this.transcription
+        : transcription as RealtimeTranslationInputTranscription?,
+    noiseReduction: identical(noiseReduction, unsetCopyWithValue)
+        ? this.noiseReduction
+        : noiseReduction as RealtimeTranslationNoiseReduction?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationSessionAudioInput &&
+          runtimeType == other.runtimeType &&
+          transcription == other.transcription &&
+          noiseReduction == other.noiseReduction;
+
+  @override
+  int get hashCode => Object.hash(transcription, noiseReduction);
+
+  @override
+  String toString() =>
+      'RealtimeTranslationSessionAudioInput(transcription: $transcription, '
+      'noiseReduction: $noiseReduction)';
+}
+
+// =============================================================================
+// RealtimeTranslationSessionAudioOutput
+// =============================================================================
+
+/// Output audio configuration for a translation session.
+@immutable
+class RealtimeTranslationSessionAudioOutput {
+  /// Creates a [RealtimeTranslationSessionAudioOutput].
+  const RealtimeTranslationSessionAudioOutput({this.language});
+
+  /// Creates from JSON.
+  factory RealtimeTranslationSessionAudioOutput.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return RealtimeTranslationSessionAudioOutput(
+      language: json['language'] as String?,
+    );
+  }
+
+  /// Target language for translated output audio and transcript deltas.
+  final String? language;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {if (language != null) 'language': language};
+
+  /// Returns a copy with the given fields replaced.
+  ///
+  /// Pass `null` for [language] to clear the existing value.
+  RealtimeTranslationSessionAudioOutput copyWith({
+    Object? language = unsetCopyWithValue,
+  }) => RealtimeTranslationSessionAudioOutput(
+    language: identical(language, unsetCopyWithValue)
+        ? this.language
+        : language as String?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationSessionAudioOutput &&
+          runtimeType == other.runtimeType &&
+          language == other.language;
+
+  @override
+  int get hashCode => language.hashCode;
+
+  @override
+  String toString() =>
+      'RealtimeTranslationSessionAudioOutput(language: $language)';
+}
+
+// =============================================================================
+// RealtimeTranslationSessionAudio
+// =============================================================================
+
+/// Audio configuration block for a translation session.
+@immutable
+class RealtimeTranslationSessionAudio {
+  /// Creates a [RealtimeTranslationSessionAudio].
+  const RealtimeTranslationSessionAudio({this.input, this.output});
+
+  /// Creates from JSON.
+  factory RealtimeTranslationSessionAudio.fromJson(Map<String, dynamic> json) {
+    return RealtimeTranslationSessionAudio(
+      input: json['input'] != null
+          ? RealtimeTranslationSessionAudioInput.fromJson(
+              json['input'] as Map<String, dynamic>,
+            )
+          : null,
+      output: json['output'] != null
+          ? RealtimeTranslationSessionAudioOutput.fromJson(
+              json['output'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+
+  /// Input audio configuration.
+  final RealtimeTranslationSessionAudioInput? input;
+
+  /// Output audio configuration.
+  final RealtimeTranslationSessionAudioOutput? output;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (input != null) 'input': input!.toJson(),
+    if (output != null) 'output': output!.toJson(),
+  };
+
+  /// Returns a copy with the given fields replaced.
+  ///
+  /// Pass `null` for any field to clear the existing value.
+  RealtimeTranslationSessionAudio copyWith({
+    Object? input = unsetCopyWithValue,
+    Object? output = unsetCopyWithValue,
+  }) => RealtimeTranslationSessionAudio(
+    input: identical(input, unsetCopyWithValue)
+        ? this.input
+        : input as RealtimeTranslationSessionAudioInput?,
+    output: identical(output, unsetCopyWithValue)
+        ? this.output
+        : output as RealtimeTranslationSessionAudioOutput?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationSessionAudio &&
+          runtimeType == other.runtimeType &&
+          input == other.input &&
+          output == other.output;
+
+  @override
+  int get hashCode => Object.hash(input, output);
+
+  @override
+  String toString() =>
+      'RealtimeTranslationSessionAudio(input: $input, output: $output)';
+}
+
+// =============================================================================
+// RealtimeTranslationSession
+// =============================================================================
+
+/// A Realtime translation session.
+///
+/// Translation sessions continuously translate input audio into the configured
+/// output language.
+@immutable
+class RealtimeTranslationSession {
+  /// Creates a [RealtimeTranslationSession].
+  const RealtimeTranslationSession({
+    required this.id,
+    required this.type,
+    required this.expiresAt,
+    required this.model,
+    required this.audio,
+  });
+
+  /// Creates from JSON.
+  factory RealtimeTranslationSession.fromJson(Map<String, dynamic> json) {
+    if (json['id'] == null ||
+        json['type'] == null ||
+        json['expires_at'] == null ||
+        json['model'] == null ||
+        json['audio'] == null) {
+      throw const FormatException(
+        'RealtimeTranslationSession.fromJson missing one or more required fields '
+        '(id, type, expires_at, model, audio)',
+      );
+    }
+    return RealtimeTranslationSession(
+      id: json['id'] as String,
+      type: json['type'] as String,
+      expiresAt: json['expires_at'] as int,
+      model: json['model'] as String,
+      audio: RealtimeTranslationSessionAudio.fromJson(
+        json['audio'] as Map<String, dynamic>,
+      ),
+    );
+  }
+
+  /// Unique session identifier (`sess_…`).
+  final String id;
+
+  /// The session type. Always `'translation'`.
+  final String type;
+
+  /// Expiration timestamp (Unix epoch seconds).
+  final int expiresAt;
+
+  /// The translation model used for this session.
+  final String model;
+
+  /// Audio configuration.
+  final RealtimeTranslationSessionAudio audio;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'type': type,
+    'expires_at': expiresAt,
+    'model': model,
+    'audio': audio.toJson(),
+  };
+
+  /// Returns a copy with the given fields replaced.
+  RealtimeTranslationSession copyWith({
+    String? id,
+    String? type,
+    int? expiresAt,
+    String? model,
+    RealtimeTranslationSessionAudio? audio,
+  }) => RealtimeTranslationSession(
+    id: id ?? this.id,
+    type: type ?? this.type,
+    expiresAt: expiresAt ?? this.expiresAt,
+    model: model ?? this.model,
+    audio: audio ?? this.audio,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationSession &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          type == other.type &&
+          expiresAt == other.expiresAt &&
+          model == other.model &&
+          audio == other.audio;
+
+  @override
+  int get hashCode => Object.hash(id, type, expiresAt, model, audio);
+
+  @override
+  String toString() =>
+      'RealtimeTranslationSession(id: $id, model: $model, expiresAt: $expiresAt)';
+}
+
+// =============================================================================
+// RealtimeTranslationSessionCreateRequest
+// =============================================================================
+
+/// Request payload for creating a translation session.
+///
+/// Streams source audio in and translated audio plus transcript deltas out
+/// continuously.
+@immutable
+class RealtimeTranslationSessionCreateRequest {
+  /// Creates a [RealtimeTranslationSessionCreateRequest].
+  const RealtimeTranslationSessionCreateRequest({
+    required this.model,
+    this.audio,
+  });
+
+  /// Creates from JSON.
+  factory RealtimeTranslationSessionCreateRequest.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    if (json['model'] == null) {
+      throw const FormatException(
+        'RealtimeTranslationSessionCreateRequest.fromJson missing required "model" field',
+      );
+    }
+    return RealtimeTranslationSessionCreateRequest(
+      model: json['model'] as String,
+      audio: json['audio'] != null
+          ? RealtimeTranslationSessionAudio.fromJson(
+              json['audio'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+
+  /// The translation model id (e.g. `'gpt-realtime-translate'`).
+  final String model;
+
+  /// Optional audio configuration.
+  final RealtimeTranslationSessionAudio? audio;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'model': model,
+    if (audio != null) 'audio': audio!.toJson(),
+  };
+
+  /// Returns a copy with the given fields replaced.
+  ///
+  /// Pass `null` for [audio] to clear the existing value.
+  RealtimeTranslationSessionCreateRequest copyWith({
+    String? model,
+    Object? audio = unsetCopyWithValue,
+  }) => RealtimeTranslationSessionCreateRequest(
+    model: model ?? this.model,
+    audio: identical(audio, unsetCopyWithValue)
+        ? this.audio
+        : audio as RealtimeTranslationSessionAudio?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationSessionCreateRequest &&
+          runtimeType == other.runtimeType &&
+          model == other.model &&
+          audio == other.audio;
+
+  @override
+  int get hashCode => Object.hash(model, audio);
+
+  @override
+  String toString() =>
+      'RealtimeTranslationSessionCreateRequest(model: $model, audio: $audio)';
+}
+
+// =============================================================================
+// RealtimeTranslationSessionUpdateRequest
+// =============================================================================
+
+/// Update payload for a translation session (`session.update` event).
+///
+/// Translation sessions support updates to `audio.input.transcription`,
+/// `audio.input.noise_reduction`, and `audio.output.language` only.
+@immutable
+class RealtimeTranslationSessionUpdateRequest {
+  /// Creates a [RealtimeTranslationSessionUpdateRequest].
+  const RealtimeTranslationSessionUpdateRequest({this.audio});
+
+  /// Creates from JSON.
+  factory RealtimeTranslationSessionUpdateRequest.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return RealtimeTranslationSessionUpdateRequest(
+      audio: json['audio'] != null
+          ? RealtimeTranslationSessionAudio.fromJson(
+              json['audio'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+
+  /// Audio configuration delta.
+  final RealtimeTranslationSessionAudio? audio;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (audio != null) 'audio': audio!.toJson(),
+  };
+
+  /// Returns a copy with the given fields replaced.
+  ///
+  /// Pass `null` for [audio] to clear the existing value.
+  RealtimeTranslationSessionUpdateRequest copyWith({
+    Object? audio = unsetCopyWithValue,
+  }) => RealtimeTranslationSessionUpdateRequest(
+    audio: identical(audio, unsetCopyWithValue)
+        ? this.audio
+        : audio as RealtimeTranslationSessionAudio?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationSessionUpdateRequest &&
+          runtimeType == other.runtimeType &&
+          audio == other.audio;
+
+  @override
+  int get hashCode => audio.hashCode;
+
+  @override
+  String toString() => 'RealtimeTranslationSessionUpdateRequest(audio: $audio)';
+}
+
+// =============================================================================
+// RealtimeTranslationClientSecretCreateRequest
+// =============================================================================
+
+/// Request for creating a translation client secret.
+///
+/// Calls `POST /realtime/translations/client_secrets`.
+///
+/// ## Example
+///
+/// ```dart
+/// final response = await client.realtimeSessions.translations
+///     .createClientSecret(
+///   RealtimeTranslationClientSecretCreateRequest(
+///     session: RealtimeTranslationSessionCreateRequest(
+///       model: 'gpt-realtime-translate',
+///       audio: RealtimeTranslationSessionAudio(
+///         output: RealtimeTranslationSessionAudioOutput(language: 'es'),
+///       ),
+///     ),
+///   ),
+/// );
+/// ```
+@immutable
+class RealtimeTranslationClientSecretCreateRequest {
+  /// Creates a [RealtimeTranslationClientSecretCreateRequest].
+  const RealtimeTranslationClientSecretCreateRequest({
+    required this.session,
+    this.expiresAfter,
+  });
+
+  /// Creates from JSON.
+  factory RealtimeTranslationClientSecretCreateRequest.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    if (json['session'] == null) {
+      throw const FormatException(
+        'RealtimeTranslationClientSecretCreateRequest.fromJson missing required "session" field',
+      );
+    }
+    return RealtimeTranslationClientSecretCreateRequest(
+      session: RealtimeTranslationSessionCreateRequest.fromJson(
+        json['session'] as Map<String, dynamic>,
+      ),
+      expiresAfter: json['expires_after'] != null
+          ? ExpiresAfter.fromJson(json['expires_after'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+
+  /// The translation session configuration.
+  final RealtimeTranslationSessionCreateRequest session;
+
+  /// Optional expiration configuration.
+  final ExpiresAfter? expiresAfter;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'session': session.toJson(),
+    if (expiresAfter != null) 'expires_after': expiresAfter!.toJson(),
+  };
+
+  /// Returns a copy with the given fields replaced.
+  ///
+  /// Pass `null` for [expiresAfter] to clear the existing value.
+  RealtimeTranslationClientSecretCreateRequest copyWith({
+    RealtimeTranslationSessionCreateRequest? session,
+    Object? expiresAfter = unsetCopyWithValue,
+  }) => RealtimeTranslationClientSecretCreateRequest(
+    session: session ?? this.session,
+    expiresAfter: identical(expiresAfter, unsetCopyWithValue)
+        ? this.expiresAfter
+        : expiresAfter as ExpiresAfter?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationClientSecretCreateRequest &&
+          runtimeType == other.runtimeType &&
+          session == other.session &&
+          expiresAfter == other.expiresAfter;
+
+  @override
+  int get hashCode => Object.hash(session, expiresAfter);
+
+  @override
+  String toString() =>
+      'RealtimeTranslationClientSecretCreateRequest(session: $session, '
+      'expiresAfter: $expiresAfter)';
+}
+
+// =============================================================================
+// RealtimeTranslationClientSecretCreateResponse
+// =============================================================================
+
+/// Response from creating a translation client secret.
+@immutable
+class RealtimeTranslationClientSecretCreateResponse {
+  /// Creates a [RealtimeTranslationClientSecretCreateResponse].
+  const RealtimeTranslationClientSecretCreateResponse({
+    required this.value,
+    required this.expiresAt,
+    required this.session,
+  });
+
+  /// Creates from JSON.
+  factory RealtimeTranslationClientSecretCreateResponse.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    if (json['value'] == null ||
+        json['expires_at'] == null ||
+        json['session'] == null) {
+      throw const FormatException(
+        'RealtimeTranslationClientSecretCreateResponse.fromJson missing one or '
+        'more required fields (value, expires_at, session)',
+      );
+    }
+    return RealtimeTranslationClientSecretCreateResponse(
+      value: json['value'] as String,
+      expiresAt: json['expires_at'] as int,
+      session: RealtimeTranslationSession.fromJson(
+        json['session'] as Map<String, dynamic>,
+      ),
+    );
+  }
+
+  /// The client secret value (starts with `ek_`).
+  final String value;
+
+  /// Expiration timestamp (Unix epoch seconds).
+  final int expiresAt;
+
+  /// The created translation session.
+  final RealtimeTranslationSession session;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'value': value,
+    'expires_at': expiresAt,
+    'session': session.toJson(),
+  };
+
+  /// Returns a copy with the given fields replaced.
+  RealtimeTranslationClientSecretCreateResponse copyWith({
+    String? value,
+    int? expiresAt,
+    RealtimeTranslationSession? session,
+  }) => RealtimeTranslationClientSecretCreateResponse(
+    value: value ?? this.value,
+    expiresAt: expiresAt ?? this.expiresAt,
+    session: session ?? this.session,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RealtimeTranslationClientSecretCreateResponse &&
+          runtimeType == other.runtimeType &&
+          value == other.value &&
+          expiresAt == other.expiresAt &&
+          session == other.session;
+
+  @override
+  int get hashCode => Object.hash(value, expiresAt, session);
+
+  @override
+  String toString() =>
+      'RealtimeTranslationClientSecretCreateResponse(expiresAt: $expiresAt, '
+      'session: $session)';
+}

--- a/packages/openai_dart/lib/src/models/realtime/realtime_translation_session.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_translation_session.dart
@@ -112,12 +112,26 @@ class RealtimeTranslationNoiseReduction {
 // =============================================================================
 
 /// Input audio configuration for a translation session.
+///
+/// **Tri-state serialization for `transcription` and `noise_reduction`** —
+/// translation `session.update` events use the same convention as
+/// realtime sessions:
+///
+/// - **Field omitted** → server keeps the current value (don't change).
+/// - **Field with value** → server sets/replaces the configuration.
+/// - **Field with explicit JSON `null`** → server *disables* the feature.
+///
+/// To send the third form, pass [clearTranscription] / [clearNoiseReduction]
+/// as `true`. The flags are ignored when the corresponding typed field is
+/// non-null. Roundtrip preserves the distinction.
 @immutable
 class RealtimeTranslationSessionAudioInput {
   /// Creates a [RealtimeTranslationSessionAudioInput].
   const RealtimeTranslationSessionAudioInput({
     this.transcription,
     this.noiseReduction,
+    this.clearTranscription = false,
+    this.clearNoiseReduction = false,
   });
 
   /// Creates from JSON.
@@ -135,27 +149,51 @@ class RealtimeTranslationSessionAudioInput {
               json['noise_reduction'] as Map<String, dynamic>,
             )
           : null,
+      clearTranscription:
+          json.containsKey('transcription') && json['transcription'] == null,
+      clearNoiseReduction:
+          json.containsKey('noise_reduction') &&
+          json['noise_reduction'] == null,
     );
   }
 
   /// Source-language transcription configuration.
   final RealtimeTranslationInputTranscription? transcription;
 
-  /// Noise reduction configuration. `null` disables noise reduction.
+  /// Noise reduction configuration.
   final RealtimeTranslationNoiseReduction? noiseReduction;
+
+  /// When `true`, emit `"transcription": null` on the wire to ask the
+  /// server to disable transcription. Has no effect when [transcription]
+  /// is non-null.
+  final bool clearTranscription;
+
+  /// When `true`, emit `"noise_reduction": null` on the wire to ask the
+  /// server to disable noise reduction. Has no effect when
+  /// [noiseReduction] is non-null.
+  final bool clearNoiseReduction;
 
   /// Converts to JSON.
   Map<String, dynamic> toJson() => {
-    if (transcription != null) 'transcription': transcription!.toJson(),
-    if (noiseReduction != null) 'noise_reduction': noiseReduction!.toJson(),
+    if (transcription != null)
+      'transcription': transcription!.toJson()
+    else if (clearTranscription)
+      'transcription': null,
+    if (noiseReduction != null)
+      'noise_reduction': noiseReduction!.toJson()
+    else if (clearNoiseReduction)
+      'noise_reduction': null,
   };
 
   /// Returns a copy of this with the given fields replaced.
   ///
-  /// Pass `null` for any field to clear the existing value.
+  /// Pass `null` for any nullable field to clear the in-memory value
+  /// (use the `clear*` flags to send explicit JSON null over the wire).
   RealtimeTranslationSessionAudioInput copyWith({
     Object? transcription = unsetCopyWithValue,
     Object? noiseReduction = unsetCopyWithValue,
+    bool? clearTranscription,
+    bool? clearNoiseReduction,
   }) => RealtimeTranslationSessionAudioInput(
     transcription: identical(transcription, unsetCopyWithValue)
         ? this.transcription
@@ -163,6 +201,8 @@ class RealtimeTranslationSessionAudioInput {
     noiseReduction: identical(noiseReduction, unsetCopyWithValue)
         ? this.noiseReduction
         : noiseReduction as RealtimeTranslationNoiseReduction?,
+    clearTranscription: clearTranscription ?? this.clearTranscription,
+    clearNoiseReduction: clearNoiseReduction ?? this.clearNoiseReduction,
   );
 
   @override
@@ -171,15 +211,24 @@ class RealtimeTranslationSessionAudioInput {
       other is RealtimeTranslationSessionAudioInput &&
           runtimeType == other.runtimeType &&
           transcription == other.transcription &&
-          noiseReduction == other.noiseReduction;
+          noiseReduction == other.noiseReduction &&
+          clearTranscription == other.clearTranscription &&
+          clearNoiseReduction == other.clearNoiseReduction;
 
   @override
-  int get hashCode => Object.hash(transcription, noiseReduction);
+  int get hashCode => Object.hash(
+    transcription,
+    noiseReduction,
+    clearTranscription,
+    clearNoiseReduction,
+  );
 
   @override
   String toString() =>
       'RealtimeTranslationSessionAudioInput(transcription: $transcription, '
-      'noiseReduction: $noiseReduction)';
+      'noiseReduction: $noiseReduction, '
+      'clearTranscription: $clearTranscription, '
+      'clearNoiseReduction: $clearNoiseReduction)';
 }
 
 // =============================================================================

--- a/packages/openai_dart/lib/src/models/realtime/realtime_truncation.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_truncation.dart
@@ -6,7 +6,7 @@ import '../common/copy_with_sentinel.dart';
 // RealtimeTruncation
 // =============================================================================
 
-/// Truncation strategy for GA Realtime sessions.
+/// Truncation strategy for Realtime sessions.
 ///
 /// A discriminated union covering the three supported strategies:
 ///

--- a/packages/openai_dart/lib/src/models/realtime/realtime_truncation.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_truncation.dart
@@ -1,0 +1,221 @@
+import 'package:meta/meta.dart';
+
+import '../common/copy_with_sentinel.dart';
+
+// =============================================================================
+// RealtimeTruncation
+// =============================================================================
+
+/// Truncation strategy for GA Realtime sessions.
+///
+/// A discriminated union covering the three supported strategies:
+///
+/// - [TruncationAuto] — string `"auto"`, the default truncation behaviour.
+/// - [TruncationDisabled] — string `"disabled"`, errors when context exceeds the
+///   token limit instead of dropping older messages.
+/// - [TruncationRetentionRatio] — object with `type: "retention_ratio"`, retains a
+///   configurable fraction of the conversation when truncating.
+///
+/// An [UnknownRealtimeTruncation] fallback preserves any unrecognised payload
+/// so future server additions do not break existing clients.
+sealed class RealtimeTruncation {
+  const RealtimeTruncation();
+
+  /// Auto strategy.
+  const factory RealtimeTruncation.auto() = TruncationAuto;
+
+  /// Disabled strategy.
+  const factory RealtimeTruncation.disabled() = TruncationDisabled;
+
+  /// Retention-ratio strategy.
+  const factory RealtimeTruncation.retentionRatio({
+    required double retentionRatio,
+    int? postInstructionsTokenLimit,
+  }) = TruncationRetentionRatio;
+
+  /// Creates from JSON.
+  ///
+  /// Accepts either the bare strings `"auto"`/`"disabled"` or an object with a
+  /// `type: "retention_ratio"` discriminator. Any other shape returns an
+  /// [UnknownRealtimeTruncation] preserving the raw payload.
+  factory RealtimeTruncation.fromJson(Object json) {
+    if (json == 'auto') return const TruncationAuto();
+    if (json == 'disabled') return const TruncationDisabled();
+    if (json is Map<String, dynamic>) {
+      if (json['type'] == 'retention_ratio') {
+        return TruncationRetentionRatio.fromJson(json);
+      }
+      return UnknownRealtimeTruncation(json);
+    }
+    return UnknownRealtimeTruncation({'value': json});
+  }
+
+  /// Converts to JSON.
+  ///
+  /// Returns either a string (`"auto"`/`"disabled"`) or a `Map`.
+  Object toJson();
+}
+
+/// `auto` truncation strategy.
+@immutable
+class TruncationAuto extends RealtimeTruncation {
+  /// Creates a [TruncationAuto].
+  const TruncationAuto();
+
+  @override
+  Object toJson() => 'auto';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TruncationAuto && runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => 'auto'.hashCode;
+
+  @override
+  String toString() => 'RealtimeTruncation.auto()';
+}
+
+/// `disabled` truncation strategy.
+@immutable
+class TruncationDisabled extends RealtimeTruncation {
+  /// Creates a [TruncationDisabled].
+  const TruncationDisabled();
+
+  @override
+  Object toJson() => 'disabled';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TruncationDisabled && runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => 'disabled'.hashCode;
+
+  @override
+  String toString() => 'RealtimeTruncation.disabled()';
+}
+
+/// Retention-ratio truncation strategy.
+///
+/// Retains [retentionRatio] (0.0–1.0) of the post-instruction conversation
+/// tokens when the conversation exceeds the input token limit. Optionally
+/// accepts a custom [postInstructionsTokenLimit].
+@immutable
+class TruncationRetentionRatio extends RealtimeTruncation {
+  /// Creates a [TruncationRetentionRatio].
+  const TruncationRetentionRatio({
+    required this.retentionRatio,
+    this.postInstructionsTokenLimit,
+  });
+
+  /// Creates from JSON.
+  factory TruncationRetentionRatio.fromJson(Map<String, dynamic> json) {
+    if (json['type'] != 'retention_ratio') {
+      throw FormatException(
+        'TruncationRetentionRatio.fromJson expected type "retention_ratio", '
+        'got ${json['type']}',
+      );
+    }
+    if (json['retention_ratio'] == null) {
+      throw const FormatException(
+        'TruncationRetentionRatio.fromJson missing required "retention_ratio" field',
+      );
+    }
+    final tokenLimits = json['token_limits'] as Map<String, dynamic>?;
+    return TruncationRetentionRatio(
+      retentionRatio: (json['retention_ratio'] as num).toDouble(),
+      postInstructionsTokenLimit: tokenLimits?['post_instructions'] as int?,
+    );
+  }
+
+  /// Fraction of post-instruction tokens to retain (0.0–1.0).
+  final double retentionRatio;
+
+  /// Optional custom post-instructions token limit.
+  final int? postInstructionsTokenLimit;
+
+  /// The discriminator value. Always `"retention_ratio"`.
+  String get type => 'retention_ratio';
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'retention_ratio': retentionRatio,
+    if (postInstructionsTokenLimit != null)
+      'token_limits': {'post_instructions': postInstructionsTokenLimit},
+  };
+
+  /// Returns a copy of this [TruncationRetentionRatio] with the given fields replaced.
+  ///
+  /// Pass `null` for [postInstructionsTokenLimit] to clear the existing value.
+  TruncationRetentionRatio copyWith({
+    double? retentionRatio,
+    Object? postInstructionsTokenLimit = unsetCopyWithValue,
+  }) => TruncationRetentionRatio(
+    retentionRatio: retentionRatio ?? this.retentionRatio,
+    postInstructionsTokenLimit:
+        identical(postInstructionsTokenLimit, unsetCopyWithValue)
+        ? this.postInstructionsTokenLimit
+        : postInstructionsTokenLimit as int?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is TruncationRetentionRatio &&
+          runtimeType == other.runtimeType &&
+          retentionRatio == other.retentionRatio &&
+          postInstructionsTokenLimit == other.postInstructionsTokenLimit;
+
+  @override
+  int get hashCode => Object.hash(retentionRatio, postInstructionsTokenLimit);
+
+  @override
+  String toString() =>
+      'TruncationRetentionRatio(retentionRatio: $retentionRatio, '
+      'postInstructionsTokenLimit: $postInstructionsTokenLimit)';
+}
+
+/// Forward-compatible fallback for unknown [RealtimeTruncation] payloads.
+///
+/// Preserves the raw JSON so the value can round-trip without loss.
+@immutable
+class UnknownRealtimeTruncation extends RealtimeTruncation {
+  /// Creates an [UnknownRealtimeTruncation] from the raw JSON.
+  const UnknownRealtimeTruncation(this.json);
+
+  /// The raw JSON map preserved verbatim.
+  final Map<String, dynamic> json;
+
+  @override
+  Object toJson() {
+    if (json.length == 1 && json.containsKey('value')) {
+      return json['value'] as Object;
+    }
+    return Map<String, dynamic>.from(json);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnknownRealtimeTruncation &&
+          runtimeType == other.runtimeType &&
+          _jsonsEqual(json, other.json);
+
+  @override
+  int get hashCode => Object.hashAllUnordered(json.entries);
+
+  @override
+  String toString() => 'UnknownRealtimeTruncation($json)';
+}
+
+bool _jsonsEqual(Map<String, dynamic> a, Map<String, dynamic> b) {
+  if (a.length != b.length) return false;
+  for (final key in a.keys) {
+    if (!b.containsKey(key) || a[key] != b[key]) return false;
+  }
+  return true;
+}

--- a/packages/openai_dart/lib/src/models/realtime/realtime_truncation.dart
+++ b/packages/openai_dart/lib/src/models/realtime/realtime_truncation.dart
@@ -1,6 +1,7 @@
 import 'package:meta/meta.dart';
 
 import '../common/copy_with_sentinel.dart';
+import '../common/equality_helpers.dart';
 
 // =============================================================================
 // RealtimeTruncation
@@ -203,19 +204,11 @@ class UnknownRealtimeTruncation extends RealtimeTruncation {
       identical(this, other) ||
       other is UnknownRealtimeTruncation &&
           runtimeType == other.runtimeType &&
-          _jsonsEqual(json, other.json);
+          mapsDeepEqual(json, other.json);
 
   @override
-  int get hashCode => Object.hashAllUnordered(json.entries);
+  int get hashCode => mapDeepHashCode(json);
 
   @override
   String toString() => 'UnknownRealtimeTruncation($json)';
-}
-
-bool _jsonsEqual(Map<String, dynamic> a, Map<String, dynamic> b) {
-  if (a.length != b.length) return false;
-  for (final key in a.keys) {
-    if (!b.containsKey(key) || a[key] != b[key]) return false;
-  }
-  return true;
 }

--- a/packages/openai_dart/lib/src/resources/realtime/websocket_connector_web.dart
+++ b/packages/openai_dart/lib/src/resources/realtime/websocket_connector_web.dart
@@ -14,14 +14,16 @@ Future<WebSocket> connectWebSocket(Uri uri, {Map<String, String>? headers}) {
     if (headers.containsKey('Authorization')) {
       throw ConnectionException(
         message:
-            'OpenAI Realtime API requires Authorization headers which are not '
-            'supported by browser WebSocket connections. '
-            'On web platforms, obtain an ephemeral client secret '
-            'server-side via realtimeSessions.createClientSecret(...) '
-            '(or createTranscriptionClientSecret(...) for transcription) '
-            'and use the returned `ek_…` value as the bearer token. '
-            'Direct Realtime API connections with the main API key are '
-            'only supported on native platforms (server, CLI, mobile).',
+            'OpenAI Realtime API requires Authorization headers, which the '
+            'browser WebSocket API does not allow. The Realtime WebSocket '
+            'transport is supported on server / CLI / mobile only. '
+            'For browser-based realtime, use the WebRTC transport: open a '
+            'peer connection client-side, generate an SDP offer, and POST '
+            'it via `client.realtimeSessions.calls.create(...)` (the SDK '
+            'handles the SDP answer + ephemeral auth). For SIP / phone '
+            'integrations, use `realtimeSessions.calls.accept/refer/hangup`. '
+            'Alternatively, route the WebSocket through a server-side '
+            'proxy that can set the Authorization header on your behalf.',
         url: uri.toString(),
       );
     }

--- a/packages/openai_dart/lib/src/resources/realtime/websocket_connector_web.dart
+++ b/packages/openai_dart/lib/src/resources/realtime/websocket_connector_web.dart
@@ -8,25 +8,28 @@ import '../../errors/exceptions.dart';
 /// so OpenAI API tokens cannot be passed via Authorization header.
 /// In this case, an error is thrown with guidance.
 Future<WebSocket> connectWebSocket(Uri uri, {Map<String, String>? headers}) {
-  // Web browsers don't support custom headers on WebSocket connections
+  // Web browsers don't support ANY custom headers on WebSocket
+  // connections (not Authorization, not OpenAI-Project, not anything).
+  // Throw early with actionable guidance instead of opening a socket
+  // whose headers were silently dropped.
   if (headers != null && headers.isNotEmpty) {
-    // Check if this is an Authorization header (required for OpenAI Realtime API)
-    if (headers.containsKey('Authorization')) {
-      throw ConnectionException(
-        message:
-            'OpenAI Realtime API requires Authorization headers, which the '
-            'browser WebSocket API does not allow. The Realtime WebSocket '
-            'transport is supported on server / CLI / mobile only. '
-            'For browser-based realtime, use the WebRTC transport: open a '
-            'peer connection client-side, generate an SDP offer, and POST '
-            'it via `client.realtimeSessions.calls.create(...)` (the SDK '
-            'handles the SDP answer + ephemeral auth). For SIP / phone '
-            'integrations, use `realtimeSessions.calls.accept/refer/hangup`. '
-            'Alternatively, route the WebSocket through a server-side '
-            'proxy that can set the Authorization header on your behalf.',
-        url: uri.toString(),
-      );
-    }
+    throw ConnectionException(
+      message:
+          'OpenAI Realtime API requires custom headers (Authorization, '
+          'OpenAI-Organization, OpenAI-Project, OpenAI-Version), which '
+          'the browser WebSocket API does not allow. The Realtime '
+          'WebSocket transport is supported on server / CLI / mobile '
+          'only. For browser-based realtime, use the WebRTC transport: '
+          'open a peer connection client-side, generate an SDP offer, '
+          'and POST it via `client.realtimeSessions.calls.create(...)` '
+          '(the SDK handles the SDP answer + ephemeral auth). For '
+          'SIP / phone integrations, use '
+          '`realtimeSessions.calls.accept/refer/hangup`. Alternatively, '
+          'route the WebSocket through a server-side proxy that can '
+          'set the required headers on your behalf. '
+          'Headers received: ${headers.keys.join(", ")}.',
+      url: uri.toString(),
+    );
   }
 
   // Use the web_socket package for browser connections

--- a/packages/openai_dart/lib/src/resources/realtime/websocket_connector_web.dart
+++ b/packages/openai_dart/lib/src/resources/realtime/websocket_connector_web.dart
@@ -16,10 +16,12 @@ Future<WebSocket> connectWebSocket(Uri uri, {Map<String, String>? headers}) {
         message:
             'OpenAI Realtime API requires Authorization headers which are not '
             'supported by browser WebSocket connections. '
-            'On web platforms, use ephemeral tokens obtained from the '
-            'realtimeSessions.create() endpoint for authentication. '
-            'Direct Realtime API connections with API keys are only '
-            'supported on native platforms (server, CLI, mobile).',
+            'On web platforms, obtain an ephemeral client secret '
+            'server-side via realtimeSessions.createClientSecret(...) '
+            '(or createTranscriptionClientSecret(...) for transcription) '
+            'and use the returned `ek_…` value as the bearer token. '
+            'Direct Realtime API connections with the main API key are '
+            'only supported on native platforms (server, CLI, mobile).',
         url: uri.toString(),
       );
     }

--- a/packages/openai_dart/lib/src/resources/realtime_resource.dart
+++ b/packages/openai_dart/lib/src/resources/realtime_resource.dart
@@ -50,7 +50,8 @@ class RealtimeResource extends ResourceBase {
   /// ## Parameters
   ///
   /// - [model] - The model to use (e.g., 'gpt-realtime-2').
-  /// - [config] - Optional session configuration.
+  /// - [config] - Optional session configuration applied via `session.update`
+  ///   immediately after the connection opens.
   ///
   /// ## Returns
   ///
@@ -59,9 +60,10 @@ class RealtimeResource extends ResourceBase {
   /// ## Platform Notes
   ///
   /// On web platforms, browser WebSocket connections do not support custom
-  /// headers. Direct connections with API keys will throw [ConnectionException].
-  /// For web, use ephemeral tokens from [OpenAIClient.realtimeSessions.create()]
-  /// to authenticate.
+  /// headers. Direct connections with API keys will throw
+  /// [ConnectionException]. For web, obtain an ephemeral client secret via
+  /// `client.realtimeSessions.createClientSecret(...)` server-side and pass
+  /// it as the bearer token from the browser.
   ///
   /// ## Example
   ///
@@ -81,55 +83,89 @@ class RealtimeResource extends ResourceBase {
     required String model,
     RealtimeSessionCreateRequest? config,
   }) async {
-    ensureNotClosed?.call();
-
-    // Build URL with proper normalization using the request builder
-    final httpUrl = requestBuilder.buildUrl(
-      '/realtime',
-      queryParams: {'model': model},
-    );
-
-    // Convert to WebSocket scheme
-    final wsUrl = httpUrl.replace(
-      scheme: httpUrl.scheme == 'https' ? 'wss' : 'ws',
-    );
-
-    // Build headers with all config options
-    final headers = <String, String>{
-      'OpenAI-Beta': 'realtime=v1',
-      ...this.config.defaultHeaders,
-    };
-
-    // Add auth headers
-    if (this.config.authProvider case final authProvider?) {
-      headers.addAll(authProvider.getHeaders());
-    }
-
-    // Add organization header if configured
-    if (this.config.organization case final org?) {
-      headers['OpenAI-Organization'] = org;
-    }
-
-    // Add project header if configured
-    if (this.config.project case final proj?) {
-      headers['OpenAI-Project'] = proj;
-    }
-
-    // Add API version if configured
-    if (this.config.apiVersion case final version?) {
-      headers['OpenAI-Version'] = version;
-    }
-
-    // Connect to WebSocket using platform-specific implementation
-    final socket = await connectWebSocket(wsUrl, headers: headers);
+    final socket = await _openSocket('/realtime', model);
     final connection = RealtimeConnection._(socket);
-
-    // Apply config if provided
     if (config != null) {
       connection.updateSession(config);
     }
-
     return connection;
+  }
+
+  /// Connects to a Realtime translation session.
+  ///
+  /// Translation sessions stream source audio in and translated audio plus
+  /// transcript deltas out continuously — there is no `response.create`
+  /// lifecycle. The WebSocket lives at
+  /// `wss://api.openai.com/v1/realtime/translations`.
+  ///
+  /// ## Parameters
+  ///
+  /// - [model] - The translation model (e.g., `'gpt-realtime-translate'`).
+  /// - [config] - Optional update applied via `session.update` immediately
+  ///   after the connection opens (e.g., to set `audio.output.language`).
+  ///
+  /// ## Example
+  ///
+  /// ```dart
+  /// final session = await client.realtime.connectTranslation(
+  ///   model: 'gpt-realtime-translate',
+  ///   config: RealtimeTranslationSessionUpdateRequest(
+  ///     audio: RealtimeTranslationSessionAudio(
+  ///       output: RealtimeTranslationSessionAudioOutput(language: 'es'),
+  ///     ),
+  ///   ),
+  /// );
+  ///
+  /// session.events.listen((event) {
+  ///   switch (event) {
+  ///     case RealtimeTranslationOutputAudioDeltaEvent(:final delta):
+  ///       // base64 PCM16 translated audio
+  ///     case RealtimeTranslationOutputTranscriptDeltaEvent(:final delta):
+  ///       stdout.write(delta);
+  ///     default:
+  ///       break;
+  ///   }
+  /// });
+  /// ```
+  Future<RealtimeTranslationConnection> connectTranslation({
+    required String model,
+    RealtimeTranslationSessionUpdateRequest? config,
+  }) async {
+    final socket = await _openSocket('/realtime/translations', model);
+    final connection = RealtimeTranslationConnection._(socket);
+    if (config != null) {
+      connection.updateSession(config);
+    }
+    return connection;
+  }
+
+  Future<WebSocket> _openSocket(String path, String model) {
+    ensureNotClosed?.call();
+    final httpUrl = requestBuilder.buildUrl(
+      path,
+      queryParams: {'model': model},
+    );
+    final wsUrl = httpUrl.replace(
+      scheme: httpUrl.scheme == 'https' ? 'wss' : 'ws',
+    );
+    // The Realtime API authenticates via the standard `Authorization`
+    // bearer token only — no `OpenAI-Beta` header is required (or
+    // accepted) on the WebSocket handshake.
+    final cfg = config;
+    final headers = <String, String>{...cfg.defaultHeaders};
+    if (cfg.authProvider case final authProvider?) {
+      headers.addAll(authProvider.getHeaders());
+    }
+    if (cfg.organization case final org?) {
+      headers['OpenAI-Organization'] = org;
+    }
+    if (cfg.project case final proj?) {
+      headers['OpenAI-Project'] = proj;
+    }
+    if (cfg.apiVersion case final version?) {
+      headers['OpenAI-Version'] = version;
+    }
+    return connectWebSocket(wsUrl, headers: headers);
   }
 }
 
@@ -277,10 +313,17 @@ class RealtimeConnection {
   /// has produced audio output; the server will ignore those fields if you
   /// supply them on update.
   void updateSession(RealtimeSessionCreateRequest config, {String? eventId}) {
+    // The `session.update` event requires a discriminated session payload
+    // (`type: 'realtime'` vs `'transcription'`). Inject the realtime
+    // discriminator when the caller didn't set it so the bare
+    // `RealtimeSessionCreateRequest.toJson` (which omits `type` to keep the
+    // HTTP endpoint happy) still works on the WebSocket wire.
+    final sessionJson = config.toJson();
+    sessionJson['type'] ??= 'realtime';
     send({
       'type': 'session.update',
       'event_id': ?eventId,
-      'session': config.toJson(),
+      'session': sessionJson,
     });
   }
 
@@ -411,30 +454,39 @@ class RealtimeConnection {
   ///
   /// ```dart
   /// session.createResponse(
-  ///   modalities: ['text', 'audio'],
+  ///   outputModalities: ['text'],
   ///   instructions: 'Respond briefly.',
   /// );
   /// ```
+  ///
+  /// The response payload follows `RealtimeResponseCreateParams` from the
+  /// spec: `output_modalities` (single-modality array), nested
+  /// `audio.output.{format, voice}`, and reasoning/parallel-tool-calls
+  /// knobs.
   void createResponse({
-    List<String>? modalities,
+    List<String>? outputModalities,
     String? instructions,
-    String? voice,
-    String? outputAudioFormat,
+    RealtimeAudioConfigOutput? audio,
     List<RealtimeTool>? tools,
     Object? toolChoice,
-    double? temperature,
     Object? maxOutputTokens,
+    bool? parallelToolCalls,
+    RealtimeReasoning? reasoning,
+    String? conversation,
+    Map<String, dynamic>? metadata,
     String? eventId,
   }) {
     final response = <String, dynamic>{
-      'modalities': ?modalities,
+      'output_modalities': ?outputModalities,
       'instructions': ?instructions,
-      'voice': ?voice,
-      'output_audio_format': ?outputAudioFormat,
-      if (tools != null) 'tools': tools.map((t) => t.toJson()).toList(),
+      'audio': ?(audio == null ? null : {'output': audio.toJson()}),
+      'tools': ?tools?.map((t) => t.toJson()).toList(),
       'tool_choice': ?toolChoice,
-      'temperature': ?temperature,
       'max_output_tokens': ?maxOutputTokens,
+      'parallel_tool_calls': ?parallelToolCalls,
+      'reasoning': ?reasoning?.toJson(),
+      'conversation': ?conversation,
+      'metadata': ?metadata,
     };
 
     send({
@@ -506,5 +558,161 @@ class _BufferedEvent {
   _BufferedEvent.error(Object this.error) : event = null;
 
   final RealtimeEvent? event;
+  final Object? error;
+}
+
+/// A connection to a Realtime translation session.
+///
+/// Translation sessions stream source audio in and translated audio plus
+/// transcript deltas out continuously. They use a different event surface
+/// from regular Realtime sessions — see [RealtimeTranslationServerEvent]
+/// for the event types you'll receive on [events].
+class RealtimeTranslationConnection {
+  RealtimeTranslationConnection._(this._socket) {
+    _eventController =
+        StreamController<RealtimeTranslationServerEvent>.broadcast(
+      onListen: _drainBuffer,
+    );
+    _subscription = _socket.events.listen(
+      _handleEvent,
+      onError: _handleError,
+      onDone: _handleDone,
+    );
+  }
+
+  final WebSocket _socket;
+  late final StreamSubscription<WebSocketEvent> _subscription;
+  late final StreamController<RealtimeTranslationServerEvent> _eventController;
+  final List<_BufferedTranslationEvent> _earlyEvents = [];
+  bool _drained = false;
+  bool _closed = false;
+
+  void _drainBuffer() {
+    if (_drained) return;
+    _drained = true;
+    for (final buffered in _earlyEvents) {
+      if (buffered.error != null) {
+        _eventController.addError(buffered.error!);
+      } else {
+        _eventController.add(buffered.event!);
+      }
+    }
+    _earlyEvents.clear();
+  }
+
+  void _emitEvent(RealtimeTranslationServerEvent event) {
+    if (_drained) {
+      _eventController.add(event);
+    } else {
+      _earlyEvents.add(_BufferedTranslationEvent.event(event));
+    }
+  }
+
+  void _emitError(Object error) {
+    if (_drained) {
+      _eventController.addError(error);
+    } else {
+      _earlyEvents.add(_BufferedTranslationEvent.error(error));
+    }
+  }
+
+  /// Stream of translation server events.
+  Stream<RealtimeTranslationServerEvent> get events => _eventController.stream;
+
+  /// Whether the connection is closed.
+  bool get isClosed => _closed;
+
+  void _handleEvent(WebSocketEvent event) {
+    switch (event) {
+      case TextDataReceived(:final text):
+        _handleMessage(text);
+      case BinaryDataReceived():
+        // Binary data not expected from OpenAI Realtime API
+        break;
+      case CloseReceived():
+        _handleDone();
+    }
+  }
+
+  void _handleMessage(String message) {
+    try {
+      final json = jsonDecode(message) as Map<String, dynamic>;
+      final event = RealtimeTranslationServerEvent.fromJson(json);
+      _emitEvent(event);
+    } catch (e) {
+      _emitError(e);
+    }
+  }
+
+  void _handleError(Object error) {
+    _emitError(error);
+  }
+
+  void _handleDone() {
+    _closed = true;
+    unawaited(_eventController.close());
+  }
+
+  void _ensureNotClosed() {
+    if (_closed) {
+      throw StateError('RealtimeTranslationConnection is closed.');
+    }
+  }
+
+  /// Sends a raw client event to the server.
+  void send(Map<String, dynamic> event) {
+    _ensureNotClosed();
+    _socket.sendText(jsonEncode(event));
+  }
+
+  /// Updates the translation session's configuration.
+  ///
+  /// Translation sessions only allow updates to `audio.input.transcription`,
+  /// `audio.input.noise_reduction`, and `audio.output.language` — `model`
+  /// and the session `type` are fixed at session creation.
+  void updateSession(
+    RealtimeTranslationSessionUpdateRequest config, {
+    String? eventId,
+  }) {
+    send({
+      'type': 'session.update',
+      'event_id': ?eventId,
+      'session': config.toJson(),
+    });
+  }
+
+  /// Appends base64-encoded 24 kHz PCM16 mono audio bytes to the input
+  /// buffer. The translation engine consumes 200 ms frames.
+  void appendAudio(String audioBase64, {String? eventId}) {
+    send({
+      'type': 'session.input_audio_buffer.append',
+      'event_id': ?eventId,
+      'audio': audioBase64,
+    });
+  }
+
+  /// Gracefully closes the translation session. The server flushes any
+  /// pending input audio and emits any remaining translated output before
+  /// closing the socket.
+  void closeSession({String? eventId}) {
+    send({'type': 'session.close', 'event_id': ?eventId});
+  }
+
+  /// Closes the WebSocket connection.
+  Future<void> close({int? code, String? reason}) async {
+    if (_closed) return;
+    _closed = true;
+    await _subscription.cancel();
+    await _socket.close(code, reason);
+    await _eventController.close();
+  }
+}
+
+class _BufferedTranslationEvent {
+  _BufferedTranslationEvent.event(RealtimeTranslationServerEvent this.event)
+    : error = null;
+  _BufferedTranslationEvent.error(Object this.error) : event = null;
+
+  final RealtimeTranslationServerEvent? event;
   final Object? error;
 }

--- a/packages/openai_dart/lib/src/resources/realtime_resource.dart
+++ b/packages/openai_dart/lib/src/resources/realtime_resource.dart
@@ -90,6 +90,16 @@ class RealtimeResource extends ResourceBase {
     required String model,
     RealtimeSessionCreateRequest? config,
   }) async {
+    if (config != null && config.model != model) {
+      throw ArgumentError.value(
+        config.model,
+        'config.model',
+        'must match the connect(model:) argument ("$model"): the WebSocket '
+            'is opened for the URL-query model and the embedded session.update '
+            'would target a different model, which the server may reject. '
+            'Pass the same value in both places.',
+      );
+    }
     final socket = await _openSocket('/realtime', model);
     final connection = RealtimeConnection._(socket);
     if (config != null) {

--- a/packages/openai_dart/lib/src/resources/realtime_resource.dart
+++ b/packages/openai_dart/lib/src/resources/realtime_resource.dart
@@ -201,6 +201,15 @@ class RealtimeConnection {
   void _drainBuffer() {
     if (_drained) return;
     _drained = true;
+    // Guard against the race where the socket closes (and
+    // [_handleDone] closes the controller) before the first listener
+    // attaches. In that case `onListen` still fires when a late
+    // subscriber arrives — emitting into a closed controller would
+    // throw `StateError`. Clear the buffer instead.
+    if (_closed) {
+      _earlyEvents.clear();
+      return;
+    }
     for (final buffered in _earlyEvents) {
       if (buffered.error != null) {
         _eventController.addError(buffered.error!);
@@ -212,6 +221,7 @@ class RealtimeConnection {
   }
 
   void _emitEvent(RealtimeEvent event) {
+    if (_closed) return;
     if (_drained) {
       _eventController.add(event);
     } else {
@@ -220,6 +230,7 @@ class RealtimeConnection {
   }
 
   void _emitError(Object error) {
+    if (_closed) return;
     if (_drained) {
       _eventController.addError(error);
     } else {
@@ -646,6 +657,15 @@ class RealtimeTranslationConnection {
   void _drainBuffer() {
     if (_drained) return;
     _drained = true;
+    // Guard against the race where the socket closes (and
+    // [_handleDone] closes the controller) before the first listener
+    // attaches. In that case `onListen` still fires when a late
+    // subscriber arrives — emitting into a closed controller would
+    // throw `StateError`. Clear the buffer instead.
+    if (_closed) {
+      _earlyEvents.clear();
+      return;
+    }
     for (final buffered in _earlyEvents) {
       if (buffered.error != null) {
         _eventController.addError(buffered.error!);
@@ -657,6 +677,7 @@ class RealtimeTranslationConnection {
   }
 
   void _emitEvent(RealtimeTranslationServerEvent event) {
+    if (_closed) return;
     if (_drained) {
       _eventController.add(event);
     } else {
@@ -665,6 +686,7 @@ class RealtimeTranslationConnection {
   }
 
   void _emitError(Object error) {
+    if (_closed) return;
     if (_drained) {
       _eventController.addError(error);
     } else {

--- a/packages/openai_dart/lib/src/resources/realtime_resource.dart
+++ b/packages/openai_dart/lib/src/resources/realtime_resource.dart
@@ -17,7 +17,7 @@ import 'realtime/websocket_connector.dart';
 /// ## Example
 ///
 /// ```dart
-/// // Connect to realtime session
+/// // Connect to a realtime session
 /// final session = await client.realtime.connect(
 ///   model: 'gpt-realtime-2',
 /// );
@@ -29,8 +29,11 @@ import 'realtime/websocket_connector.dart';
 ///   }
 /// });
 ///
-/// // Send audio
-/// session.sendAudio(audioBytes);
+/// // Send a user text message and let the model respond
+/// session.sendUserMessage('Say hello');
+///
+/// // Or stream audio bytes (24 kHz PCM16 mono for realtime sessions)
+/// session.appendAudioBytes(audioBytes);
 ///
 /// // Close when done
 /// await session.close();
@@ -304,7 +307,7 @@ class RealtimeConnection {
   ///     audio: RealtimeAudioConfig(
   ///       output: RealtimeAudioConfigOutput(voice: 'shimmer'),
   ///     ),
-  ///     temperature: 0.8,
+  ///     instructions: 'Be terse.',
   ///   ),
   /// );
   /// ```
@@ -349,6 +352,16 @@ class RealtimeConnection {
     });
   }
 
+  /// Convenience over [appendAudio]: base64-encodes the raw audio bytes
+  /// for you.
+  ///
+  /// The audio must be in the format negotiated for the session
+  /// (typically 24 kHz PCM16 mono little-endian for realtime sessions;
+  /// G.711 μ-law/A-law for telephony). This helper does **not** validate
+  /// or transcode — it only wraps `base64Encode`.
+  void appendAudioBytes(List<int> audioBytes, {String? eventId}) =>
+      appendAudio(base64Encode(audioBytes), eventId: eventId);
+
   /// Commits the audio buffer, creating a new conversation item.
   ///
   /// ## Parameters
@@ -369,21 +382,26 @@ class RealtimeConnection {
 
   /// Creates a new conversation item.
   ///
+  /// For the canonical "send a user text turn" flow, prefer
+  /// [sendUserMessage] — it wraps this method plus [createResponse] in
+  /// one call.
+  ///
   /// ## Parameters
   ///
-  /// - [item] - The item to create.
+  /// - [item] - The item to create. Use this for advanced item types
+  ///   (function-call output, assistant messages, system items,
+  ///   item-references) or any flow not covered by [sendUserMessage].
   /// - [previousItemId] - Optional ID of the previous item.
   /// - [eventId] - Optional event ID.
   ///
   /// ## Example
   ///
   /// ```dart
+  /// // Function-call output (assistant tool result):
   /// session.createItem({
-  ///   'type': 'message',
-  ///   'role': 'user',
-  ///   'content': [
-  ///     {'type': 'input_text', 'text': 'Hello!'},
-  ///   ],
+  ///   'type': 'function_call_output',
+  ///   'call_id': 'call_abc123',
+  ///   'output': '{"temperature": 22, "unit": "C"}',
   /// });
   /// ```
   void createItem(
@@ -397,6 +415,40 @@ class RealtimeConnection {
       'previous_item_id': ?previousItemId,
       'item': item,
     });
+  }
+
+  /// Sends a user text message as a conversation item, and (optionally)
+  /// requests a response immediately afterwards.
+  ///
+  /// Convenience over [createItem] + [createResponse] for the canonical
+  /// "send a turn" flow.
+  ///
+  /// **Caveat:** when the session has server-side VAD with
+  /// `create_response: true` (the default), the server will already
+  /// generate a response automatically; passing `createResponse: true`
+  /// here would queue a duplicate request. Set `createResponse: false`
+  /// in that mode.
+  ///
+  /// ## Example
+  ///
+  /// ```dart
+  /// session.sendUserMessage('Say hello and nothing else.');
+  /// ```
+  void sendUserMessage(
+    String text, {
+    bool createResponse = true,
+    String? eventId,
+  }) {
+    createItem({
+      'type': 'message',
+      'role': 'user',
+      'content': [
+        {'type': 'input_text', 'text': text},
+      ],
+    }, eventId: eventId);
+    if (createResponse) {
+      this.createResponse();
+    }
   }
 
   /// Truncates a conversation item.
@@ -440,14 +492,18 @@ class RealtimeConnection {
   ///
   /// ## Parameters
   ///
-  /// - [modalities] - The response modalities (e.g., ['text', 'audio']).
-  /// - [instructions] - Additional instructions for this response.
-  /// - [voice] - The voice to use.
-  /// - [outputAudioFormat] - The audio output format.
+  /// - [outputModalities] - Response modality (`['text']` or `['audio']`).
+  /// - [instructions] - Per-response instruction override.
+  /// - [audio] - Per-response audio output config (format + voice).
   /// - [tools] - Tools available for this response.
   /// - [toolChoice] - The tool choice mode.
-  /// - [temperature] - Sampling temperature.
   /// - [maxOutputTokens] - Maximum output tokens.
+  /// - [parallelToolCalls] - Whether to allow parallel tool calls.
+  /// - [reasoning] - Reasoning configuration.
+  /// - [conversation] - Which conversation the response belongs to
+  ///   (`'auto'` to add to the default conversation, `'none'` for an
+  ///   out-of-band response).
+  /// - [metadata] - Arbitrary metadata for disambiguating responses.
   /// - [eventId] - Optional event ID.
   ///
   /// ## Example
@@ -571,8 +627,8 @@ class RealtimeTranslationConnection {
   RealtimeTranslationConnection._(this._socket) {
     _eventController =
         StreamController<RealtimeTranslationServerEvent>.broadcast(
-      onListen: _drainBuffer,
-    );
+          onListen: _drainBuffer,
+        );
     _subscription = _socket.events.listen(
       _handleEvent,
       onError: _handleError,
@@ -690,6 +746,13 @@ class RealtimeTranslationConnection {
       'audio': audioBase64,
     });
   }
+
+  /// Convenience over [appendAudio]: base64-encodes the raw audio bytes
+  /// for you. The translation flow expects 24 kHz PCM16 mono
+  /// little-endian audio in 200 ms frames. This helper does **not**
+  /// validate or transcode — it only wraps `base64Encode`.
+  void appendAudioBytes(List<int> audioBytes, {String? eventId}) =>
+      appendAudio(base64Encode(audioBytes), eventId: eventId);
 
   /// Gracefully closes the translation session. The server flushes any
   /// pending input audio and emits any remaining translated output before

--- a/packages/openai_dart/lib/src/resources/realtime_resource.dart
+++ b/packages/openai_dart/lib/src/resources/realtime_resource.dart
@@ -62,11 +62,15 @@ class RealtimeResource extends ResourceBase {
   ///
   /// ## Platform Notes
   ///
-  /// On web platforms, browser WebSocket connections do not support custom
-  /// headers. Direct connections with API keys will throw
-  /// [ConnectionException]. For web, obtain an ephemeral client secret via
-  /// `client.realtimeSessions.createClientSecret(...)` server-side and pass
-  /// it as the bearer token from the browser.
+  /// The browser WebSocket API does not allow custom headers, so the
+  /// Realtime WebSocket transport is supported on server / CLI / mobile
+  /// only — calling `connect(...)` from a browser raises
+  /// [ConnectionException]. For browser-based realtime, use the WebRTC
+  /// transport via `client.realtimeSessions.calls.create(...)` (open a
+  /// peer connection client-side, POST the SDP offer, complete the
+  /// handshake with the returned answer). Alternatively, route the
+  /// WebSocket through a server-side proxy that can set the
+  /// `Authorization` header.
   ///
   /// ## Example
   ///

--- a/packages/openai_dart/lib/src/resources/realtime_resource.dart
+++ b/packages/openai_dart/lib/src/resources/realtime_resource.dart
@@ -19,7 +19,7 @@ import 'realtime/websocket_connector.dart';
 /// ```dart
 /// // Connect to realtime session
 /// final session = await client.realtime.connect(
-///   model: 'gpt-realtime-1.5',
+///   model: 'gpt-realtime-2',
 /// );
 ///
 /// // Listen for events
@@ -49,7 +49,7 @@ class RealtimeResource extends ResourceBase {
   ///
   /// ## Parameters
   ///
-  /// - [model] - The model to use (e.g., 'gpt-realtime-1.5').
+  /// - [model] - The model to use (e.g., 'gpt-realtime-2').
   /// - [config] - Optional session configuration.
   ///
   /// ## Returns
@@ -67,16 +67,19 @@ class RealtimeResource extends ResourceBase {
   ///
   /// ```dart
   /// final session = await client.realtime.connect(
-  ///   model: 'gpt-realtime-1.5',
-  ///   config: SessionUpdateConfig(
-  ///     voice: 'alloy',
+  ///   model: 'gpt-realtime-2',
+  ///   config: RealtimeSessionCreateRequest(
+  ///     model: 'gpt-realtime-2',
+  ///     audio: RealtimeAudioConfig(
+  ///       output: RealtimeAudioConfigOutput(voice: 'alloy'),
+  ///     ),
   ///     instructions: 'You are a helpful assistant.',
   ///   ),
   /// );
   /// ```
   Future<RealtimeConnection> connect({
     required String model,
-    SessionUpdateConfig? config,
+    RealtimeSessionCreateRequest? config,
   }) async {
     ensureNotClosed?.call();
 
@@ -135,6 +138,13 @@ class RealtimeResource extends ResourceBase {
 /// Use this to send and receive events from the Realtime API.
 class RealtimeConnection {
   RealtimeConnection._(this._socket) {
+    // Buffer events emitted before the first listener attaches; drain them
+    // when the broadcast stream gets its first subscriber. Without this,
+    // early frames from the server (notably `session.created`) get dropped
+    // because broadcast streams discard events when nobody is listening.
+    _eventController = StreamController<RealtimeEvent>.broadcast(
+      onListen: _drainBuffer,
+    );
     _subscription = _socket.events.listen(
       _handleEvent,
       onError: _handleError,
@@ -144,8 +154,39 @@ class RealtimeConnection {
 
   final WebSocket _socket;
   late final StreamSubscription<WebSocketEvent> _subscription;
-  final _eventController = StreamController<RealtimeEvent>.broadcast();
+  late final StreamController<RealtimeEvent> _eventController;
+  final List<_BufferedEvent> _earlyEvents = [];
+  bool _drained = false;
   bool _closed = false;
+
+  void _drainBuffer() {
+    if (_drained) return;
+    _drained = true;
+    for (final buffered in _earlyEvents) {
+      if (buffered.error != null) {
+        _eventController.addError(buffered.error!);
+      } else {
+        _eventController.add(buffered.event!);
+      }
+    }
+    _earlyEvents.clear();
+  }
+
+  void _emitEvent(RealtimeEvent event) {
+    if (_drained) {
+      _eventController.add(event);
+    } else {
+      _earlyEvents.add(_BufferedEvent.event(event));
+    }
+  }
+
+  void _emitError(Object error) {
+    if (_drained) {
+      _eventController.addError(error);
+    } else {
+      _earlyEvents.add(_BufferedEvent.error(error));
+    }
+  }
 
   /// Stream of events from the server.
   ///
@@ -186,14 +227,14 @@ class RealtimeConnection {
     try {
       final json = jsonDecode(message) as Map<String, dynamic>;
       final event = RealtimeEvent.fromJson(json);
-      _eventController.add(event);
+      _emitEvent(event);
     } catch (e) {
-      _eventController.addError(e);
+      _emitError(e);
     }
   }
 
   void _handleError(Object error) {
-    _eventController.addError(error);
+    _emitError(error);
   }
 
   void _handleDone() {
@@ -222,13 +263,20 @@ class RealtimeConnection {
   ///
   /// ```dart
   /// session.updateSession(
-  ///   SessionUpdateConfig(
-  ///     voice: 'shimmer',
+  ///   RealtimeSessionCreateRequest(
+  ///     model: 'gpt-realtime-2',
+  ///     audio: RealtimeAudioConfig(
+  ///       output: RealtimeAudioConfigOutput(voice: 'shimmer'),
+  ///     ),
   ///     temperature: 0.8,
   ///   ),
   /// );
   /// ```
-  void updateSession(SessionUpdateConfig config, {String? eventId}) {
+  ///
+  /// Per the spec, `model` and `voice` cannot be changed after the session
+  /// has produced audio output; the server will ignore those fields if you
+  /// supply them on update.
+  void updateSession(RealtimeSessionCreateRequest config, {String? eventId}) {
     send({
       'type': 'session.update',
       'event_id': ?eventId,
@@ -449,4 +497,14 @@ class RealtimeConnection {
     await _socket.close(code, reason);
     await _eventController.close();
   }
+}
+
+/// Internal: buffered event/error pair used while no listener is yet
+/// attached to [RealtimeConnection.events].
+class _BufferedEvent {
+  _BufferedEvent.event(RealtimeEvent this.event) : error = null;
+  _BufferedEvent.error(Object this.error) : event = null;
+
+  final RealtimeEvent? event;
+  final Object? error;
 }

--- a/packages/openai_dart/lib/src/resources/realtime_resource.dart
+++ b/packages/openai_dart/lib/src/resources/realtime_resource.dart
@@ -220,11 +220,24 @@ class RealtimeConnection {
     _earlyEvents.clear();
   }
 
+  /// Maximum events buffered before the first listener attaches.
+  ///
+  /// Drops the oldest entry when full. Prevents unbounded memory growth
+  /// if a caller never attaches a listener to [events] (or attaches very
+  /// late in a long-running session). 1024 entries is large enough to
+  /// cover the realistic "session.created" race window and an opening
+  /// burst of frames; beyond that the loss is on partial early state
+  /// the consumer chose not to read.
+  static const int _maxBufferedEvents = 1024;
+
   void _emitEvent(RealtimeEvent event) {
     if (_closed) return;
     if (_drained) {
       _eventController.add(event);
     } else {
+      if (_earlyEvents.length >= _maxBufferedEvents) {
+        _earlyEvents.removeAt(0);
+      }
       _earlyEvents.add(_BufferedEvent.event(event));
     }
   }
@@ -234,6 +247,9 @@ class RealtimeConnection {
     if (_drained) {
       _eventController.addError(error);
     } else {
+      if (_earlyEvents.length >= _maxBufferedEvents) {
+        _earlyEvents.removeAt(0);
+      }
       _earlyEvents.add(_BufferedEvent.error(error));
     }
   }
@@ -288,6 +304,12 @@ class RealtimeConnection {
   }
 
   void _handleDone() {
+    // Idempotent: `_handleEvent` calls this on `CloseReceived`, and the
+    // socket subscription's `onDone` also fires it. Without the guard,
+    // `_eventController.close()` would run twice (the second call is a
+    // no-op on `StreamController` but the explicit short-circuit makes
+    // the contract clear and prevents future regressions).
+    if (_closed) return;
     _closed = true;
     unawaited(_eventController.close());
   }
@@ -676,11 +698,21 @@ class RealtimeTranslationConnection {
     _earlyEvents.clear();
   }
 
+  /// Maximum events buffered before the first listener attaches.
+  ///
+  /// Drops the oldest entry when full. Prevents unbounded memory growth
+  /// in long-lived translation sessions where a listener attaches late
+  /// (or never).
+  static const int _maxBufferedEvents = 1024;
+
   void _emitEvent(RealtimeTranslationServerEvent event) {
     if (_closed) return;
     if (_drained) {
       _eventController.add(event);
     } else {
+      if (_earlyEvents.length >= _maxBufferedEvents) {
+        _earlyEvents.removeAt(0);
+      }
       _earlyEvents.add(_BufferedTranslationEvent.event(event));
     }
   }
@@ -690,6 +722,9 @@ class RealtimeTranslationConnection {
     if (_drained) {
       _eventController.addError(error);
     } else {
+      if (_earlyEvents.length >= _maxBufferedEvents) {
+        _earlyEvents.removeAt(0);
+      }
       _earlyEvents.add(_BufferedTranslationEvent.error(error));
     }
   }
@@ -727,6 +762,12 @@ class RealtimeTranslationConnection {
   }
 
   void _handleDone() {
+    // Idempotent: `_handleEvent` calls this on `CloseReceived`, and the
+    // socket subscription's `onDone` also fires it. Without the guard,
+    // `_eventController.close()` would run twice (the second call is a
+    // no-op on `StreamController` but the explicit short-circuit makes
+    // the contract clear and prevents future regressions).
+    if (_closed) return;
     _closed = true;
     unawaited(_eventController.close());
   }

--- a/packages/openai_dart/lib/src/resources/realtime_sessions_resource.dart
+++ b/packages/openai_dart/lib/src/resources/realtime_sessions_resource.dart
@@ -15,18 +15,22 @@ import 'base_resource.dart';
 /// ## Example
 ///
 /// ```dart
-/// // Create a realtime session with ephemeral key
-/// final session = await client.realtimeSessions.create(
-///   RealtimeSessionCreateRequest(
-///     model: 'gpt-realtime-1.5',
-///     voice: RealtimeVoice.alloy,
+/// // Create a realtime session and a separate ephemeral client secret
+/// final secret = await client.realtimeSessions.createClientSecret(
+///   RealtimeClientSecretCreateRequest(
+///     session: RealtimeSessionCreateRequest(
+///       model: 'gpt-realtime-2',
+///       audio: RealtimeAudioConfig(
+///         output: RealtimeAudioConfigOutput(voice: 'alloy'),
+///       ),
+///     ),
 ///   ),
 /// );
 ///
 /// // Use the client secret for WebSocket connection
 /// final ws = await WebSocket.connect(
 ///   'wss://api.openai.com/v1/realtime',
-///   headers: {'Authorization': 'Bearer ${session.clientSecret.value}'},
+///   headers: {'Authorization': 'Bearer ${secret.value}'},
 /// );
 /// ```
 class RealtimeSessionsResource extends ResourceBase {
@@ -39,11 +43,10 @@ class RealtimeSessionsResource extends ResourceBase {
     super.ensureNotClosed,
   });
 
-  static const _sessionsEndpoint = '/realtime/sessions';
-  static const _transcriptionEndpoint = '/realtime/transcription_sessions';
   static const _clientSecretsEndpoint = '/realtime/client_secrets';
 
   RealtimeCallsResource? _calls;
+  RealtimeTranslationsResource? _translations;
 
   /// Access to WebRTC call operations.
   RealtimeCallsResource get calls => _calls ??= RealtimeCallsResource(
@@ -54,105 +57,19 @@ class RealtimeSessionsResource extends ResourceBase {
     ensureNotClosed: ensureNotClosed,
   );
 
-  /// Creates a realtime session with an ephemeral API key.
+  /// Access to Realtime translation operations.
   ///
-  /// This endpoint creates a session configuration and returns an ephemeral
-  /// client secret that can be used to authenticate WebSocket connections
-  /// without exposing your main API key.
-  ///
-  /// ## Parameters
-  ///
-  /// - [request] - The session creation request parameters.
-  ///
-  /// ## Returns
-  ///
-  /// A [RealtimeSessionCreateResponse] containing the session configuration
-  /// and client secret.
-  ///
-  /// ## Example
-  ///
-  /// ```dart
-  /// final session = await client.realtimeSessions.create(
-  ///   RealtimeSessionCreateRequest(
-  ///     model: 'gpt-realtime-1.5',
-  ///     voice: RealtimeVoice.alloy,
-  ///     instructions: 'You are a helpful assistant.',
-  ///     turnDetection: TurnDetection(
-  ///       type: TurnDetectionType.serverVad,
-  ///       threshold: 0.5,
-  ///     ),
-  ///   ),
-  /// );
-  ///
-  /// print('Session ID: ${session.id}');
-  /// print('Client secret: ${session.clientSecret.value}');
-  /// ```
-  Future<RealtimeSessionCreateResponse> create(
-    RealtimeSessionCreateRequest request, {
-    Future<void>? abortTrigger,
-  }) async {
-    ensureNotClosed?.call();
-    final url = requestBuilder.buildUrl(_sessionsEndpoint);
-    final headers = requestBuilder.buildHeaders();
-    final httpRequest = http.Request('POST', url)
-      ..headers.addAll(headers)
-      ..body = jsonEncode(request.toJson());
-    final response = await interceptorChain.execute(
-      httpRequest,
-      abortTrigger: abortTrigger,
-    );
-    return RealtimeSessionCreateResponse.fromJson(
-      jsonDecode(response.body) as Map<String, dynamic>,
-    );
-  }
-
-  /// Creates a realtime transcription session.
-  ///
-  /// Transcription sessions are optimized for audio-to-text scenarios
-  /// without generating audio responses.
-  ///
-  /// ## Parameters
-  ///
-  /// - [request] - The transcription session creation request.
-  ///
-  /// ## Returns
-  ///
-  /// A [RealtimeTranscriptionSessionCreateResponse] containing the session
-  /// configuration and client secret.
-  ///
-  /// ## Example
-  ///
-  /// ```dart
-  /// final session = await client.realtimeSessions.createTranscription(
-  ///   RealtimeTranscriptionSessionCreateRequest(
-  ///     inputAudioFormat: RealtimeAudioFormat.pcm16,
-  ///     inputAudioTranscription: InputAudioTranscription(
-  ///       model: 'whisper-1',
-  ///     ),
-  ///     turnDetection: TurnDetection(
-  ///       type: TurnDetectionType.serverVad,
-  ///     ),
-  ///   ),
-  /// );
-  /// ```
-  Future<RealtimeTranscriptionSessionCreateResponse> createTranscription(
-    RealtimeTranscriptionSessionCreateRequest request, {
-    Future<void>? abortTrigger,
-  }) async {
-    ensureNotClosed?.call();
-    final url = requestBuilder.buildUrl(_transcriptionEndpoint);
-    final headers = requestBuilder.buildHeaders();
-    final httpRequest = http.Request('POST', url)
-      ..headers.addAll(headers)
-      ..body = jsonEncode(request.toJson());
-    final response = await interceptorChain.execute(
-      httpRequest,
-      abortTrigger: abortTrigger,
-    );
-    return RealtimeTranscriptionSessionCreateResponse.fromJson(
-      jsonDecode(response.body) as Map<String, dynamic>,
-    );
-  }
+  /// Mirrors the Python SDK split (`client.realtime.client_secrets` /
+  /// `client.realtime.calls`) — final user-facing path:
+  /// `client.realtimeSessions.translations.createClientSecret(...)`.
+  RealtimeTranslationsResource get translations =>
+      _translations ??= RealtimeTranslationsResource(
+        config: config,
+        httpClient: httpClient,
+        interceptorChain: interceptorChain,
+        requestBuilder: requestBuilder,
+        ensureNotClosed: ensureNotClosed,
+      );
 
   /// Creates a client secret with custom configuration.
   ///
@@ -175,8 +92,10 @@ class RealtimeSessionsResource extends ResourceBase {
   ///   RealtimeClientSecretCreateRequest(
   ///     expiresAfter: ExpiresAfter(anchor: 'created_at', seconds: 3600),
   ///     session: RealtimeSessionCreateRequest(
-  ///       model: 'gpt-realtime-1.5',
-  ///       voice: RealtimeVoice.shimmer,
+  ///       model: 'gpt-realtime-2',
+  ///       audio: RealtimeAudioConfig(
+  ///         output: RealtimeAudioConfigOutput(voice: 'shimmer'),
+  ///       ),
   ///     ),
   ///   ),
   /// );
@@ -187,13 +106,48 @@ class RealtimeSessionsResource extends ResourceBase {
   Future<RealtimeClientSecretCreateResponse> createClientSecret(
     RealtimeClientSecretCreateRequest request, {
     Future<void>? abortTrigger,
+  }) => _postClientSecret(request.toJson(), abortTrigger: abortTrigger);
+
+  /// Creates an ephemeral client secret for a **transcription** session.
+  ///
+  /// Transcription sessions use a different shape than realtime sessions —
+  /// they don't carry a `model` on the inner session payload. This helper
+  /// posts to the same `/realtime/client_secrets` endpoint with the
+  /// transcription discriminator (`type: 'transcription'`).
+  ///
+  /// ## Example
+  ///
+  /// ```dart
+  /// final response =
+  ///     await client.realtimeSessions.createTranscriptionClientSecret(
+  ///   RealtimeTranscriptionClientSecretCreateRequest(
+  ///     session: RealtimeTranscriptionSessionCreateRequest(
+  ///       audio: RealtimeTranscriptionSessionAudio(
+  ///         input: RealtimeAudioConfigInput(
+  ///           transcription: InputAudioTranscription(
+  ///             model: 'gpt-realtime-whisper',
+  ///           ),
+  ///         ),
+  ///       ),
+  ///     ),
+  ///   ),
+  /// );
+  /// ```
+  Future<RealtimeClientSecretCreateResponse> createTranscriptionClientSecret(
+    RealtimeTranscriptionClientSecretCreateRequest request, {
+    Future<void>? abortTrigger,
+  }) => _postClientSecret(request.toJson(), abortTrigger: abortTrigger);
+
+  Future<RealtimeClientSecretCreateResponse> _postClientSecret(
+    Map<String, dynamic> body, {
+    Future<void>? abortTrigger,
   }) async {
     ensureNotClosed?.call();
     final url = requestBuilder.buildUrl(_clientSecretsEndpoint);
     final headers = requestBuilder.buildHeaders();
     final httpRequest = http.Request('POST', url)
       ..headers.addAll(headers)
-      ..body = jsonEncode(request.toJson());
+      ..body = jsonEncode(body);
     final response = await interceptorChain.execute(
       httpRequest,
       abortTrigger: abortTrigger,
@@ -245,8 +199,10 @@ class RealtimeCallsResource extends ResourceBase {
   ///   RealtimeCallCreateRequest(
   ///     sdp: myPeerConnection.localDescription.sdp,
   ///     session: RealtimeSessionCreateRequest(
-  ///       model: 'gpt-realtime-1.5',
-  ///       voice: RealtimeVoice.alloy,
+  ///       model: 'gpt-realtime-2',
+  ///       audio: RealtimeAudioConfig(
+  ///         output: RealtimeAudioConfigOutput(voice: 'alloy'),
+  ///       ),
   ///     ),
   ///   ),
   /// );
@@ -365,5 +321,69 @@ class RealtimeCallsResource extends ResourceBase {
       ..headers.addAll(headers)
       ..body = jsonEncode(request?.toJson() ?? <String, dynamic>{});
     await interceptorChain.execute(httpRequest, abortTrigger: abortTrigger);
+  }
+}
+
+/// Resource for Realtime translation operations.
+///
+/// Translation sessions continuously translate input audio into the configured
+/// output language using `gpt-realtime-translate`.
+class RealtimeTranslationsResource extends ResourceBase {
+  /// Creates a [RealtimeTranslationsResource].
+  RealtimeTranslationsResource({
+    required super.config,
+    required super.httpClient,
+    required super.interceptorChain,
+    required super.requestBuilder,
+    super.ensureNotClosed,
+  });
+
+  static const _translationClientSecretsEndpoint =
+      '/realtime/translations/client_secrets';
+
+  /// Creates a translation client secret with session configuration.
+  ///
+  /// `POST /realtime/translations/client_secrets`. Returns an ephemeral
+  /// client secret that authenticates a translation WebSocket session.
+  ///
+  /// ## Example
+  ///
+  /// ```dart
+  /// final response =
+  ///     await client.realtimeSessions.translations.createClientSecret(
+  ///   RealtimeTranslationClientSecretCreateRequest(
+  ///     session: RealtimeTranslationSessionCreateRequest(
+  ///       model: 'gpt-realtime-translate',
+  ///       audio: RealtimeTranslationSessionAudio(
+  ///         input: RealtimeTranslationSessionAudioInput(
+  ///           transcription: RealtimeTranslationInputTranscription(
+  ///             model: 'gpt-realtime-whisper',
+  ///           ),
+  ///         ),
+  ///         output: RealtimeTranslationSessionAudioOutput(language: 'es'),
+  ///       ),
+  ///     ),
+  ///   ),
+  /// );
+  ///
+  /// print('Secret: ${response.value}');
+  /// ```
+  Future<RealtimeTranslationClientSecretCreateResponse> createClientSecret(
+    RealtimeTranslationClientSecretCreateRequest request, {
+    Future<void>? abortTrigger,
+  }) async {
+    ensureNotClosed?.call();
+    final url = requestBuilder.buildUrl(_translationClientSecretsEndpoint);
+    final headers = requestBuilder.buildHeaders();
+    final httpRequest = http.Request('POST', url)
+      ..headers.addAll(headers)
+      ..body = jsonEncode(request.toJson());
+    final response = await interceptorChain.execute(
+      httpRequest,
+      abortTrigger: abortTrigger,
+    );
+    return RealtimeTranslationClientSecretCreateResponse.fromJson(
+      jsonDecode(response.body) as Map<String, dynamic>,
+    );
   }
 }

--- a/packages/openai_dart/lib/src/resources/realtime_sessions_resource.dart
+++ b/packages/openai_dart/lib/src/resources/realtime_sessions_resource.dart
@@ -235,18 +235,53 @@ class RealtimeCallsResource extends ResourceBase {
     return response.body;
   }
 
-  /// Accepts an incoming SIP call.
+  /// Accepts an incoming SIP call, optionally overriding the realtime
+  /// session configuration.
   ///
   /// ## Parameters
   ///
   /// - [callId] - The ID of the call to accept.
-  Future<void> accept(String callId, {Future<void>? abortTrigger}) async {
+  /// - [request] - Optional session configuration to apply on accept
+  ///   (model, audio, instructions, tools, reasoning, tracing, …). When
+  ///   omitted, the call is accepted with the server's default session.
+  ///
+  /// ## Example
+  ///
+  /// ```dart
+  /// await client.realtimeSessions.calls.accept(
+  ///   callId,
+  ///   request: const RealtimeSessionCreateRequest(
+  ///     model: 'gpt-realtime-2',
+  ///     audio: RealtimeAudioConfig(
+  ///       output: RealtimeAudioConfigOutput(voice: 'alloy'),
+  ///     ),
+  ///     instructions: 'Greet the caller in English.',
+  ///   ),
+  /// );
+  /// ```
+  Future<void> accept(
+    String callId, {
+    RealtimeSessionCreateRequest? request,
+    Future<void>? abortTrigger,
+  }) async {
     ensureNotClosed?.call();
     final url = requestBuilder.buildUrl('$_callsEndpoint/$callId/accept');
     final headers = requestBuilder.buildHeaders();
+    // The /realtime/calls/{id}/accept endpoint requires the `type`
+    // discriminator on the embedded session payload (whereas the bare
+    // /realtime/sessions endpoint rejects it). Inject `'realtime'` when
+    // the caller didn't set it explicitly — same trick as
+    // `RealtimeClientSecretCreateRequest.toJson`.
+    final Map<String, dynamic> body;
+    if (request != null) {
+      body = request.toJson();
+      body['type'] ??= 'realtime';
+    } else {
+      body = <String, dynamic>{};
+    }
     final httpRequest = http.Request('POST', url)
       ..headers.addAll(headers)
-      ..body = jsonEncode(<String, dynamic>{});
+      ..body = jsonEncode(body);
     await interceptorChain.execute(httpRequest, abortTrigger: abortTrigger);
   }
 

--- a/packages/openai_dart/specs/openapi.json
+++ b/packages/openai_dart/specs/openapi.json
@@ -40,7 +40,7 @@
           "created_at": {
             "description": "The Unix timestamp (in seconds) of when the API key was created",
             "example": 1711471533,
-            "format": "int64",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -53,7 +53,7 @@
               {
                 "description": "The Unix timestamp (in seconds) of when the API key was last used",
                 "example": 1711471534,
-                "format": "int64",
+                "format": "unixtime",
                 "type": "integer"
               },
               {
@@ -62,13 +62,22 @@
             ]
           },
           "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "description": "The name of the API key",
-            "example": "Administration Key",
-            "type": "string"
+            "example": "Administration Key"
           },
           "object": {
             "description": "The object type, which is always `organization.admin_api_key`",
-            "example": "organization.admin_api_key",
+            "enum": [
+              "organization.admin_api_key"
+            ],
             "type": "string",
             "x-stainless-const": true
           },
@@ -77,7 +86,7 @@
               "created_at": {
                 "description": "The Unix timestamp (in seconds) of when the user was created",
                 "example": 1711471533,
-                "format": "int64",
+                "format": "unixtime",
                 "type": "integer"
               },
               "id": {
@@ -112,19 +121,12 @@
             "description": "The redacted value of the API key",
             "example": "sk-admin...def",
             "type": "string"
-          },
-          "value": {
-            "description": "The value of the API key. Only shown on create.",
-            "example": "sk-admin-1234abcd",
-            "type": "string"
           }
         },
         "required": [
           "object",
           "redacted_value",
-          "name",
           "created_at",
-          "last_used_at",
           "id",
           "owner"
         ],
@@ -133,6 +135,27 @@
           "example": "{\n  \"object\": \"organization.admin_api_key\",\n  \"id\": \"key_abc\",\n  \"name\": \"Main Admin Key\",\n  \"redacted_value\": \"sk-admin...xyz\",\n  \"created_at\": 1711471533,\n  \"last_used_at\": 1711471534,\n  \"owner\": {\n    \"type\": \"user\",\n    \"object\": \"organization.user\",\n    \"id\": \"user_123\",\n    \"name\": \"John Doe\",\n    \"created_at\": 1711471533,\n    \"role\": \"owner\"\n  }\n}\n",
           "name": "The admin API key object"
         }
+      },
+      "AdminApiKeyCreateResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AdminApiKey"
+          },
+          {
+            "description": "The newly created admin API key. The `value` field is only returned once, when the key is created.",
+            "properties": {
+              "value": {
+                "description": "The value of the API key. Only shown on create.",
+                "example": "sk-admin-1234abcd",
+                "type": "string"
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "type": "object"
+          }
+        ]
       },
       "Annotation": {
         "anyOf": [
@@ -163,22 +186,45 @@
             "type": "array"
           },
           "first_id": {
-            "example": "key_abc",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "example": "key_abc"
           },
           "has_more": {
             "example": false,
             "type": "boolean"
           },
           "last_id": {
-            "example": "key_xyz",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "example": "key_xyz"
           },
           "object": {
+            "enum": [
+              "list"
+            ],
             "example": "list",
-            "type": "string"
+            "type": "string",
+            "x-stainless-const": true
           }
         },
+        "required": [
+          "object",
+          "data",
+          "has_more"
+        ],
         "type": "object"
       },
       "ApplyPatchCallOutputStatus": {
@@ -695,7 +741,7 @@
           "created_at": {
             "anyOf": [
               {
-                "format": "int64",
+                "format": "unixtime",
                 "type": "integer"
               },
               {
@@ -813,6 +859,7 @@
           },
           "created_at": {
             "description": "Unix timestamp (in seconds) for when the item was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -859,6 +906,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) for when the assistant was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "description": {
@@ -1291,6 +1339,7 @@
             "anyOf": [
               {
                 "description": "Preview URL for rendering the attachment inline.",
+                "format": "uri",
                 "type": "string"
               },
               {
@@ -1335,6 +1384,17 @@
       },
       "AudioTranscription": {
         "properties": {
+          "delay": {
+            "description": "Controls how long the model waits before emitting transcription text.\nHigher values can improve transcription accuracy at the cost of latency.\nOnly supported with `gpt-realtime-whisper` in GA Realtime sessions.\n",
+            "enum": [
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
+            "type": "string"
+          },
           "language": {
             "description": "The language of the input audio. Supplying the input language in\n[ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format\nwill improve accuracy and latency.\n",
             "type": "string"
@@ -1350,15 +1410,48 @@
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
                   "gpt-4o-transcribe",
-                  "gpt-4o-transcribe-diarize"
+                  "gpt-4o-transcribe-diarize",
+                  "gpt-realtime-whisper"
                 ],
                 "type": "string"
               }
             ],
-            "description": "The model to use for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, and `gpt-4o-transcribe-diarize`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels.\n"
+            "description": "The model to use for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels.\n"
           },
           "prompt": {
-            "description": "An optional text to guide the model's style or continue a previous audio\nsegment.\nFor `whisper-1`, the [prompt is a list of keywords](https://platform.openai.com/docs/guides/speech-to-text#prompting).\nFor `gpt-4o-transcribe` models (excluding `gpt-4o-transcribe-diarize`), the prompt is a free text string, for example \"expect words related to technology\".\n",
+            "description": "An optional text to guide the model's style or continue a previous audio\nsegment.\nFor `whisper-1`, the [prompt is a list of keywords](https://platform.openai.com/docs/guides/speech-to-text#prompting).\nFor `gpt-4o-transcribe` models (excluding `gpt-4o-transcribe-diarize`), the prompt is a free text string, for example \"expect words related to technology\".\nPrompt is not supported with `gpt-realtime-whisper` in GA Realtime sessions.\n",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "AudioTranscriptionResponse": {
+        "properties": {
+          "language": {
+            "description": "The language of the input audio.\n",
+            "type": "string"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "whisper-1",
+                  "gpt-4o-mini-transcribe",
+                  "gpt-4o-mini-transcribe-2025-12-15",
+                  "gpt-4o-transcribe",
+                  "gpt-4o-transcribe-diarize",
+                  "gpt-realtime-whisper"
+                ],
+                "type": "string"
+              }
+            ],
+            "description": "The model used for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`.\n"
+          },
+          "prompt": {
+            "description": "The prompt configured for input audio transcription, when present.\n",
             "type": "string"
           }
         },
@@ -1368,7 +1461,14 @@
         "description": "A log of a user action or configuration change within this organization.",
         "properties": {
           "actor": {
-            "$ref": "#/components/schemas/AuditLogActor"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AuditLogActor"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "api_key.created": {
             "description": "The details for events with this `type`.",
@@ -1552,6 +1652,7 @@
           },
           "effective_at": {
             "description": "The Unix timestamp (in seconds) of the event.",
+            "format": "unixtime",
             "type": "integer"
           },
           "external_key.registered": {
@@ -2257,8 +2358,7 @@
         "required": [
           "id",
           "type",
-          "effective_at",
-          "actor"
+          "effective_at"
         ],
         "type": "object",
         "x-oaiMeta": {
@@ -2439,14 +2539,17 @@
         "properties": {
           "cancelled_at": {
             "description": "The Unix timestamp (in seconds) for when the batch was cancelled.",
+            "format": "unixtime",
             "type": "integer"
           },
           "cancelling_at": {
             "description": "The Unix timestamp (in seconds) for when the batch started cancelling.",
+            "format": "unixtime",
             "type": "integer"
           },
           "completed_at": {
             "description": "The Unix timestamp (in seconds) for when the batch was completed.",
+            "format": "unixtime",
             "type": "integer"
           },
           "completion_window": {
@@ -2455,6 +2558,7 @@
           },
           "created_at": {
             "description": "The Unix timestamp (in seconds) for when the batch was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "endpoint": {
@@ -2482,18 +2586,22 @@
           },
           "expired_at": {
             "description": "The Unix timestamp (in seconds) for when the batch expired.",
+            "format": "unixtime",
             "type": "integer"
           },
           "expires_at": {
             "description": "The Unix timestamp (in seconds) for when the batch will expire.",
+            "format": "unixtime",
             "type": "integer"
           },
           "failed_at": {
             "description": "The Unix timestamp (in seconds) for when the batch failed.",
+            "format": "unixtime",
             "type": "integer"
           },
           "finalizing_at": {
             "description": "The Unix timestamp (in seconds) for when the batch started finalizing.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -2501,6 +2609,7 @@
           },
           "in_progress_at": {
             "description": "The Unix timestamp (in seconds) for when the batch started processing.",
+            "format": "unixtime",
             "type": "integer"
           },
           "input_file_id": {
@@ -2658,6 +2767,7 @@
           },
           "seconds": {
             "description": "The number of seconds after the anchor time that the file will expire. Must be between 3600 (1 hour) and 2592000 (30 days).",
+            "format": "int64",
             "maximum": 2592000,
             "minimum": 3600,
             "type": "integer"
@@ -2708,10 +2818,12 @@
               },
               "expires_at": {
                 "description": "The Unix timestamp (in seconds) of when the certificate expires.",
+                "format": "unixtime",
                 "type": "integer"
               },
               "valid_at": {
                 "description": "The Unix timestamp (in seconds) of when the certificate becomes valid.",
+                "format": "unixtime",
                 "type": "integer"
               }
             },
@@ -2719,6 +2831,7 @@
           },
           "created_at": {
             "description": "The Unix timestamp (in seconds) of when the certificate was uploaded.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -2726,8 +2839,15 @@
             "type": "string"
           },
           "name": {
-            "description": "The name of the certificate.",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The name of the certificate."
           },
           "object": {
             "description": "The object type.\n\n- If creating, updating, or getting a specific certificate, the object type is `certificate`.\n- If listing, activating, or deactivating certificates for the organization, the object type is `organization.certificate`.\n- If listing, activating, or deactivating certificates for a project, the object type is `organization.project.certificate`.\n",
@@ -3848,6 +3968,7 @@
                     },
                     "url": {
                       "description": "The URL of the web resource.",
+                      "format": "uri",
                       "type": "string"
                     }
                   },
@@ -3879,6 +4000,7 @@
                   },
                   "expires_at": {
                     "description": "The Unix timestamp (in seconds) for when this audio response will\nno longer be accessible on the server for use in multi-turn\nconversations.\n",
+                    "format": "unixtime",
                     "type": "integer"
                   },
                   "id": {
@@ -4081,7 +4203,7 @@
             "type": "string"
           },
           "top_logprobs": {
-            "description": "List of the most likely tokens and their log probability, at this token position. In rare cases, there may be fewer than the number of requested `top_logprobs` returned.",
+            "description": "List of the most likely tokens and their log probability, at this token position. The number of entries may be fewer than the requested `top_logprobs`.",
             "items": {
               "properties": {
                 "bytes": {
@@ -4387,6 +4509,7 @@
           },
           "expires_at": {
             "description": "Unix timestamp (in seconds) for when the session expires.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -4641,6 +4764,7 @@
           },
           "created_at": {
             "description": "Unix timestamp (in seconds) for when the item was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -4853,6 +4977,7 @@
           },
           "url": {
             "description": "The URL of the image output from the code interpreter.",
+            "format": "uri",
             "type": "string"
           }
         },
@@ -5026,6 +5151,7 @@
         "properties": {
           "created_at": {
             "description": "Unix timestamp (in seconds) when the compacted conversation was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -5592,6 +5718,7 @@
             "anyOf": [
               {
                 "description": "The URL of the screenshot image.",
+                "format": "uri",
                 "type": "string"
               },
               {
@@ -5627,6 +5754,7 @@
           },
           "image_url": {
             "description": "The URL of the screenshot image.",
+            "format": "uri",
             "type": "string"
           },
           "type": {
@@ -5985,6 +6113,7 @@
           },
           "created_at": {
             "description": "Unix timestamp (in seconds) when the file was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -6192,6 +6321,7 @@
         "properties": {
           "created_at": {
             "description": "Unix timestamp (in seconds) when the container was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "expires_after": {
@@ -6217,6 +6347,7 @@
           },
           "last_active_at": {
             "description": "Unix timestamp (in seconds) when the container was last active.",
+            "format": "unixtime",
             "type": "integer"
           },
           "memory_limit": {
@@ -6493,6 +6624,7 @@
         "properties": {
           "created_at": {
             "description": "The time at which the conversation was created, measured in seconds since the Unix epoch.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -6556,6 +6688,17 @@
             },
             "type": "object"
           },
+          "api_key_id": {
+            "anyOf": [
+              {
+                "description": "When `group_by=api_key_id`, this field provides the API Key ID of the grouped costs result.",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "line_item": {
             "anyOf": [
               {
@@ -6584,6 +6727,17 @@
                 "type": "null"
               }
             ]
+          },
+          "quantity": {
+            "anyOf": [
+              {
+                "description": "When `group_by=line_item`, this field provides the quantity of the grouped costs result.",
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [
@@ -6591,7 +6745,7 @@
         ],
         "type": "object",
         "x-oaiMeta": {
-          "example": "{\n    \"object\": \"organization.costs.result\",\n    \"amount\": {\n      \"value\": 0.06,\n      \"currency\": \"usd\"\n    },\n    \"line_item\": \"Image models\",\n    \"project_id\": \"proj_abc\"\n}\n",
+          "example": "{\n    \"object\": \"organization.costs.result\",\n    \"amount\": {\n      \"value\": 0.06,\n      \"currency\": \"usd\"\n    },\n    \"line_item\": \"Image models\",\n    \"project_id\": \"proj_abc\",\n    \"quantity\": 10000\n}\n",
           "name": "Costs object"
         }
       },
@@ -7071,7 +7225,7 @@
                 "type": "array"
               },
               "top_logprobs": {
-                "description": "An integer between 0 and 20 specifying the number of most likely tokens to\nreturn at each token position, each with an associated log probability.\n`logprobs` must be set to `true` if this parameter is used.\n",
+                "description": "An integer between 0 and 20 specifying the maximum number of most likely\ntokens to return at each token position, each with an associated log\nprobability. In some cases, the number of returned tokens may be fewer than\nrequested.\n`logprobs` must be set to `true` if this parameter is used.\n",
                 "maximum": 20,
                 "minimum": 0,
                 "nullable": true,
@@ -7204,6 +7358,7 @@
           },
           "created": {
             "description": "The Unix timestamp (in seconds) of when the chat completion was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -7313,6 +7468,7 @@
           },
           "created": {
             "description": "The Unix timestamp (in seconds) of when the chat completion was created. Each chunk has the same timestamp.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -7645,6 +7801,7 @@
           },
           "created": {
             "description": "The Unix timestamp (in seconds) of when the completion was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -8848,7 +9005,7 @@
         "properties": {
           "background": {
             "default": "auto",
-            "description": "Allows to set transparency for the background of the generated image(s).\nThis parameter is only supported for the GPT image models. Must be one of\n`transparent`, `opaque` or `auto` (default value). When `auto` is used, the\nmodel will automatically determine the best background for the image.\n\nIf `transparent`, the output format needs to support transparency, so it\nshould be set to either `png` (default value) or `webp`.\n",
+            "description": "Allows to set transparency for the background of the generated image(s).\nThis parameter is only supported for GPT image models that support\ntransparent backgrounds. Must be one of `transparent`, `opaque`, or\n`auto` (default value). When `auto` is used, the model will\nautomatically determine the best background for the image.\n\n`gpt-image-2` and `gpt-image-2-2026-04-21` do not support\ntransparent backgrounds. Requests with `background` set to\n`transparent` will return an error for these models; use `opaque` or\n`auto` instead.\n\nIf `transparent`, the output format needs to support transparency,\nso it should be set to either `png` (default value) or `webp`.\n",
             "enum": [
               "transparent",
               "opaque",
@@ -8873,7 +9030,7 @@
                 "type": "array"
               }
             ],
-            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n\nFor the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`\nfile less than 50MB. You can provide up to 16 images.\n`chatgpt-image-latest` follows the same input constraints as GPT image models.\n\nFor `dall-e-2`, you can only provide one image, and it should be a square\n`png` file less than 4MB.\n",
+            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n\nFor the GPT image models (`gpt-image-1`, `gpt-image-1-mini`,\n`gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, and\n`chatgpt-image-latest`), each image should be a `png`, `webp`, or\n`jpg` file less than 50MB. You can provide up to 16 images.\n\nFor `dall-e-2`, you can only provide one image, and it should be a\nsquare `png` file less than 4MB.\n",
             "x-oaiMeta": {
               "exampleFilePath": "otter.png"
             }
@@ -8886,7 +9043,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Controls fidelity to the original input image(s). This parameter is supported for GPT image models that support input fidelity. `gpt-image-2` and `gpt-image-2-2026-04-21` ignore this parameter."
           },
           "mask": {
             "description": "An additional image whose fully transparent areas (e.g. where alpha is zero) indicate where `image` should be edited. If there are multiple images provided, the mask will be applied on the first image. Must be a valid PNG file, less than 4MB, and have the same dimensions as `image`.",
@@ -8903,17 +9061,20 @@
               },
               {
                 "enum": [
-                  "gpt-image-1.5",
-                  "dall-e-2",
                   "gpt-image-1",
                   "gpt-image-1-mini",
-                  "chatgpt-image-latest"
+                  "gpt-image-2",
+                  "gpt-image-2-2026-04-21",
+                  "gpt-image-1.5",
+                  "chatgpt-image-latest",
+                  "dall-e-2"
                 ],
                 "type": "string",
                 "x-stainless-const": true
               }
             ],
-            "description": "The model to use for image generation. Defaults to `gpt-image-1.5`.",
+            "description": "The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.",
+            "example": "gpt-image-2",
             "nullable": true,
             "x-oaiTypeLabel": "string"
           },
@@ -8978,19 +9139,24 @@
             "type": "string"
           },
           "size": {
-            "default": "1024x1024",
-            "description": "The size of the generated images. Must be one of `1024x1024`, `1536x1024` (landscape), `1024x1536` (portrait), or `auto` (default value) for the GPT image models, and one of `256x256`, `512x512`, or `1024x1024` for `dall-e-2`.",
-            "enum": [
-              "256x256",
-              "512x512",
-              "1024x1024",
-              "1536x1024",
-              "1024x1536",
-              "auto"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "256x256",
+                  "512x512",
+                  "1024x1024",
+                  "1536x1024",
+                  "1024x1536",
+                  "auto"
+                ],
+                "type": "string"
+              }
             ],
-            "example": "1024x1024",
-            "nullable": true,
-            "type": "string"
+            "description": "The size of the generated images. For `gpt-image-2` and `gpt-image-2-2026-04-21`, arbitrary resolutions are supported as `WIDTHxHEIGHT` strings, for example `1536x864`. Width and height must both be divisible by 16 and the requested aspect ratio must be between 1:3 and 3:1. Resolutions above `2560x1440` are experimental, and the maximum supported resolution is `3840x2160`. The requested size must also satisfy the model's current pixel and edge limits. The standard sizes `1024x1024`, `1536x1024`, and `1024x1536` are supported by the GPT image models; `auto` is supported for models that allow automatic sizing. For `dall-e-2`, use one of `256x256`, `512x512`, or `1024x1024`. For `dall-e-3`, use one of `1024x1024`, `1792x1024`, or `1024x1792`.",
+            "nullable": true
           },
           "stream": {
             "default": false,
@@ -9015,7 +9181,7 @@
         "properties": {
           "background": {
             "default": "auto",
-            "description": "Allows to set transparency for the background of the generated image(s).\nThis parameter is only supported for the GPT image models. Must be one of\n`transparent`, `opaque` or `auto` (default value). When `auto` is used, the\nmodel will automatically determine the best background for the image.\n\nIf `transparent`, the output format needs to support transparency, so it\nshould be set to either `png` (default value) or `webp`.\n",
+            "description": "Allows to set transparency for the background of the generated image(s).\nThis parameter is only supported for GPT image models that support\ntransparent backgrounds. Must be one of `transparent`, `opaque`, or\n`auto` (default value). When `auto` is used, the model will\nautomatically determine the best background for the image.\n\n`gpt-image-2` and `gpt-image-2-2026-04-21` do not support\ntransparent backgrounds. Requests with `background` set to\n`transparent` will return an error for these models; use `opaque` or\n`auto` instead.\n\nIf `transparent`, the output format needs to support transparency,\nso it should be set to either `png` (default value) or `webp`.\n",
             "enum": [
               "transparent",
               "opaque",
@@ -9032,17 +9198,21 @@
               },
               {
                 "enum": [
-                  "gpt-image-1.5",
-                  "dall-e-2",
-                  "dall-e-3",
                   "gpt-image-1",
-                  "gpt-image-1-mini"
+                  "gpt-image-1-mini",
+                  "gpt-image-2",
+                  "gpt-image-2-2026-04-21",
+                  "gpt-image-1.5",
+                  "chatgpt-image-latest",
+                  "dall-e-2",
+                  "dall-e-3"
                 ],
                 "type": "string",
                 "x-stainless-nominal": false
               }
             ],
-            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
+            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, or `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
+            "example": "gpt-image-2",
             "nullable": true,
             "x-oaiTypeLabel": "string"
           },
@@ -9120,21 +9290,26 @@
             "type": "string"
           },
           "size": {
-            "default": "auto",
-            "description": "The size of the generated images. Must be one of `1024x1024`, `1536x1024` (landscape), `1024x1536` (portrait), or `auto` (default value) for the GPT image models, one of `256x256`, `512x512`, or `1024x1024` for `dall-e-2`, and one of `1024x1024`, `1792x1024`, or `1024x1792` for `dall-e-3`.",
-            "enum": [
-              "auto",
-              "1024x1024",
-              "1536x1024",
-              "1024x1536",
-              "256x256",
-              "512x512",
-              "1792x1024",
-              "1024x1792"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "auto",
+                  "1024x1024",
+                  "1536x1024",
+                  "1024x1536",
+                  "256x256",
+                  "512x512",
+                  "1792x1024",
+                  "1024x1792"
+                ],
+                "type": "string"
+              }
             ],
-            "example": "1024x1024",
-            "nullable": true,
-            "type": "string"
+            "description": "The size of the generated images. For `gpt-image-2` and `gpt-image-2-2026-04-21`, arbitrary resolutions are supported as `WIDTHxHEIGHT` strings, for example `1536x864`. Width and height must both be divisible by 16 and the requested aspect ratio must be between 1:3 and 3:1. Resolutions above `2560x1440` are experimental, and the maximum supported resolution is `3840x2160`. The requested size must also satisfy the model's current pixel and edge limits. The standard sizes `1024x1024`, `1536x1024`, and `1024x1536` are supported by the GPT image models; `auto` is supported for models that allow automatic sizing. For `dall-e-2`, use one of `256x256`, `512x512`, or `1024x1024`. For `dall-e-3`, use one of `1024x1024`, `1792x1024`, or `1024x1792`.",
+            "nullable": true
           },
           "stream": {
             "default": false,
@@ -9336,7 +9511,7 @@
           {
             "properties": {
               "top_logprobs": {
-                "description": "An integer between 0 and 20 specifying the number of most likely tokens to\nreturn at each token position, each with an associated log probability.\n",
+                "description": "An integer between 0 and 20 specifying the maximum number of most likely\ntokens to return at each token position, each with an associated log\nprobability. In some cases, the number of returned tokens may be fewer than\nrequested.\n",
                 "maximum": 20,
                 "minimum": 0,
                 "type": "integer"
@@ -10904,6 +11079,7 @@
         "properties": {
           "duration": {
             "description": "Duration of the input audio in seconds.",
+            "format": "double",
             "type": "number"
           },
           "segments": {
@@ -11037,6 +11213,7 @@
         "properties": {
           "duration": {
             "description": "The duration of the input audio.",
+            "format": "double",
             "type": "number"
           },
           "language": {
@@ -11149,6 +11326,7 @@
         "properties": {
           "duration": {
             "description": "The duration of the input audio.",
+            "format": "double",
             "type": "number"
           },
           "language": {
@@ -12513,7 +12691,7 @@
                 "type": "null"
               }
             ],
-            "description": "Controls fidelity to the original input image(s)."
+            "description": "Controls fidelity to the original input image(s). This parameter is supported for GPT image models that support input fidelity. `gpt-image-2` and `gpt-image-2-2026-04-21` ignore this parameter."
           },
           "mask": {
             "$ref": "#/components/schemas/ImageRefParam"
@@ -12813,6 +12991,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) for when the eval was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "data_source_config": {
@@ -13149,6 +13328,7 @@
           },
           "image_url": {
             "description": "The URL of the image input.\n",
+            "format": "uri",
             "type": "string"
           },
           "type": {
@@ -13454,6 +13634,7 @@
         "properties": {
           "created_at": {
             "description": "Unix timestamp (in seconds) when the evaluation run was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "data_source": {
@@ -13579,6 +13760,7 @@
           },
           "report_url": {
             "description": "The URL to the rendered evaluation run report on the UI dashboard.",
+            "format": "uri",
             "type": "string"
           },
           "result_counts": {
@@ -13690,6 +13872,7 @@
         "properties": {
           "created_at": {
             "description": "Unix timestamp (in seconds) when the evaluation run was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "datasource_item": {
@@ -14073,6 +14256,7 @@
           },
           "seconds": {
             "description": "Number of seconds after the anchor when the session expires.",
+            "format": "int64",
             "maximum": 600,
             "minimum": 1,
             "type": "integer"
@@ -14187,6 +14371,7 @@
           },
           "seconds": {
             "description": "The number of seconds after the anchor time that the file will expire. Must be between 3600 (1 hour) and 2592000 (30 days).",
+            "format": "int64",
             "maximum": 2592000,
             "minimum": 3600,
             "type": "integer"
@@ -14797,6 +14982,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) for when the permission was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -14896,6 +15082,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) for when the fine-tuning job was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "error": {
@@ -14939,6 +15126,7 @@
             "anyOf": [
               {
                 "description": "The Unix timestamp (in seconds) for when the fine-tuning job is estimated to finish. The value will be null if the fine-tuning job is not running.",
+                "format": "unixtime",
                 "type": "integer"
               },
               {
@@ -14961,6 +15149,7 @@
             "anyOf": [
               {
                 "description": "The Unix timestamp (in seconds) for when the fine-tuning job was finished. The value will be null if the fine-tuning job is still running.",
+                "format": "unixtime",
                 "type": "integer"
               },
               {
@@ -15166,6 +15355,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) for when the checkpoint was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "fine_tuned_model_checkpoint": {
@@ -15241,6 +15431,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) for when the fine-tuning job was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "data": {
@@ -15571,7 +15762,7 @@
             "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/LocalShellCallStatus",
+            "$ref": "#/components/schemas/FunctionShellCallStatus",
             "description": "The status of the shell call. One of `in_progress`, `completed`, or `incomplete`."
           },
           "type": {
@@ -15714,7 +15905,7 @@
             "type": "array"
           },
           "status": {
-            "$ref": "#/components/schemas/LocalShellCallOutputStatusEnum",
+            "$ref": "#/components/schemas/FunctionShellCallOutputStatusEnum",
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
           },
           "type": {
@@ -15934,6 +16125,14 @@
         },
         "title": "Shell call outcome"
       },
+      "FunctionShellCallOutputStatusEnum": {
+        "enum": [
+          "in_progress",
+          "completed",
+          "incomplete"
+        ],
+        "type": "string"
+      },
       "FunctionShellCallOutputTimeoutOutcome": {
         "description": "Indicates that the shell call exceeded its configured time limit.",
         "properties": {
@@ -15971,6 +16170,14 @@
         ],
         "title": "Shell call timeout outcome",
         "type": "object"
+      },
+      "FunctionShellCallStatus": {
+        "enum": [
+          "in_progress",
+          "completed",
+          "incomplete"
+        ],
+        "type": "string"
       },
       "FunctionShellToolParam": {
         "description": "A tool that allows the model to execute shell commands.",
@@ -16668,7 +16875,7 @@
         "properties": {
           "created_at": {
             "description": "Unix timestamp (in seconds) when the group was created.",
-            "format": "int64",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -16786,7 +16993,7 @@
         "properties": {
           "created_at": {
             "description": "Unix timestamp (in seconds) when the group was created.",
-            "format": "int64",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -16818,8 +17025,12 @@
         "properties": {
           "created_at": {
             "description": "Unix timestamp (in seconds) when the group was created.",
-            "format": "int64",
+            "format": "unixtime",
             "type": "integer"
+          },
+          "group_type": {
+            "description": "The type of the group.",
+            "type": "string"
           },
           "id": {
             "description": "Identifier for the group.",
@@ -16838,11 +17049,12 @@
           "id",
           "name",
           "created_at",
-          "is_scim_managed"
+          "is_scim_managed",
+          "group_type"
         ],
         "type": "object",
         "x-oaiMeta": {
-          "example": "{\n    \"id\": \"group_01J1F8ABCDXYZ\",\n    \"name\": \"Support Team\",\n    \"created_at\": 1711471533,\n    \"is_scim_managed\": false\n}\n",
+          "example": "{\n    \"id\": \"group_01J1F8ABCDXYZ\",\n    \"name\": \"Support Team\",\n    \"created_at\": 1711471533,\n    \"is_scim_managed\": false,\n    \"group_type\": \"group\"\n}\n",
           "name": "Group"
         }
       },
@@ -16874,6 +17086,36 @@
           "example": "{\n    \"object\": \"group.role\",\n    \"group\": {\n        \"object\": \"group\",\n        \"id\": \"group_01J1F8ABCDXYZ\",\n        \"name\": \"Support Team\",\n        \"created_at\": 1711471533,\n        \"scim_managed\": false\n    },\n    \"role\": {\n        \"object\": \"role\",\n        \"id\": \"role_01J1F8ROLE01\",\n        \"name\": \"API Group Manager\",\n        \"description\": \"Allows managing organization groups\",\n        \"permissions\": [\n            \"api.groups.read\",\n            \"api.groups.write\"\n        ],\n        \"resource_type\": \"api.organization\",\n        \"predefined_role\": false\n    }\n}\n",
           "name": "The group role object"
         }
+      },
+      "GroupUser": {
+        "description": "Represents an individual user returned when inspecting group membership.",
+        "properties": {
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The email address of the user."
+          },
+          "id": {
+            "description": "The identifier, which can be referenced in API endpoints",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the user.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "email"
+        ],
+        "type": "object"
       },
       "GroupUserAssignment": {
         "description": "Confirmation payload returned after adding a user to a group.",
@@ -16979,6 +17221,7 @@
           },
           "url": {
             "description": "When using `dall-e-2` or `dall-e-3`, the URL of the generated image if `response_format` is set to `url` (default value). Unsupported for the GPT image models.",
+            "format": "uri",
             "type": "string"
           }
         },
@@ -17011,6 +17254,7 @@
           },
           "created_at": {
             "description": "The Unix timestamp when the event was created.\n",
+            "format": "unixtime",
             "type": "integer"
           },
           "output_format": {
@@ -17089,6 +17333,7 @@
           },
           "created_at": {
             "description": "The Unix timestamp when the event was created.\n",
+            "format": "unixtime",
             "type": "integer"
           },
           "output_format": {
@@ -17189,6 +17434,7 @@
           },
           "created_at": {
             "description": "The Unix timestamp when the event was created.\n",
+            "format": "unixtime",
             "type": "integer"
           },
           "output_format": {
@@ -17305,6 +17551,7 @@
           },
           "created_at": {
             "description": "The Unix timestamp when the event was created.\n",
+            "format": "unixtime",
             "type": "integer"
           },
           "output_format": {
@@ -17388,7 +17635,7 @@
           },
           "background": {
             "default": "auto",
-            "description": "Background type for the generated image. One of `transparent`,\n`opaque`, or `auto`. Default: `auto`.\n",
+            "description": "Allows to set transparency for the background of the generated image(s).\nThis parameter is only supported for GPT image models that support\ntransparent backgrounds. Must be one of `transparent`, `opaque`, or\n`auto` (default value). When `auto` is used, the model will\nautomatically determine the best background for the image.\n\n`gpt-image-2` and `gpt-image-2-2026-04-21` do not support\ntransparent backgrounds. Requests with `background` set to\n`transparent` will return an error for these models; use `opaque` or\n`auto` instead.\n\nIf `transparent`, the output format needs to support transparency,\nso it should be set to either `png` (default value) or `webp`.\n",
             "enum": [
               "transparent",
               "opaque",
@@ -17404,7 +17651,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Controls fidelity to the original input image(s). This parameter is supported for GPT image models that support input fidelity. `gpt-image-2` and `gpt-image-2-2026-04-21` ignore this parameter."
           },
           "input_image_mask": {
             "additionalProperties": false,
@@ -17433,7 +17681,10 @@
                 "enum": [
                   "gpt-image-1",
                   "gpt-image-1-mini",
-                  "gpt-image-1.5"
+                  "gpt-image-2",
+                  "gpt-image-2-2026-04-21",
+                  "gpt-image-1.5",
+                  "chatgpt-image-latest"
                 ],
                 "type": "string"
               }
@@ -17484,15 +17735,22 @@
             "type": "string"
           },
           "size": {
-            "default": "auto",
-            "description": "The size of the generated image. One of `1024x1024`, `1024x1536`,\n`1536x1024`, or `auto`. Default: `auto`.\n",
-            "enum": [
-              "1024x1024",
-              "1024x1536",
-              "1536x1024",
-              "auto"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "enum": [
+                  "1024x1024",
+                  "1024x1536",
+                  "1536x1024",
+                  "auto"
+                ],
+                "type": "string"
+              }
             ],
-            "type": "string"
+            "default": "auto",
+            "description": "The size of the generated images. For `gpt-image-2` and `gpt-image-2-2026-04-21`, arbitrary resolutions are supported as `WIDTHxHEIGHT` strings, for example `1536x864`. Width and height must both be divisible by 16 and the requested aspect ratio must be between 1:3 and 3:1. Resolutions above `2560x1440` are experimental, and the maximum supported resolution is `3840x2160`. The requested size must also satisfy the model's current pixel and edge limits. The standard sizes `1024x1024`, `1536x1024`, and `1024x1536` are supported by the GPT image models; `auto` is supported for models that allow automatic sizing. For `dall-e-2`, use one of `256x256`, `512x512`, or `1024x1024`. For `dall-e-3`, use one of `1024x1024`, `1792x1024`, or `1024x1792`."
           },
           "type": {
             "description": "The type of the image generation tool. Always `image_generation`.\n",
@@ -17616,6 +17874,7 @@
           "image_url": {
             "description": "A fully qualified URL or base64-encoded data URL.",
             "example": "https://example.com/source-image.png",
+            "format": "uri",
             "maxLength": 20971520,
             "type": "string"
           }
@@ -17630,6 +17889,7 @@
           },
           "image_url": {
             "description": "A fully qualified URL or base64-encoded data URL.",
+            "format": "uri",
             "maxLength": 20971520,
             "type": "string"
           }
@@ -17650,6 +17910,7 @@
           },
           "created": {
             "description": "The Unix timestamp (in seconds) of when the image was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "data": {
@@ -17744,7 +18005,7 @@
         "type": "object"
       },
       "IncludeEnum": {
-        "description": "Specify additional output data to include in the model response. Currently supported values are:\n- `web_search_call.action.sources`: Include the sources of the web search tool call.\n- `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.\n- `computer_call_output.output.image_url`: Include image urls from the computer call output.\n- `file_search_call.results`: Include the search results of the file search tool call.\n- `message.input_image.image_url`: Include image urls from the input message.\n- `message.output_text.logprobs`: Include logprobs with assistant messages.\n- `reasoning.encrypted_content`: Includes an encrypted version of reasoning tokens in reasoning item outputs. This enables reasoning items to be used in multi-turn conversations when using the Responses API statelessly (like when the `store` parameter is set to `false`, or when an organization is enrolled in the zero data retention program).",
+        "description": "Specify additional output data to include in the model response. Currently supported values are:\n- `web_search_call.results`: Include the search results of the web search tool call.\n- `web_search_call.action.sources`: Include the sources of the web search tool call.\n- `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.\n- `computer_call_output.output.image_url`: Include image urls from the computer call output.\n- `file_search_call.results`: Include the search results of the file search tool call.\n- `message.input_image.image_url`: Include image urls from the input message.\n- `message.output_text.logprobs`: Include logprobs with assistant messages.\n- `reasoning.encrypted_content`: Includes an encrypted version of reasoning tokens in reasoning item outputs. This enables reasoning items to be used in multi-turn conversations when using the Responses API statelessly (like when the `store` parameter is set to `false`, or when an organization is enrolled in the zero data retention program).",
         "enum": [
           "file_search_call.results",
           "web_search_call.results",
@@ -17945,6 +18206,7 @@
           },
           "file_url": {
             "description": "The URL of the file to be sent to the model.",
+            "format": "uri",
             "type": "string"
           },
           "filename": {
@@ -18002,6 +18264,7 @@
             "anyOf": [
               {
                 "description": "The URL of the file to be sent to the model.",
+                "format": "uri",
                 "type": "string"
               },
               {
@@ -18058,6 +18321,7 @@
             "anyOf": [
               {
                 "description": "The URL of the image to be sent to the model. A fully qualified URL or base64 encoded image in a data URL.",
+                "format": "uri",
                 "type": "string"
               },
               {
@@ -18112,6 +18376,7 @@
             "anyOf": [
               {
                 "description": "The URL of the image to be sent to the model. A fully qualified URL or base64 encoded image in a data URL.",
+                "format": "uri",
                 "maxLength": 20971520,
                 "type": "string"
               },
@@ -18294,7 +18559,20 @@
         "description": "Represents an individual `invite` to the organization.",
         "properties": {
           "accepted_at": {
-            "description": "The Unix timestamp (in seconds) of when the invite was accepted.",
+            "anyOf": [
+              {
+                "format": "unixtime",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The Unix timestamp (in seconds) of when the invite was accepted."
+          },
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) of when the invite was sent.",
+            "format": "unixtime",
             "type": "integer"
           },
           "email": {
@@ -18302,16 +18580,20 @@
             "type": "string"
           },
           "expires_at": {
-            "description": "The Unix timestamp (in seconds) of when the invite expires.",
-            "type": "integer"
+            "anyOf": [
+              {
+                "format": "unixtime",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The Unix timestamp (in seconds) of when the invite expires."
           },
           "id": {
             "description": "The identifier, which can be referenced in API endpoints",
             "type": "string"
-          },
-          "invited_at": {
-            "description": "The Unix timestamp (in seconds) of when the invite was sent.",
-            "type": "integer"
           },
           "object": {
             "description": "The object type, which is always `organization.invite`",
@@ -18338,6 +18620,10 @@
                   "type": "string"
                 }
               },
+              "required": [
+                "id",
+                "role"
+              ],
               "type": "object"
             },
             "type": "array"
@@ -18366,12 +18652,12 @@
           "email",
           "role",
           "status",
-          "invited_at",
-          "expires_at"
+          "created_at",
+          "projects"
         ],
         "type": "object",
         "x-oaiMeta": {
-          "example": "{\n  \"object\": \"organization.invite\",\n  \"id\": \"invite-abc\",\n  \"email\": \"user@example.com\",\n  \"role\": \"owner\",\n  \"status\": \"accepted\",\n  \"invited_at\": 1711471533,\n  \"expires_at\": 1711471533,\n  \"accepted_at\": 1711471533,\n  \"projects\": [\n    {\n      \"id\": \"project-xyz\",\n      \"role\": \"member\"\n    }\n  ]\n}\n",
+          "example": "{\n  \"object\": \"organization.invite\",\n  \"id\": \"invite-abc\",\n  \"email\": \"user@example.com\",\n  \"role\": \"owner\",\n  \"status\": \"accepted\",\n  \"created_at\": 1711471533,\n  \"expires_at\": 1711471533,\n  \"accepted_at\": 1711471533,\n  \"projects\": [\n    {\n      \"id\": \"project-xyz\",\n      \"role\": \"member\"\n    }\n  ]\n}\n",
           "name": "The invite object"
         }
       },
@@ -18408,16 +18694,30 @@
             "type": "array"
           },
           "first_id": {
-            "description": "The first `invite_id` in the retrieved `list`",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The first `invite_id` in the retrieved `list`"
           },
           "has_more": {
             "description": "The `has_more` property is used for pagination to indicate there are additional results.",
             "type": "boolean"
           },
           "last_id": {
-            "description": "The last `invite_id` in the retrieved `list`",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The last `invite_id` in the retrieved `list`"
           },
           "object": {
             "description": "The object type, which is always `list`",
@@ -18430,7 +18730,8 @@
         },
         "required": [
           "object",
-          "data"
+          "data",
+          "has_more"
         ],
         "type": "object"
       },
@@ -18630,10 +18931,12 @@
             "$ref": "#/components/schemas/CodeInterpreterToolCall"
           },
           {
-            "$ref": "#/components/schemas/LocalShellToolCall"
+            "$ref": "#/components/schemas/LocalShellToolCall",
+            "deprecated": true
           },
           {
-            "$ref": "#/components/schemas/LocalShellToolCallOutput"
+            "$ref": "#/components/schemas/LocalShellToolCallOutput",
+            "deprecated": true
           },
           {
             "$ref": "#/components/schemas/FunctionShellCall"
@@ -18897,15 +19200,29 @@
             "type": "array"
           },
           "first_id": {
-            "example": "audit_log-defb456h8dks",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "example": "audit_log-defb456h8dks"
           },
           "has_more": {
             "type": "boolean"
           },
           "last_id": {
-            "example": "audit_log-hnbkd8s93s",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "example": "audit_log-hnbkd8s93s"
           },
           "object": {
             "enum": [
@@ -18918,8 +19235,6 @@
         "required": [
           "object",
           "data",
-          "first_id",
-          "last_id",
           "has_more"
         ],
         "type": "object"
@@ -18962,20 +19277,34 @@
         "properties": {
           "data": {
             "items": {
-              "$ref": "#/components/schemas/Certificate"
+              "$ref": "#/components/schemas/OrganizationCertificate"
             },
             "type": "array"
           },
           "first_id": {
-            "example": "cert_abc",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "example": "cert_abc"
           },
           "has_more": {
             "type": "boolean"
           },
           "last_id": {
-            "example": "cert_abc",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "example": "cert_abc"
           },
           "object": {
             "enum": [
@@ -18988,7 +19317,9 @@
         "required": [
           "object",
           "data",
-          "has_more"
+          "has_more",
+          "first_id",
+          "last_id"
         ],
         "type": "object"
       },
@@ -19225,6 +19556,56 @@
         ],
         "type": "object"
       },
+      "ListProjectCertificatesResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/OrganizationProjectCertificate"
+            },
+            "type": "array"
+          },
+          "first_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "example": "cert_abc"
+          },
+          "has_more": {
+            "type": "boolean"
+          },
+          "last_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "example": "cert_abc"
+          },
+          "object": {
+            "enum": [
+              "list"
+            ],
+            "type": "string",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "object",
+          "data",
+          "has_more",
+          "first_id",
+          "last_id"
+        ],
+        "type": "object"
+      },
       "ListRunStepsResponse": {
         "properties": {
           "data": {
@@ -19401,22 +19782,6 @@
         ],
         "title": "Local Environment",
         "type": "object"
-      },
-      "LocalShellCallOutputStatusEnum": {
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ],
-        "type": "string"
-      },
-      "LocalShellCallStatus": {
-        "enum": [
-          "in_progress",
-          "completed",
-          "incomplete"
-        ],
-        "type": "string"
       },
       "LocalShellExecAction": {
         "description": "Execute a shell command on the server.",
@@ -20033,6 +20398,7 @@
           },
           "server_url": {
             "description": "The URL for the MCP server. One of `server_url` or `connector_id` must be\nprovided.\n",
+            "format": "uri",
             "type": "string"
           },
           "type": {
@@ -20574,6 +20940,7 @@
               },
               "url": {
                 "description": "The URL of the image, must be a supported image types: jpeg, jpg, png, gif, webp.",
+                "format": "uri",
                 "type": "string"
               }
             },
@@ -20857,6 +21224,7 @@
             "anyOf": [
               {
                 "description": "The Unix timestamp (in seconds) for when the message was completed.",
+                "format": "unixtime",
                 "type": "integer"
               },
               {
@@ -20873,6 +21241,7 @@
           },
           "created_at": {
             "description": "The Unix timestamp (in seconds) for when the message was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -20883,6 +21252,7 @@
             "anyOf": [
               {
                 "description": "The Unix timestamp (in seconds) for when the message was marked as incomplete.",
+                "format": "unixtime",
                 "type": "integer"
               },
               {
@@ -21186,6 +21556,7 @@
         "properties": {
           "created": {
             "description": "The Unix timestamp (in seconds) when the model was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -21295,7 +21666,7 @@
               {
                 "description": "The retention policy for the prompt cache. Set to `24h` to enable extended prompt caching, which keeps cached prefixes active for longer, up to a maximum of 24 hours. [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).\n",
                 "enum": [
-                  "in-memory",
+                  "in_memory",
                   "24h"
                 ],
                 "type": "string"
@@ -21332,7 +21703,7 @@
           "top_logprobs": {
             "anyOf": [
               {
-                "description": "An integer between 0 and 20 specifying the number of most likely tokens to\nreturn at each token position, each with an associated log probability.\n",
+                "description": "An integer between 0 and 20 specifying the maximum number of most likely\ntokens to return at each token position, each with an associated log\nprobability. In some cases, the number of returned tokens may be fewer than\nrequested.\n",
                 "maximum": 20,
                 "minimum": 0,
                 "type": "integer"
@@ -21577,9 +21948,6 @@
             "type": "string"
           }
         },
-        "required": [
-          "name"
-        ],
         "type": "object"
       },
       "ModifyMessageRequest": {
@@ -21773,10 +22141,12 @@
           },
           "created_at": {
             "description": "The Unix timestamp (in seconds) for when the file was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "expires_at": {
             "description": "The Unix timestamp (in seconds) for when the file will expire.",
+            "format": "unixtime",
             "type": "integer"
           },
           "filename": {
@@ -21846,6 +22216,220 @@
           "desc"
         ],
         "type": "string"
+      },
+      "OrganizationCertificate": {
+        "description": "Represents an individual certificate configured at the organization level.",
+        "properties": {
+          "active": {
+            "description": "Whether the certificate is currently active at the organization level.",
+            "type": "boolean"
+          },
+          "certificate_details": {
+            "properties": {
+              "expires_at": {
+                "description": "The Unix timestamp (in seconds) of when the certificate expires.",
+                "format": "unixtime",
+                "type": "integer"
+              },
+              "valid_at": {
+                "description": "The Unix timestamp (in seconds) of when the certificate becomes valid.",
+                "format": "unixtime",
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) of when the certificate was uploaded.",
+            "format": "unixtime",
+            "type": "integer"
+          },
+          "id": {
+            "description": "The identifier, which can be referenced in API endpoints",
+            "type": "string"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The name of the certificate."
+          },
+          "object": {
+            "description": "The object type, which is always `organization.certificate`.",
+            "enum": [
+              "organization.certificate"
+            ],
+            "type": "string",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "object",
+          "id",
+          "name",
+          "created_at",
+          "certificate_details",
+          "active"
+        ],
+        "type": "object"
+      },
+      "OrganizationCertificateActivationResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/OrganizationCertificate"
+            },
+            "type": "array"
+          },
+          "object": {
+            "description": "The organization certificate activation result type.",
+            "enum": [
+              "organization.certificate.activation"
+            ],
+            "type": "string",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "object",
+          "data"
+        ],
+        "type": "object"
+      },
+      "OrganizationCertificateDeactivationResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/OrganizationCertificate"
+            },
+            "type": "array"
+          },
+          "object": {
+            "description": "The organization certificate deactivation result type.",
+            "enum": [
+              "organization.certificate.deactivation"
+            ],
+            "type": "string",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "object",
+          "data"
+        ],
+        "type": "object"
+      },
+      "OrganizationProjectCertificate": {
+        "description": "Represents an individual certificate configured at the project level.",
+        "properties": {
+          "active": {
+            "description": "Whether the certificate is currently active at the project level.",
+            "type": "boolean"
+          },
+          "certificate_details": {
+            "properties": {
+              "expires_at": {
+                "description": "The Unix timestamp (in seconds) of when the certificate expires.",
+                "format": "unixtime",
+                "type": "integer"
+              },
+              "valid_at": {
+                "description": "The Unix timestamp (in seconds) of when the certificate becomes valid.",
+                "format": "unixtime",
+                "type": "integer"
+              }
+            },
+            "type": "object"
+          },
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) of when the certificate was uploaded.",
+            "format": "unixtime",
+            "type": "integer"
+          },
+          "id": {
+            "description": "The identifier, which can be referenced in API endpoints",
+            "type": "string"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The name of the certificate."
+          },
+          "object": {
+            "description": "The object type, which is always `organization.project.certificate`.",
+            "enum": [
+              "organization.project.certificate"
+            ],
+            "type": "string",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "object",
+          "id",
+          "name",
+          "created_at",
+          "certificate_details",
+          "active"
+        ],
+        "type": "object"
+      },
+      "OrganizationProjectCertificateActivationResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/OrganizationProjectCertificate"
+            },
+            "type": "array"
+          },
+          "object": {
+            "description": "The project certificate activation result type.",
+            "enum": [
+              "organization.project.certificate.activation"
+            ],
+            "type": "string",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "object",
+          "data"
+        ],
+        "type": "object"
+      },
+      "OrganizationProjectCertificateDeactivationResponse": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/OrganizationProjectCertificate"
+            },
+            "type": "array"
+          },
+          "object": {
+            "description": "The project certificate deactivation result type.",
+            "enum": [
+              "organization.project.certificate.deactivation"
+            ],
+            "type": "string",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "object",
+          "data"
+        ],
+        "type": "object"
       },
       "OtherChunkingStrategyResponseParam": {
         "additionalProperties": false,
@@ -22169,6 +22753,7 @@
             "anyOf": [
               {
                 "description": "The Unix timestamp (in seconds) of when the project was archived or `null`.",
+                "format": "unixtime",
                 "type": "integer"
               },
               {
@@ -22178,15 +22763,34 @@
           },
           "created_at": {
             "description": "The Unix timestamp (in seconds) of when the project was created.",
+            "format": "unixtime",
             "type": "integer"
+          },
+          "external_key_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The external key associated with the project."
           },
           "id": {
             "description": "The identifier, which can be referenced in API endpoints",
             "type": "string"
           },
           "name": {
-            "description": "The name of the project. This appears in reporting.",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The name of the project. This appears in reporting."
           },
           "object": {
             "description": "The object type, which is always `organization.project`",
@@ -22197,24 +22801,25 @@
             "x-stainless-const": true
           },
           "status": {
-            "description": "`active` or `archived`",
-            "enum": [
-              "active",
-              "archived"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
             ],
-            "type": "string"
+            "description": "`active` or `archived`"
           }
         },
         "required": [
           "id",
           "object",
-          "name",
-          "created_at",
-          "status"
+          "created_at"
         ],
         "type": "object",
         "x-oaiMeta": {
-          "example": "{\n    \"id\": \"proj_abc\",\n    \"object\": \"organization.project\",\n    \"name\": \"Project example\",\n    \"created_at\": 1711471533,\n    \"archived_at\": null,\n    \"status\": \"active\"\n}\n",
+          "example": "{\n    \"id\": \"proj_abc\",\n    \"object\": \"organization.project\",\n    \"name\": \"Project example\",\n    \"created_at\": 1711471533,\n    \"archived_at\": null,\n    \"status\": \"active\",\n    \"external_key_id\": null\n}\n",
           "name": "The project object"
         }
       },
@@ -22223,6 +22828,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) of when the API key was created",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -22230,8 +22836,16 @@
             "type": "string"
           },
           "last_used_at": {
-            "description": "The Unix timestamp (in seconds) of when the API key was last used.",
-            "type": "integer"
+            "anyOf": [
+              {
+                "format": "unixtime",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The Unix timestamp (in seconds) of when the API key was last used."
           },
           "name": {
             "description": "The name of the API key",
@@ -22248,7 +22862,7 @@
           "owner": {
             "properties": {
               "service_account": {
-                "$ref": "#/components/schemas/ProjectServiceAccount"
+                "$ref": "#/components/schemas/ProjectApiKeyOwnerServiceAccount"
               },
               "type": {
                 "description": "`user` or `service_account`",
@@ -22259,7 +22873,7 @@
                 "type": "string"
               },
               "user": {
-                "$ref": "#/components/schemas/ProjectUser"
+                "$ref": "#/components/schemas/ProjectApiKeyOwnerUser"
               }
             },
             "type": "object"
@@ -22280,7 +22894,7 @@
         ],
         "type": "object",
         "x-oaiMeta": {
-          "example": "{\n    \"object\": \"organization.project.api_key\",\n    \"redacted_value\": \"sk-abc...def\",\n    \"name\": \"My API Key\",\n    \"created_at\": 1711471533,\n    \"last_used_at\": 1711471534,\n    \"id\": \"key_abc\",\n    \"owner\": {\n        \"type\": \"user\",\n        \"user\": {\n            \"object\": \"organization.project.user\",\n            \"id\": \"user_abc\",\n            \"name\": \"First Last\",\n            \"email\": \"user@example.com\",\n            \"role\": \"owner\",\n            \"created_at\": 1711471533\n        }\n    }\n}\n",
+          "example": "{\n    \"object\": \"organization.project.api_key\",\n    \"redacted_value\": \"sk-abc...def\",\n    \"name\": \"My API Key\",\n    \"created_at\": 1711471533,\n    \"last_used_at\": 1711471534,\n    \"id\": \"key_abc\",\n    \"owner\": {\n        \"type\": \"user\",\n        \"user\": {\n            \"id\": \"user_abc\",\n            \"name\": \"First Last\",\n            \"email\": \"user@example.com\",\n            \"role\": \"owner\",\n            \"created_at\": 1711471533\n        }\n    }\n}\n",
           "name": "The project API key object"
         }
       },
@@ -22316,13 +22930,27 @@
             "type": "array"
           },
           "first_id": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "has_more": {
             "type": "boolean"
           },
           "last_id": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "object": {
             "enum": [
@@ -22335,27 +22963,96 @@
         "required": [
           "object",
           "data",
-          "first_id",
-          "last_id",
           "has_more"
+        ],
+        "type": "object"
+      },
+      "ProjectApiKeyOwnerServiceAccount": {
+        "description": "The service account that owns a project API key.",
+        "properties": {
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) of when the service account was created.",
+            "format": "unixtime",
+            "type": "integer"
+          },
+          "id": {
+            "description": "The identifier, which can be referenced in API endpoints",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the service account.",
+            "type": "string"
+          },
+          "role": {
+            "description": "The service account's project role.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "created_at",
+          "role"
+        ],
+        "type": "object"
+      },
+      "ProjectApiKeyOwnerUser": {
+        "description": "The user that owns a project API key.",
+        "properties": {
+          "created_at": {
+            "description": "The Unix timestamp (in seconds) of when the user was created.",
+            "format": "unixtime",
+            "type": "integer"
+          },
+          "email": {
+            "description": "The email address of the user.",
+            "type": "string"
+          },
+          "id": {
+            "description": "The identifier, which can be referenced in API endpoints",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the user.",
+            "type": "string"
+          },
+          "role": {
+            "description": "The user's project role.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "email",
+          "name",
+          "created_at",
+          "role"
         ],
         "type": "object"
       },
       "ProjectCreateRequest": {
         "properties": {
-          "geography": {
-            "description": "Create the project with the specified data residency region. Your organization must have access to Data residency functionality in order to use. See [data residency controls](https://platform.openai.com/docs/guides/your-data#data-residency-controls) to review the functionality and limitations of setting this field.",
-            "enum": [
-              "US",
-              "EU",
-              "JP",
-              "IN",
-              "KR",
-              "CA",
-              "AU",
-              "SG"
+          "external_key_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
             ],
-            "type": "string"
+            "description": "External key ID to associate with the project."
+          },
+          "geography": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Create the project with the specified data residency region. Your organization must have access to Data residency functionality in order to use. See [data residency controls](https://platform.openai.com/docs/guides/your-data#data-residency-controls) to review the functionality and limitations of setting this field."
           },
           "name": {
             "description": "The friendly name of the project, this name appears in reports.",
@@ -22372,7 +23069,7 @@
         "properties": {
           "created_at": {
             "description": "Unix timestamp (in seconds) when the group was granted project access.",
-            "format": "int64",
+            "format": "unixtime",
             "type": "integer"
           },
           "group_id": {
@@ -22381,6 +23078,10 @@
           },
           "group_name": {
             "description": "Display name of the group.",
+            "type": "string"
+          },
+          "group_type": {
+            "description": "The type of the group.",
             "type": "string"
           },
           "object": {
@@ -22401,11 +23102,12 @@
           "project_id",
           "group_id",
           "group_name",
+          "group_type",
           "created_at"
         ],
         "type": "object",
         "x-oaiMeta": {
-          "example": "{\n    \"object\": \"project.group\",\n    \"project_id\": \"proj_abc123\",\n    \"group_id\": \"group_01J1F8ABCDXYZ\",\n    \"group_name\": \"Support Team\",\n    \"created_at\": 1711471533\n}\n",
+          "example": "{\n    \"object\": \"project.group\",\n    \"project_id\": \"proj_abc123\",\n    \"group_id\": \"group_01J1F8ABCDXYZ\",\n    \"group_name\": \"Support Team\",\n    \"group_type\": \"group\",\n    \"created_at\": 1711471533\n}\n",
           "name": "The project group object"
         }
       },
@@ -22490,13 +23192,27 @@
             "type": "array"
           },
           "first_id": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "has_more": {
             "type": "boolean"
           },
           "last_id": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "object": {
             "enum": [
@@ -22509,8 +23225,6 @@
         "required": [
           "object",
           "data",
-          "first_id",
-          "last_id",
           "has_more"
         ],
         "type": "object"
@@ -22581,13 +23295,27 @@
             "type": "array"
           },
           "first_id": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "has_more": {
             "type": "boolean"
           },
           "last_id": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "object": {
             "enum": [
@@ -22600,8 +23328,6 @@
         "required": [
           "object",
           "data",
-          "first_id",
-          "last_id",
           "has_more"
         ],
         "type": "object"
@@ -22640,6 +23366,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) of when the service account was created",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -22683,6 +23410,7 @@
       "ProjectServiceAccountApiKey": {
         "properties": {
           "created_at": {
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -22727,9 +23455,17 @@
       "ProjectServiceAccountCreateResponse": {
         "properties": {
           "api_key": {
-            "$ref": "#/components/schemas/ProjectServiceAccountApiKey"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProjectServiceAccountApiKey"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "created_at": {
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -22796,13 +23532,27 @@
             "type": "array"
           },
           "first_id": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "has_more": {
             "type": "boolean"
           },
           "last_id": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "object": {
             "enum": [
@@ -22815,22 +23565,46 @@
         "required": [
           "object",
           "data",
-          "first_id",
-          "last_id",
           "has_more"
         ],
         "type": "object"
       },
       "ProjectUpdateRequest": {
         "properties": {
+          "external_key_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "External key ID to associate with the project."
+          },
+          "geography": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Geography for the project."
+          },
           "name": {
-            "description": "The updated name of the project, this name appears in reports.",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The updated name of the project, this name appears in reports."
           }
         },
-        "required": [
-          "name"
-        ],
         "type": "object"
       },
       "ProjectUser": {
@@ -22838,19 +23612,34 @@
         "properties": {
           "added_at": {
             "description": "The Unix timestamp (in seconds) of when the project was added.",
+            "format": "unixtime",
             "type": "integer"
           },
           "email": {
-            "description": "The email address of the user",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The email address of the user"
           },
           "id": {
             "description": "The identifier, which can be referenced in API endpoints",
             "type": "string"
           },
           "name": {
-            "description": "The name of the user",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The name of the user"
           },
           "object": {
             "description": "The object type, which is always `organization.project.user`",
@@ -22862,18 +23651,12 @@
           },
           "role": {
             "description": "`owner` or `member`",
-            "enum": [
-              "owner",
-              "member"
-            ],
             "type": "string"
           }
         },
         "required": [
           "object",
           "id",
-          "name",
-          "email",
           "role",
           "added_at"
         ],
@@ -22885,21 +23668,34 @@
       },
       "ProjectUserCreateRequest": {
         "properties": {
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Email of the user to add."
+          },
           "role": {
             "description": "`owner` or `member`",
-            "enum": [
-              "owner",
-              "member"
-            ],
             "type": "string"
           },
           "user_id": {
-            "description": "The ID of the user.",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The ID of the user."
           }
         },
         "required": [
-          "user_id",
           "role"
         ],
         "type": "object"
@@ -22936,13 +23732,27 @@
             "type": "array"
           },
           "first_id": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "has_more": {
             "type": "boolean"
           },
           "last_id": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "object": {
             "type": "string"
@@ -22951,8 +23761,6 @@
         "required": [
           "object",
           "data",
-          "first_id",
-          "last_id",
           "has_more"
         ],
         "type": "object"
@@ -22960,17 +23768,17 @@
       "ProjectUserUpdateRequest": {
         "properties": {
           "role": {
-            "description": "`owner` or `member`",
-            "enum": [
-              "owner",
-              "member"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
             ],
-            "type": "string"
+            "description": "`owner` or `member`"
           }
         },
-        "required": [
-          "role"
-        ],
         "type": "object"
       },
       "Prompt": {
@@ -24160,7 +24968,7 @@
           },
           "end": {
             "description": "End time of the segment in seconds.",
-            "format": "float",
+            "format": "double",
             "type": "number"
           },
           "event_id": {
@@ -24181,7 +24989,7 @@
           },
           "start": {
             "description": "Start time of the segment in seconds.",
-            "format": "float",
+            "format": "double",
             "type": "number"
           },
           "text": {
@@ -26368,6 +27176,7 @@
                 },
                 "image_url": {
                   "description": "Base64-encoded image bytes (for `input_image`) as a data URI. For example `data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...`. Supported formats are PNG and JPEG.",
+                  "format": "uri",
                   "type": "string"
                 },
                 "text": {
@@ -26553,6 +27362,7 @@
               "seconds": {
                 "default": 600,
                 "description": "The number of seconds from the anchor point to the expiration. Select a value between `10` and `7200` (2 hours). This default to 600 seconds (10 minutes) if not specified.\n",
+                "format": "int64",
                 "maximum": 7200,
                 "minimum": 10,
                 "type": "integer"
@@ -26585,6 +27395,7 @@
         "properties": {
           "expires_at": {
             "description": "Expiration timestamp for the client secret, in seconds since epoch.",
+            "format": "unixtime",
             "type": "integer"
           },
           "session": {
@@ -26915,6 +27726,28 @@
         "title": "Realtime MCP tool execution error",
         "type": "object"
       },
+      "RealtimeReasoning": {
+        "description": "Configuration for reasoning-capable Realtime models such as `gpt-realtime-2`.\n",
+        "properties": {
+          "effort": {
+            "$ref": "#/components/schemas/RealtimeReasoningEffort"
+          }
+        },
+        "title": "Realtime reasoning configuration",
+        "type": "object"
+      },
+      "RealtimeReasoningEffort": {
+        "default": "low",
+        "description": "Constrains effort on reasoning for reasoning-capable Realtime models such as\n`gpt-realtime-2`.\n",
+        "enum": [
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh"
+        ],
+        "type": "string"
+      },
       "RealtimeResponse": {
         "description": "The response resource.",
         "properties": {
@@ -27192,8 +28025,15 @@
             },
             "type": "array"
           },
+          "parallel_tool_calls": {
+            "description": "Whether the model may call multiple tools in parallel. Only supported by\nreasoning Realtime models such as `gpt-realtime-2`.\n",
+            "type": "boolean"
+          },
           "prompt": {
             "$ref": "#/components/schemas/Prompt"
+          },
+          "reasoning": {
+            "$ref": "#/components/schemas/RealtimeReasoning"
           },
           "tool_choice": {
             "anyOf": [
@@ -27749,7 +28589,7 @@
           },
           "end": {
             "description": "End time of the segment in seconds.",
-            "format": "float",
+            "format": "double",
             "type": "number"
           },
           "event_id": {
@@ -27770,7 +28610,7 @@
           },
           "start": {
             "description": "Start time of the segment in seconds.",
-            "format": "float",
+            "format": "double",
             "type": "number"
           },
           "text": {
@@ -29344,6 +30184,7 @@
         "properties": {
           "expires_at": {
             "description": "Expiration timestamp for the session, in seconds since epoch.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -29569,6 +30410,7 @@
             "properties": {
               "expires_at": {
                 "description": "Timestamp for when the token expires. Currently, all tokens expire\nafter one minute.\n",
+                "format": "unixtime",
                 "type": "integer"
               },
               "value": {
@@ -29843,6 +30685,7 @@
                 "enum": [
                   "gpt-realtime",
                   "gpt-realtime-1.5",
+                  "gpt-realtime-2",
                   "gpt-realtime-2025-08-28",
                   "gpt-4o-realtime-preview",
                   "gpt-4o-realtime-preview-2024-10-01",
@@ -29878,8 +30721,15 @@
             },
             "type": "array"
           },
+          "parallel_tool_calls": {
+            "description": "Whether the model may call multiple tools in parallel. Only supported by\nreasoning Realtime models such as `gpt-realtime-2`.\n",
+            "type": "boolean"
+          },
           "prompt": {
             "$ref": "#/components/schemas/Prompt"
+          },
+          "reasoning": {
+            "$ref": "#/components/schemas/RealtimeReasoning"
           },
           "tool_choice": {
             "anyOf": [
@@ -29988,8 +30838,7 @@
                     "type": "object"
                   },
                   "transcription": {
-                    "$ref": "#/components/schemas/AudioTranscription",
-                    "description": "Configuration for input audio transcription.\n"
+                    "$ref": "#/components/schemas/AudioTranscription"
                   },
                   "turn_detection": {
                     "description": "Configuration for turn detection.\n",
@@ -30032,6 +30881,7 @@
           },
           "expires_at": {
             "description": "Expiration timestamp for the session, in seconds since epoch.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -30162,7 +31012,7 @@
         }
       },
       "RealtimeSessionCreateResponseGA": {
-        "description": "A new Realtime session configuration, with an ephemeral key. Default TTL\nfor keys is one minute.\n",
+        "description": "A Realtime session configuration object.\n",
         "properties": {
           "audio": {
             "description": "Configuration for input and output audio.\n",
@@ -30183,8 +31033,7 @@
                     "type": "object"
                   },
                   "transcription": {
-                    "$ref": "#/components/schemas/AudioTranscription",
-                    "description": "Configuration for input audio transcription, defaults to off and can be set to `null` to turn off once on. Input audio transcription is not native to the model, since the model consumes audio directly. Transcription runs asynchronously through [the /audio/transcriptions endpoint](https://platform.openai.com/docs/api-reference/audio/createTranscription) and should be treated as guidance of input audio content rather than precisely what the model heard. The client can optionally set the language and prompt for transcription, these offer additional guidance to the transcription service.\n"
+                    "$ref": "#/components/schemas/AudioTranscription"
                   },
                   "turn_detection": {
                     "$ref": "#/components/schemas/RealtimeTurnDetection"
@@ -30216,23 +31065,14 @@
             },
             "type": "object"
           },
-          "client_secret": {
-            "description": "Ephemeral key returned by the API.",
-            "properties": {
-              "expires_at": {
-                "description": "Timestamp for when the token expires. Currently, all tokens expire\nafter one minute.\n",
-                "type": "integer"
-              },
-              "value": {
-                "description": "Ephemeral key usable in client environments to authenticate connections to the Realtime API. Use this in client-side environments rather than a standard API token, which should only be used server-side.\n",
-                "type": "string"
-              }
-            },
-            "required": [
-              "value",
-              "expires_at"
-            ],
-            "type": "object"
+          "expires_at": {
+            "description": "Expiration timestamp for the session, in seconds since epoch.",
+            "format": "unixtime",
+            "type": "integer"
+          },
+          "id": {
+            "description": "Unique identifier for the session that looks like `sess_1234567890abcdef`.\n",
+            "type": "string"
           },
           "include": {
             "description": "Additional fields to include in server outputs.\n\n`item.input_audio_transcription.logprobs`: Include logprobs for input audio transcription.\n",
@@ -30272,6 +31112,7 @@
                 "enum": [
                   "gpt-realtime",
                   "gpt-realtime-1.5",
+                  "gpt-realtime-2",
                   "gpt-realtime-2025-08-28",
                   "gpt-4o-realtime-preview",
                   "gpt-4o-realtime-preview-2024-10-01",
@@ -30292,6 +31133,14 @@
             ],
             "description": "The Realtime model used for this session.\n"
           },
+          "object": {
+            "description": "The object type. Always `realtime.session`.",
+            "enum": [
+              "realtime.session"
+            ],
+            "type": "string",
+            "x-stainless-const": true
+          },
           "output_modalities": {
             "default": [
               "audio"
@@ -30308,6 +31157,9 @@
           },
           "prompt": {
             "$ref": "#/components/schemas/Prompt"
+          },
+          "reasoning": {
+            "$ref": "#/components/schemas/RealtimeReasoning"
           },
           "tool_choice": {
             "anyOf": [
@@ -30393,9 +31245,11 @@
           }
         },
         "required": [
-          "client_secret",
-          "type"
+          "type",
+          "id",
+          "object"
         ],
+        "title": "Realtime session configuration object",
         "type": "object",
         "x-oaiMeta": {
           "group": "realtime",
@@ -30533,6 +31387,7 @@
             "properties": {
               "expires_at": {
                 "description": "Timestamp for when the token expires. Currently, all tokens expire\nafter one minute.\n",
+                "format": "unixtime",
                 "type": "integer"
               },
               "value": {
@@ -30551,8 +31406,7 @@
             "type": "string"
           },
           "input_audio_transcription": {
-            "$ref": "#/components/schemas/AudioTranscription",
-            "description": "Configuration of the transcription model.\n"
+            "$ref": "#/components/schemas/AudioTranscription"
           },
           "modalities": {
             "description": "The set of modalities the model can respond with. To disable audio,\nset this to [\"text\"].\n",
@@ -30618,30 +31472,37 @@
                     "type": "object"
                   },
                   "transcription": {
-                    "$ref": "#/components/schemas/AudioTranscription",
-                    "description": "Configuration of the transcription model.\n"
+                    "$ref": "#/components/schemas/AudioTranscription"
                   },
                   "turn_detection": {
-                    "description": "Configuration for turn detection. Can be set to `null` to turn off. Server\nVAD means that the model will detect the start and end of speech based on\naudio volume and respond at the end of user speech.\n",
-                    "properties": {
-                      "prefix_padding_ms": {
-                        "description": "Amount of audio to include before the VAD detected speech (in\nmilliseconds). Defaults to 300ms.\n",
-                        "type": "integer"
+                    "anyOf": [
+                      {
+                        "description": "Configuration for turn detection. Can be set to `null` to turn off. Server\nVAD means that the model will detect the start and end of speech based on\naudio volume and respond at the end of user speech. For `gpt-realtime-whisper`, this must be `null`; VAD is not supported.\n",
+                        "properties": {
+                          "prefix_padding_ms": {
+                            "description": "Amount of audio to include before the VAD detected speech (in\nmilliseconds). Defaults to 300ms.\n",
+                            "type": "integer"
+                          },
+                          "silence_duration_ms": {
+                            "description": "Duration of silence to detect speech stop (in milliseconds). Defaults\nto 500ms. With shorter values the model will respond more quickly,\nbut may jump in on short pauses from the user.\n",
+                            "type": "integer"
+                          },
+                          "threshold": {
+                            "description": "Activation threshold for VAD (0.0 to 1.0), this defaults to 0.5. A\nhigher threshold will require louder audio to activate the model, and\nthus might perform better in noisy environments.\n",
+                            "type": "number"
+                          },
+                          "type": {
+                            "description": "Type of turn detection, only `server_vad` is currently supported.\n",
+                            "type": "string"
+                          }
+                        },
+                        "type": "object"
                       },
-                      "silence_duration_ms": {
-                        "description": "Duration of silence to detect speech stop (in milliseconds). Defaults\nto 500ms. With shorter values the model will respond more quickly,\nbut may jump in on short pauses from the user.\n",
-                        "type": "integer"
-                      },
-                      "threshold": {
-                        "description": "Activation threshold for VAD (0.0 to 1.0), this defaults to 0.5. A\nhigher threshold will require louder audio to activate the model, and\nthus might perform better in noisy environments.\n",
-                        "type": "number"
-                      },
-                      "type": {
-                        "description": "Type of turn detection, only `server_vad` is currently supported.\n",
-                        "type": "string"
+                      {
+                        "type": "null"
                       }
-                    },
-                    "type": "object"
+                    ],
+                    "description": "Configuration for turn detection. For `gpt-realtime-whisper`, this must be `null`; VAD is not supported.\n"
                   }
                 },
                 "type": "object"
@@ -30651,6 +31512,7 @@
           },
           "expires_at": {
             "description": "Expiration timestamp for the session, in seconds since epoch.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -30692,6 +31554,640 @@
           "group": "realtime",
           "name": "The transcription session object"
         }
+      },
+      "RealtimeTranslationClientEvent": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/RealtimeTranslationClientEventSessionUpdate"
+          },
+          {
+            "$ref": "#/components/schemas/RealtimeTranslationClientEventInputAudioBufferAppend"
+          },
+          {
+            "$ref": "#/components/schemas/RealtimeTranslationClientEventSessionClose"
+          }
+        ],
+        "description": "A Realtime translation client event.\n",
+        "discriminator": {
+          "propertyName": "type"
+        }
+      },
+      "RealtimeTranslationClientEventInputAudioBufferAppend": {
+        "description": "Send this event to append audio bytes to the translation session input audio buffer.\n\nWebSocket translation sessions accept base64-encoded 24 kHz PCM16 mono\nlittle-endian raw audio bytes. Unsupported websocket audio formats return a\nvalidation error because lower-quality audio materially degrades translation\nquality.\n\nTranslation consumes 200 ms engine frames. For best realtime behavior, append\naudio in 200 ms chunks. If a chunk is shorter, the server buffers it until it\nhas enough audio for one frame. If a chunk is longer, the server splits it into\n200 ms frames and enqueues them back-to-back.\n\nKeep appending silence while the session is active. If a client stops sending\naudio and later resumes, model time treats the resumed audio as contiguous with\nthe previous audio rather than as a real-world pause.\n",
+        "properties": {
+          "audio": {
+            "description": "Base64-encoded 24 kHz PCM16 mono audio bytes.",
+            "type": "string"
+          },
+          "event_id": {
+            "description": "Optional client-generated ID used to identify this event.",
+            "maxLength": 512,
+            "type": "string"
+          },
+          "type": {
+            "const": "session.input_audio_buffer.append",
+            "description": "The event type, must be `session.input_audio_buffer.append`.",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "type",
+          "audio"
+        ],
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"event_id\": \"event_456\",\n  \"type\": \"session.input_audio_buffer.append\",\n  \"audio\": \"Base64EncodedAudioData\"\n}\n",
+          "group": "realtime",
+          "name": "session.input_audio_buffer.append"
+        }
+      },
+      "RealtimeTranslationClientEventSessionClose": {
+        "description": "Gracefully close the realtime translation session. The server flushes pending\ninput audio and emits any remaining translated output before closing the\nsession.\n",
+        "properties": {
+          "event_id": {
+            "description": "Optional client-generated ID used to identify this event.",
+            "maxLength": 512,
+            "type": "string"
+          },
+          "type": {
+            "const": "session.close",
+            "description": "The event type, must be `session.close`.",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"event_id\": \"event_789\",\n  \"type\": \"session.close\"\n}\n",
+          "group": "realtime",
+          "name": "session.close"
+        }
+      },
+      "RealtimeTranslationClientEventSessionUpdate": {
+        "description": "Send this event to update the translation session configuration. Translation\nsessions support updates to `audio.output.language`, `audio.input.transcription`,\nand `audio.input.noise_reduction`.\n",
+        "properties": {
+          "event_id": {
+            "description": "Optional client-generated ID used to identify this event.",
+            "maxLength": 512,
+            "type": "string"
+          },
+          "session": {
+            "$ref": "#/components/schemas/RealtimeTranslationSessionUpdateRequest",
+            "description": "Translation session fields to update. The session `type` and `model` are set\nat creation and cannot be changed with `session.update`.\n"
+          },
+          "type": {
+            "const": "session.update",
+            "description": "The event type, must be `session.update`.",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "type",
+          "session"
+        ],
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"type\": \"session.update\",\n  \"session\": {\n    \"audio\": {\n      \"input\": {\n        \"transcription\": {\n          \"model\": \"gpt-realtime-whisper\"\n        },\n        \"noise_reduction\": null\n      },\n      \"output\": {\n        \"language\": \"es\"\n      }\n    }\n  }\n}\n",
+          "group": "realtime",
+          "name": "session.update"
+        }
+      },
+      "RealtimeTranslationClientSecretCreateRequest": {
+        "description": "Create a translation session and client secret for the Realtime API.\n",
+        "properties": {
+          "expires_after": {
+            "description": "Configuration for the client secret expiration. Expiration refers to the time after which\na client secret will no longer be valid for creating sessions. The session itself may\ncontinue after that time once started. A secret can be used to create multiple sessions\nuntil it expires.\n",
+            "properties": {
+              "anchor": {
+                "default": "created_at",
+                "description": "The anchor point for the client secret expiration, meaning that `seconds` will be added to the `created_at` time of the client secret to produce an expiration timestamp. Only `created_at` is currently supported.\n",
+                "enum": [
+                  "created_at"
+                ],
+                "type": "string",
+                "x-stainless-const": true
+              },
+              "seconds": {
+                "default": 600,
+                "description": "The number of seconds from the anchor point to the expiration. Select a value between `10` and `7200` (2 hours). This default to 600 seconds (10 minutes) if not specified.\n",
+                "format": "int64",
+                "maximum": 7200,
+                "minimum": 10,
+                "type": "integer"
+              }
+            },
+            "title": "Client secret expiration",
+            "type": "object"
+          },
+          "session": {
+            "$ref": "#/components/schemas/RealtimeTranslationSessionCreateRequest"
+          }
+        },
+        "required": [
+          "session"
+        ],
+        "title": "Realtime translation client secret creation request",
+        "type": "object"
+      },
+      "RealtimeTranslationClientSecretCreateResponse": {
+        "description": "Response from creating a translation session and client secret for the Realtime API.\n",
+        "properties": {
+          "expires_at": {
+            "description": "Expiration timestamp for the client secret, in seconds since epoch.",
+            "format": "unixtime",
+            "type": "integer"
+          },
+          "session": {
+            "$ref": "#/components/schemas/RealtimeTranslationSession"
+          },
+          "value": {
+            "description": "The generated client secret value.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "value",
+          "expires_at",
+          "session"
+        ],
+        "title": "Realtime translation session and client secret",
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"value\": \"ek_68af296e8e408191a1120ab6383263c2\",\n  \"expires_at\": 1756310470,\n  \"session\": {\n    \"id\": \"sess_C9CiUVUzUzYIssh3ELY1d\",\n    \"type\": \"translation\",\n    \"expires_at\": 1756310470,\n    \"model\": \"gpt-realtime-translate\",\n    \"audio\": {\n      \"input\": {\n        \"transcription\": null,\n        \"noise_reduction\": null\n      },\n      \"output\": {\n        \"language\": \"es\"\n      }\n    }\n  }\n}\n",
+          "group": "realtime",
+          "name": "Translation session response object"
+        }
+      },
+      "RealtimeTranslationServerEvent": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/RealtimeServerEventError"
+          },
+          {
+            "$ref": "#/components/schemas/RealtimeTranslationServerEventSessionCreated"
+          },
+          {
+            "$ref": "#/components/schemas/RealtimeTranslationServerEventSessionUpdated"
+          },
+          {
+            "$ref": "#/components/schemas/RealtimeTranslationServerEventSessionClosed"
+          },
+          {
+            "$ref": "#/components/schemas/RealtimeTranslationServerEventSessionInputTranscriptDelta"
+          },
+          {
+            "$ref": "#/components/schemas/RealtimeTranslationServerEventSessionOutputTranscriptDelta"
+          },
+          {
+            "$ref": "#/components/schemas/RealtimeTranslationServerEventSessionOutputAudioDelta"
+          }
+        ],
+        "description": "A Realtime translation server event.\n",
+        "discriminator": {
+          "propertyName": "type"
+        }
+      },
+      "RealtimeTranslationServerEventSessionClosed": {
+        "description": "Returned when a realtime translation session is closed.\n",
+        "properties": {
+          "event_id": {
+            "description": "The unique ID of the server event.",
+            "type": "string"
+          },
+          "type": {
+            "const": "session.closed",
+            "description": "The event type, must be `session.closed`.",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "event_id",
+          "type"
+        ],
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"event_id\": \"event_987\",\n  \"type\": \"session.closed\"\n}\n",
+          "group": "realtime",
+          "name": "session.closed"
+        }
+      },
+      "RealtimeTranslationServerEventSessionCreated": {
+        "description": "Returned when a translation session is created. Emitted automatically when a\nnew connection is established as the first server event. This event contains\nthe default translation session configuration.\n",
+        "properties": {
+          "event_id": {
+            "description": "The unique ID of the server event.",
+            "type": "string"
+          },
+          "session": {
+            "$ref": "#/components/schemas/RealtimeTranslationSession",
+            "description": "The translation session configuration."
+          },
+          "type": {
+            "const": "session.created",
+            "description": "The event type, must be `session.created`.",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "event_id",
+          "type",
+          "session"
+        ],
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"type\": \"session.created\",\n  \"event_id\": \"event_123\",\n  \"session\": {\n    \"id\": \"sess_123\",\n    \"type\": \"translation\",\n    \"model\": \"gpt-realtime-translate\",\n    \"expires_at\": 1714857600,\n    \"audio\": {\n      \"input\": {\n        \"transcription\": {\n          \"model\": \"gpt-realtime-whisper\",\n          \"language\": \"en\"\n        },\n        \"noise_reduction\": {\n          \"type\": \"near_field\"\n        }\n      },\n      \"output\": {\n        \"language\": \"fr\"\n      }\n    }\n  }\n}\n",
+          "group": "realtime",
+          "name": "session.created"
+        }
+      },
+      "RealtimeTranslationServerEventSessionInputTranscriptDelta": {
+        "description": "Returned when optional source-language transcript text is available. This event\nis emitted only when `audio.input.transcription` is configured.\n\nTranscript deltas are append-only text fragments. Clients should not insert\nunconditional spaces between deltas.\n",
+        "properties": {
+          "delta": {
+            "description": "Append-only source-language transcript text.",
+            "type": "string"
+          },
+          "elapsed_ms": {
+            "description": "Timing metadata for stream alignment, derived from the translation frame\nwhen available. It advances in 200 ms increments, but multiple transcript\ndeltas may share the same `elapsed_ms`. Treat it as alignment metadata,\nnot a unique transcript-delta identifier.\n",
+            "nullable": true,
+            "type": "integer"
+          },
+          "event_id": {
+            "description": "The unique ID of the server event.",
+            "type": "string"
+          },
+          "type": {
+            "const": "session.input_transcript.delta",
+            "description": "The event type, must be `session.input_transcript.delta`.",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "event_id",
+          "type",
+          "delta"
+        ],
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"event_id\": \"event_125\",\n  \"type\": \"session.input_transcript.delta\",\n  \"delta\": \" hear\",\n  \"elapsed_ms\": 1200\n}\n",
+          "group": "realtime",
+          "name": "session.input_transcript.delta"
+        }
+      },
+      "RealtimeTranslationServerEventSessionOutputAudioDelta": {
+        "description": "Returned when translated output audio is available. Output audio deltas are\n200 ms frames of PCM16 audio.\n",
+        "properties": {
+          "channels": {
+            "default": 1,
+            "description": "Number of audio channels.",
+            "type": "integer"
+          },
+          "delta": {
+            "description": "Base64-encoded translated audio data.",
+            "type": "string"
+          },
+          "elapsed_ms": {
+            "description": "Timing metadata for stream alignment, derived from the translation frame\nwhen available. Treat `elapsed_ms` as alignment metadata, not a unique\nevent identifier.\n",
+            "nullable": true,
+            "type": "integer"
+          },
+          "event_id": {
+            "description": "The unique ID of the server event.",
+            "type": "string"
+          },
+          "format": {
+            "description": "Audio encoding for `delta`.",
+            "enum": [
+              "pcm16"
+            ],
+            "type": "string",
+            "x-stainless-const": true
+          },
+          "sample_rate": {
+            "default": 24000,
+            "description": "Sample rate of the audio delta.",
+            "type": "integer"
+          },
+          "type": {
+            "const": "session.output_audio.delta",
+            "description": "The event type, must be `session.output_audio.delta`.",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "event_id",
+          "type",
+          "delta"
+        ],
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"event_id\": \"event_123\",\n  \"type\": \"session.output_audio.delta\",\n  \"delta\": \"Base64EncodedAudioDelta\",\n  \"sample_rate\": 24000,\n  \"channels\": 1,\n  \"format\": \"pcm16\",\n  \"elapsed_ms\": 1200\n}\n",
+          "group": "realtime",
+          "name": "session.output_audio.delta"
+        }
+      },
+      "RealtimeTranslationServerEventSessionOutputTranscriptDelta": {
+        "description": "Returned when translated transcript text is available.\n\nTranscript deltas are append-only text fragments. Clients should not insert\nunconditional spaces between deltas.\n",
+        "properties": {
+          "delta": {
+            "description": "Append-only transcript text for the translated output audio.",
+            "type": "string"
+          },
+          "elapsed_ms": {
+            "description": "Timing metadata for stream alignment, derived from the translation frame\nwhen available. It advances in 200 ms increments, but multiple transcript\ndeltas may share the same `elapsed_ms`. Treat it as alignment metadata,\nnot a unique transcript-delta identifier.\n",
+            "nullable": true,
+            "type": "integer"
+          },
+          "event_id": {
+            "description": "The unique ID of the server event.",
+            "type": "string"
+          },
+          "type": {
+            "const": "session.output_transcript.delta",
+            "description": "The event type, must be `session.output_transcript.delta`.",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "event_id",
+          "type",
+          "delta"
+        ],
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"event_id\": \"event_124\",\n  \"type\": \"session.output_transcript.delta\",\n  \"delta\": \" escuch\",\n  \"elapsed_ms\": 1200\n}\n",
+          "group": "realtime",
+          "name": "session.output_transcript.delta"
+        }
+      },
+      "RealtimeTranslationServerEventSessionUpdated": {
+        "description": "Returned when a translation session is updated with a `session.update` event,\nunless there is an error.\n",
+        "properties": {
+          "event_id": {
+            "description": "The unique ID of the server event.",
+            "type": "string"
+          },
+          "session": {
+            "$ref": "#/components/schemas/RealtimeTranslationSession",
+            "description": "The translation session configuration."
+          },
+          "type": {
+            "const": "session.updated",
+            "description": "The event type, must be `session.updated`.",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "event_id",
+          "type",
+          "session"
+        ],
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"type\": \"session.updated\",\n  \"event_id\": \"event_124\",\n  \"session\": {\n    \"id\": \"sess_123\",\n    \"type\": \"translation\",\n    \"model\": \"gpt-realtime-translate\",\n    \"expires_at\": 1714857600,\n    \"audio\": {\n      \"input\": {\n        \"transcription\": {\n          \"model\": \"gpt-realtime-whisper\",\n          \"language\": \"en\"\n        },\n        \"noise_reduction\": {\n          \"type\": \"near_field\"\n        }\n      },\n      \"output\": {\n        \"language\": \"es\"\n      }\n    }\n  }\n}\n",
+          "group": "realtime",
+          "name": "session.updated"
+        }
+      },
+      "RealtimeTranslationSession": {
+        "description": "A Realtime translation session. Translation sessions continuously translate input\naudio into the configured output language.\n",
+        "properties": {
+          "audio": {
+            "description": "Configuration for translation input and output audio.\n",
+            "properties": {
+              "input": {
+                "properties": {
+                  "noise_reduction": {
+                    "anyOf": [
+                      {
+                        "description": "Optional input noise reduction.\n",
+                        "properties": {
+                          "type": {
+                            "$ref": "#/components/schemas/NoiseReductionType"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "transcription": {
+                    "anyOf": [
+                      {
+                        "description": "Optional source-language transcription. When configured, the server emits\n`session.input_transcript.delta` events. Translation itself still runs from\nthe input audio stream.\n",
+                        "properties": {
+                          "model": {
+                            "description": "The transcription model used for source transcript deltas.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "output": {
+                "properties": {
+                  "language": {
+                    "description": "Target language for translated output audio and transcript deltas.\n",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "expires_at": {
+            "description": "Expiration timestamp for the session, in seconds since epoch.",
+            "format": "unixtime",
+            "type": "integer"
+          },
+          "id": {
+            "description": "Unique identifier for the session that looks like `sess_1234567890abcdef`.\n",
+            "type": "string"
+          },
+          "model": {
+            "description": "The Realtime translation model used for this session. This field is set at\nsession creation and cannot be changed with `session.update`.\n",
+            "type": "string"
+          },
+          "type": {
+            "description": "The session type. Always `translation` for Realtime translation sessions.\n",
+            "enum": [
+              "translation"
+            ],
+            "type": "string",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "expires_at",
+          "model",
+          "audio"
+        ],
+        "title": "Realtime translation session",
+        "type": "object",
+        "x-oaiMeta": {
+          "example": "{\n  \"id\": \"sess_C9G5QPteg4UIbotdKLoYQ\",\n  \"type\": \"translation\",\n  \"expires_at\": 1756324625,\n  \"model\": \"gpt-realtime-translate\",\n  \"audio\": {\n    \"input\": {\n      \"transcription\": {\n        \"model\": \"gpt-realtime-whisper\"\n      },\n      \"noise_reduction\": null\n    },\n    \"output\": {\n      \"language\": \"es\"\n    }\n  }\n}\n",
+          "group": "realtime",
+          "name": "The translation session object"
+        }
+      },
+      "RealtimeTranslationSessionCreateRequest": {
+        "description": "Realtime translation session configuration. Translation sessions stream source\naudio in and translated audio plus transcript deltas out continuously.\n",
+        "properties": {
+          "audio": {
+            "description": "Configuration for translation input and output audio.\n",
+            "properties": {
+              "input": {
+                "properties": {
+                  "noise_reduction": {
+                    "anyOf": [
+                      {
+                        "description": "Optional input noise reduction. Set to `null` to disable it.\n",
+                        "properties": {
+                          "type": {
+                            "$ref": "#/components/schemas/NoiseReductionType"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "transcription": {
+                    "anyOf": [
+                      {
+                        "description": "Optional source-language transcription. When configured, the server emits\n`session.input_transcript.delta` events. Translation itself still runs from\nthe input audio stream.\n",
+                        "properties": {
+                          "model": {
+                            "description": "The transcription model to use for source transcript deltas.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "output": {
+                "properties": {
+                  "language": {
+                    "description": "Target language for translated output audio and transcript deltas.\n",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          },
+          "model": {
+            "description": "The Realtime translation model used for this session.\n",
+            "type": "string"
+          }
+        },
+        "required": [
+          "model"
+        ],
+        "title": "Realtime translation session configuration",
+        "type": "object"
+      },
+      "RealtimeTranslationSessionUpdateRequest": {
+        "description": "Realtime translation session fields that can be updated with `session.update`.\n",
+        "properties": {
+          "audio": {
+            "description": "Configuration for translation input and output audio.\n",
+            "properties": {
+              "input": {
+                "properties": {
+                  "noise_reduction": {
+                    "anyOf": [
+                      {
+                        "description": "Optional input noise reduction. Set to `null` to disable it.\n",
+                        "properties": {
+                          "type": {
+                            "$ref": "#/components/schemas/NoiseReductionType"
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "transcription": {
+                    "anyOf": [
+                      {
+                        "description": "Optional source-language transcription. When configured, the server emits\n`session.input_transcript.delta` events. Translation itself still runs from\nthe input audio stream.\n",
+                        "properties": {
+                          "model": {
+                            "description": "The transcription model to use for source transcript deltas.",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "model"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "output": {
+                "properties": {
+                  "language": {
+                    "description": "Target language for translated output audio and transcript deltas.\n",
+                    "type": "string"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
+          }
+        },
+        "title": "Realtime translation session update",
+        "type": "object"
       },
       "RealtimeTruncation": {
         "anyOf": [
@@ -30836,7 +32332,7 @@
                 "type": "object"
               }
             ],
-            "description": "Configuration for turn detection, ether Server VAD or Semantic VAD. This can be set to `null` to turn off, in which case the client must manually trigger model response.\n\nServer VAD means that the model will detect the start and end of speech based on audio volume and respond at the end of user speech.\n\nSemantic VAD is more advanced and uses a turn detection model (in conjunction with VAD) to semantically estimate whether the user has finished speaking, then dynamically sets a timeout based on this probability. For example, if user audio trails off with \"uhhm\", the model will score a low probability of turn end and wait longer for the user to continue speaking. This can be useful for more natural conversations, but may have a higher latency.\n",
+            "description": "Configuration for turn detection, ether Server VAD or Semantic VAD. This can be set to `null` to turn off, in which case the client must manually trigger model response.\n\nServer VAD means that the model will detect the start and end of speech based on audio volume and respond at the end of user speech.\n\nSemantic VAD is more advanced and uses a turn detection model (in conjunction with VAD) to semantically estimate whether the user has finished speaking, then dynamically sets a timeout based on this probability. For example, if user audio trails off with \"uhhm\", the model will score a low probability of turn end and wait longer for the user to continue speaking. This can be useful for more natural conversations, but may have a higher latency.\n\nFor `gpt-realtime-whisper` transcription sessions, turn detection must be\nset to `null`; VAD is not supported.\n",
             "discriminator": {
               "propertyName": "type"
             },
@@ -31030,6 +32526,7 @@
                 "anyOf": [
                   {
                     "description": "Unix timestamp (in seconds) of when this Response was completed.\nOnly present when the status is `completed`.\n",
+                    "format": "unixtime",
                     "type": "number"
                   },
                   {
@@ -31049,6 +32546,7 @@
               },
               "created_at": {
                 "description": "Unix timestamp (in seconds) of when this Response was created.\n",
+                "format": "unixtime",
                 "type": "number"
               },
               "error": {
@@ -32497,7 +33995,7 @@
             "type": "string"
           },
           "top_logprobs": {
-            "description": "The log probability of the top 20 most likely tokens.\n",
+            "description": "The log probabilities of up to 20 of the most likely tokens.\n",
             "items": {
               "properties": {
                 "logprob": {
@@ -34465,25 +35963,30 @@
           },
           "cancelled_at": {
             "description": "The Unix timestamp (in seconds) for when the run was cancelled.",
+            "format": "unixtime",
             "nullable": true,
             "type": "integer"
           },
           "completed_at": {
             "description": "The Unix timestamp (in seconds) for when the run was completed.",
+            "format": "unixtime",
             "nullable": true,
             "type": "integer"
           },
           "created_at": {
             "description": "The Unix timestamp (in seconds) for when the run was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "expires_at": {
             "description": "The Unix timestamp (in seconds) for when the run will expire.",
+            "format": "unixtime",
             "nullable": true,
             "type": "integer"
           },
           "failed_at": {
             "description": "The Unix timestamp (in seconds) for when the run failed.",
+            "format": "unixtime",
             "nullable": true,
             "type": "integer"
           },
@@ -34605,6 +36108,7 @@
           },
           "started_at": {
             "description": "The Unix timestamp (in seconds) for when the run was started.",
+            "format": "unixtime",
             "nullable": true,
             "type": "integer"
           },
@@ -35425,6 +36929,7 @@
             "anyOf": [
               {
                 "description": "The Unix timestamp (in seconds) for when the run step was cancelled.",
+                "format": "unixtime",
                 "type": "integer"
               },
               {
@@ -35436,6 +36941,7 @@
             "anyOf": [
               {
                 "description": "The Unix timestamp (in seconds) for when the run step completed.",
+                "format": "unixtime",
                 "type": "integer"
               },
               {
@@ -35445,12 +36951,14 @@
           },
           "created_at": {
             "description": "The Unix timestamp (in seconds) for when the run step was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "expired_at": {
             "anyOf": [
               {
                 "description": "The Unix timestamp (in seconds) for when the run step expired. A step is considered expired if the parent run is expired.",
+                "format": "unixtime",
                 "type": "integer"
               },
               {
@@ -35462,6 +36970,7 @@
             "anyOf": [
               {
                 "description": "The Unix timestamp (in seconds) for when the run step failed.",
+                "format": "unixtime",
                 "type": "integer"
               },
               {
@@ -36234,6 +37743,7 @@
         "properties": {
           "created_at": {
             "description": "Unix timestamp (seconds) for when the skill was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "default_version": {
@@ -36332,6 +37842,7 @@
         "properties": {
           "created_at": {
             "description": "Unix timestamp (seconds) for when the version was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "description": {
@@ -36688,6 +38199,7 @@
         "properties": {
           "created_at": {
             "description": "Unix timestamp (in seconds) for when the item was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -36778,6 +38290,7 @@
         "properties": {
           "created_at": {
             "description": "Unix timestamp (in seconds) for when the item was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "heading": {
@@ -37098,6 +38611,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) for when the thread was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -37186,6 +38700,7 @@
         "properties": {
           "created_at": {
             "description": "Unix timestamp (in seconds) for when the thread was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -38139,7 +39654,7 @@
         "properties": {
           "end": {
             "description": "End timestamp of the segment in seconds.",
-            "format": "float",
+            "format": "double",
             "type": "number"
           },
           "id": {
@@ -38152,7 +39667,7 @@
           },
           "start": {
             "description": "Start timestamp of the segment in seconds.",
-            "format": "float",
+            "format": "double",
             "type": "number"
           },
           "text": {
@@ -38188,6 +39703,7 @@
         "properties": {
           "seconds": {
             "description": "Duration of the input audio in seconds.",
+            "format": "double",
             "type": "number"
           },
           "type": {
@@ -38283,7 +39799,7 @@
         "properties": {
           "end": {
             "description": "End timestamp of the segment in seconds.",
-            "format": "float",
+            "format": "double",
             "type": "number"
           },
           "id": {
@@ -38296,7 +39812,7 @@
           },
           "start": {
             "description": "Start timestamp of the segment in seconds.",
-            "format": "float",
+            "format": "double",
             "type": "number"
           },
           "text": {
@@ -38342,7 +39858,7 @@
           },
           "end": {
             "description": "End time of the segment in seconds.",
-            "format": "float",
+            "format": "double",
             "type": "number"
           },
           "id": {
@@ -38360,7 +39876,7 @@
           },
           "start": {
             "description": "Start time of the segment in seconds.",
-            "format": "float",
+            "format": "double",
             "type": "number"
           },
           "temperature": {
@@ -38398,12 +39914,12 @@
         "properties": {
           "end": {
             "description": "End time of the word in seconds.",
-            "format": "float",
+            "format": "double",
             "type": "number"
           },
           "start": {
             "description": "Start time of the word in seconds.",
-            "format": "float",
+            "format": "double",
             "type": "number"
           },
           "word": {
@@ -38570,10 +40086,12 @@
           },
           "created_at": {
             "description": "The Unix timestamp (in seconds) for when the Upload was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "expires_at": {
             "description": "The Unix timestamp (in seconds) for when the Upload will expire.",
+            "format": "unixtime",
             "type": "integer"
           },
           "file": {
@@ -38637,7 +40155,7 @@
       },
       "UploadCertificateRequest": {
         "properties": {
-          "content": {
+          "certificate": {
             "description": "The certificate content in PEM format",
             "type": "string"
           },
@@ -38647,7 +40165,7 @@
           }
         },
         "required": [
-          "content"
+          "certificate"
         ],
         "type": "object"
       },
@@ -38656,6 +40174,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) for when the Part was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -38726,6 +40245,7 @@
           },
           "url": {
             "description": "URL referenced by the annotation.",
+            "format": "uri",
             "type": "string"
           }
         },
@@ -38762,6 +40282,7 @@
           },
           "url": {
             "description": "The URL of the web resource.",
+            "format": "uri",
             "type": "string"
           }
         },
@@ -38898,6 +40419,7 @@
           },
           "seconds": {
             "description": "The number of seconds processed.",
+            "format": "int64",
             "type": "integer"
           },
           "user_id": {
@@ -38951,7 +40473,7 @@
         },
         "required": [
           "object",
-          "sessions"
+          "num_sessions"
         ],
         "type": "object",
         "x-oaiMeta": {
@@ -39328,7 +40850,14 @@
             "type": "boolean"
           },
           "next_page": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "object": {
             "enum": [
@@ -39358,7 +40887,7 @@
             "type": "string",
             "x-stainless-const": true
           },
-          "result": {
+          "results": {
             "items": {
               "anyOf": [
                 {
@@ -39403,7 +40932,7 @@
           "object",
           "start_time",
           "end_time",
-          "result"
+          "results"
         ],
         "type": "object"
       },
@@ -39448,19 +40977,85 @@
         "properties": {
           "added_at": {
             "description": "The Unix timestamp (in seconds) of when the user was added.",
+            "format": "unixtime",
             "type": "integer"
           },
+          "api_key_last_used_at": {
+            "anyOf": [
+              {
+                "format": "unixtime",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The Unix timestamp (in seconds) of the user's last API key usage."
+          },
+          "created": {
+            "description": "The Unix timestamp (in seconds) of when the user was created.",
+            "format": "unixtime",
+            "type": "integer"
+          },
+          "developer_persona": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The developer persona metadata for the user."
+          },
           "email": {
-            "description": "The email address of the user",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The email address of the user"
           },
           "id": {
             "description": "The identifier, which can be referenced in API endpoints",
             "type": "string"
           },
+          "is_default": {
+            "description": "Whether this is the organization's default user.",
+            "type": "boolean"
+          },
+          "is_scale_tier_authorized_purchaser": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Whether the user is an authorized purchaser for Scale Tier."
+          },
+          "is_scim_managed": {
+            "description": "Whether the user is managed through SCIM.",
+            "type": "boolean"
+          },
+          "is_service_account": {
+            "description": "Whether the user is a service account.",
+            "type": "boolean"
+          },
           "name": {
-            "description": "The name of the user",
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The name of the user"
           },
           "object": {
             "description": "The object type, which is always `organization.user`",
@@ -39470,21 +41065,175 @@
             "type": "string",
             "x-stainless-const": true
           },
-          "role": {
-            "description": "`owner` or `reader`",
-            "enum": [
-              "owner",
-              "reader"
+          "projects": {
+            "anyOf": [
+              {
+                "properties": {
+                  "data": {
+                    "items": {
+                      "properties": {
+                        "id": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "name": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        },
+                        "role": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "object": {
+                    "enum": [
+                      "list"
+                    ],
+                    "type": "string",
+                    "x-stainless-const": true
+                  }
+                },
+                "required": [
+                  "object",
+                  "data"
+                ],
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
             ],
-            "type": "string"
+            "description": "Projects associated with the user, if included."
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "`owner` or `reader`"
+          },
+          "technical_level": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The technical level metadata for the user."
+          },
+          "user": {
+            "description": "Nested user details.",
+            "properties": {
+              "banned": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "banned_at": {
+                "anyOf": [
+                  {
+                    "format": "unixtime",
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "email": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "enabled": {
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "object": {
+                "enum": [
+                  "user"
+                ],
+                "type": "string",
+                "x-stainless-const": true
+              },
+              "picture": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "object",
+              "id"
+            ],
+            "type": "object"
           }
         },
         "required": [
           "object",
           "id",
-          "name",
-          "email",
-          "role",
           "added_at"
         ],
         "type": "object",
@@ -39522,7 +41271,7 @@
           "data": {
             "description": "Users in the current page.",
             "items": {
-              "$ref": "#/components/schemas/User"
+              "$ref": "#/components/schemas/GroupUser"
             },
             "type": "array"
           },
@@ -39558,7 +41307,7 @@
         ],
         "type": "object",
         "x-oaiMeta": {
-          "example": "{\n    \"object\": \"list\",\n    \"data\": [\n        {\n            \"object\": \"organization.user\",\n            \"id\": \"user_abc123\",\n            \"name\": \"Ada Lovelace\",\n            \"email\": \"ada@example.com\",\n            \"role\": \"owner\",\n            \"added_at\": 1711471533\n        }\n    ],\n    \"has_more\": false,\n    \"next\": null\n}\n",
+          "example": "{\n    \"object\": \"list\",\n    \"data\": [\n        {\n            \"id\": \"user_abc123\",\n            \"name\": \"Ada Lovelace\",\n            \"email\": \"ada@example.com\"\n        }\n    ],\n    \"has_more\": false,\n    \"next\": null\n}\n",
           "name": "Group user list"
         }
       },
@@ -39571,13 +41320,27 @@
             "type": "array"
           },
           "first_id": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "has_more": {
             "type": "boolean"
           },
           "last_id": {
-            "type": "string"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "object": {
             "enum": [
@@ -39590,8 +41353,6 @@
         "required": [
           "object",
           "data",
-          "first_id",
-          "last_id",
           "has_more"
         ],
         "type": "object"
@@ -39650,6 +41411,7 @@
           },
           "created_at": {
             "description": "Unix timestamp (in seconds) for when the item was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -39757,18 +41519,51 @@
       },
       "UserRoleUpdateRequest": {
         "properties": {
-          "role": {
-            "description": "`owner` or `reader`",
-            "enum": [
-              "owner",
-              "reader"
+          "developer_persona": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
             ],
-            "type": "string"
+            "description": "Developer persona metadata."
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "`owner` or `reader`"
+          },
+          "role_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Role ID to assign to the user."
+          },
+          "technical_level": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Technical level metadata."
           }
         },
-        "required": [
-          "role"
-        ],
         "type": "object"
       },
       "VadConfig": {
@@ -39920,6 +41715,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) for when the vector store files batch was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "file_counts": {
@@ -40060,6 +41856,7 @@
           },
           "created_at": {
             "description": "The Unix timestamp (in seconds) for when the vector store file was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -40145,6 +41942,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) for when the vector store was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "expires_after": {
@@ -40154,6 +41952,7 @@
             "anyOf": [
               {
                 "description": "The Unix timestamp (in seconds) for when the vector store will expire.",
+                "format": "unixtime",
                 "type": "integer"
               },
               {
@@ -40201,6 +42000,7 @@
             "anyOf": [
               {
                 "description": "The Unix timestamp (in seconds) for when the vector store was last active.",
+                "format": "unixtime",
                 "type": "integer"
               },
               {
@@ -40468,6 +42268,7 @@
         "properties": {
           "created_at": {
             "description": "Unix timestamp (in seconds) when the character was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -40597,6 +42398,7 @@
             "anyOf": [
               {
                 "description": "Unix timestamp (seconds) for when the job completed, if finished.",
+                "format": "unixtime",
                 "type": "integer"
               },
               {
@@ -40606,6 +42408,7 @@
           },
           "created_at": {
             "description": "Unix timestamp (seconds) for when the job was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "error": {
@@ -40623,6 +42426,7 @@
             "anyOf": [
               {
                 "description": "Unix timestamp (seconds) for when the downloadable assets expire, if set.",
+                "format": "unixtime",
                 "type": "integer"
               },
               {
@@ -40824,6 +42628,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) for when the consent recording was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -40915,6 +42720,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) for when the voice was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -41056,6 +42862,7 @@
                 },
                 "url": {
                   "description": "The URL of the source.\n",
+                  "format": "uri",
                   "type": "string"
                 }
               },
@@ -41346,6 +43153,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) of when the batch API request was cancelled.\n",
+            "format": "unixtime",
             "type": "integer"
           },
           "data": {
@@ -41401,6 +43209,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) of when the batch API request was completed.\n",
+            "format": "unixtime",
             "type": "integer"
           },
           "data": {
@@ -41456,6 +43265,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) of when the batch API request expired.\n",
+            "format": "unixtime",
             "type": "integer"
           },
           "data": {
@@ -41511,6 +43321,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) of when the batch API request failed.\n",
+            "format": "unixtime",
             "type": "integer"
           },
           "data": {
@@ -41566,6 +43377,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) of when the eval run was canceled.\n",
+            "format": "unixtime",
             "type": "integer"
           },
           "data": {
@@ -41621,6 +43433,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) of when the eval run failed.\n",
+            "format": "unixtime",
             "type": "integer"
           },
           "data": {
@@ -41676,6 +43489,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) of when the eval run succeeded.\n",
+            "format": "unixtime",
             "type": "integer"
           },
           "data": {
@@ -41731,6 +43545,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) of when the fine-tuning job was cancelled.\n",
+            "format": "unixtime",
             "type": "integer"
           },
           "data": {
@@ -41786,6 +43601,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) of when the fine-tuning job failed.\n",
+            "format": "unixtime",
             "type": "integer"
           },
           "data": {
@@ -41841,6 +43657,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) of when the fine-tuning job succeeded.\n",
+            "format": "unixtime",
             "type": "integer"
           },
           "data": {
@@ -41896,6 +43713,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) of when the model response was completed.\n",
+            "format": "unixtime",
             "type": "integer"
           },
           "data": {
@@ -41974,6 +43792,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) of when the model response was cancelled.\n",
+            "format": "unixtime",
             "type": "integer"
           },
           "data": {
@@ -42029,6 +43848,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) of when the model response was completed.\n",
+            "format": "unixtime",
             "type": "integer"
           },
           "data": {
@@ -42084,6 +43904,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) of when the model response failed.\n",
+            "format": "unixtime",
             "type": "integer"
           },
           "data": {
@@ -42139,6 +43960,7 @@
         "properties": {
           "created_at": {
             "description": "The Unix timestamp (in seconds) of when the model response was interrupted.\n",
+            "format": "unixtime",
             "type": "integer"
           },
           "data": {
@@ -42194,6 +44016,7 @@
         "properties": {
           "created_at": {
             "description": "Unix timestamp (in seconds) for when the item was created.",
+            "format": "unixtime",
             "type": "integer"
           },
           "id": {
@@ -42297,6 +44120,10 @@
       }
     },
     "securitySchemes": {
+      "AdminApiKeyAuth": {
+        "scheme": "bearer",
+        "type": "http"
+      },
       "ApiKeyAuth": {
         "scheme": "bearer",
         "type": "http"
@@ -46008,7 +47835,7 @@
         }
       },
       "post": {
-        "description": "Upload a file that can be used across various endpoints. Individual files\ncan be up to 512 MB, and each project can store up to 2.5 TB of files in\ntotal. There is no organization-wide storage limit.\n\n- The Assistants API supports files up to 2 million tokens and of specific\n  file types. See the [Assistants Tools guide](https://platform.openai.com/docs/assistants/tools) for\n  details.\n- The Fine-tuning API only supports `.jsonl` files. The input also has\n  certain required formats for fine-tuning\n  [chat](https://platform.openai.com/docs/api-reference/fine-tuning/chat-input) or\n  [completions](https://platform.openai.com/docs/api-reference/fine-tuning/completions-input) models.\n- The Batch API only supports `.jsonl` files up to 200 MB in size. The input\n  also has a specific required\n  [format](https://platform.openai.com/docs/api-reference/batch/request-input).\n\nPlease [contact us](https://help.openai.com/) if you need to increase these\nstorage limits.\n",
+        "description": "Upload a file that can be used across various endpoints. Individual files\ncan be up to 512 MB, and each project can store up to 2.5 TB of files in\ntotal. There is no organization-wide storage limit. Uploads to this\nendpoint are rate-limited to 1,000 requests per minute per authenticated\nuser.\n\n- The Assistants API supports files up to 2 million tokens and of specific\n  file types. See the [Assistants Tools guide](https://platform.openai.com/docs/assistants/tools) for\n  details.\n- The Fine-tuning API only supports `.jsonl` files. The input also has\n  certain required formats for fine-tuning\n  [chat](https://platform.openai.com/docs/api-reference/fine-tuning/chat-input) or\n  [completions](https://platform.openai.com/docs/api-reference/fine-tuning/completions-input) models.\n- The Batch API only supports `.jsonl` files up to 200 MB in size. The input\n  also has a specific required\n  [format](https://platform.openai.com/docs/api-reference/batch/request-input).\n- For Retrieval or `file_search` ingestion, upload files here first. If\n  you need to attach multiple uploaded files to the same vector store, use\n  [`/vector_stores/{vector_store_id}/file_batches`](https://platform.openai.com/docs/api-reference/vector-stores-file-batches/createBatch)\n  instead of attaching them one by one. Vector store attachment has separate\n  limits from file upload, including 2,000 attached files per minute per\n  organization.\n\nPlease [contact us](https://help.openai.com/) if you need to increase these\nstorage limits.\n",
         "operationId": "createFile",
         "requestBody": {
           "content": {
@@ -46037,6 +47864,7 @@
           "Files"
         ],
         "x-oaiMeta": {
+          "description": "Uploads a file for later use across OpenAI APIs. Uploads to this endpoint are rate-limited to 1,000 requests per minute per authenticated user. For Retrieval or `file_search` ingestion, upload files here first. If you need to attach multiple uploaded files to the same vector store, use vector store file batches instead of attaching them one by one.\n",
           "examples": {
             "request": {
               "curl": "curl https://api.openai.com/v1/files \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -F purpose=\"fine-tune\" \\\n  -F file=\"@mydata.jsonl\"\n  -F expires_after[anchor]=\"created_at\"\n  -F expires_after[seconds]=2592000\n",
@@ -47347,6 +49175,11 @@
             "description": "A list of organization API keys."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "List all organization and project API keys.",
         "x-oaiMeta": {
           "examples": {
@@ -47386,13 +49219,18 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AdminApiKey"
+                  "$ref": "#/components/schemas/AdminApiKeyCreateResponse"
                 }
               }
             },
             "description": "The newly created admin API key."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Create admin API key",
         "x-oaiMeta": {
           "examples": {
@@ -47436,10 +49274,19 @@
                       "type": "string"
                     },
                     "object": {
+                      "enum": [
+                        "organization.admin_api_key.deleted"
+                      ],
                       "example": "organization.admin_api_key.deleted",
-                      "type": "string"
+                      "type": "string",
+                      "x-stainless-const": true
                     }
                   },
+                  "required": [
+                    "id",
+                    "object",
+                    "deleted"
+                  ],
                   "type": "object"
                 }
               }
@@ -47447,6 +49294,11 @@
             "description": "Confirmation that the API key was deleted."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Delete admin API key",
         "x-oaiMeta": {
           "examples": {
@@ -47485,6 +49337,11 @@
             "description": "Details of the requested API key."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Retrieve admin API key",
         "x-oaiMeta": {
           "examples": {
@@ -47629,6 +49486,11 @@
             "description": "Audit logs listed successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "List audit logs",
         "tags": [
           "Audit Logs"
@@ -47695,6 +49557,11 @@
             "description": "Certificates listed successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "List organization certificates",
         "tags": [
           "Certificates"
@@ -47736,6 +49603,11 @@
             "description": "Certificate uploaded successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Upload certificate",
         "tags": [
           "Certificates"
@@ -47772,13 +49644,18 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListCertificatesResponse"
+                  "$ref": "#/components/schemas/OrganizationCertificateActivationResponse"
                 }
               }
             },
             "description": "Certificates activated successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Activate certificates for organization",
         "tags": [
           "Certificates"
@@ -47786,7 +49663,7 @@
         "x-oaiMeta": {
           "examples": {
             "request": {
-              "curl": "curl https://api.openai.com/v1/organization/certificates/activate \\\n-H \"Authorization: Bearer $OPENAI_ADMIN_KEY\" \\\n-H \"Content-Type: application/json\" \\\n-d '{\n  \"data\": [\"cert_abc\", \"cert_def\"]\n}'\n"
+              "curl": "curl https://api.openai.com/v1/organization/certificates/activate \\\n-H \"Authorization: Bearer $OPENAI_ADMIN_KEY\" \\\n-H \"Content-Type: application/json\" \\\n-d '{\n  \"certificate_ids\": [\"cert_abc\", \"cert_def\"]\n}'\n"
             },
             "response": "{\n  \"object\": \"organization.certificate.activation\",\n  \"data\": [\n    {\n      \"object\": \"organization.certificate\",\n      \"id\": \"cert_abc\",\n      \"name\": \"My Example Certificate\",\n      \"active\": true,\n      \"created_at\": 1234567,\n      \"certificate_details\": {\n        \"valid_at\": 12345667,\n        \"expires_at\": 12345678\n      }\n    },\n    {\n      \"object\": \"organization.certificate\",\n      \"id\": \"cert_def\",\n      \"name\": \"My Example Certificate 2\",\n      \"active\": true,\n      \"created_at\": 1234567,\n      \"certificate_details\": {\n        \"valid_at\": 12345667,\n        \"expires_at\": 12345678\n      }\n    },\n  ],\n}\n"
           },
@@ -47815,13 +49692,18 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListCertificatesResponse"
+                  "$ref": "#/components/schemas/OrganizationCertificateDeactivationResponse"
                 }
               }
             },
             "description": "Certificates deactivated successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Deactivate certificates for organization",
         "tags": [
           "Certificates"
@@ -47829,7 +49711,7 @@
         "x-oaiMeta": {
           "examples": {
             "request": {
-              "curl": "curl https://api.openai.com/v1/organization/certificates/deactivate \\\n-H \"Authorization: Bearer $OPENAI_ADMIN_KEY\" \\\n-H \"Content-Type: application/json\" \\\n-d '{\n  \"data\": [\"cert_abc\", \"cert_def\"]\n}'\n"
+              "curl": "curl https://api.openai.com/v1/organization/certificates/deactivate \\\n-H \"Authorization: Bearer $OPENAI_ADMIN_KEY\" \\\n-H \"Content-Type: application/json\" \\\n-d '{\n  \"certificate_ids\": [\"cert_abc\", \"cert_def\"]\n}'\n"
             },
             "response": "{\n  \"object\": \"organization.certificate.deactivation\",\n  \"data\": [\n    {\n      \"object\": \"organization.certificate\",\n      \"id\": \"cert_abc\",\n      \"name\": \"My Example Certificate\",\n      \"active\": false,\n      \"created_at\": 1234567,\n      \"certificate_details\": {\n        \"valid_at\": 12345667,\n        \"expires_at\": 12345678\n      }\n    },\n    {\n      \"object\": \"organization.certificate\",\n      \"id\": \"cert_def\",\n      \"name\": \"My Example Certificate 2\",\n      \"active\": false,\n      \"created_at\": 1234567,\n      \"certificate_details\": {\n        \"valid_at\": 12345667,\n        \"expires_at\": 12345678\n      }\n    },\n  ],\n}\n"
           },
@@ -47865,6 +49747,11 @@
             "description": "Certificate deleted successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Delete certificate",
         "tags": [
           "Certificates"
@@ -47921,6 +49808,11 @@
             "description": "Certificate retrieved successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Get certificate",
         "tags": [
           "Certificates"
@@ -47973,6 +49865,11 @@
             "description": "Certificate modified successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Modify certificate",
         "tags": [
           "Certificates"
@@ -48038,7 +49935,19 @@
             }
           },
           {
-            "description": "Group the costs by the specified fields. Support fields include `project_id`, `line_item` and any combination of them.",
+            "description": "Return only costs for these API keys.",
+            "in": "query",
+            "name": "api_key_ids",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Group the costs by the specified fields. Support fields include `project_id`, `line_item`, `api_key_id` and any combination of them.",
             "in": "query",
             "name": "group_by",
             "required": false,
@@ -48046,7 +49955,8 @@
               "items": {
                 "enum": [
                   "project_id",
-                  "line_item"
+                  "line_item",
+                  "api_key_id"
                 ],
                 "type": "string"
               },
@@ -48084,6 +49994,11 @@
             "description": "Costs data retrieved successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Costs",
         "tags": [
           "Usage"
@@ -48093,7 +50008,7 @@
             "request": {
               "curl": "curl \"https://api.openai.com/v1/organization/costs?start_time=1730419200&limit=1\" \\\n-H \"Authorization: Bearer $OPENAI_ADMIN_KEY\" \\\n-H \"Content-Type: application/json\"\n"
             },
-            "response": "{\n    \"object\": \"page\",\n    \"data\": [\n        {\n            \"object\": \"bucket\",\n            \"start_time\": 1730419200,\n            \"end_time\": 1730505600,\n            \"results\": [\n                {\n                    \"object\": \"organization.costs.result\",\n                    \"amount\": {\n                        \"value\": 0.06,\n                        \"currency\": \"usd\"\n                    },\n                    \"line_item\": null,\n                    \"project_id\": null\n                }\n            ]\n        }\n    ],\n    \"has_more\": false,\n    \"next_page\": null\n}\n"
+            "response": "{\n    \"object\": \"page\",\n    \"data\": [\n        {\n            \"object\": \"bucket\",\n            \"start_time\": 1730419200,\n            \"end_time\": 1730505600,\n            \"results\": [\n                {\n                    \"object\": \"organization.costs.result\",\n                    \"amount\": {\n                        \"value\": 0.06,\n                        \"currency\": \"usd\"\n                    },\n                    \"line_item\": null,\n                    \"project_id\": null,\n                    \"api_key_id\": null,\n                    \"quantity\": null\n                }\n            ]\n        }\n    ],\n    \"has_more\": false,\n    \"next_page\": null\n}\n"
           },
           "group": "usage-costs",
           "name": "Costs"
@@ -48153,6 +50068,11 @@
             "description": "Groups listed successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "List groups",
         "tags": [
           "Groups"
@@ -48194,6 +50114,11 @@
             "description": "Group created successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Create group",
         "tags": [
           "Groups"
@@ -48237,6 +50162,11 @@
             "description": "Group deleted successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Delete group",
         "tags": [
           "Groups"
@@ -48289,6 +50219,11 @@
             "description": "Group updated successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Update group",
         "tags": [
           "Groups"
@@ -48365,6 +50300,11 @@
             "description": "Group organization role assignments listed successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "List group organization role assignments",
         "tags": [
           "Group organization role assignments"
@@ -48417,6 +50357,11 @@
             "description": "Organization role assigned to the group successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Assign organization role to group",
         "tags": [
           "Group organization role assignments"
@@ -48469,6 +50414,11 @@
             "description": "Organization role unassigned from the group successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Unassign organization role from group",
         "tags": [
           "Group organization role assignments"
@@ -48547,6 +50497,11 @@
             "description": "Group users listed successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "List group users",
         "tags": [
           "Group users"
@@ -48556,7 +50511,7 @@
             "request": {
               "curl": "curl https://api.openai.com/v1/organization/groups/group_01J1F8ABCDXYZ/users?limit=20 \\\n  -H \"Authorization: Bearer $OPENAI_ADMIN_KEY\" \\\n  -H \"Content-Type: application/json\"\n"
             },
-            "response": "{\n    \"object\": \"list\",\n    \"data\": [\n        {\n            \"object\": \"organization.user\",\n            \"id\": \"user_abc123\",\n            \"name\": \"Ada Lovelace\",\n            \"email\": \"ada@example.com\",\n            \"role\": \"owner\",\n            \"added_at\": 1711471533\n        }\n    ],\n    \"has_more\": false,\n    \"next\": null\n}\n"
+            "response": "{\n    \"object\": \"list\",\n    \"data\": [\n        {\n            \"id\": \"user_abc123\",\n            \"name\": \"Ada Lovelace\",\n            \"email\": \"ada@example.com\"\n        }\n    ],\n    \"has_more\": false,\n    \"next\": null\n}\n"
           },
           "group": "administration",
           "name": "List group users"
@@ -48599,6 +50554,11 @@
             "description": "User added to the group successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Add group user",
         "tags": [
           "Group users"
@@ -48651,6 +50611,11 @@
             "description": "User removed from the group successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Remove group user",
         "tags": [
           "Group users"
@@ -48704,6 +50669,11 @@
             "description": "Invites listed successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "List invites",
         "tags": [
           "Invites"
@@ -48713,7 +50683,7 @@
             "request": {
               "curl": "curl https://api.openai.com/v1/organization/invites?after=invite-abc&limit=20 \\\n  -H \"Authorization: Bearer $OPENAI_ADMIN_KEY\" \\\n  -H \"Content-Type: application/json\"\n"
             },
-            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"object\": \"organization.invite\",\n      \"id\": \"invite-abc\",\n      \"email\": \"user@example.com\",\n      \"role\": \"owner\",\n      \"status\": \"accepted\",\n      \"invited_at\": 1711471533,\n      \"expires_at\": 1711471533,\n      \"accepted_at\": 1711471533\n    }\n  ],\n  \"first_id\": \"invite-abc\",\n  \"last_id\": \"invite-abc\",\n  \"has_more\": false\n}\n"
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"object\": \"organization.invite\",\n      \"id\": \"invite-abc\",\n      \"email\": \"user@example.com\",\n      \"role\": \"owner\",\n      \"status\": \"accepted\",\n      \"created_at\": 1711471533,\n      \"expires_at\": 1711471533,\n      \"accepted_at\": 1711471533\n    }\n  ],\n  \"first_id\": \"invite-abc\",\n  \"last_id\": \"invite-abc\",\n  \"has_more\": false\n}\n"
           },
           "group": "administration",
           "name": "List invites"
@@ -48745,6 +50715,11 @@
             "description": "User invited successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Create invite",
         "tags": [
           "Invites"
@@ -48754,7 +50729,7 @@
             "request": {
               "curl": "curl -X POST https://api.openai.com/v1/organization/invites \\\n  -H \"Authorization: Bearer $OPENAI_ADMIN_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n      \"email\": \"anotheruser@example.com\",\n      \"role\": \"reader\",\n      \"projects\": [\n        {\n          \"id\": \"project-xyz\",\n          \"role\": \"member\"\n        },\n        {\n          \"id\": \"project-abc\",\n          \"role\": \"owner\"\n        }\n      ]\n  }'\n"
             },
-            "response": "{\n  \"object\": \"organization.invite\",\n  \"id\": \"invite-def\",\n  \"email\": \"anotheruser@example.com\",\n  \"role\": \"reader\",\n  \"status\": \"pending\",\n  \"invited_at\": 1711471533,\n  \"expires_at\": 1711471533,\n  \"accepted_at\": null,\n  \"projects\": [\n    {\n      \"id\": \"project-xyz\",\n      \"role\": \"member\"\n    },\n    {\n      \"id\": \"project-abc\",\n      \"role\": \"owner\"\n    }\n  ]\n}\n"
+            "response": "{\n  \"object\": \"organization.invite\",\n  \"id\": \"invite-def\",\n  \"email\": \"anotheruser@example.com\",\n  \"role\": \"reader\",\n  \"status\": \"pending\",\n  \"created_at\": 1711471533,\n  \"expires_at\": 1711471533,\n  \"accepted_at\": null,\n  \"projects\": [\n    {\n      \"id\": \"project-xyz\",\n      \"role\": \"member\"\n    },\n    {\n      \"id\": \"project-abc\",\n      \"role\": \"owner\"\n    }\n  ]\n}\n"
           },
           "group": "administration",
           "name": "Create invite"
@@ -48788,6 +50763,11 @@
             "description": "Invite deleted successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Delete invite",
         "tags": [
           "Invites"
@@ -48829,6 +50809,11 @@
             "description": "Invite retrieved successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Retrieve invite",
         "tags": [
           "Invites"
@@ -48838,7 +50823,7 @@
             "request": {
               "curl": "curl https://api.openai.com/v1/organization/invites/invite-abc \\\n  -H \"Authorization: Bearer $OPENAI_ADMIN_KEY\" \\\n  -H \"Content-Type: application/json\"\n"
             },
-            "response": "{\n    \"object\": \"organization.invite\",\n    \"id\": \"invite-abc\",\n    \"email\": \"user@example.com\",\n    \"role\": \"owner\",\n    \"status\": \"accepted\",\n    \"invited_at\": 1711471533,\n    \"expires_at\": 1711471533,\n    \"accepted_at\": 1711471533\n}\n"
+            "response": "{\n    \"object\": \"organization.invite\",\n    \"id\": \"invite-abc\",\n    \"email\": \"user@example.com\",\n    \"role\": \"owner\",\n    \"status\": \"accepted\",\n    \"created_at\": 1711471533,\n    \"expires_at\": 1711471533,\n    \"accepted_at\": 1711471533\n}\n"
           },
           "group": "administration",
           "name": "Retrieve invite"
@@ -48891,6 +50876,11 @@
             "description": "Projects listed successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "List projects",
         "tags": [
           "Projects"
@@ -48932,6 +50922,11 @@
             "description": "Project created successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Create project",
         "tags": [
           "Projects"
@@ -48975,6 +50970,11 @@
             "description": "Project retrieved successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Retrieve project",
         "tags": [
           "Projects"
@@ -49038,6 +51038,11 @@
             "description": "Error response when updating the default project."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Modify project",
         "tags": [
           "Projects"
@@ -49099,6 +51104,11 @@
             "description": "Project API keys listed successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "List project API keys",
         "tags": [
           "Projects"
@@ -49108,14 +51118,14 @@
             "request": {
               "curl": "curl https://api.openai.com/v1/organization/projects/proj_abc/api_keys?after=key_abc&limit=20 \\\n  -H \"Authorization: Bearer $OPENAI_ADMIN_KEY\" \\\n  -H \"Content-Type: application/json\"\n"
             },
-            "response": "{\n    \"object\": \"list\",\n    \"data\": [\n        {\n            \"object\": \"organization.project.api_key\",\n            \"redacted_value\": \"sk-abc...def\",\n            \"name\": \"My API Key\",\n            \"created_at\": 1711471533,\n            \"last_used_at\": 1711471534,\n            \"id\": \"key_abc\",\n            \"owner\": {\n                \"type\": \"user\",\n                \"user\": {\n                    \"object\": \"organization.project.user\",\n                    \"id\": \"user_abc\",\n                    \"name\": \"First Last\",\n                    \"email\": \"user@example.com\",\n                    \"role\": \"owner\",\n                    \"added_at\": 1711471533\n                }\n            }\n        }\n    ],\n    \"first_id\": \"key_abc\",\n    \"last_id\": \"key_xyz\",\n    \"has_more\": false\n}\n"
+            "response": "{\n    \"object\": \"list\",\n    \"data\": [\n        {\n            \"object\": \"organization.project.api_key\",\n            \"redacted_value\": \"sk-abc...def\",\n            \"name\": \"My API Key\",\n            \"created_at\": 1711471533,\n            \"last_used_at\": 1711471534,\n            \"id\": \"key_abc\",\n            \"owner\": {\n                \"type\": \"user\",\n                \"user\": {\n                    \"id\": \"user_abc\",\n                    \"name\": \"First Last\",\n                    \"email\": \"user@example.com\",\n                    \"role\": \"owner\",\n                    \"created_at\": 1711471533\n                }\n            }\n        }\n    ],\n    \"first_id\": \"key_abc\",\n    \"last_id\": \"key_xyz\",\n    \"has_more\": false\n}\n"
           },
           "group": "administration",
           "name": "List project API keys"
         }
       }
     },
-    "/organization/projects/{project_id}/api_keys/{key_id}": {
+    "/organization/projects/{project_id}/api_keys/{api_key_id}": {
       "delete": {
         "description": "Deletes an API key from the project.\n\nReturns confirmation of the key deletion, or an error if the key belonged to\na service account.\n",
         "operationId": "delete-project-api-key",
@@ -49132,7 +51142,7 @@
           {
             "description": "The ID of the API key.",
             "in": "path",
-            "name": "key_id",
+            "name": "api_key_id",
             "required": true,
             "schema": {
               "type": "string"
@@ -49161,6 +51171,11 @@
             "description": "Error response for various conditions."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Delete project API key",
         "tags": [
           "Projects"
@@ -49192,7 +51207,7 @@
           {
             "description": "The ID of the API key.",
             "in": "path",
-            "name": "key_id",
+            "name": "api_key_id",
             "required": true,
             "schema": {
               "type": "string"
@@ -49211,6 +51226,11 @@
             "description": "Project API key retrieved successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Retrieve project API key",
         "tags": [
           "Projects"
@@ -49220,7 +51240,7 @@
             "request": {
               "curl": "curl https://api.openai.com/v1/organization/projects/proj_abc/api_keys/key_abc \\\n  -H \"Authorization: Bearer $OPENAI_ADMIN_KEY\" \\\n  -H \"Content-Type: application/json\"\n"
             },
-            "response": "{\n    \"object\": \"organization.project.api_key\",\n    \"redacted_value\": \"sk-abc...def\",\n    \"name\": \"My API Key\",\n    \"created_at\": 1711471533,\n    \"last_used_at\": 1711471534,\n    \"id\": \"key_abc\",\n    \"owner\": {\n        \"type\": \"user\",\n        \"user\": {\n            \"object\": \"organization.project.user\",\n            \"id\": \"user_abc\",\n            \"name\": \"First Last\",\n            \"email\": \"user@example.com\",\n            \"role\": \"owner\",\n            \"added_at\": 1711471533\n        }\n    }\n}\n"
+            "response": "{\n    \"object\": \"organization.project.api_key\",\n    \"redacted_value\": \"sk-abc...def\",\n    \"name\": \"My API Key\",\n    \"created_at\": 1711471533,\n    \"last_used_at\": 1711471534,\n    \"id\": \"key_abc\",\n    \"owner\": {\n        \"type\": \"user\",\n        \"user\": {\n            \"id\": \"user_abc\",\n            \"name\": \"First Last\",\n            \"email\": \"user@example.com\",\n            \"role\": \"owner\",\n            \"created_at\": 1711471533\n        }\n    }\n}\n"
           },
           "group": "administration",
           "name": "Retrieve project API key"
@@ -49254,6 +51274,11 @@
             "description": "Project archived successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Archive project",
         "tags": [
           "Projects"
@@ -49322,13 +51347,18 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListCertificatesResponse"
+                  "$ref": "#/components/schemas/ListProjectCertificatesResponse"
                 }
               }
             },
             "description": "Certificates listed successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "List project certificates",
         "tags": [
           "Certificates"
@@ -49376,13 +51406,18 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListCertificatesResponse"
+                  "$ref": "#/components/schemas/OrganizationProjectCertificateActivationResponse"
                 }
               }
             },
             "description": "Certificates activated successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Activate certificates for project",
         "tags": [
           "Certificates"
@@ -49390,7 +51425,7 @@
         "x-oaiMeta": {
           "examples": {
             "request": {
-              "curl": "curl https://api.openai.com/v1/organization/projects/proj_abc/certificates/activate \\\n-H \"Authorization: Bearer $OPENAI_ADMIN_KEY\" \\\n-H \"Content-Type: application/json\" \\\n-d '{\n  \"data\": [\"cert_abc\", \"cert_def\"]\n}'\n"
+              "curl": "curl https://api.openai.com/v1/organization/projects/proj_abc/certificates/activate \\\n-H \"Authorization: Bearer $OPENAI_ADMIN_KEY\" \\\n-H \"Content-Type: application/json\" \\\n-d '{\n  \"certificate_ids\": [\"cert_abc\", \"cert_def\"]\n}'\n"
             },
             "response": "{\n  \"object\": \"organization.project.certificate.activation\",\n  \"data\": [\n    {\n      \"object\": \"organization.project.certificate\",\n      \"id\": \"cert_abc\",\n      \"name\": \"My Example Certificate\",\n      \"active\": true,\n      \"created_at\": 1234567,\n      \"certificate_details\": {\n        \"valid_at\": 12345667,\n        \"expires_at\": 12345678\n      }\n    },\n    {\n      \"object\": \"organization.project.certificate\",\n      \"id\": \"cert_def\",\n      \"name\": \"My Example Certificate 2\",\n      \"active\": true,\n      \"created_at\": 1234567,\n      \"certificate_details\": {\n        \"valid_at\": 12345667,\n        \"expires_at\": 12345678\n      }\n    },\n  ],\n}\n"
           },
@@ -49430,13 +51465,18 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ListCertificatesResponse"
+                  "$ref": "#/components/schemas/OrganizationProjectCertificateDeactivationResponse"
                 }
               }
             },
             "description": "Certificates deactivated successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Deactivate certificates for project",
         "tags": [
           "Certificates"
@@ -49444,7 +51484,7 @@
         "x-oaiMeta": {
           "examples": {
             "request": {
-              "curl": "curl https://api.openai.com/v1/organization/projects/proj_abc/certificates/deactivate \\\n-H \"Authorization: Bearer $OPENAI_ADMIN_KEY\" \\\n-H \"Content-Type: application/json\" \\\n-d '{\n  \"data\": [\"cert_abc\", \"cert_def\"]\n}'\n"
+              "curl": "curl https://api.openai.com/v1/organization/projects/proj_abc/certificates/deactivate \\\n-H \"Authorization: Bearer $OPENAI_ADMIN_KEY\" \\\n-H \"Content-Type: application/json\" \\\n-d '{\n  \"certificate_ids\": [\"cert_abc\", \"cert_def\"]\n}'\n"
             },
             "response": "{\n  \"object\": \"organization.project.certificate.deactivation\",\n  \"data\": [\n    {\n      \"object\": \"organization.project.certificate\",\n      \"id\": \"cert_abc\",\n      \"name\": \"My Example Certificate\",\n      \"active\": false,\n      \"created_at\": 1234567,\n      \"certificate_details\": {\n        \"valid_at\": 12345667,\n        \"expires_at\": 12345678\n      }\n    },\n    {\n      \"object\": \"organization.project.certificate\",\n      \"id\": \"cert_def\",\n      \"name\": \"My Example Certificate 2\",\n      \"active\": false,\n      \"created_at\": 1234567,\n      \"certificate_details\": {\n        \"valid_at\": 12345667,\n        \"expires_at\": 12345678\n      }\n    },\n  ],\n}\n"
           },
@@ -49515,6 +51555,11 @@
             "description": "Project groups listed successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "List project groups",
         "tags": [
           "Project groups"
@@ -49567,6 +51612,11 @@
             "description": "Group granted access to the project successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Add project group",
         "tags": [
           "Project groups"
@@ -49619,6 +51669,11 @@
             "description": "Group removed from the project successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Remove project group",
         "tags": [
           "Project groups"
@@ -49690,6 +51745,11 @@
             "description": "Project rate limits listed successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "List project rate limits",
         "tags": [
           "Projects"
@@ -49764,6 +51824,11 @@
             "description": "Error response for various conditions."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Modify project rate limit",
         "tags": [
           "Projects"
@@ -49837,6 +51902,11 @@
             "description": "Error response when project is archived."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "List project service accounts",
         "tags": [
           "Projects"
@@ -49899,6 +51969,11 @@
             "description": "Error response when project is archived."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Create project service account",
         "tags": [
           "Projects"
@@ -49951,6 +52026,11 @@
             "description": "Project service account deleted successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Delete project service account",
         "tags": [
           "Projects"
@@ -50001,6 +52081,11 @@
             "description": "Project service account retrieved successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Retrieve project service account",
         "tags": [
           "Projects"
@@ -50073,6 +52158,11 @@
             "description": "Error response when project is archived."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "List project users",
         "tags": [
           "Projects"
@@ -50135,6 +52225,11 @@
             "description": "Error response for various conditions."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Create project user",
         "tags": [
           "Projects"
@@ -50197,6 +52292,11 @@
             "description": "Error response for various conditions."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Delete project user",
         "tags": [
           "Projects"
@@ -50247,6 +52347,11 @@
             "description": "Project user retrieved successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Retrieve project user",
         "tags": [
           "Projects"
@@ -50318,6 +52423,11 @@
             "description": "Error response for various conditions."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Modify project user",
         "tags": [
           "Projects"
@@ -50387,6 +52497,11 @@
             "description": "Roles listed successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "List organization roles",
         "tags": [
           "Roles"
@@ -50428,6 +52543,11 @@
             "description": "Role created successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Create organization role",
         "tags": [
           "Roles"
@@ -50471,6 +52591,11 @@
             "description": "Role deleted successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Delete organization role",
         "tags": [
           "Roles"
@@ -50523,6 +52648,11 @@
             "description": "Role updated successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Update organization role",
         "tags": [
           "Roles"
@@ -50673,6 +52803,11 @@
             "description": "Usage data retrieved successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Audio speeches",
         "tags": [
           "Usage"
@@ -50823,6 +52958,11 @@
             "description": "Usage data retrieved successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Audio transcriptions",
         "tags": [
           "Usage"
@@ -50934,6 +53074,11 @@
             "description": "Usage data retrieved successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Code interpreter sessions",
         "tags": [
           "Usage"
@@ -51095,6 +53240,11 @@
             "description": "Usage data retrieved successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Completions",
         "tags": [
           "Usage"
@@ -51245,6 +53395,11 @@
             "description": "Usage data retrieved successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Embeddings",
         "tags": [
           "Usage"
@@ -51433,6 +53588,11 @@
             "description": "Usage data retrieved successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Images",
         "tags": [
           "Usage"
@@ -51583,6 +53743,11 @@
             "description": "Usage data retrieved successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Moderations",
         "tags": [
           "Usage"
@@ -51694,6 +53859,11 @@
             "description": "Usage data retrieved successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Vector stores",
         "tags": [
           "Usage"
@@ -51759,6 +53929,11 @@
             "description": "Users listed successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "List users",
         "tags": [
           "Users"
@@ -51802,6 +53977,11 @@
             "description": "User deleted successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Delete user",
         "tags": [
           "Users"
@@ -51843,6 +54023,11 @@
             "description": "User retrieved successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Retrieve user",
         "tags": [
           "Users"
@@ -51895,6 +54080,11 @@
             "description": "User role updated successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Modify user",
         "tags": [
           "Users"
@@ -51971,6 +54161,11 @@
             "description": "User organization role assignments listed successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "List user organization role assignments",
         "tags": [
           "User organization role assignments"
@@ -52023,6 +54218,11 @@
             "description": "Organization role assigned to the user successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Assign organization role to user",
         "tags": [
           "User organization role assignments"
@@ -52075,6 +54275,11 @@
             "description": "Organization role unassigned from the user successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Unassign organization role from user",
         "tags": [
           "User organization role assignments"
@@ -52160,6 +54365,11 @@
             "description": "Project group role assignments listed successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "List project group role assignments",
         "tags": [
           "Project group role assignments"
@@ -52221,6 +54431,11 @@
             "description": "Project role assigned to the group successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Assign project role to group",
         "tags": [
           "Project group role assignments"
@@ -52282,6 +54497,11 @@
             "description": "Project role unassigned from the group successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Unassign project role from group",
         "tags": [
           "Project group role assignments"
@@ -52360,6 +54580,11 @@
             "description": "Project roles listed successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "List project roles",
         "tags": [
           "Roles"
@@ -52412,6 +54637,11 @@
             "description": "Project role created successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Create project role",
         "tags": [
           "Roles"
@@ -52464,6 +54694,11 @@
             "description": "Project role deleted successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Delete project role",
         "tags": [
           "Roles"
@@ -52525,6 +54760,11 @@
             "description": "Project role updated successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Update project role",
         "tags": [
           "Roles"
@@ -52610,6 +54850,11 @@
             "description": "Project user role assignments listed successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "List project user role assignments",
         "tags": [
           "Project user role assignments"
@@ -52671,6 +54916,11 @@
             "description": "Project role assigned to the user successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Assign project role to user",
         "tags": [
           "Project user role assignments"
@@ -52732,6 +54982,11 @@
             "description": "Project role unassigned from the user successfully."
           }
         },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
         "summary": "Unassign project role from user",
         "tags": [
           "Project user role assignments"
@@ -53117,6 +55372,49 @@
           },
           "group": "realtime",
           "name": "Create transcription session"
+        }
+      }
+    },
+    "/realtime/translations/client_secrets": {
+      "post": {
+        "description": "Create a Realtime translation client secret with an associated translation session configuration.\n\nClient secrets are short-lived tokens that can be passed to a client app,\nsuch as a web frontend or mobile client, which grants access to the Realtime\nTranslation API without leaking your main API key. You can configure a custom\nTTL for each client secret.\n\nReturns the created client secret and the effective translation session object.\nThe client secret is a string that looks like `ek_1234`.\n",
+        "operationId": "create-realtime-translation-client-secret",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RealtimeTranslationClientSecretCreateRequest"
+              }
+            }
+          },
+          "description": "Create a client secret with the given translation session configuration.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RealtimeTranslationClientSecretCreateResponse"
+                }
+              }
+            },
+            "description": "Translation client secret created successfully."
+          }
+        },
+        "summary": "Create translation client secret",
+        "tags": [
+          "Realtime"
+        ],
+        "x-oaiMeta": {
+          "examples": {
+            "request": {
+              "curl": "curl -X POST https://api.openai.com/v1/realtime/translations/client_secrets \\\n  -H \"Authorization: Bearer $OPENAI_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n    \"expires_after\": {\n      \"anchor\": \"created_at\",\n      \"seconds\": 600\n    },\n    \"session\": {\n      \"model\": \"gpt-realtime-translate\",\n      \"audio\": {\n        \"input\": {\n          \"transcription\": {\n            \"model\": \"gpt-realtime-whisper\"\n          },\n          \"noise_reduction\": null\n        },\n        \"output\": {\n          \"language\": \"es\"\n        }\n      }\n    }\n  }'\n"
+            },
+            "response": "{\n  \"value\": \"ek_68af296e8e408191a1120ab6383263c2\",\n  \"expires_at\": 1756310470,\n  \"session\": {\n    \"id\": \"sess_C9CiUVUzUzYIssh3ELY1d\",\n    \"type\": \"translation\",\n    \"expires_at\": 1756310470,\n    \"model\": \"gpt-realtime-translate\",\n    \"audio\": {\n      \"input\": {\n        \"transcription\": {\n          \"model\": \"gpt-realtime-whisper\"\n        },\n        \"noise_reduction\": null\n      },\n      \"output\": {\n        \"language\": \"es\"\n      }\n    }\n  }\n}\n"
+          },
+          "group": "realtime",
+          "name": "Create translation client secret"
         }
       }
     },
@@ -57942,6 +60240,72 @@
           }
         ],
         "title": "Server events"
+      },
+      {
+        "description": "These are events that the OpenAI Realtime Translation WebSocket server will accept from the client.\n",
+        "id": "realtime-translation-client-events",
+        "navigationGroup": "realtime",
+        "sections": [
+          {
+            "key": "RealtimeTranslationClientEventSessionUpdate",
+            "path": "<auto>",
+            "type": "object"
+          },
+          {
+            "key": "RealtimeTranslationClientEventInputAudioBufferAppend",
+            "path": "<auto>",
+            "type": "object"
+          },
+          {
+            "key": "RealtimeTranslationClientEventSessionClose",
+            "path": "<auto>",
+            "type": "object"
+          }
+        ],
+        "title": "Translation client events"
+      },
+      {
+        "description": "These are events emitted from the OpenAI Realtime Translation WebSocket server to the client.\n",
+        "id": "realtime-translation-server-events",
+        "navigationGroup": "realtime",
+        "sections": [
+          {
+            "key": "RealtimeServerEventError",
+            "path": "<auto>",
+            "type": "object"
+          },
+          {
+            "key": "RealtimeTranslationServerEventSessionCreated",
+            "path": "<auto>",
+            "type": "object"
+          },
+          {
+            "key": "RealtimeTranslationServerEventSessionUpdated",
+            "path": "<auto>",
+            "type": "object"
+          },
+          {
+            "key": "RealtimeTranslationServerEventSessionClosed",
+            "path": "<auto>",
+            "type": "object"
+          },
+          {
+            "key": "RealtimeTranslationServerEventSessionInputTranscriptDelta",
+            "path": "<auto>",
+            "type": "object"
+          },
+          {
+            "key": "RealtimeTranslationServerEventSessionOutputTranscriptDelta",
+            "path": "<auto>",
+            "type": "object"
+          },
+          {
+            "key": "RealtimeTranslationServerEventSessionOutputAudioDelta",
+            "path": "<auto>",
+            "type": "object"
+          }
+        ],
+        "title": "Translation server events"
       },
       {
         "description": "Stream Chat Completions in real time. Receive chunks of completions\nreturned from the model using server-sent events.\n[Learn more](https://platform.openai.com/docs/guides/streaming-responses?api-mode=chat).\n",

--- a/packages/openai_dart/specs/spec_metadata.json
+++ b/packages/openai_dart/specs/spec_metadata.json
@@ -2,10 +2,17 @@
   "specs": {
     "main": {
       "current_version": "2.3.0",
-      "last_fetched": "2026-05-02T08:00:03.586206Z",
-      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai%2Fopenai-64c6ba619ccbf87e56b4f464230d04401fd78ad924d2606176309d19ca281af5.yml",
+      "last_fetched": "2026-05-07T22:20:39.687825Z",
+      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-371f497afe4d6070f6e252e5febbe8f453c7058a8dff0c26a01b4d88442a4ac2.yml",
       "title": "OpenAI API",
-      "version_history": []
+      "version_history": [
+        {
+          "version": "2.3.0",
+          "fetched_at": "2026-05-02T08:00:03.586206Z",
+          "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai%2Fopenai-64c6ba619ccbf87e56b4f464230d04401fd78ad924d2606176309d19ca281af5.yml",
+          "note": "Pre-GA Realtime spec; replaced by 371f497… on 2026-05-08 to pick up GA Realtime sessions, Realtime Translation API, gpt-realtime-2/translate/whisper models, and transcription delay."
+        }
+      ]
     }
   }
 }

--- a/packages/openai_dart/test/integration/realtime_test.dart
+++ b/packages/openai_dart/test/integration/realtime_test.dart
@@ -66,7 +66,7 @@ void main() {
     );
 
     test(
-      'creates realtime session with GA-shape configuration',
+      'creates realtime session with full configuration',
       timeout: const Timeout(Duration(seconds: 30)),
       () async {
         if (apiKey == null) {
@@ -78,7 +78,9 @@ void main() {
           const realtime.RealtimeClientSecretCreateRequest(
             session: realtime.RealtimeSessionCreateRequest(
               model: 'gpt-realtime-2',
-              outputModalities: ['text', 'audio'],
+              // The server only accepts a single modality at a time —
+              // `['text', 'audio']` is rejected; pick `['text']` or `['audio']`.
+              outputModalities: ['audio'],
               audio: realtime.RealtimeAudioConfig(
                 input: realtime.RealtimeAudioConfigInput(
                   turnDetection:
@@ -91,17 +93,16 @@ void main() {
                 output: realtime.RealtimeAudioConfigOutput(voice: 'alloy'),
               ),
               instructions: 'You are a helpful assistant.',
-              temperature: 0.8,
             ),
           ),
         );
 
         expect(response.session.id, startsWith('sess_'));
         expect(response.session.audio?.output?.voice, isNotNull);
-        expect(response.session.outputModalities, contains('text'));
+        expect(response.session.outputModalities, contains('audio'));
         expect(response.session.audio?.input?.turnDetection, isNotNull);
 
-        print('GA session with config: ${response.session.id}');
+        print('Session with full config: ${response.session.id}');
       },
     );
 
@@ -115,8 +116,8 @@ void main() {
         }
 
         // Transcription sessions are created via
-        // `createTranscriptionClientSecret(...)` — the GA `/realtime/client_secrets`
-        // endpoint accepts both realtime and transcription session shapes
+        // `createTranscriptionClientSecret(...)` — `/realtime/client_secrets`
+        // accepts both realtime and transcription session shapes
         // discriminated by `type`, but the transcription shape carries no
         // top-level `model`.
         final response = await client!.realtimeSessions
@@ -143,7 +144,7 @@ void main() {
     );
 
     test(
-      'creates client secret with custom expiration (GA-shape session)',
+      'creates client secret with custom expiration',
       timeout: const Timeout(Duration(seconds: 30)),
       () async {
         if (apiKey == null) {
@@ -279,7 +280,7 @@ void main() {
   });
 
   // ============================================================
-  // Group 3: Session Configuration (GA shape)
+  // Group 3: Session Configuration
   // ============================================================
 
   group('Session Configuration', () {
@@ -299,7 +300,7 @@ void main() {
         try {
           await waitForEvent<realtime.SessionCreatedEvent>(connection);
 
-          // Update session in GA shape.
+          // Update the session configuration.
           connection.updateSession(
             const realtime.RealtimeSessionCreateRequest(
               model: 'gpt-realtime-2',
@@ -308,7 +309,6 @@ void main() {
                 output: realtime.RealtimeAudioConfigOutput(voice: 'shimmer'),
               ),
               instructions: 'You are a helpful assistant.',
-              temperature: 0.9,
             ),
           );
 
@@ -344,7 +344,7 @@ void main() {
           model: 'gpt-realtime-2',
           config: const realtime.RealtimeSessionCreateRequest(
             model: 'gpt-realtime-2',
-            outputModalities: ['text', 'audio'],
+            outputModalities: ['audio'],
             audio: realtime.RealtimeAudioConfig(
               output: realtime.RealtimeAudioConfigOutput(voice: 'echo'),
             ),
@@ -569,7 +569,7 @@ void main() {
               ],
             })
             ..createResponse(
-              modalities: ['text'],
+              outputModalities: ['text'],
               instructions: 'Be very brief.',
               maxOutputTokens: 50,
             );
@@ -664,12 +664,15 @@ void main() {
             ],
           });
 
-          final itemCreated =
-              await waitForEvent<realtime.ConversationItemCreatedEvent>(
+          // The server emits `conversation.item.added` after a client
+          // `conversation.item.create`. The `conversation.item.created`
+          // event is reserved for `item_reference` lookup paths.
+          final itemAdded =
+              await waitForEvent<realtime.ConversationItemAddedEvent>(
                 connection,
               );
 
-          final itemId = itemCreated.item['id'] as String;
+          final itemId = itemAdded.item['id'] as String;
           expect(itemId, isNotEmpty);
 
           connection.deleteItem(itemId);
@@ -753,7 +756,7 @@ void main() {
           model: 'gpt-realtime-2',
           config: const realtime.RealtimeSessionCreateRequest(
             model: 'gpt-realtime-2',
-            outputModalities: ['text', 'audio'],
+            outputModalities: ['text'],
             audio: realtime.RealtimeAudioConfig(
               input: realtime.RealtimeAudioConfigInput(
                 format: realtime.AudioPcm(rate: 24000),
@@ -794,7 +797,7 @@ void main() {
           );
 
           connection.createResponse(
-            modalities: ['text'],
+            outputModalities: ['text'],
             instructions: 'Please repeat what the user said.',
           );
 
@@ -833,7 +836,7 @@ void main() {
           model: 'gpt-realtime-2',
           config: const realtime.RealtimeSessionCreateRequest(
             model: 'gpt-realtime-2',
-            outputModalities: ['text', 'audio'],
+            outputModalities: ['audio'],
             audio: realtime.RealtimeAudioConfig(
               input: realtime.RealtimeAudioConfigInput(
                 format: realtime.AudioPcm(rate: 24000),
@@ -866,7 +869,7 @@ void main() {
   });
 
   // ============================================================
-  // Group 10: Reasoning + parallel tool calls (NEW for GA)
+  // Group 10: Reasoning + parallel tool calls
   // ============================================================
 
   group('Reasoning + parallel tool calls', () {
@@ -921,7 +924,7 @@ void main() {
   });
 
   // ============================================================
-  // Group 11: Translation client secret (NEW for GA)
+  // Group 11: Translation client secret
   // ============================================================
 
   group('Translation client secret', () {
@@ -969,7 +972,7 @@ void main() {
   });
 
   // ============================================================
-  // Group 12: Transcription delay (NEW for GA)
+  // Group 12: Transcription delay
   // ============================================================
 
   group('Transcription delay', () {

--- a/packages/openai_dart/test/integration/realtime_test.dart
+++ b/packages/openai_dart/test/integration/realtime_test.dart
@@ -43,89 +43,107 @@ void main() {
           return;
         }
 
-        final response = await client!.realtimeSessions.create(
-          const realtime.RealtimeSessionCreateRequest(
-            model: 'gpt-realtime-1.5',
-          ),
-        );
-
-        expect(response.id, startsWith('sess_'));
-        expect(response.object, 'realtime.session');
-        expect(response.model, contains('realtime'));
-        expect(response.clientSecret, isNotNull);
-        expect(response.clientSecret!.value, isNotEmpty);
-        expect(response.clientSecret!.expiresAt, greaterThan(0));
-
-        print('Session ID: ${response.id}');
-        print('Client secret expires at: ${response.clientSecret!.expiresAt}');
-      },
-    );
-
-    test(
-      'creates realtime session with configuration',
-      timeout: const Timeout(Duration(seconds: 30)),
-      () async {
-        if (apiKey == null) {
-          markTestSkipped('API key not available');
-          return;
-        }
-
-        final response = await client!.realtimeSessions.create(
-          const realtime.RealtimeSessionCreateRequest(
-            model: 'gpt-realtime-1.5',
-            modalities: ['text', 'audio'],
-            voice: realtime.RealtimeVoice.alloy,
-            instructions: 'You are a helpful assistant.',
-            turnDetection: realtime.TurnDetection(
-              type: realtime.TurnDetectionType.serverVad,
-              threshold: 0.5,
-              prefixPaddingMs: 300,
-              silenceDurationMs: 500,
-            ),
-            temperature: 0.8,
-          ),
-        );
-
-        expect(response.id, startsWith('sess_'));
-        expect(response.voice, realtime.RealtimeVoice.alloy);
-        expect(response.modalities, contains('text'));
-        expect(response.modalities, contains('audio'));
-        expect(response.turnDetection, isNotNull);
-
-        print('Session with config: ${response.id}');
-      },
-    );
-
-    test(
-      'creates transcription session',
-      timeout: const Timeout(Duration(seconds: 30)),
-      () async {
-        if (apiKey == null) {
-          markTestSkipped('API key not available');
-          return;
-        }
-
-        final response = await client!.realtimeSessions.createTranscription(
-          const realtime.RealtimeTranscriptionSessionCreateRequest(
-            inputAudioFormat: realtime.RealtimeAudioFormat.pcm16,
-            inputAudioTranscription: realtime.InputAudioTranscription(
-              model: 'whisper-1',
+        final response = await client!.realtimeSessions.createClientSecret(
+          const realtime.RealtimeClientSecretCreateRequest(
+            session: realtime.RealtimeSessionCreateRequest(
+              model: 'gpt-realtime-2',
             ),
           ),
         );
 
-        expect(response.clientSecret, isNotNull);
-        expect(response.clientSecret.value, isNotEmpty);
+        expect(response.value, startsWith('ek_'));
+        expect(response.session.id, startsWith('sess_'));
+        expect(response.session.object, 'realtime.session');
+        expect(response.session.type, 'realtime');
+        expect(response.session.model, contains('realtime'));
+        expect(response.expiresAt, greaterThan(0));
 
         print(
-          'Transcription session secret: '
-          '${response.clientSecret.value.substring(0, 20)}...',
+          'Session ID: ${response.session.id}, '
+          'secret expires at: ${response.expiresAt}',
         );
       },
     );
 
     test(
-      'creates client secret with custom expiration',
+      'creates realtime session with GA-shape configuration',
+      timeout: const Timeout(Duration(seconds: 30)),
+      () async {
+        if (apiKey == null) {
+          markTestSkipped('API key not available');
+          return;
+        }
+
+        final response = await client!.realtimeSessions.createClientSecret(
+          const realtime.RealtimeClientSecretCreateRequest(
+            session: realtime.RealtimeSessionCreateRequest(
+              model: 'gpt-realtime-2',
+              outputModalities: ['text', 'audio'],
+              audio: realtime.RealtimeAudioConfig(
+                input: realtime.RealtimeAudioConfigInput(
+                  turnDetection:
+                      realtime.RealtimeAudioInputTurnDetection.serverVad(
+                        threshold: 0.5,
+                        prefixPaddingMs: 300,
+                        silenceDurationMs: 500,
+                      ),
+                ),
+                output: realtime.RealtimeAudioConfigOutput(voice: 'alloy'),
+              ),
+              instructions: 'You are a helpful assistant.',
+              temperature: 0.8,
+            ),
+          ),
+        );
+
+        expect(response.session.id, startsWith('sess_'));
+        expect(response.session.audio?.output?.voice, isNotNull);
+        expect(response.session.outputModalities, contains('text'));
+        expect(response.session.audio?.input?.turnDetection, isNotNull);
+
+        print('GA session with config: ${response.session.id}');
+      },
+    );
+
+    test(
+      'creates transcription client secret',
+      timeout: const Timeout(Duration(seconds: 30)),
+      () async {
+        if (apiKey == null) {
+          markTestSkipped('API key not available');
+          return;
+        }
+
+        // Transcription sessions are created via
+        // `createTranscriptionClientSecret(...)` — the GA `/realtime/client_secrets`
+        // endpoint accepts both realtime and transcription session shapes
+        // discriminated by `type`, but the transcription shape carries no
+        // top-level `model`.
+        final response = await client!.realtimeSessions
+            .createTranscriptionClientSecret(
+              const realtime.RealtimeTranscriptionClientSecretCreateRequest(
+                session: realtime.RealtimeTranscriptionSessionCreateRequest(
+                  audio: realtime.RealtimeTranscriptionSessionAudio(
+                    input: realtime.RealtimeAudioConfigInput(
+                      format: realtime.AudioPcm(rate: 24000),
+                      transcription: realtime.InputAudioTranscription(
+                        model: 'whisper-1',
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            );
+
+        expect(response.value, startsWith('ek_'));
+        expect(response.expiresAt, greaterThan(0));
+
+        print('Transcription client secret: ${response.session.id}');
+      },
+    );
+
+    test(
+      'creates client secret with custom expiration (GA-shape session)',
       timeout: const Timeout(Duration(seconds: 30)),
       () async {
         if (apiKey == null) {
@@ -140,18 +158,19 @@ void main() {
               seconds: 120,
             ),
             session: realtime.RealtimeSessionCreateRequest(
-              type: 'realtime', // Required discriminator for client secrets
-              model: 'gpt-realtime-1.5',
+              model: 'gpt-realtime-2',
             ),
           ),
         );
 
-        expect(response.value, isNotEmpty);
+        expect(response.value, startsWith('ek_'));
         expect(response.expiresAt, greaterThan(0));
-        expect(response.session, isNotNull);
         expect(response.session.id, startsWith('sess_'));
 
-        print('Client secret expires at: ${response.expiresAt}');
+        print(
+          'Client secret expires at: ${response.expiresAt}, '
+          'session: ${response.session.id}',
+        );
       },
     );
   });
@@ -171,7 +190,7 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-realtime-1.5',
+          model: 'gpt-realtime-2',
         );
 
         expect(connection.isClosed, isFalse);
@@ -191,7 +210,7 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-realtime-1.5',
+          model: 'gpt-realtime-2',
         );
 
         try {
@@ -220,10 +239,9 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-realtime-1.5',
+          model: 'gpt-realtime-2',
         );
 
-        // Wait for session created
         await waitForEvent<realtime.SessionCreatedEvent>(connection);
 
         expect(connection.isClosed, isFalse);
@@ -245,7 +263,7 @@ void main() {
 
         for (var i = 0; i < 2; i++) {
           final connection = await client!.realtime.connect(
-            model: 'gpt-realtime-1.5',
+            model: 'gpt-realtime-2',
           );
 
           await waitForEvent<realtime.SessionCreatedEvent>(connection);
@@ -261,7 +279,7 @@ void main() {
   });
 
   // ============================================================
-  // Group 3: Session Configuration
+  // Group 3: Session Configuration (GA shape)
   // ============================================================
 
   group('Session Configuration', () {
@@ -275,32 +293,38 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-realtime-1.5',
+          model: 'gpt-realtime-2',
         );
 
         try {
-          // Wait for initial session
           await waitForEvent<realtime.SessionCreatedEvent>(connection);
 
-          // Update session
+          // Update session in GA shape.
           connection.updateSession(
-            const realtime.SessionUpdateConfig(
-              voice: realtime.RealtimeVoice.shimmer,
-              modalities: ['text'],
+            const realtime.RealtimeSessionCreateRequest(
+              model: 'gpt-realtime-2',
+              outputModalities: ['text'],
+              audio: realtime.RealtimeAudioConfig(
+                output: realtime.RealtimeAudioConfigOutput(voice: 'shimmer'),
+              ),
               instructions: 'You are a helpful assistant.',
               temperature: 0.9,
             ),
           );
 
-          // Wait for update confirmation
           final updateEvent = await waitForEvent<realtime.SessionUpdatedEvent>(
             connection,
           );
 
           expect(updateEvent.type, 'session.updated');
-          expect(updateEvent.session.voice, realtime.RealtimeVoice.shimmer);
+          // The server may or may not allow voice changes; assert nesting
+          // works rather than the exact value.
+          expect(updateEvent.session.audio?.output?.voice, isNotNull);
+          expect(updateEvent.session.outputModalities, contains('text'));
 
-          print('Session updated with voice: ${updateEvent.session.voice}');
+          print(
+            'Session updated, voice: ${updateEvent.session.audio?.output?.voice}',
+          );
         } finally {
           await connection.close();
         }
@@ -308,7 +332,7 @@ void main() {
     );
 
     test(
-      'configures voice and modalities',
+      'configures voice and modalities at connect time',
       timeout: const Timeout(Duration(seconds: 30)),
       () async {
         if (apiKey == null) {
@@ -317,10 +341,13 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-realtime-1.5',
-          config: const realtime.SessionUpdateConfig(
-            voice: realtime.RealtimeVoice.echo,
-            modalities: ['text', 'audio'],
+          model: 'gpt-realtime-2',
+          config: const realtime.RealtimeSessionCreateRequest(
+            model: 'gpt-realtime-2',
+            outputModalities: ['text', 'audio'],
+            audio: realtime.RealtimeAudioConfig(
+              output: realtime.RealtimeAudioConfigOutput(voice: 'echo'),
+            ),
           ),
         );
 
@@ -329,16 +356,14 @@ void main() {
             connection,
           );
 
-          // The initial config should be applied
-          expect(sessionEvent.session, isNotNull);
+          expect(sessionEvent.session.id, isNotEmpty);
           print('Initial session: ${sessionEvent.session.id}');
 
-          // Wait for the update from our config
           final updateEvent = await waitForEvent<realtime.SessionUpdatedEvent>(
             connection,
           );
 
-          expect(updateEvent.session.voice, realtime.RealtimeVoice.echo);
+          expect(updateEvent.session.audio?.output?.voice, isNotNull);
         } finally {
           await connection.close();
         }
@@ -361,16 +386,17 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-realtime-1.5',
-          config: const realtime.SessionUpdateConfig(modalities: ['text']),
+          model: 'gpt-realtime-2',
+          config: const realtime.RealtimeSessionCreateRequest(
+            model: 'gpt-realtime-2',
+            outputModalities: ['text'],
+          ),
         );
 
         try {
-          // Wait for session
           await waitForEvent<realtime.SessionCreatedEvent>(connection);
           await waitForEvent<realtime.SessionUpdatedEvent>(connection);
 
-          // Send a text message
           connection
             ..createItem({
               'type': 'message',
@@ -379,10 +405,8 @@ void main() {
                 {'type': 'input_text', 'text': 'Say "hello" and nothing else.'},
               ],
             })
-            // Create response
             ..createResponse();
 
-          // Collect text deltas
           final textBuffer = StringBuffer();
           final events = await collectEventsUntil<realtime.ResponseDoneEvent>(
             connection,
@@ -421,9 +445,10 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-realtime-1.5',
-          config: const realtime.SessionUpdateConfig(
-            modalities: ['text'],
+          model: 'gpt-realtime-2',
+          config: const realtime.RealtimeSessionCreateRequest(
+            model: 'gpt-realtime-2',
+            outputModalities: ['text'],
             tools: [
               realtime.RealtimeTool(
                 type: 'function',
@@ -446,11 +471,9 @@ void main() {
         );
 
         try {
-          // Wait for session setup
           await waitForEvent<realtime.SessionCreatedEvent>(connection);
           await waitForEvent<realtime.SessionUpdatedEvent>(connection);
 
-          // Send message that should trigger tool call
           connection
             ..createItem({
               'type': 'message',
@@ -461,7 +484,6 @@ void main() {
             })
             ..createResponse();
 
-          // Look for function call
           String? callId;
           String? functionArgs;
 
@@ -485,12 +507,10 @@ void main() {
           print('Tool call ID: $callId');
           print('Tool arguments: $functionArgs');
 
-          // Send function result
           connection
             ..sendFunctionOutput(callId!, '{"temperature": 22, "unit": "C"}')
             ..createResponse();
 
-          // Wait for final response
           final finalEvents =
               await collectEventsUntil<realtime.ResponseDoneEvent>(
                 connection,
@@ -529,15 +549,17 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-realtime-1.5',
-          config: const realtime.SessionUpdateConfig(modalities: ['text']),
+          model: 'gpt-realtime-2',
+          config: const realtime.RealtimeSessionCreateRequest(
+            model: 'gpt-realtime-2',
+            outputModalities: ['text'],
+          ),
         );
 
         try {
           await waitForEvent<realtime.SessionCreatedEvent>(connection);
           await waitForEvent<realtime.SessionUpdatedEvent>(connection);
 
-          // Add user message
           connection
             ..createItem({
               'type': 'message',
@@ -546,7 +568,6 @@ void main() {
                 {'type': 'input_text', 'text': 'Say "test response"'},
               ],
             })
-            // Explicitly create response with parameters
             ..createResponse(
               modalities: ['text'],
               instructions: 'Be very brief.',
@@ -559,7 +580,6 @@ void main() {
 
           print('Response created: ${responseCreated.response['id']}');
 
-          // Wait for completion
           await waitForEvent<realtime.ResponseDoneEvent>(connection);
         } finally {
           await connection.close();
@@ -577,15 +597,17 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-realtime-1.5',
-          config: const realtime.SessionUpdateConfig(modalities: ['text']),
+          model: 'gpt-realtime-2',
+          config: const realtime.RealtimeSessionCreateRequest(
+            model: 'gpt-realtime-2',
+            outputModalities: ['text'],
+          ),
         );
 
         try {
           await waitForEvent<realtime.SessionCreatedEvent>(connection);
           await waitForEvent<realtime.SessionUpdatedEvent>(connection);
 
-          // Add message that would generate long response
           connection
             ..createItem({
               'type': 'message',
@@ -596,14 +618,10 @@ void main() {
             })
             ..createResponse();
 
-          // Wait for response to start
           await waitForEvent<realtime.ResponseCreatedEvent>(connection);
 
-          // Cancel it
           connection.cancelResponse();
 
-          // The response should be cancelled (might get a cancelled status)
-          // We just verify we don't hang
           print('Response cancelled');
         } finally {
           await connection.close();
@@ -627,15 +645,17 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-realtime-1.5',
-          config: const realtime.SessionUpdateConfig(modalities: ['text']),
+          model: 'gpt-realtime-2',
+          config: const realtime.RealtimeSessionCreateRequest(
+            model: 'gpt-realtime-2',
+            outputModalities: ['text'],
+          ),
         );
 
         try {
           await waitForEvent<realtime.SessionCreatedEvent>(connection);
           await waitForEvent<realtime.SessionUpdatedEvent>(connection);
 
-          // Create an item
           connection.createItem({
             'type': 'message',
             'role': 'user',
@@ -644,7 +664,6 @@ void main() {
             ],
           });
 
-          // Wait for item creation
           final itemCreated =
               await waitForEvent<realtime.ConversationItemCreatedEvent>(
                 connection,
@@ -653,10 +672,8 @@ void main() {
           final itemId = itemCreated.item['id'] as String;
           expect(itemId, isNotEmpty);
 
-          // Delete the item
           connection.deleteItem(itemId);
 
-          // Wait for deletion confirmation
           final itemDeleted =
               await waitForEvent<realtime.ConversationItemDeletedEvent>(
                 connection,
@@ -686,16 +703,14 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-realtime-1.5',
+          model: 'gpt-realtime-2',
         );
 
         try {
           await waitForEvent<realtime.SessionCreatedEvent>(connection);
 
-          // Send an invalid event type
           connection.send({'type': 'invalid.event.type', 'data': 'test'});
 
-          // Should receive an error event
           final errorEvent = await waitForEvent<realtime.ErrorEvent>(
             connection,
             timeout: const Duration(seconds: 10),
@@ -726,7 +741,6 @@ void main() {
           return;
         }
 
-        // Read the sample audio file
         final audioFile = File('test/samples/harvard.wav');
         if (!audioFile.existsSync()) {
           markTestSkipped('Sample audio file not found');
@@ -736,18 +750,23 @@ void main() {
         final audioBytes = await audioFile.readAsBytes();
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-realtime-1.5',
-          config: const realtime.SessionUpdateConfig(
-            modalities: ['text', 'audio'],
-            inputAudioFormat: realtime.RealtimeAudioFormat.pcm16,
-            inputAudioTranscription: realtime.InputAudioTranscription(
-              model: 'whisper-1',
-            ),
-            turnDetection: realtime.TurnDetection(
-              type: realtime.TurnDetectionType.serverVad,
-              threshold: 0.3,
-              silenceDurationMs: 1000,
-              createResponse: false, // We'll manually trigger response
+          model: 'gpt-realtime-2',
+          config: const realtime.RealtimeSessionCreateRequest(
+            model: 'gpt-realtime-2',
+            outputModalities: ['text', 'audio'],
+            audio: realtime.RealtimeAudioConfig(
+              input: realtime.RealtimeAudioConfigInput(
+                format: realtime.AudioPcm(rate: 24000),
+                transcription: realtime.InputAudioTranscription(
+                  model: 'whisper-1',
+                ),
+                turnDetection:
+                    realtime.RealtimeAudioInputTurnDetection.serverVad(
+                      threshold: 0.3,
+                      silenceDurationMs: 1000,
+                      createResponse: false,
+                    ),
+              ),
             ),
           ),
         );
@@ -756,10 +775,9 @@ void main() {
           await waitForEvent<realtime.SessionCreatedEvent>(connection);
           await waitForEvent<realtime.SessionUpdatedEvent>(connection);
 
-          // WAV header is typically 44 bytes - skip it for raw PCM
+          // WAV header is typically 44 bytes - skip it for raw PCM.
           final pcmData = audioBytes.sublist(44);
 
-          // Send audio in chunks
           const chunkSize = 4800; // 100ms of 24kHz mono PCM16
           for (var i = 0; i < pcmData.length; i += chunkSize) {
             final end = (i + chunkSize < pcmData.length)
@@ -769,21 +787,17 @@ void main() {
             connection.appendAudio(base64Encode(chunk));
           }
 
-          // Commit the audio
           connection.commitAudio();
 
-          // Wait for audio to be processed
           await waitForEvent<realtime.InputAudioBufferCommittedEvent>(
             connection,
           );
 
-          // Request a response
           connection.createResponse(
             modalities: ['text'],
             instructions: 'Please repeat what the user said.',
           );
 
-          // Collect response
           final events = await collectEventsUntil<realtime.ResponseDoneEvent>(
             connection,
             timeout: const Duration(minutes: 2),
@@ -799,7 +813,6 @@ void main() {
           final response = textBuffer.toString();
           print('Audio response: $response');
 
-          // The Harvard sentences should produce some response
           expect(response, isNotEmpty);
         } finally {
           await connection.close();
@@ -817,10 +830,15 @@ void main() {
         }
 
         final connection = await client!.realtime.connect(
-          model: 'gpt-realtime-1.5',
-          config: const realtime.SessionUpdateConfig(
-            modalities: ['text', 'audio'],
-            inputAudioFormat: realtime.RealtimeAudioFormat.pcm16,
+          model: 'gpt-realtime-2',
+          config: const realtime.RealtimeSessionCreateRequest(
+            model: 'gpt-realtime-2',
+            outputModalities: ['text', 'audio'],
+            audio: realtime.RealtimeAudioConfig(
+              input: realtime.RealtimeAudioConfigInput(
+                format: realtime.AudioPcm(rate: 24000),
+              ),
+            ),
           ),
         );
 
@@ -828,14 +846,11 @@ void main() {
           await waitForEvent<realtime.SessionCreatedEvent>(connection);
           await waitForEvent<realtime.SessionUpdatedEvent>(connection);
 
-          // Append some dummy audio
           final dummyAudio = List.filled(1000, 0);
           connection
             ..appendAudio(base64Encode(dummyAudio))
-            // Clear the buffer
             ..clearAudio();
 
-          // Should receive cleared event
           final cleared =
               await waitForEvent<realtime.InputAudioBufferClearedEvent>(
                 connection,
@@ -846,6 +861,148 @@ void main() {
         } finally {
           await connection.close();
         }
+      },
+    );
+  });
+
+  // ============================================================
+  // Group 10: Reasoning + parallel tool calls (NEW for GA)
+  // ============================================================
+
+  group('Reasoning + parallel tool calls', () {
+    test(
+      'session honours reasoning + parallel_tool_calls',
+      timeout: const Timeout(Duration(seconds: 30)),
+      () async {
+        if (apiKey == null) {
+          markTestSkipped('API key not available');
+          return;
+        }
+
+        final response = await client!.realtimeSessions.createClientSecret(
+          const realtime.RealtimeClientSecretCreateRequest(
+            session: realtime.RealtimeSessionCreateRequest(
+              model: 'gpt-realtime-2',
+              outputModalities: ['text'],
+              parallelToolCalls: true,
+              reasoning: realtime.RealtimeReasoning(
+                effort: realtime.RealtimeReasoningEffort.minimal,
+              ),
+              tools: [
+                realtime.RealtimeTool(
+                  type: 'function',
+                  name: 'get_weather',
+                  description: 'Get the current weather for a location',
+                  parameters: {
+                    'type': 'object',
+                    'properties': {
+                      'location': {'type': 'string'},
+                    },
+                    'required': ['location'],
+                  },
+                ),
+              ],
+            ),
+          ),
+        );
+
+        // The server doesn't necessarily echo every input field back on the
+        // session response (e.g., `parallel_tool_calls` may be elided). The
+        // important contract is that the request was accepted.
+        expect(response.value, startsWith('ek_'));
+        expect(response.session.id, startsWith('sess_'));
+        print(
+          'Reasoning session: ${response.session.id}, '
+          'effort: ${response.session.reasoning?.effort}, '
+          'parallelToolCalls: ${response.session.parallelToolCalls}',
+        );
+      },
+    );
+  });
+
+  // ============================================================
+  // Group 11: Translation client secret (NEW for GA)
+  // ============================================================
+
+  group('Translation client secret', () {
+    test(
+      'creates a translation session and ephemeral client secret',
+      timeout: const Timeout(Duration(seconds: 30)),
+      () async {
+        if (apiKey == null) {
+          markTestSkipped('API key not available');
+          return;
+        }
+
+        final response = await client!.realtimeSessions.translations
+            .createClientSecret(
+              const realtime.RealtimeTranslationClientSecretCreateRequest(
+                session: realtime.RealtimeTranslationSessionCreateRequest(
+                  model: 'gpt-realtime-translate',
+                  audio: realtime.RealtimeTranslationSessionAudio(
+                    input: realtime.RealtimeTranslationSessionAudioInput(
+                      transcription:
+                          realtime.RealtimeTranslationInputTranscription(
+                            model: 'gpt-realtime-whisper',
+                          ),
+                    ),
+                    output: realtime.RealtimeTranslationSessionAudioOutput(
+                      language: 'es',
+                    ),
+                  ),
+                ),
+              ),
+            );
+
+        expect(response.value, startsWith('ek_'));
+        expect(response.expiresAt, greaterThan(0));
+        expect(response.session.type, 'translation');
+        expect(response.session.model, contains('translate'));
+
+        print(
+          'Translation client secret: '
+          '${response.value.substring(0, 12)}…, '
+          'session: ${response.session.id}',
+        );
+      },
+    );
+  });
+
+  // ============================================================
+  // Group 12: Transcription delay (NEW for GA)
+  // ============================================================
+
+  group('Transcription delay', () {
+    test(
+      'transcription session accepts gpt-realtime-whisper + delay knob',
+      timeout: const Timeout(Duration(seconds: 30)),
+      () async {
+        if (apiKey == null) {
+          markTestSkipped('API key not available');
+          return;
+        }
+
+        final response = await client!.realtimeSessions
+            .createTranscriptionClientSecret(
+              const realtime.RealtimeTranscriptionClientSecretCreateRequest(
+                session: realtime.RealtimeTranscriptionSessionCreateRequest(
+                  audio: realtime.RealtimeTranscriptionSessionAudio(
+                    input: realtime.RealtimeAudioConfigInput(
+                      format: realtime.AudioPcm(rate: 24000),
+                      transcription: realtime.InputAudioTranscription(
+                        model: 'gpt-realtime-whisper',
+                        delay: realtime.AudioTranscriptionDelay.high,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            );
+
+        expect(response.value, startsWith('ek_'));
+        expect(response.session.id, startsWith('sess_'));
+
+        print('Transcription session w/ delay: ${response.session.id}');
       },
     );
   });

--- a/packages/openai_dart/test/integration/realtime_test.dart
+++ b/packages/openai_dart/test/integration/realtime_test.dart
@@ -3,7 +3,6 @@
 library;
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:openai_dart/openai_dart.dart';
@@ -397,15 +396,7 @@ void main() {
           await waitForEvent<realtime.SessionCreatedEvent>(connection);
           await waitForEvent<realtime.SessionUpdatedEvent>(connection);
 
-          connection
-            ..createItem({
-              'type': 'message',
-              'role': 'user',
-              'content': [
-                {'type': 'input_text', 'text': 'Say "hello" and nothing else.'},
-              ],
-            })
-            ..createResponse();
+          connection.sendUserMessage('Say "hello" and nothing else.');
 
           final textBuffer = StringBuffer();
           final events = await collectEventsUntil<realtime.ResponseDoneEvent>(
@@ -787,7 +778,7 @@ void main() {
                 ? i + chunkSize
                 : pcmData.length;
             final chunk = pcmData.sublist(i, end);
-            connection.appendAudio(base64Encode(chunk));
+            connection.appendAudioBytes(chunk);
           }
 
           connection.commitAudio();
@@ -851,7 +842,7 @@ void main() {
 
           final dummyAudio = List.filled(1000, 0);
           connection
-            ..appendAudio(base64Encode(dummyAudio))
+            ..appendAudioBytes(dummyAudio)
             ..clearAudio();
 
           final cleared =

--- a/packages/openai_dart/test/unit/models/realtime_audio_formats_test.dart
+++ b/packages/openai_dart/test/unit/models/realtime_audio_formats_test.dart
@@ -1,0 +1,101 @@
+import 'package:openai_dart/openai_dart_realtime.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RealtimeAudioFormats', () {
+    test('AudioPcm with rate roundtrips', () {
+      const format = AudioPcm(rate: 24000);
+      expect(format.toJson(), {'type': 'audio/pcm', 'rate': 24000});
+
+      final parsed = RealtimeAudioFormats.fromJson(format.toJson());
+      expect(parsed, isA<AudioPcm>());
+      expect((parsed as AudioPcm).rate, 24000);
+      expect(parsed, format);
+    });
+
+    test('AudioPcm with null rate roundtrips and omits the field', () {
+      const format = AudioPcm();
+      expect(format.toJson(), {'type': 'audio/pcm'});
+      final parsed = RealtimeAudioFormats.fromJson(format.toJson());
+      expect(parsed, isA<AudioPcm>());
+      expect((parsed as AudioPcm).rate, isNull);
+    });
+
+    test('AudioPcmu roundtrips', () {
+      const format = AudioPcmu();
+      expect(format.toJson(), {'type': 'audio/pcmu'});
+      final parsed = RealtimeAudioFormats.fromJson(format.toJson());
+      expect(parsed, isA<AudioPcmu>());
+    });
+
+    test('AudioPcma roundtrips', () {
+      const format = AudioPcma();
+      expect(format.toJson(), {'type': 'audio/pcma'});
+      final parsed = RealtimeAudioFormats.fromJson(format.toJson());
+      expect(parsed, isA<AudioPcma>());
+    });
+
+    test('discriminator dispatch returns correct subclass', () {
+      expect(
+        RealtimeAudioFormats.fromJson({'type': 'audio/pcm', 'rate': 24000}),
+        isA<AudioPcm>(),
+      );
+      expect(
+        RealtimeAudioFormats.fromJson({'type': 'audio/pcmu'}),
+        isA<AudioPcmu>(),
+      );
+      expect(
+        RealtimeAudioFormats.fromJson({'type': 'audio/pcma'}),
+        isA<AudioPcma>(),
+      );
+    });
+
+    test('unknown type round-trips through UnknownRealtimeAudioFormats', () {
+      final json = <String, dynamic>{'type': 'audio/future', 'extra': 42};
+      final parsed = RealtimeAudioFormats.fromJson(json);
+      expect(parsed, isA<UnknownRealtimeAudioFormats>());
+      expect(parsed.type, 'audio/future');
+      final encoded = parsed.toJson();
+      expect(encoded['type'], 'audio/future');
+      expect(encoded['extra'], 42);
+
+      // Round-trip preserves the raw payload byte-for-byte.
+      expect(
+        RealtimeAudioFormats.fromJson(encoded),
+        isA<UnknownRealtimeAudioFormats>(),
+      );
+    });
+
+    test('factory constructors produce correct subclasses', () {
+      expect(
+        const RealtimeAudioFormats.pcm(rate: 24000),
+        const AudioPcm(rate: 24000),
+      );
+      expect(const RealtimeAudioFormats.pcmu(), const AudioPcmu());
+      expect(const RealtimeAudioFormats.pcma(), const AudioPcma());
+    });
+
+    test('AudioPcm copyWith updates and clears rate', () {
+      const format = AudioPcm(rate: 24000);
+      expect(format.copyWith(rate: 16000).rate, 16000);
+      expect(format.copyWith(rate: null).rate, isNull);
+      expect(format.copyWith().rate, 24000);
+    });
+
+    test('AudioPcm equality and hashCode are content-based', () {
+      const a = AudioPcm(rate: 24000);
+      const b = AudioPcm(rate: 24000);
+      const c = AudioPcm(rate: 16000);
+      expect(a == b, isTrue);
+      expect(a.hashCode, b.hashCode);
+      expect(a == c, isFalse);
+    });
+
+    test('subclass fromJson rejects mismatched type', () {
+      final pcmuJson = <String, dynamic>{'type': 'audio/pcmu'};
+      final pcmJson = <String, dynamic>{'type': 'audio/pcm'};
+      expect(() => AudioPcm.fromJson(pcmuJson), throwsFormatException);
+      expect(() => AudioPcmu.fromJson(pcmJson), throwsFormatException);
+    });
+  });
+}

--- a/packages/openai_dart/test/unit/models/realtime_reasoning_test.dart
+++ b/packages/openai_dart/test/unit/models/realtime_reasoning_test.dart
@@ -1,0 +1,87 @@
+import 'package:openai_dart/openai_dart_realtime.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RealtimeReasoning', () {
+    test('roundtrips each effort value', () {
+      for (final effort in RealtimeReasoningEffort.values) {
+        final reasoning = RealtimeReasoning(effort: effort);
+        final json = reasoning.toJson();
+        expect(json['effort'], effort.toJson());
+
+        final parsed = RealtimeReasoning.fromJson(json);
+        expect(parsed.effort, effort);
+        expect(parsed, reasoning);
+      }
+    });
+
+    test('null effort omits the field', () {
+      const reasoning = RealtimeReasoning();
+      expect(reasoning.toJson(), isEmpty);
+
+      final parsed = RealtimeReasoning.fromJson(const {});
+      expect(parsed.effort, isNull);
+      expect(parsed, reasoning);
+    });
+
+    test('copyWith updates and clears effort', () {
+      const reasoning = RealtimeReasoning(
+        effort: RealtimeReasoningEffort.medium,
+      );
+      expect(
+        reasoning.copyWith(effort: RealtimeReasoningEffort.high).effort,
+        RealtimeReasoningEffort.high,
+      );
+      expect(reasoning.copyWith(effort: null).effort, isNull);
+      expect(reasoning.copyWith().effort, RealtimeReasoningEffort.medium);
+    });
+
+    test('toString includes effort', () {
+      const reasoning = RealtimeReasoning(
+        effort: RealtimeReasoningEffort.minimal,
+      );
+      expect(reasoning.toString(), contains('minimal'));
+    });
+
+    test('equality is content-based', () {
+      const a = RealtimeReasoning(effort: RealtimeReasoningEffort.low);
+      const b = RealtimeReasoning(effort: RealtimeReasoningEffort.low);
+      const c = RealtimeReasoning(effort: RealtimeReasoningEffort.high);
+      expect(a == b, isTrue);
+      expect(a.hashCode, b.hashCode);
+      expect(a == c, isFalse);
+    });
+  });
+
+  group('RealtimeReasoningEffort', () {
+    test('fromJson parses every value', () {
+      expect(
+        RealtimeReasoningEffort.fromJson('minimal'),
+        RealtimeReasoningEffort.minimal,
+      );
+      expect(
+        RealtimeReasoningEffort.fromJson('low'),
+        RealtimeReasoningEffort.low,
+      );
+      expect(
+        RealtimeReasoningEffort.fromJson('medium'),
+        RealtimeReasoningEffort.medium,
+      );
+      expect(
+        RealtimeReasoningEffort.fromJson('high'),
+        RealtimeReasoningEffort.high,
+      );
+      expect(
+        RealtimeReasoningEffort.fromJson('xhigh'),
+        RealtimeReasoningEffort.xhigh,
+      );
+    });
+
+    test('throws on unknown value (matches package convention)', () {
+      expect(
+        () => RealtimeReasoningEffort.fromJson('extreme'),
+        throwsFormatException,
+      );
+    });
+  });
+}

--- a/packages/openai_dart/test/unit/models/realtime_test.dart
+++ b/packages/openai_dart/test/unit/models/realtime_test.dart
@@ -3,7 +3,7 @@ import 'package:openai_dart/openai_dart_realtime.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('RealtimeSessionCreateRequest (GA shape)', () {
+  group('RealtimeSessionCreateRequest', () {
     test('minimal payload roundtrip omits type discriminator', () {
       const request = RealtimeSessionCreateRequest(model: 'gpt-realtime');
       final json = request.toJson();
@@ -83,7 +83,6 @@ void main() {
           },
         ],
         'tool_choice': 'none',
-        'temperature': 0.8,
         'max_output_tokens': 'inf',
         'parallel_tool_calls': true,
         'reasoning': {'effort': 'minimal'},
@@ -272,8 +271,8 @@ void main() {
     });
   });
 
-  group('RealtimeSessionCreateResponse (GA shape)', () {
-    test('GA response roundtrip and omits client_secret', () {
+  group('RealtimeSessionCreateResponse', () {
+    test('response roundtrip omits client_secret', () {
       final json = <String, dynamic>{
         'id': 'sess_abc123',
         'object': 'realtime.session',
@@ -292,7 +291,7 @@ void main() {
 
       final encoded = parsed.toJson();
       expect(encoded, json);
-      // Regression guard: the GA response no longer has `client_secret`
+      // Regression guard: the response shape does not have `client_secret`
       // nested on the session object.
       expect(encoded.containsKey('client_secret'), isFalse);
     });

--- a/packages/openai_dart/test/unit/models/realtime_test.dart
+++ b/packages/openai_dart/test/unit/models/realtime_test.dart
@@ -296,17 +296,16 @@ void main() {
       expect(encoded.containsKey('client_secret'), isFalse);
     });
 
-    test('fromJson defaults missing fields rather than throwing', () {
-      // Live API has been observed to omit these on early frames; the parser
-      // is intentionally lenient (defaults) rather than strict (throws).
-      final parsed = RealtimeSessionCreateResponse.fromJson(const {
-        'object': 'realtime.session',
-        'type': 'realtime',
-        'model': 'gpt-realtime-2',
-        'expires_at': 0,
-      });
-      expect(parsed.id, '');
-      expect(parsed.expiresAt, 0);
+    test('fromJson throws FormatException on missing required fields', () {
+      expect(
+        () => RealtimeSessionCreateResponse.fromJson(const {
+          'object': 'realtime.session',
+          'type': 'realtime',
+          'model': 'gpt-realtime-2',
+          'expires_at': 0,
+        }),
+        throwsFormatException,
+      );
     });
   });
 
@@ -424,6 +423,83 @@ void main() {
 
     test('throws on invalid payload', () {
       expect(() => RealtimeToolChoice.fromJson(42), throwsFormatException);
+    });
+  });
+
+  group('Sealed Unknown-variant fallbacks', () {
+    test(
+      'RealtimeEvent.fromJson unrecognised type roundtrips through Unknown',
+      () {
+        final json = <String, dynamic>{
+          'type': 'session.future_event',
+          'event_id': 'evt_123',
+          'extra': <String, dynamic>{'nested': true},
+        };
+        final parsed = RealtimeEvent.fromJson(json);
+        expect(parsed, isA<UnknownRealtimeEvent>());
+        expect(parsed.type, 'session.future_event');
+        expect(parsed.eventId, 'evt_123');
+        // Round-trip preserves unknown keys including nested maps.
+        expect(parsed.toJson(), equals(json));
+
+        // Equality is content-based and deep.
+        final twin = RealtimeEvent.fromJson(<String, dynamic>{
+          'type': 'session.future_event',
+          'event_id': 'evt_123',
+          'extra': <String, dynamic>{'nested': true},
+        });
+        expect(parsed, equals(twin));
+        expect(parsed.hashCode, twin.hashCode);
+      },
+    );
+
+    test('RealtimeAudioInputTurnDetection.fromJson unknown discriminator '
+        'roundtrips', () {
+      final json = <String, dynamic>{
+        'type': 'experimental_vad',
+        'threshold': 0.7,
+      };
+      final parsed = RealtimeAudioInputTurnDetection.fromJson(json);
+      expect(parsed, isA<UnknownRealtimeAudioInputTurnDetection>());
+      expect(parsed.type, 'experimental_vad');
+      expect(parsed.toJson(), equals(json));
+
+      // Deep equality + hash consistency.
+      final twin = RealtimeAudioInputTurnDetection.fromJson(<String, dynamic>{
+        'type': 'experimental_vad',
+        'threshold': 0.7,
+      });
+      expect(parsed, equals(twin));
+      expect(parsed.hashCode, twin.hashCode);
+    });
+
+    test('RealtimeTracingConfig.fromJson non-map non-auto value yields '
+        'UnknownRealtimeTracingConfig', () {
+      // Maps always parse into [TracingConfiguration] (any keys are valid
+      // — they're all optional). The Unknown fallback only triggers for
+      // non-map values that aren't the literal `'auto'` string, e.g. if
+      // a future spec allows `'enabled'`/`'disabled'` strings.
+      final parsed = RealtimeTracingConfig.fromJson('enabled');
+      expect(parsed, isA<UnknownRealtimeTracingConfig>());
+      expect(parsed.toJson(), equals('enabled'));
+    });
+
+    test('RealtimeTruncation.fromJson unknown discriminator roundtrips', () {
+      final json = <String, dynamic>{
+        'type': 'experimental',
+        'config': <String, dynamic>{'mode': 'aggressive'},
+      };
+      final parsed = RealtimeTruncation.fromJson(json);
+      expect(parsed, isA<UnknownRealtimeTruncation>());
+      expect(parsed.toJson(), equals(json));
+
+      // Deep-equality semantics on nested maps.
+      final twin = RealtimeTruncation.fromJson(<String, dynamic>{
+        'type': 'experimental',
+        'config': <String, dynamic>{'mode': 'aggressive'},
+      });
+      expect(parsed, equals(twin));
+      expect(parsed.hashCode, twin.hashCode);
     });
   });
 }

--- a/packages/openai_dart/test/unit/models/realtime_test.dart
+++ b/packages/openai_dart/test/unit/models/realtime_test.dart
@@ -426,6 +426,58 @@ void main() {
     });
   });
 
+  group('RealtimeAudioConfigInput tri-state serialization', () {
+    test('omits keys when fields are null and clear flags are false', () {
+      const input = RealtimeAudioConfigInput();
+      expect(input.toJson(), isEmpty);
+    });
+
+    test('emits explicit JSON null when clear flag is true', () {
+      const input = RealtimeAudioConfigInput(
+        clearNoiseReduction: true,
+        clearTranscription: true,
+        clearTurnDetection: true,
+      );
+      final json = input.toJson();
+      expect(json, containsPair('noise_reduction', null));
+      expect(json, containsPair('transcription', null));
+      expect(json, containsPair('turn_detection', null));
+    });
+
+    test('value wins over clear flag', () {
+      const input = RealtimeAudioConfigInput(
+        transcription: InputAudioTranscription(model: 'whisper-1'),
+        clearTranscription: true,
+      );
+      final json = input.toJson();
+      expect(json['transcription'], isA<Map<String, dynamic>>());
+    });
+
+    test('roundtrips explicit JSON null back to clear flag = true', () {
+      final json = <String, dynamic>{
+        'noise_reduction': null,
+        'transcription': null,
+        'turn_detection': null,
+      };
+      final parsed = RealtimeAudioConfigInput.fromJson(json);
+      expect(parsed.noiseReduction, isNull);
+      expect(parsed.transcription, isNull);
+      expect(parsed.turnDetection, isNull);
+      expect(parsed.clearNoiseReduction, isTrue);
+      expect(parsed.clearTranscription, isTrue);
+      expect(parsed.clearTurnDetection, isTrue);
+      // Round-trip shape preserved.
+      expect(parsed.toJson(), equals(json));
+    });
+
+    test('absent keys parse with clear flag = false', () {
+      final parsed = RealtimeAudioConfigInput.fromJson(const {});
+      expect(parsed.clearNoiseReduction, isFalse);
+      expect(parsed.clearTranscription, isFalse);
+      expect(parsed.clearTurnDetection, isFalse);
+    });
+  });
+
   group('Sealed Unknown-variant fallbacks', () {
     test(
       'RealtimeEvent.fromJson unrecognised type roundtrips through Unknown',

--- a/packages/openai_dart/test/unit/models/realtime_test.dart
+++ b/packages/openai_dart/test/unit/models/realtime_test.dart
@@ -1,268 +1,430 @@
-import 'package:openai_dart/openai_dart.dart' show InfOrIntInf, InfOrIntValue;
+import 'package:openai_dart/openai_dart.dart' show InfOrInt;
 import 'package:openai_dart/openai_dart_realtime.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('RealtimeVoice', () {
-    test('fromJson parses all values', () {
-      expect(RealtimeVoice.fromJson('alloy'), RealtimeVoice.alloy);
-      expect(RealtimeVoice.fromJson('ash'), RealtimeVoice.ash);
-      expect(RealtimeVoice.fromJson('ballad'), RealtimeVoice.ballad);
-      expect(RealtimeVoice.fromJson('coral'), RealtimeVoice.coral);
-      expect(RealtimeVoice.fromJson('echo'), RealtimeVoice.echo);
-      expect(RealtimeVoice.fromJson('sage'), RealtimeVoice.sage);
-      expect(RealtimeVoice.fromJson('shimmer'), RealtimeVoice.shimmer);
-      expect(RealtimeVoice.fromJson('verse'), RealtimeVoice.verse);
+  group('RealtimeSessionCreateRequest (GA shape)', () {
+    test('minimal payload roundtrip omits type discriminator', () {
+      const request = RealtimeSessionCreateRequest(model: 'gpt-realtime');
+      final json = request.toJson();
+      // The bare `/realtime/sessions` endpoint rejects unknown parameters,
+      // so `type` must be omitted unless the caller (or the
+      // `/realtime/client_secrets` wrapper) sets it explicitly.
+      expect(json, {'model': 'gpt-realtime'});
+
+      final parsed = RealtimeSessionCreateRequest.fromJson(json);
+      expect(parsed.model, request.model);
+      expect(parsed.toJson(), json);
     });
 
-    test('toJson returns correct string', () {
-      expect(RealtimeVoice.alloy.toJson(), 'alloy');
-      expect(RealtimeVoice.shimmer.toJson(), 'shimmer');
+    test('explicit type discriminator is preserved on the wire', () {
+      const request = RealtimeSessionCreateRequest(
+        model: 'gpt-realtime',
+        type: 'realtime',
+      );
+      expect(request.toJson(), {'type': 'realtime', 'model': 'gpt-realtime'});
     });
 
-    test('fromJson throws on unknown value', () {
-      expect(() => RealtimeVoice.fromJson('unknown'), throwsFormatException);
+    test('client-secret wrapper injects the type discriminator', () {
+      const wrapped = RealtimeClientSecretCreateRequest(
+        session: RealtimeSessionCreateRequest(model: 'gpt-realtime-2'),
+      );
+      final json = wrapped.toJson();
+      // The bare session does not emit `type`, but the wrapper must.
+      expect((json['session'] as Map<String, dynamic>)['type'], 'realtime');
+    });
+
+    test('exhaustive payload roundtrip', () {
+      // Mirrors the Python SDK
+      // tests/api_resources/realtime/test_client_secrets.py
+      // ::test_method_create_with_all_params fixture, minus `prompt`.
+      final json = <String, dynamic>{
+        'type': 'realtime',
+        'model': 'gpt-realtime',
+        'audio': {
+          'input': {
+            'format': {'type': 'audio/pcm', 'rate': 24000},
+            'noise_reduction': {'type': 'near_field'},
+            'transcription': {
+              'delay': 'minimal',
+              'language': 'en',
+              'model': 'whisper-1',
+              'prompt': 'expect words about the weather',
+            },
+            'turn_detection': {
+              'type': 'server_vad',
+              'create_response': true,
+              'idle_timeout_ms': 5000,
+              'interrupt_response': true,
+              'prefix_padding_ms': 300,
+              'silence_duration_ms': 500,
+              'threshold': 0.5,
+            },
+          },
+          'output': {
+            'format': {'type': 'audio/pcm', 'rate': 24000},
+            'speed': 0.25,
+            'voice': 'alloy',
+          },
+        },
+        'output_modalities': ['text'],
+        'instructions': 'instructions',
+        'tools': [
+          {
+            'type': 'function',
+            'name': 'get_weather',
+            'description': 'Get the weather',
+            'parameters': {
+              'type': 'object',
+              'properties': {
+                'location': {'type': 'string'},
+              },
+            },
+          },
+        ],
+        'tool_choice': 'none',
+        'temperature': 0.8,
+        'max_output_tokens': 'inf',
+        'parallel_tool_calls': true,
+        'reasoning': {'effort': 'minimal'},
+        'tracing': 'auto',
+        'truncation': 'auto',
+        'include': ['item.input_audio_transcription.logprobs'],
+      };
+
+      final parsed = RealtimeSessionCreateRequest.fromJson(json);
+      expect(parsed.toJson(), json);
+
+      // Spot-check a few field types to catch typos.
+      expect(parsed.audio?.input?.format, const AudioPcm(rate: 24000));
+      expect(
+        parsed.audio?.input?.transcription?.delay,
+        AudioTranscriptionDelay.minimal,
+      );
+      expect(
+        parsed.audio?.input?.turnDetection,
+        isA<ServerVad>().having((v) => v.idleTimeoutMs, 'idleTimeoutMs', 5000),
+      );
+      expect(parsed.maxOutputTokens, isA<InfOrInt>());
+      expect(parsed.maxOutputTokens?.toJson(), 'inf');
+      expect(parsed.parallelToolCalls, true);
+      expect(parsed.reasoning?.effort, RealtimeReasoningEffort.minimal);
+      expect(parsed.tracing, isA<TracingAuto>());
+      expect(parsed.truncation, isA<TruncationAuto>());
+    });
+
+    test('format variant: AudioPcmu', () {
+      const request = RealtimeSessionCreateRequest(
+        model: 'gpt-realtime-2',
+        audio: RealtimeAudioConfig(
+          input: RealtimeAudioConfigInput(format: AudioPcmu()),
+        ),
+      );
+      final json = request.toJson();
+      expect((json['audio'] as Map)['input'], {
+        'format': {'type': 'audio/pcmu'},
+      });
+      final parsed = RealtimeSessionCreateRequest.fromJson(json);
+      expect(parsed.audio?.input?.format, const AudioPcmu());
+    });
+
+    test('format variant: AudioPcma', () {
+      const request = RealtimeSessionCreateRequest(
+        model: 'gpt-realtime-2',
+        audio: RealtimeAudioConfig(
+          output: RealtimeAudioConfigOutput(format: AudioPcma()),
+        ),
+      );
+      final json = request.toJson();
+      expect((json['audio'] as Map)['output'], {
+        'format': {'type': 'audio/pcma'},
+      });
+      final parsed = RealtimeSessionCreateRequest.fromJson(json);
+      expect(parsed.audio?.output?.format, const AudioPcma());
+    });
+
+    test('turn_detection semantic_vad variant', () {
+      final json = <String, dynamic>{
+        'type': 'realtime',
+        'model': 'gpt-realtime-2',
+        'audio': {
+          'input': {
+            'turn_detection': {
+              'type': 'semantic_vad',
+              'eagerness': 'auto',
+              'interrupt_response': true,
+            },
+          },
+        },
+      };
+      final parsed = RealtimeSessionCreateRequest.fromJson(json);
+      expect(parsed.audio?.input?.turnDetection, isA<SemanticVad>());
+      expect(parsed.toJson(), json);
+    });
+
+    test('truncation retention_ratio variant', () {
+      final json = <String, dynamic>{
+        'type': 'realtime',
+        'model': 'gpt-realtime-2',
+        'truncation': {'type': 'retention_ratio', 'retention_ratio': 0.8},
+      };
+      final parsed = RealtimeSessionCreateRequest.fromJson(json);
+      expect(parsed.truncation, isA<TruncationRetentionRatio>());
+      expect(
+        (parsed.truncation! as TruncationRetentionRatio).retentionRatio,
+        0.8,
+      );
+      expect(parsed.toJson(), json);
+    });
+
+    test('truncation retention_ratio with token_limits', () {
+      final json = <String, dynamic>{
+        'type': 'realtime',
+        'model': 'gpt-realtime-2',
+        'truncation': {
+          'type': 'retention_ratio',
+          'retention_ratio': 0.5,
+          'token_limits': {'post_instructions': 5000},
+        },
+      };
+      final parsed = RealtimeSessionCreateRequest.fromJson(json);
+      expect(
+        (parsed.truncation! as TruncationRetentionRatio)
+            .postInstructionsTokenLimit,
+        5000,
+      );
+      expect(parsed.toJson(), json);
+    });
+
+    test('truncation disabled variant', () {
+      final json = <String, dynamic>{
+        'type': 'realtime',
+        'model': 'gpt-realtime-2',
+        'truncation': 'disabled',
+      };
+      final parsed = RealtimeSessionCreateRequest.fromJson(json);
+      expect(parsed.truncation, isA<TruncationDisabled>());
+      expect(parsed.toJson(), json);
+    });
+
+    test('tracing TracingConfiguration variant', () {
+      final json = <String, dynamic>{
+        'type': 'realtime',
+        'model': 'gpt-realtime-2',
+        'tracing': {
+          'group_id': 'g-123',
+          'workflow_name': 'demo',
+          'metadata': {'env': 'staging'},
+        },
+      };
+      final parsed = RealtimeSessionCreateRequest.fromJson(json);
+      expect(parsed.tracing, isA<TracingConfiguration>());
+      final cfg = parsed.tracing! as TracingConfiguration;
+      expect(cfg.groupId, 'g-123');
+      expect(cfg.workflowName, 'demo');
+      expect(cfg.metadata, {'env': 'staging'});
+      expect(parsed.toJson(), json);
+    });
+
+    test('max_output_tokens integer variant', () {
+      final json = <String, dynamic>{
+        'type': 'realtime',
+        'model': 'gpt-realtime-2',
+        'max_output_tokens': 4096,
+      };
+      final parsed = RealtimeSessionCreateRequest.fromJson(json);
+      expect(parsed.maxOutputTokens?.toJson(), 4096);
+      expect(parsed.toJson(), json);
+    });
+
+    test('include omitted yields null and stays null on roundtrip', () {
+      const request = RealtimeSessionCreateRequest(model: 'gpt-realtime-2');
+      expect(request.include, isNull);
+      final parsed = RealtimeSessionCreateRequest.fromJson(request.toJson());
+      expect(parsed.include, isNull);
+    });
+
+    test('copyWith updates and clears nullable fields', () {
+      const request = RealtimeSessionCreateRequest(
+        model: 'gpt-realtime-2',
+        instructions: 'be helpful',
+        parallelToolCalls: true,
+      );
+      final updated = request.copyWith(instructions: 'be terse');
+      expect(updated.instructions, 'be terse');
+      expect(updated.parallelToolCalls, true);
+
+      final cleared = request.copyWith(instructions: null);
+      expect(cleared.instructions, isNull);
+      expect(cleared.parallelToolCalls, true);
+    });
+
+    test('toString includes key fields', () {
+      const request = RealtimeSessionCreateRequest(
+        model: 'gpt-realtime-2',
+        instructions: 'hi',
+        parallelToolCalls: true,
+      );
+      final str = request.toString();
+      expect(str, contains('gpt-realtime-2'));
+      expect(str, contains('hi'));
+      expect(str, contains('parallelToolCalls: true'));
     });
   });
 
-  group('RealtimeAudioFormat', () {
-    test('fromJson parses all values', () {
-      expect(RealtimeAudioFormat.fromJson('pcm16'), RealtimeAudioFormat.pcm16);
-      expect(
-        RealtimeAudioFormat.fromJson('g711_ulaw'),
-        RealtimeAudioFormat.g711Ulaw,
-      );
-      expect(
-        RealtimeAudioFormat.fromJson('g711_alaw'),
-        RealtimeAudioFormat.g711Alaw,
-      );
+  group('RealtimeSessionCreateResponse (GA shape)', () {
+    test('GA response roundtrip and omits client_secret', () {
+      final json = <String, dynamic>{
+        'id': 'sess_abc123',
+        'object': 'realtime.session',
+        'type': 'realtime',
+        'model': 'gpt-realtime-2',
+        'expires_at': 1714857600,
+        'audio': {
+          'output': {'voice': 'alloy'},
+        },
+      };
+      final parsed = RealtimeSessionCreateResponse.fromJson(json);
+      expect(parsed.id, 'sess_abc123');
+      expect(parsed.type, 'realtime');
+      expect(parsed.expiresAt, 1714857600);
+      expect(parsed.audio?.output?.voice, 'alloy');
+
+      final encoded = parsed.toJson();
+      expect(encoded, json);
+      // Regression guard: the GA response no longer has `client_secret`
+      // nested on the session object.
+      expect(encoded.containsKey('client_secret'), isFalse);
     });
 
-    test('toJson returns correct string', () {
-      expect(RealtimeAudioFormat.pcm16.toJson(), 'pcm16');
-      expect(RealtimeAudioFormat.g711Ulaw.toJson(), 'g711_ulaw');
+    test('fromJson defaults missing fields rather than throwing', () {
+      // Live API has been observed to omit these on early frames; the parser
+      // is intentionally lenient (defaults) rather than strict (throws).
+      final parsed = RealtimeSessionCreateResponse.fromJson(const {
+        'object': 'realtime.session',
+        'type': 'realtime',
+        'model': 'gpt-realtime-2',
+        'expires_at': 0,
+      });
+      expect(parsed.id, '');
+      expect(parsed.expiresAt, 0);
     });
   });
 
-  group('TurnDetectionType', () {
-    test('fromJson parses all values', () {
-      expect(
-        TurnDetectionType.fromJson('server_vad'),
-        TurnDetectionType.serverVad,
+  group('InputAudioTranscription', () {
+    test('roundtrips delay xhigh + gpt-realtime-whisper model', () {
+      const transcription = InputAudioTranscription(
+        delay: AudioTranscriptionDelay.xhigh,
+        model: 'gpt-realtime-whisper',
       );
-      expect(TurnDetectionType.fromJson('none'), TurnDetectionType.none);
+      final json = transcription.toJson();
+      expect(json, {'delay': 'xhigh', 'model': 'gpt-realtime-whisper'});
+
+      final parsed = InputAudioTranscription.fromJson(json);
+      expect(parsed, transcription);
     });
 
-    test('toJson returns correct string', () {
-      expect(TurnDetectionType.serverVad.toJson(), 'server_vad');
-      expect(TurnDetectionType.none.toJson(), 'none');
+    test('omits null delay', () {
+      const transcription = InputAudioTranscription(model: 'whisper-1');
+      expect(transcription.toJson(), {'model': 'whisper-1'});
+
+      final parsed = InputAudioTranscription.fromJson(transcription.toJson());
+      expect(parsed.delay, isNull);
+    });
+
+    test('copyWith clears delay', () {
+      const transcription = InputAudioTranscription(
+        model: 'gpt-realtime-whisper',
+        delay: AudioTranscriptionDelay.high,
+      );
+      final cleared = transcription.copyWith(delay: null);
+      expect(cleared.delay, isNull);
+      expect(cleared.model, 'gpt-realtime-whisper');
+    });
+
+    test('toString includes all fields', () {
+      const transcription = InputAudioTranscription(
+        delay: AudioTranscriptionDelay.medium,
+        language: 'en',
+        model: 'whisper-1',
+        prompt: 'guidance',
+      );
+      final str = transcription.toString();
+      expect(str, contains('medium'));
+      expect(str, contains('en'));
+      expect(str, contains('whisper-1'));
+      expect(str, contains('guidance'));
+    });
+  });
+
+  group('AudioTranscriptionDelay', () {
+    test('all values roundtrip', () {
+      for (final value in AudioTranscriptionDelay.values) {
+        expect(AudioTranscriptionDelay.fromJson(value.toJson()), value);
+      }
+    });
+
+    test('throws on unknown value', () {
+      expect(
+        () => AudioTranscriptionDelay.fromJson('zzz'),
+        throwsFormatException,
+      );
+    });
+  });
+
+  group('NoiseReductionType', () {
+    test('values roundtrip', () {
+      expect(
+        NoiseReductionType.fromJson('near_field'),
+        NoiseReductionType.nearField,
+      );
+      expect(
+        NoiseReductionType.fromJson('far_field'),
+        NoiseReductionType.farField,
+      );
+      expect(NoiseReductionType.nearField.toJson(), 'near_field');
+    });
+
+    test('throws on unknown value', () {
+      expect(
+        () => NoiseReductionType.fromJson('on_axis'),
+        throwsFormatException,
+      );
     });
   });
 
   group('RealtimeToolChoice', () {
-    test('auto() creates auto choice', () {
-      const choice = RealtimeToolChoice.auto();
-      expect(choice, isA<RealtimeToolChoiceAuto>());
-      expect(choice.toJson(), 'auto');
-    });
-
-    test('none() creates none choice', () {
-      const choice = RealtimeToolChoice.none();
-      expect(choice, isA<RealtimeToolChoiceNone>());
-      expect(choice.toJson(), 'none');
-    });
-
-    test('required() creates required choice', () {
-      const choice = RealtimeToolChoice.required();
-      expect(choice, isA<RealtimeToolChoiceRequired>());
-      expect(choice.toJson(), 'required');
-    });
-
-    test('function() creates function choice', () {
-      const choice = RealtimeToolChoice.function('get_weather');
-      expect(choice, isA<RealtimeToolChoiceFunction>());
-      expect(choice.toJson(), {
-        'type': 'function',
-        'function': {'name': 'get_weather'},
-      });
-    });
-
-    test('fromJson parses string choices', () {
+    test('string variants roundtrip', () {
       expect(
         RealtimeToolChoice.fromJson('auto'),
-        isA<RealtimeToolChoiceAuto>(),
+        const RealtimeToolChoiceAuto(),
       );
       expect(
         RealtimeToolChoice.fromJson('none'),
-        isA<RealtimeToolChoiceNone>(),
+        const RealtimeToolChoiceNone(),
       );
       expect(
         RealtimeToolChoice.fromJson('required'),
-        isA<RealtimeToolChoiceRequired>(),
+        const RealtimeToolChoiceRequired(),
       );
+      expect(const RealtimeToolChoiceAuto().toJson(), 'auto');
     });
 
-    test('fromJson parses function choice', () {
-      final choice = RealtimeToolChoice.fromJson({
+    test('function variant roundtrips', () {
+      const choice = RealtimeToolChoice.function('get_weather');
+      final json = choice.toJson();
+      expect(json, {
         'type': 'function',
-        'function': {'name': 'my_func'},
+        'function': {'name': 'get_weather'},
       });
-      expect(choice, isA<RealtimeToolChoiceFunction>());
-      expect((choice as RealtimeToolChoiceFunction).name, 'my_func');
-    });
-
-    test('equality works correctly', () {
       expect(
-        const RealtimeToolChoiceAuto(),
-        equals(const RealtimeToolChoiceAuto()),
-      );
-      expect(
-        const RealtimeToolChoiceFunction('test'),
-        equals(const RealtimeToolChoiceFunction('test')),
-      );
-      expect(
-        const RealtimeToolChoiceFunction('a'),
-        isNot(equals(const RealtimeToolChoiceFunction('b'))),
+        RealtimeToolChoice.fromJson(json),
+        const RealtimeToolChoiceFunction('get_weather'),
       );
     });
-  });
 
-  group('RealtimeSession', () {
-    test('fromJson parses correctly', () {
-      final json = {
-        'id': 'sess_abc123',
-        'object': 'realtime.session',
-        'model': 'gpt-realtime-1.5',
-        'modalities': ['text', 'audio'],
-        'instructions': 'You are a helpful assistant.',
-        'voice': 'alloy',
-        'input_audio_format': 'pcm16',
-        'output_audio_format': 'pcm16',
-        'turn_detection': {
-          'type': 'server_vad',
-          'threshold': 0.5,
-          'prefix_padding_ms': 300,
-          'silence_duration_ms': 500,
-        },
-        'tool_choice': 'auto',
-        'temperature': 0.7,
-        'max_response_output_tokens': 'inf',
-      };
-
-      final session = RealtimeSession.fromJson(json);
-
-      expect(session.id, 'sess_abc123');
-      expect(session.model, 'gpt-realtime-1.5');
-      expect(session.modalities, ['text', 'audio']);
-      expect(session.voice, RealtimeVoice.alloy);
-      expect(session.inputAudioFormat, RealtimeAudioFormat.pcm16);
-      expect(session.outputAudioFormat, RealtimeAudioFormat.pcm16);
-      expect(session.turnDetection?.type, TurnDetectionType.serverVad);
-      expect(session.turnDetection?.threshold, 0.5);
-      expect(session.toolChoice, isA<RealtimeToolChoiceAuto>());
-      expect(session.temperature, 0.7);
-      expect(session.maxResponseOutputTokens, isA<InfOrIntInf>());
-    });
-
-    test('fromJson parses numeric max tokens', () {
-      final json = {
-        'id': 'sess_abc123',
-        'object': 'realtime.session',
-        'model': 'gpt-realtime-1.5',
-        'max_response_output_tokens': 4096,
-      };
-
-      final session = RealtimeSession.fromJson(json);
-
-      expect(session.maxResponseOutputTokens, isA<InfOrIntValue>());
-      expect((session.maxResponseOutputTokens! as InfOrIntValue).value, 4096);
-    });
-
-    test('toJson serializes correctly', () {
-      const session = RealtimeSession(
-        id: 'sess_abc123',
-        object: 'realtime.session',
-        model: 'gpt-realtime-1.5',
-        voice: RealtimeVoice.shimmer,
-        inputAudioFormat: RealtimeAudioFormat.g711Ulaw,
-        toolChoice: RealtimeToolChoiceRequired(),
-        maxResponseOutputTokens: InfOrIntValue(2048),
-      );
-
-      final json = session.toJson();
-
-      expect(json['id'], 'sess_abc123');
-      expect(json['voice'], 'shimmer');
-      expect(json['input_audio_format'], 'g711_ulaw');
-      expect(json['tool_choice'], 'required');
-      expect(json['max_response_output_tokens'], 2048);
-    });
-  });
-
-  group('SessionUpdateConfig', () {
-    test('fromJson parses correctly', () {
-      final json = {
-        'voice': 'coral',
-        'temperature': 0.8,
-        'tool_choice': 'none',
-        'max_response_output_tokens': 'inf',
-      };
-
-      final config = SessionUpdateConfig.fromJson(json);
-
-      expect(config.voice, RealtimeVoice.coral);
-      expect(config.temperature, 0.8);
-      expect(config.toolChoice, isA<RealtimeToolChoiceNone>());
-      expect(config.maxResponseOutputTokens, isA<InfOrIntInf>());
-    });
-
-    test('toJson serializes correctly', () {
-      const config = SessionUpdateConfig(
-        voice: RealtimeVoice.sage,
-        toolChoice: RealtimeToolChoiceFunction('search'),
-        maxResponseOutputTokens: InfOrIntInf(),
-      );
-
-      final json = config.toJson();
-
-      expect(json['voice'], 'sage');
-      expect(json['tool_choice'], {
-        'type': 'function',
-        'function': {'name': 'search'},
-      });
-      expect(json['max_response_output_tokens'], 'inf');
-    });
-  });
-
-  group('TurnDetection', () {
-    test('fromJson parses correctly', () {
-      final json = {
-        'type': 'server_vad',
-        'threshold': 0.5,
-        'prefix_padding_ms': 300,
-        'silence_duration_ms': 500,
-        'create_response': true,
-      };
-
-      final detection = TurnDetection.fromJson(json);
-
-      expect(detection.type, TurnDetectionType.serverVad);
-      expect(detection.threshold, 0.5);
-      expect(detection.prefixPaddingMs, 300);
-      expect(detection.silenceDurationMs, 500);
-      expect(detection.createResponse, isTrue);
-    });
-
-    test('toJson serializes correctly', () {
-      const detection = TurnDetection(
-        type: TurnDetectionType.serverVad,
-        threshold: 0.6,
-      );
-
-      final json = detection.toJson();
-
-      expect(json['type'], 'server_vad');
-      expect(json['threshold'], 0.6);
+    test('throws on invalid payload', () {
+      expect(() => RealtimeToolChoice.fromJson(42), throwsFormatException);
     });
   });
 }

--- a/packages/openai_dart/test/unit/models/realtime_translation_test.dart
+++ b/packages/openai_dart/test/unit/models/realtime_translation_test.dart
@@ -1,0 +1,279 @@
+import 'package:openai_dart/openai_dart_realtime.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RealtimeTranslationClientSecretCreateRequest', () {
+    test('roundtrips spec example payload', () {
+      final json = <String, dynamic>{
+        'expires_after': {'anchor': 'created_at', 'seconds': 600},
+        'session': {
+          'model': 'gpt-realtime-translate',
+          'audio': {
+            'input': {
+              'transcription': {'model': 'gpt-realtime-whisper'},
+            },
+            'output': {'language': 'es'},
+          },
+        },
+      };
+
+      final parsed = RealtimeTranslationClientSecretCreateRequest.fromJson(
+        json,
+      );
+      expect(parsed.session.model, 'gpt-realtime-translate');
+      expect(
+        parsed.session.audio?.input?.transcription?.model,
+        'gpt-realtime-whisper',
+      );
+      expect(parsed.session.audio?.output?.language, 'es');
+      expect(parsed.expiresAfter?.seconds, 600);
+
+      expect(parsed.toJson(), json);
+    });
+
+    test('fromJson throws on missing required session', () {
+      expect(
+        () => RealtimeTranslationClientSecretCreateRequest.fromJson(const {}),
+        throwsFormatException,
+      );
+    });
+  });
+
+  group('RealtimeTranslationClientSecretCreateResponse', () {
+    test('roundtrips spec example payload', () {
+      final json = <String, dynamic>{
+        'value': 'ek_68af296e8e408191a1120ab6383263c2',
+        'expires_at': 1756310470,
+        'session': {
+          'id': 'sess_C9CiUVUzUzYIssh3ELY1d',
+          'type': 'translation',
+          'expires_at': 1756310470,
+          'model': 'gpt-realtime-translate',
+          'audio': {
+            'input': <String, dynamic>{},
+            'output': {'language': 'es'},
+          },
+        },
+      };
+
+      final parsed = RealtimeTranslationClientSecretCreateResponse.fromJson(
+        json,
+      );
+      expect(parsed.value.startsWith('ek_'), isTrue);
+      expect(parsed.expiresAt, 1756310470);
+      expect(parsed.session.id, 'sess_C9CiUVUzUzYIssh3ELY1d');
+      expect(parsed.session.type, 'translation');
+
+      expect(parsed.toJson(), json);
+    });
+  });
+
+  group('RealtimeTranslationClientEvent variants', () {
+    test('session.update roundtrips', () {
+      final json = <String, dynamic>{
+        'type': 'session.update',
+        'session': {
+          'audio': {
+            'input': {
+              'transcription': {'model': 'gpt-realtime-whisper'},
+            },
+            'output': {'language': 'es'},
+          },
+        },
+      };
+      final parsed = RealtimeTranslationClientEvent.fromJson(json);
+      expect(parsed, isA<RealtimeTranslationSessionUpdateEvent>());
+      expect(parsed.toJson(), json);
+    });
+
+    test('session.input_audio_buffer.append roundtrips', () {
+      final json = <String, dynamic>{
+        'type': 'session.input_audio_buffer.append',
+        'audio': 'BASE64AUDIO',
+        'event_id': 'evt_1',
+      };
+      final parsed = RealtimeTranslationClientEvent.fromJson(json);
+      expect(parsed, isA<RealtimeTranslationInputAudioBufferAppendEvent>());
+      expect(parsed.eventId, 'evt_1');
+      expect(parsed.toJson(), json);
+    });
+
+    test('session.close roundtrips', () {
+      final json = <String, dynamic>{
+        'type': 'session.close',
+        'event_id': 'evt_close',
+      };
+      final parsed = RealtimeTranslationClientEvent.fromJson(json);
+      expect(parsed, isA<RealtimeTranslationSessionCloseEvent>());
+      expect(parsed.eventId, 'evt_close');
+      expect(parsed.toJson(), json);
+    });
+
+    test('unknown discriminator yields Unknown variant', () {
+      final json = <String, dynamic>{
+        'type': 'session.future',
+        'event_id': 'evt_zz',
+        'extra': 'preserved',
+      };
+      final parsed = RealtimeTranslationClientEvent.fromJson(json);
+      expect(parsed, isA<UnknownRealtimeTranslationClientEvent>());
+      expect(parsed.toJson(), json);
+    });
+  });
+
+  group('RealtimeTranslationServerEvent variants', () {
+    test('error roundtrips', () {
+      final json = <String, dynamic>{
+        'type': 'error',
+        'event_id': 'evt_err',
+        'error': {'type': 'invalid_request_error', 'message': 'bad input'},
+      };
+      final parsed = RealtimeTranslationServerEvent.fromJson(json);
+      expect(parsed, isA<RealtimeTranslationErrorEvent>());
+      expect(parsed.toJson(), json);
+    });
+
+    test('session.created roundtrips', () {
+      final json = <String, dynamic>{
+        'type': 'session.created',
+        'event_id': 'evt_1',
+        'session': {
+          'id': 'sess_x',
+          'type': 'translation',
+          'expires_at': 1714857600,
+          'model': 'gpt-realtime-translate',
+          'audio': {
+            'input': {
+              'transcription': {'model': 'gpt-realtime-whisper'},
+            },
+            'output': {'language': 'fr'},
+          },
+        },
+      };
+      final parsed = RealtimeTranslationServerEvent.fromJson(json);
+      expect(parsed, isA<RealtimeTranslationSessionCreatedEvent>());
+      expect(parsed.toJson(), json);
+    });
+
+    test('session.updated roundtrips', () {
+      final json = <String, dynamic>{
+        'type': 'session.updated',
+        'event_id': 'evt_2',
+        'session': {
+          'id': 'sess_x',
+          'type': 'translation',
+          'expires_at': 1714857600,
+          'model': 'gpt-realtime-translate',
+          'audio': {
+            'input': <String, dynamic>{},
+            'output': {'language': 'es'},
+          },
+        },
+      };
+      final parsed = RealtimeTranslationServerEvent.fromJson(json);
+      expect(parsed, isA<RealtimeTranslationSessionUpdatedEvent>());
+      expect(parsed.toJson(), json);
+    });
+
+    test('session.closed roundtrips', () {
+      final json = <String, dynamic>{
+        'type': 'session.closed',
+        'event_id': 'evt_close',
+      };
+      final parsed = RealtimeTranslationServerEvent.fromJson(json);
+      expect(parsed, isA<RealtimeTranslationSessionClosedEvent>());
+      expect(parsed.toJson(), json);
+    });
+
+    test('session.input_transcript.delta roundtrips', () {
+      final json = <String, dynamic>{
+        'type': 'session.input_transcript.delta',
+        'event_id': 'evt_3',
+        'delta': ' hear',
+        'elapsed_ms': 1200,
+      };
+      final parsed = RealtimeTranslationServerEvent.fromJson(json);
+      expect(parsed, isA<RealtimeTranslationInputTranscriptDeltaEvent>());
+      expect(parsed.toJson(), json);
+    });
+
+    test('session.output_transcript.delta roundtrips', () {
+      final json = <String, dynamic>{
+        'type': 'session.output_transcript.delta',
+        'event_id': 'evt_4',
+        'delta': ' escuch',
+        'elapsed_ms': 1200,
+      };
+      final parsed = RealtimeTranslationServerEvent.fromJson(json);
+      expect(parsed, isA<RealtimeTranslationOutputTranscriptDeltaEvent>());
+      expect(parsed.toJson(), json);
+    });
+
+    test('session.output_audio.delta roundtrips with base64 payload', () {
+      final json = <String, dynamic>{
+        'type': 'session.output_audio.delta',
+        'event_id': 'evt_5',
+        'delta': 'Base64EncodedAudioDelta',
+        'sample_rate': 24000,
+        'channels': 1,
+        'format': 'pcm16',
+      };
+      final parsed = RealtimeTranslationServerEvent.fromJson(json);
+      expect(parsed, isA<RealtimeTranslationOutputAudioDeltaEvent>());
+      final delta = parsed as RealtimeTranslationOutputAudioDeltaEvent;
+      expect(delta.delta, 'Base64EncodedAudioDelta');
+      expect(parsed.toJson(), json);
+    });
+
+    test('discriminator dispatch returns the correct subclass', () {
+      final cases = <String, Type>{
+        'error': RealtimeTranslationErrorEvent,
+        'session.created': RealtimeTranslationSessionCreatedEvent,
+        'session.updated': RealtimeTranslationSessionUpdatedEvent,
+        'session.closed': RealtimeTranslationSessionClosedEvent,
+        'session.input_transcript.delta':
+            RealtimeTranslationInputTranscriptDeltaEvent,
+        'session.output_transcript.delta':
+            RealtimeTranslationOutputTranscriptDeltaEvent,
+        'session.output_audio.delta': RealtimeTranslationOutputAudioDeltaEvent,
+      };
+      for (final entry in cases.entries) {
+        final json = <String, dynamic>{
+          'type': entry.key,
+          'event_id': 'evt',
+          if (entry.key.contains('transcript.delta')) 'delta': '',
+          if (entry.key == 'session.output_audio.delta') 'delta': '',
+          if (entry.key == 'error') 'error': {'type': 't', 'message': 'm'},
+          if (entry.key.startsWith('session.created') ||
+              entry.key.startsWith('session.updated'))
+            'session': {
+              'id': 's',
+              'type': 'translation',
+              'expires_at': 0,
+              'model': 'gpt-realtime-translate',
+              'audio': <String, dynamic>{
+                'input': <String, dynamic>{},
+                'output': <String, dynamic>{},
+              },
+            },
+        };
+        final parsed = RealtimeTranslationServerEvent.fromJson(json);
+        expect(
+          parsed.runtimeType,
+          entry.value,
+          reason: 'for type ${entry.key}',
+        );
+      }
+    });
+
+    test('unknown discriminator yields Unknown variant', () {
+      final json = <String, dynamic>{
+        'type': 'session.future',
+        'event_id': 'evt_zz',
+      };
+      final parsed = RealtimeTranslationServerEvent.fromJson(json);
+      expect(parsed, isA<UnknownRealtimeTranslationServerEvent>());
+      expect(parsed.toJson(), json);
+    });
+  });
+}

--- a/packages/openai_dart/test/unit/resources/realtime_calls_test.dart
+++ b/packages/openai_dart/test/unit/resources/realtime_calls_test.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:openai_dart/openai_dart.dart';
+import 'package:openai_dart/openai_dart_realtime.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RealtimeCallsResource.accept', () {
+    test(
+      'with no request body posts {} to /realtime/calls/{id}/accept',
+      () async {
+        final requestCompleter = Completer<http.BaseRequest>();
+
+        final mockClient = MockClient((request) async {
+          requestCompleter.complete(request);
+          return http.Response('', 200);
+        });
+
+        final client = OpenAIClient(
+          config: const OpenAIConfig(
+            authProvider: ApiKeyProvider('sk-test-key'),
+          ),
+          httpClient: mockClient,
+        );
+
+        await client.realtimeSessions.calls.accept('call_abc123');
+
+        final request = await requestCompleter.future as http.Request;
+        expect(request.method, equals('POST'));
+        expect(
+          request.url.path,
+          endsWith('/realtime/calls/call_abc123/accept'),
+        );
+        expect(jsonDecode(request.body), equals(<String, dynamic>{}));
+      },
+    );
+
+    test(
+      'with request body JSON-encodes session config and injects type=realtime',
+      () async {
+        final requestCompleter = Completer<http.BaseRequest>();
+
+        final mockClient = MockClient((request) async {
+          requestCompleter.complete(request);
+          return http.Response('', 200);
+        });
+
+        final client = OpenAIClient(
+          config: const OpenAIConfig(
+            authProvider: ApiKeyProvider('sk-test-key'),
+          ),
+          httpClient: mockClient,
+        );
+
+        await client.realtimeSessions.calls.accept(
+          'call_xyz789',
+          request: const RealtimeSessionCreateRequest(
+            model: 'gpt-realtime-2',
+            audio: RealtimeAudioConfig(
+              output: RealtimeAudioConfigOutput(voice: 'alloy'),
+            ),
+            instructions: 'Greet the caller in English.',
+          ),
+        );
+
+        final request = await requestCompleter.future as http.Request;
+        expect(request.method, equals('POST'));
+        expect(
+          request.url.path,
+          endsWith('/realtime/calls/call_xyz789/accept'),
+        );
+        expect(
+          request.headers['authorization'] ?? request.headers['Authorization'],
+          equals('Bearer sk-test-key'),
+        );
+
+        final body = jsonDecode(request.body) as Map<String, dynamic>;
+        expect(body['model'], equals('gpt-realtime-2'));
+        expect(body['instructions'], equals('Greet the caller in English.'));
+        expect(
+          body['audio'],
+          equals(<String, dynamic>{
+            'output': <String, dynamic>{'voice': 'alloy'},
+          }),
+        );
+        // The accept endpoint requires a `type` discriminator on the
+        // embedded session — the helper injects it when the caller didn't
+        // set it explicitly.
+        expect(body['type'], equals('realtime'));
+      },
+    );
+
+    test('preserves explicit type discriminator from the caller', () async {
+      final requestCompleter = Completer<http.BaseRequest>();
+
+      final mockClient = MockClient((request) async {
+        requestCompleter.complete(request);
+        return http.Response('', 200);
+      });
+
+      final client = OpenAIClient(
+        config: const OpenAIConfig(authProvider: ApiKeyProvider('sk-test-key')),
+        httpClient: mockClient,
+      );
+
+      await client.realtimeSessions.calls.accept(
+        'call_typed',
+        request: const RealtimeSessionCreateRequest(
+          model: 'gpt-realtime-2',
+          type: 'realtime',
+        ),
+      );
+
+      final request = await requestCompleter.future as http.Request;
+      final body = jsonDecode(request.body) as Map<String, dynamic>;
+      expect(body['type'], equals('realtime'));
+    });
+
+    test('accepts abortTrigger parameter', () async {
+      // Companion to the abort-trigger pattern shared with streaming
+      // methods (see streaming_abort_test.dart): we only verify here
+      // that the parameter is accepted and the request flows through.
+      // The interceptor chain already has dedicated abort tests.
+      final mockClient = MockClient((request) async => http.Response('', 200));
+
+      final client = OpenAIClient(
+        config: const OpenAIConfig(authProvider: ApiKeyProvider('sk-test-key')),
+        httpClient: mockClient,
+      );
+
+      final completer = Completer<void>();
+      await client.realtimeSessions.calls.accept(
+        'call_abort',
+        abortTrigger: completer.future,
+      );
+
+      // Without an abort, the request completes normally — the parameter
+      // is wired through without affecting the happy path.
+      expect(completer.isCompleted, isFalse);
+    });
+  });
+}

--- a/packages/openai_dart/test/unit/resources/realtime_url_test.dart
+++ b/packages/openai_dart/test/unit/resources/realtime_url_test.dart
@@ -15,13 +15,13 @@ void main() {
       // Test that buildUrl works correctly for the realtime endpoint
       final httpUrl = builder.buildUrl(
         '/realtime',
-        queryParams: {'model': 'gpt-realtime-1.5'},
+        queryParams: {'model': 'gpt-realtime-2'},
       );
 
       expect(httpUrl.scheme, equals('https'));
       expect(httpUrl.host, equals('api.openai.com'));
       expect(httpUrl.path, equals('/v1/realtime'));
-      expect(httpUrl.queryParameters['model'], equals('gpt-realtime-1.5'));
+      expect(httpUrl.queryParameters['model'], equals('gpt-realtime-2'));
 
       // Verify scheme conversion
       final wsUrl = httpUrl.replace(
@@ -30,7 +30,7 @@ void main() {
       expect(wsUrl.scheme, equals('wss'));
       expect(wsUrl.host, equals('api.openai.com'));
       expect(wsUrl.path, equals('/v1/realtime'));
-      expect(wsUrl.queryParameters['model'], equals('gpt-realtime-1.5'));
+      expect(wsUrl.queryParameters['model'], equals('gpt-realtime-2'));
     });
 
     test('buildUrl handles HTTP base URL (converts to WS)', () {
@@ -43,7 +43,7 @@ void main() {
 
       final httpUrl = builder.buildUrl(
         '/realtime',
-        queryParams: {'model': 'gpt-realtime-1.5'},
+        queryParams: {'model': 'gpt-realtime-2'},
       );
 
       // Verify scheme conversion for HTTP -> WS
@@ -67,7 +67,7 @@ void main() {
 
       final httpUrl = builder.buildUrl(
         '/realtime',
-        queryParams: {'model': 'gpt-realtime-1.5'},
+        queryParams: {'model': 'gpt-realtime-2'},
       );
 
       expect(httpUrl.scheme, equals('https'));
@@ -75,7 +75,7 @@ void main() {
       expect(httpUrl.path, equals('/openai/deployments/my-deploy/realtime'));
       // Both base URL params and request params should be present
       expect(httpUrl.queryParameters['api-version'], equals('2024-10-01'));
-      expect(httpUrl.queryParameters['model'], equals('gpt-realtime-1.5'));
+      expect(httpUrl.queryParameters['model'], equals('gpt-realtime-2'));
 
       // Verify scheme conversion
       final wsUrl = httpUrl.replace(


### PR DESCRIPTION
## Summary

- Migrates the openai_dart Realtime API client to the GA shape announced on 2026-05-07 (Voice Intelligence drop): nested `audio.input.*` / `audio.output.*` block, `outputModalities`/`maxOutputTokens` rename, sealed unions for `RealtimeAudioFormats` / `RealtimeAudioInputTurnDetection` / `RealtimeTruncation` / `RealtimeTracingConfig`, plus new `RealtimeReasoning`, `parallelToolCalls`, transcription `delay`, and the realtime translation surface (`gpt-realtime-translate` + `gpt-realtime-whisper`).
- Spec refresh `64c6ba6…` → `371f497…` (same `2.3.0` label).
- Adds `client.realtimeSessions.translations.createClientSecret(...)`, `client.realtimeSessions.createTranscriptionClientSecret(...)`, and `client.realtime.connectTranslation(...)` for the realtime translation WebSocket flow.
- Adds DX helpers `RealtimeConnection.sendUserMessage(text)` and `appendAudioBytes(List<int>)` (and matching translation helper) — both go beyond what the official Python SDK ships.
- `realtimeSessions.calls.accept(callId, request: ...)` now accepts a full `RealtimeSessionCreateRequest` body to override session config on call accept (matches Python SDK + spec).
- Removes `client.realtimeSessions.create()` and `createTranscription()` — the legacy `/realtime/sessions` and `/realtime/transcription_sessions` HTTP endpoints reject the new payload shape; the supported path is `createClientSecret(...)` / `createTranscriptionClientSecret(...)`. Matches the Python SDK.
- Drops the legacy `OpenAI-Beta: realtime=v1` WebSocket header — the Python SDK explicitly omits it, and sending it routes to a stale surface that never emits `session.created`.
- Drops `RealtimeSession.temperature` (no longer in the spec — was silently making `session.update` fail).
- Drops `RealtimeSessionCreateResponse.clientSecret` (the secret is a sibling of the session on `/realtime/client_secrets`, not nested).
- Lenient event parser: `RealtimeEvent.fromJson` returns `UnknownRealtimeEvent` for unmodelled types instead of throwing, accepts both historical wire names (`response.text.*` / `response.output_text.*`, `response.audio.*` / `response.output_audio.*`, etc.), and adds `ConversationItemAddedEvent` (the primary item-creation signal).
- Buffers WebSocket events emitted before the first listener attaches and drains them on first subscribe — fixes a pre-existing broadcast-stream race. The drain is closed-controller-safe so a late listener attaching after the socket already finished can no longer hit `StateError`.

## Details

### Models (9 new files + 3 rewrites + enum overhaul)

New sealed-union/helper files under `lib/src/models/realtime/`:

- `realtime_audio_config.dart` — `RealtimeAudioConfig`, `RealtimeAudioConfigInput`, `RealtimeAudioConfigOutput`, `AudioInputNoiseReduction`, `InputAudioTranscription` (with new `delay` field).
- `realtime_audio_formats.dart` — sealed `RealtimeAudioFormats` (`AudioPcm` / `AudioPcmu` / `AudioPcma` + `UnknownRealtimeAudioFormats` fallback).
- `realtime_audio_input_turn_detection.dart` — sealed `RealtimeAudioInputTurnDetection` (`ServerVad` / `SemanticVad` + Unknown fallback).
- `realtime_truncation.dart` — sealed `RealtimeTruncation` (`TruncationAuto` / `TruncationDisabled` / `TruncationRetentionRatio` + Unknown fallback).
- `realtime_tracing_config.dart` — sealed `RealtimeTracingConfig` (`TracingAuto` / `TracingConfiguration` + Unknown fallback).
- `realtime_reasoning.dart` — `RealtimeReasoning` + `RealtimeReasoningEffort` enum (minimal/low/medium/high/xhigh).
- `realtime_translation_session.dart` — `RealtimeTranslationSession`, `…CreateRequest`, `…UpdateRequest`, `…ClientSecretCreateRequest`, `…ClientSecretCreateResponse`, audio sub-shapes.
- `realtime_translation_event.dart` — sealed `RealtimeTranslationClientEvent` (3 variants) and `RealtimeTranslationServerEvent` (7 variants including the shared `error`), with Unknown fallbacks for forward-compat.

Rewritten:

- `realtime_session.dart` — nested-audio shape with `audio`, `outputModalities`, `maxOutputTokens`, `parallelToolCalls`, `reasoning`, `tracing`, `truncation`, `include`, `expiresAt`, `type`. All `id`/`object`/`type`/`model`/`expires_at` now nullable per the spec (`required` is empty for this Beta-shape model).
- `realtime_session_create.dart` — request/response classes. Response keeps `id`/`object`/`type` strict; `model`/`expires_at` are nullable since transcription session responses don't carry a top-level `model`.
- `realtime_transcription_session.dart` — nested-`audio` transcription session.

Enums (`realtime_enums.dart`):

- **Removed**: `RealtimeAudioFormat`, `RealtimeVoice`, `TurnDetection`, `TurnDetectionType`.
- **Added**: `NoiseReductionType` (`nearField` / `farField`), `AudioTranscriptionDelay` (minimal/low/medium/high/xhigh).

### Resources

- `realtime_sessions_resource.dart` — `realtimeSessions.translations` exposes `RealtimeTranslationsResource`; adds `createTranscriptionClientSecret(...)`; removes legacy `create()` / `createTranscription()`. **`calls.accept(callId, {request, abortTrigger})` now takes an optional session-override body**, matching the spec and the Python SDK.
- `realtime_resource.dart` — `connect(config:)` and `updateSession(...)` accept `RealtimeSessionCreateRequest`. Adds `connectTranslation(...)` returning a typed `RealtimeTranslationConnection`. Drops the `OpenAI-Beta` header. Adds the broadcast-stream buffer drain (closed-controller-safe). **Adds `sendUserMessage` and `appendAudioBytes` convenience helpers** on `RealtimeConnection`, plus `appendAudioBytes` on `RealtimeTranslationConnection`.
- `realtime_client_secret.dart` — adds `RealtimeTranscriptionClientSecretCreateRequest`. Both wrapper request types inject the `type` discriminator into the embedded session payload.
- `RealtimeConnection.createResponse(...)` rewritten to the spec shape: `outputModalities`, `audio: RealtimeAudioConfigOutput?`, `parallelToolCalls`, `reasoning`, `conversation`, `metadata`.

### New API surface

```dart
// HTTP — realtime client secret
final response = await client.realtimeSessions.createClientSecret(
  RealtimeClientSecretCreateRequest(
    session: RealtimeSessionCreateRequest(
      model: 'gpt-realtime-2',
      audio: RealtimeAudioConfig(
        output: RealtimeAudioConfigOutput(voice: 'alloy'),
      ),
      reasoning: RealtimeReasoning(effort: RealtimeReasoningEffort.minimal),
      parallelToolCalls: true,
    ),
  ),
);

// HTTP — transcription client secret
final t = await client.realtimeSessions.createTranscriptionClientSecret(
  RealtimeTranscriptionClientSecretCreateRequest(
    session: RealtimeTranscriptionSessionCreateRequest(
      audio: RealtimeTranscriptionSessionAudio(
        input: RealtimeAudioConfigInput(
          format: AudioPcm(rate: 24000),
          transcription: InputAudioTranscription(
            model: 'gpt-realtime-whisper',
            delay: AudioTranscriptionDelay.high,
          ),
        ),
      ),
    ),
  ),
);

// HTTP — translation client secret
final tr = await client.realtimeSessions.translations.createClientSecret(
  RealtimeTranslationClientSecretCreateRequest(
    session: RealtimeTranslationSessionCreateRequest(
      model: 'gpt-realtime-translate',
      audio: RealtimeTranslationSessionAudio(
        input: RealtimeTranslationSessionAudioInput(
          transcription: RealtimeTranslationInputTranscription(
            model: 'gpt-realtime-whisper',
          ),
        ),
        output: RealtimeTranslationSessionAudioOutput(language: 'es'),
      ),
    ),
  ),
);

// HTTP — accept a SIP call with a custom session
await client.realtimeSessions.calls.accept(
  callId,
  request: RealtimeSessionCreateRequest(
    model: 'gpt-realtime-2',
    instructions: 'Greet the caller in English.',
  ),
);

// WebSocket — text turn (one helper call) + audio bytes (no manual base64)
final session = await client.realtime.connect(model: 'gpt-realtime-2');
session.sendUserMessage('Say hello and nothing else.');
session.appendAudioBytes(rawPcmBytes);

// WebSocket — translation streaming
final translation = await client.realtime.connectTranslation(
  model: 'gpt-realtime-translate',
  config: RealtimeTranslationSessionUpdateRequest(
    audio: RealtimeTranslationSessionAudio(
      output: RealtimeTranslationSessionAudioOutput(language: 'es'),
    ),
  ),
);
translation.appendAudioBytes(rawPcmBytes);
translation.events.listen((event) {
  switch (event) {
    case RealtimeTranslationOutputAudioDeltaEvent(:final delta): /* base64 PCM16 */
    case RealtimeTranslationOutputTranscriptDeltaEvent(:final delta): stdout.write(delta);
    default: break;
  }
});
```

### Tests

- 5 unit test files added/rewritten — 65 tests for model classes (round-trips for every sealed-union variant including `Unknown*` fallbacks with deep-equality assertions), plus 4 MockClient tests for `calls.accept` (empty body, with-body + type-discriminator injection, explicit-type pass-through, abortTrigger wiring).
- Integration test rewrite + 3 new happy-path groups (Reasoning + parallel tool calls, Translation client secret, Transcription delay). Existing Text Conversation and Audio Input groups now exercise `sendUserMessage` and `appendAudioBytes` end-to-end.

### Documentation audit

Verified our SDK against every model and guide page on developers.openai.com:

- `gpt-realtime-2` / `gpt-realtime-translate` / `gpt-realtime-whisper` model overview pages — every documented capability reachable.
- `guides/realtime` — coverage check passed.
- `guides/realtime-translation` — added `connectTranslation()` helper for `wss://.../realtime/translations` after the audit flagged the gap.
- `guides/realtime-transcription` — coverage check passed.
- `guides/realtime-models-prompting` — coverage check passed.

DX comparison vs the official OpenAI Python SDK:

- **Where Dart is now superior**: typed `session.update` (Python uses TypedDict), sealed-union factory constructors, `copyWith` with sentinel, translation WebSocket connect helper (Python has no `client.realtime.translations.*` resource at all), `sendUserMessage` and `appendAudioBytes` helpers (Python has neither), forward-compat `UnknownRealtimeEvent` parsing.
- **Where Python is still ahead**: built-in WebSocket reconnect with backoff and `WebSocketConnectionClosedError` typed error. Tracked as follow-up — robustness work that needs its own PR with chaos-test harness.

## Breaking Changes

(see `## Details` for code samples)

- Nested `audio.{input,output}` replaces top-level audio fields.
- `RealtimeAudioFormat` enum → `RealtimeAudioFormats` sealed union.
- `RealtimeVoice` enum removed (`audio.output.voice` is now an open `String`).
- `TurnDetection` flat class → `RealtimeAudioInputTurnDetection` sealed union.
- `SessionUpdateConfig` → `RealtimeSessionCreateRequest` for `connect(config:)` and `updateSession(...)`.
- `RealtimeSessionCreateResponse.clientSecret` removed.
- `client.realtimeSessions.create()` / `createTranscription()` removed → use `createClientSecret(...)` / `createTranscriptionClientSecret(...)`.
- `RealtimeSession.temperature` removed (no longer in the spec).
- `RealtimeSession` and `RealtimeSessionCreateResponse` field nullability tightened to match the spec (`model`/`expires_at` are nullable on the response since transcription responses omit them).
- `RealtimeConnection.createResponse(...)` signature: `modalities`/`voice`/`outputAudioFormat`/`temperature` removed; replaced by `outputModalities`/`audio: RealtimeAudioConfigOutput?`/`parallelToolCalls`/`reasoning`/`conversation`/`metadata`.
- `RealtimeEvent.fromJson` no longer throws on unrecognised types — returns `UnknownRealtimeEvent` instead.

## References

- [Advancing voice intelligence with new models in the API](https://openai.com/index/advancing-voice-intelligence-with-new-models-in-the-api/) — OpenAI announcement (2026-05-07).
- [Realtime guide](https://developers.openai.com/api/docs/guides/realtime), [Realtime translation](https://developers.openai.com/api/docs/guides/realtime-translation), [Realtime transcription](https://developers.openai.com/api/docs/guides/realtime-transcription), [Prompting guide](https://developers.openai.com/api/docs/guides/realtime-models-prompting) — all documented flows audited and matched.
- [openai-python `realtime` types](https://github.com/openai/openai-python/tree/main/src/openai/types/realtime) and [`realtime` resources](https://github.com/openai/openai-python/tree/main/src/openai/resources/realtime) — reference Python SDK shape that this PR mirrors.

## Test Plan

- [x] `dart format --show=none --summary=line .` — clean
- [x] `dart fix --apply` — nothing to fix
- [x] `dart analyze --fatal-infos` — 0 issues
- [x] `dart test --reporter=failures-only test/unit/` — 1273 passed (2 skipped, env-key negative-path tests)
- [x] `api_toolkit review` — 0 coverage gaps, 0 missing manifest entries
- [x] `api_toolkit verify --checks all --scope all` — 0 errors across consistency/docs/exports/implementation/readme (39 pre-existing info-level lints unchanged)
- [x] **Live integration — 21/21 pass** against `gpt-realtime-2`, `gpt-realtime-translate`, `gpt-realtime-whisper` (HTTP + WebSocket realtime + WebSocket translation client-secret + transcription + tool calling + reasoning).
- [x] **`calls.accept` unit coverage** — 4 MockClient tests in `test/unit/resources/realtime_calls_test.dart`.
- [x] **`Unknown*` deep-equality coverage** — round-trip tests for `UnknownRealtimeEvent`, `UnknownRealtimeAudioInputTurnDetection`, `UnknownRealtimeTracingConfig` (non-map non-auto path), and `UnknownRealtimeTruncation` in `test/unit/models/realtime_test.dart`.
- [x] Cross-package check — no other package re-uses the renamed types.
- [x] Barrel sanity check — every new public type re-exports cleanly through `package:openai_dart/openai_dart_realtime.dart`.
- [x] Doc comments / examples / README updated to the current API; helpers showcased in user-facing documentation.
- [x] Code-review pass against `REVIEW_CHECKLIST-core.md` — `==`/`hashCode` content-vs-identity mismatches fixed across `RealtimeClientSecretCreateRequest`, `RealtimeError`, `RateLimit`, and the `Unknown*` variants. `_drainBuffer()` race vs `_handleDone()` fixed on both `RealtimeConnection` and `RealtimeTranslationConnection`.
- [x] Copilot PR review — 11/11 review threads addressed (5 fixes, 6 already-resolved confirmations referencing prior commits).

> **Note for `/release`**: this is a BREAKING release. `CHANGELOG.md`, `MIGRATION.md`, `pubspec.yaml` version bump, and `README.md` install snippet are intentionally **not** modified here — they're authored by the `/release` skill. Suggested bump: 5.0.0 → 6.0.0.