### PR TITLE
chore: refresh spec metadata for unchanged clients

### DIFF
--- a/packages/chromadb/specs/spec_metadata.json
+++ b/packages/chromadb/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "1.0.0",
-      "last_fetched": "2026-05-02T07:56:05.163900Z",
+      "last_fetched": "2026-05-09T16:14:09.593073Z",
       "source_url": "https://api.trychroma.com/openapi.json",
       "title": "chroma-frontend",
       "version_history": []

--- a/packages/ollama_dart/specs/spec_metadata.json
+++ b/packages/ollama_dart/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "0.1.0",
-      "last_fetched": "2026-05-02T07:57:28.923839Z",
+      "last_fetched": "2026-05-09T16:23:47.644511Z",
       "source_url": "https://raw.githubusercontent.com/ollama/ollama/refs/heads/main/docs/openapi.yaml",
       "title": "Ollama API",
       "version_history": []

--- a/packages/open_responses/specs/spec_metadata.json
+++ b/packages/open_responses/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "2.3.0",
-      "last_fetched": "2026-05-02T07:59:16.747093Z",
+      "last_fetched": "2026-05-09T16:24:14.498340Z",
       "source_url": "https://www.openresponses.org/openapi/openapi.json",
       "title": "OpenAI API",
       "version_history": []

--- a/packages/openai_dart/specs/spec_metadata.json
+++ b/packages/openai_dart/specs/spec_metadata.json
@@ -2,15 +2,15 @@
   "specs": {
     "main": {
       "current_version": "2.3.0",
-      "last_fetched": "2026-05-07T22:20:39.687825Z",
+      "last_fetched": "2026-05-09T16:03:37.233975Z",
       "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-371f497afe4d6070f6e252e5febbe8f453c7058a8dff0c26a01b4d88442a4ac2.yml",
       "title": "OpenAI API",
       "version_history": [
         {
-          "version": "2.3.0",
           "fetched_at": "2026-05-02T08:00:03.586206Z",
+          "note": "Pre-GA Realtime spec; replaced by 371f497\u2026 on 2026-05-08 to pick up GA Realtime sessions, Realtime Translation API, gpt-realtime-2/translate/whisper models, and transcription delay.",
           "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai%2Fopenai-64c6ba619ccbf87e56b4f464230d04401fd78ad924d2606176309d19ca281af5.yml",
-          "note": "Pre-GA Realtime spec; replaced by 371f497… on 2026-05-08 to pick up GA Realtime sessions, Realtime Translation API, gpt-realtime-2/translate/whisper models, and transcription delay."
+          "version": "2.3.0"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Refresh `last_fetched` timestamps for `chromadb`, `ollama_dart`, `openai_dart`, and `open_responses` after re-fetching their upstream OpenAPI specs with no content changes.
- Normalize key ordering in the `openai_dart` `version_history` entry (no semantic change).

## Details

Routine bookkeeping update: the spec sync was re-run against the upstream sources and the fetched specs matched the current ones byte-for-byte (aside from one already-recorded `version_history` entry in `openai_dart` whose keys got re-ordered by the serializer). No generated code, models, or public APIs changed — only the `last_fetched` timestamps in `specs/spec_metadata.json` were touched.

The `openai_dart` actual spec change to GA Realtime was already shipped in #220; this PR only records that subsequent re-fetches see no further drift.

## Test Plan

- [x] Verified diffs are limited to `last_fetched` timestamps and key reordering in `version_history`
- [x] No generated code or model files modified