### PR TITLE
feat(mistralai_dart): prompt cache key and OCR confidence scores

### DIFF
--- a/packages/mistralai_dart/.agents/skills/openapi-mistral/config/manifest.json
+++ b/packages/mistralai_dart/.agents/skills/openapi-mistral/config/manifest.json
@@ -1066,6 +1066,13 @@
       ],
       "note": "Internal platform API \u2014 filtering"
     },
+    "FIMCompletionRequest": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "FimCompletionRequest",
+      "file": "lib/src/models/fim/fim_completion_request.dart",
+      "schema": "FIMCompletionRequest"
+    },
     "FunctionName": {
       "spec": "main",
       "kind": "sealed_variant",
@@ -1393,12 +1400,26 @@
       "schema": "OAuth2TokenAuth",
       "parent": "ConnectorAuth"
     },
+    "OCRConfidenceScore": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "OcrConfidenceScore",
+      "file": "lib/src/models/ocr/ocr_confidence_score.dart",
+      "schema": "OCRConfidenceScore"
+    },
     "OCRImageObject": {
       "spec": "main",
       "kind": "object",
       "dart_class": "OcrImage",
       "file": "lib/src/models/ocr/ocr_image.dart",
       "schema": "OCRImageObject"
+    },
+    "OCRPageConfidenceScores": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "OcrPageConfidenceScores",
+      "file": "lib/src/models/ocr/ocr_page_confidence_scores.dart",
+      "schema": "OCRPageConfidenceScores"
     },
     "OCRPageDimensions": {
       "spec": "main",

--- a/packages/mistralai_dart/lib/mistralai_dart.dart
+++ b/packages/mistralai_dart/lib/mistralai_dart.dart
@@ -242,9 +242,12 @@ export 'src/models/observability/put_dataset_record_payload_in_schema.dart';
 export 'src/models/observability/put_dataset_record_properties_in_schema.dart';
 export 'src/models/observability/put_judge_in_schema.dart';
 // --- Models: OCR ---
+export 'src/models/ocr/ocr_confidence_score.dart';
+export 'src/models/ocr/ocr_confidence_scores_granularity.dart';
 export 'src/models/ocr/ocr_document.dart';
 export 'src/models/ocr/ocr_image.dart';
 export 'src/models/ocr/ocr_page.dart';
+export 'src/models/ocr/ocr_page_confidence_scores.dart';
 export 'src/models/ocr/ocr_page_dimensions.dart';
 export 'src/models/ocr/ocr_request.dart';
 export 'src/models/ocr/ocr_response.dart';

--- a/packages/mistralai_dart/lib/src/models/agents/agent_completion_request.dart
+++ b/packages/mistralai_dart/lib/src/models/agents/agent_completion_request.dart
@@ -80,6 +80,13 @@ class AgentCompletionRequest {
   /// Controls the reasoning effort level for reasoning models.
   final ReasoningEffort? reasoningEffort;
 
+  /// Optional cache key used to enable Mistral's prompt cache.
+  ///
+  /// Requests sharing the same `promptCacheKey` and matching prefix tokens
+  /// will reuse a cached prefix; cached prefix tokens are billed at 10% of
+  /// the standard input token price.
+  final String? promptCacheKey;
+
   /// Creates an [AgentCompletionRequest].
   const AgentCompletionRequest({
     required this.agentId,
@@ -101,6 +108,7 @@ class AgentCompletionRequest {
     this.prediction,
     this.promptMode,
     this.reasoningEffort,
+    this.promptCacheKey,
   });
 
   /// Creates an [AgentCompletionRequest] from JSON.
@@ -145,6 +153,7 @@ class AgentCompletionRequest {
         reasoningEffort: ReasoningEffort.fromString(
           json['reasoning_effort'] as String?,
         ),
+        promptCacheKey: json['prompt_cache_key'] as String?,
       );
 
   /// Converts to JSON.
@@ -168,6 +177,7 @@ class AgentCompletionRequest {
     if (prediction != null) 'prediction': prediction!.toJson(),
     if (promptMode != null) 'prompt_mode': promptMode!.value,
     if (reasoningEffort != null) 'reasoning_effort': reasoningEffort!.value,
+    if (promptCacheKey != null) 'prompt_cache_key': promptCacheKey,
   };
 
   /// Creates a copy with replaced values.
@@ -191,6 +201,7 @@ class AgentCompletionRequest {
     Object? prediction = unsetCopyWithValue,
     Object? promptMode = unsetCopyWithValue,
     Object? reasoningEffort = unsetCopyWithValue,
+    Object? promptCacheKey = unsetCopyWithValue,
   }) {
     return AgentCompletionRequest(
       agentId: agentId ?? this.agentId,
@@ -236,6 +247,9 @@ class AgentCompletionRequest {
       reasoningEffort: reasoningEffort == unsetCopyWithValue
           ? this.reasoningEffort
           : reasoningEffort as ReasoningEffort?,
+      promptCacheKey: promptCacheKey == unsetCopyWithValue
+          ? this.promptCacheKey
+          : promptCacheKey as String?,
     );
   }
 
@@ -265,7 +279,8 @@ class AgentCompletionRequest {
         mapsEqual(metadata, other.metadata) &&
         prediction == other.prediction &&
         promptMode == other.promptMode &&
-        reasoningEffort == other.reasoningEffort;
+        reasoningEffort == other.reasoningEffort &&
+        promptCacheKey == other.promptCacheKey;
     // messages and tools compared above via listsEqual
   }
 
@@ -288,6 +303,7 @@ class AgentCompletionRequest {
     parallelToolCalls,
     mapHash(metadata),
     Object.hash(prediction, promptMode, reasoningEffort),
+    promptCacheKey,
   );
 
   @override
@@ -310,5 +326,6 @@ class AgentCompletionRequest {
       'metadata: $metadata, '
       'prediction: $prediction, '
       'promptMode: $promptMode, '
-      'reasoningEffort: $reasoningEffort)';
+      'reasoningEffort: $reasoningEffort, '
+      'promptCacheKey: $promptCacheKey)';
 }

--- a/packages/mistralai_dart/lib/src/models/chat/chat_completion_request.dart
+++ b/packages/mistralai_dart/lib/src/models/chat/chat_completion_request.dart
@@ -106,6 +106,13 @@ class ChatCompletionRequest {
   /// Guardrail configurations for content moderation.
   final List<GuardrailConfig>? guardrails;
 
+  /// Optional cache key used to enable Mistral's prompt cache.
+  ///
+  /// Requests sharing the same `promptCacheKey` and matching prefix tokens
+  /// will reuse a cached prefix; cached prefix tokens are billed at 10% of
+  /// the standard input token price.
+  final String? promptCacheKey;
+
   /// Creates a [ChatCompletionRequest].
   const ChatCompletionRequest({
     required this.model,
@@ -129,6 +136,7 @@ class ChatCompletionRequest {
     this.promptMode,
     this.reasoningEffort,
     this.guardrails,
+    this.promptCacheKey,
   });
 
   /// Creates a [ChatCompletionRequest] from JSON.
@@ -177,6 +185,7 @@ class ChatCompletionRequest {
         guardrails: (json['guardrails'] as List?)
             ?.map((e) => GuardrailConfig.fromJson(e as Map<String, dynamic>))
             .toList(),
+        promptCacheKey: json['prompt_cache_key'] as String?,
       );
 
   /// Converts to JSON.
@@ -203,6 +212,7 @@ class ChatCompletionRequest {
     if (reasoningEffort != null) 'reasoning_effort': reasoningEffort!.value,
     if (guardrails != null)
       'guardrails': guardrails!.map((e) => e.toJson()).toList(),
+    if (promptCacheKey != null) 'prompt_cache_key': promptCacheKey,
   };
 
   /// Creates a copy with replaced values.
@@ -228,6 +238,7 @@ class ChatCompletionRequest {
     Object? promptMode = unsetCopyWithValue,
     Object? reasoningEffort = unsetCopyWithValue,
     Object? guardrails = unsetCopyWithValue,
+    Object? promptCacheKey = unsetCopyWithValue,
   }) {
     return ChatCompletionRequest(
       model: model ?? this.model,
@@ -279,6 +290,9 @@ class ChatCompletionRequest {
       guardrails: guardrails == unsetCopyWithValue
           ? this.guardrails
           : guardrails as List<GuardrailConfig>?,
+      promptCacheKey: promptCacheKey == unsetCopyWithValue
+          ? this.promptCacheKey
+          : promptCacheKey as String?,
     );
   }
 
@@ -310,7 +324,8 @@ class ChatCompletionRequest {
         mapsEqual(metadata, other.metadata) &&
         prediction == other.prediction &&
         promptMode == other.promptMode &&
-        reasoningEffort == other.reasoningEffort;
+        reasoningEffort == other.reasoningEffort &&
+        promptCacheKey == other.promptCacheKey;
     // guardrails compared above via listsEqual
   }
 
@@ -335,6 +350,7 @@ class ChatCompletionRequest {
     mapHash(metadata),
     Object.hash(prediction, promptMode, reasoningEffort),
     listHash(guardrails),
+    promptCacheKey,
   );
 
   @override
@@ -359,5 +375,6 @@ class ChatCompletionRequest {
       'prediction: $prediction, '
       'promptMode: $promptMode, '
       'reasoningEffort: $reasoningEffort, '
-      'guardrails: $guardrails)';
+      'guardrails: $guardrails, '
+      'promptCacheKey: $promptCacheKey)';
 }

--- a/packages/mistralai_dart/lib/src/models/fim/fim_completion_request.dart
+++ b/packages/mistralai_dart/lib/src/models/fim/fim_completion_request.dart
@@ -1,6 +1,7 @@
 import 'package:meta/meta.dart';
 
 import '../common/copy_with_sentinel.dart';
+import '../common/equality_helpers.dart';
 import '../metadata/stop_sequence.dart';
 
 /// Request for a fill-in-the-middle (FIM) completion.
@@ -57,6 +58,18 @@ class FimCompletionRequest {
   /// Random seed for deterministic generation.
   final int? randomSeed;
 
+  /// Custom request metadata.
+  ///
+  /// Allows attaching arbitrary key-value pairs to the request.
+  final Map<String, dynamic>? metadata;
+
+  /// Optional cache key used to enable Mistral's prompt cache.
+  ///
+  /// Requests sharing the same `promptCacheKey` and matching prefix tokens
+  /// will reuse a cached prefix; cached prefix tokens are billed at 10% of
+  /// the standard input token price.
+  final String? promptCacheKey;
+
   /// Creates a [FimCompletionRequest].
   const FimCompletionRequest({
     required this.model,
@@ -69,6 +82,8 @@ class FimCompletionRequest {
     this.stream,
     this.stop,
     this.randomSeed,
+    this.metadata,
+    this.promptCacheKey,
   });
 
   /// Creates a [FimCompletionRequest] from JSON.
@@ -86,6 +101,8 @@ class FimCompletionRequest {
             ? StopSequence.fromJson(json['stop'] as Object)
             : null,
         randomSeed: json['random_seed'] as int?,
+        metadata: json['metadata'] as Map<String, dynamic>?,
+        promptCacheKey: json['prompt_cache_key'] as String?,
       );
 
   /// Converts to JSON.
@@ -100,6 +117,8 @@ class FimCompletionRequest {
     if (stream != null) 'stream': stream,
     if (stop != null) 'stop': stop!.toJson(),
     if (randomSeed != null) 'random_seed': randomSeed,
+    if (metadata != null) 'metadata': metadata,
+    if (promptCacheKey != null) 'prompt_cache_key': promptCacheKey,
   };
 
   /// Creates a copy with replaced values.
@@ -114,6 +133,8 @@ class FimCompletionRequest {
     Object? stream = unsetCopyWithValue,
     Object? stop = unsetCopyWithValue,
     Object? randomSeed = unsetCopyWithValue,
+    Object? metadata = unsetCopyWithValue,
+    Object? promptCacheKey = unsetCopyWithValue,
   }) {
     return FimCompletionRequest(
       model: model ?? this.model,
@@ -134,6 +155,12 @@ class FimCompletionRequest {
       randomSeed: randomSeed == unsetCopyWithValue
           ? this.randomSeed
           : randomSeed as int?,
+      metadata: metadata == unsetCopyWithValue
+          ? this.metadata
+          : metadata as Map<String, dynamic>?,
+      promptCacheKey: promptCacheKey == unsetCopyWithValue
+          ? this.promptCacheKey
+          : promptCacheKey as String?,
     );
   }
 
@@ -144,10 +171,13 @@ class FimCompletionRequest {
           runtimeType == other.runtimeType &&
           model == other.model &&
           prompt == other.prompt &&
-          suffix == other.suffix;
+          suffix == other.suffix &&
+          mapsEqual(metadata, other.metadata) &&
+          promptCacheKey == other.promptCacheKey;
 
   @override
-  int get hashCode => Object.hash(model, prompt, suffix);
+  int get hashCode =>
+      Object.hash(model, prompt, suffix, mapHash(metadata), promptCacheKey);
 
   @override
   String toString() =>

--- a/packages/mistralai_dart/lib/src/models/fim/fim_completion_request.dart
+++ b/packages/mistralai_dart/lib/src/models/fim/fim_completion_request.dart
@@ -172,12 +172,31 @@ class FimCompletionRequest {
           model == other.model &&
           prompt == other.prompt &&
           suffix == other.suffix &&
+          temperature == other.temperature &&
+          topP == other.topP &&
+          maxTokens == other.maxTokens &&
+          minTokens == other.minTokens &&
+          stream == other.stream &&
+          stop == other.stop &&
+          randomSeed == other.randomSeed &&
           mapsEqual(metadata, other.metadata) &&
           promptCacheKey == other.promptCacheKey;
 
   @override
-  int get hashCode =>
-      Object.hash(model, prompt, suffix, mapHash(metadata), promptCacheKey);
+  int get hashCode => Object.hash(
+    model,
+    prompt,
+    suffix,
+    temperature,
+    topP,
+    maxTokens,
+    minTokens,
+    stream,
+    stop,
+    randomSeed,
+    mapHash(metadata),
+    promptCacheKey,
+  );
 
   @override
   String toString() =>

--- a/packages/mistralai_dart/lib/src/models/ocr/ocr_confidence_score.dart
+++ b/packages/mistralai_dart/lib/src/models/ocr/ocr_confidence_score.dart
@@ -1,0 +1,90 @@
+import 'package:meta/meta.dart';
+
+/// Confidence score for a span of OCR-extracted text.
+///
+/// Each entry corresponds to a contiguous span of characters within the
+/// containing text (page or table) starting at [startIndex] with the given
+/// [text]. [confidence] is in the range `[0, 1]` where higher values indicate
+/// higher reliability of the OCR for that span.
+@immutable
+class OcrConfidenceScore {
+  /// Reliability score for the OCR-extracted span (0.0 to 1.0).
+  final double confidence;
+
+  /// Start index of the span in the containing text (0-based).
+  final int startIndex;
+
+  /// The extracted text for this span.
+  final String text;
+
+  /// Creates an [OcrConfidenceScore].
+  const OcrConfidenceScore({
+    required this.confidence,
+    required this.startIndex,
+    required this.text,
+  });
+
+  /// Creates an [OcrConfidenceScore] from JSON.
+  ///
+  /// Throws a [FormatException] if any required field is missing or null.
+  factory OcrConfidenceScore.fromJson(Map<String, dynamic> json) {
+    final confidence = json['confidence'];
+    if (confidence is! num) {
+      throw const FormatException(
+        'OcrConfidenceScore: missing required field "confidence"',
+      );
+    }
+    final startIndex = json['start_index'];
+    if (startIndex is! int) {
+      throw const FormatException(
+        'OcrConfidenceScore: missing required field "start_index"',
+      );
+    }
+    final text = json['text'];
+    if (text is! String) {
+      throw const FormatException(
+        'OcrConfidenceScore: missing required field "text"',
+      );
+    }
+    return OcrConfidenceScore(
+      confidence: confidence.toDouble(),
+      startIndex: startIndex,
+      text: text,
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'confidence': confidence,
+    'start_index': startIndex,
+    'text': text,
+  };
+
+  /// Creates a copy with the specified fields replaced.
+  OcrConfidenceScore copyWith({
+    double? confidence,
+    int? startIndex,
+    String? text,
+  }) => OcrConfidenceScore(
+    confidence: confidence ?? this.confidence,
+    startIndex: startIndex ?? this.startIndex,
+    text: text ?? this.text,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OcrConfidenceScore &&
+          runtimeType == other.runtimeType &&
+          confidence == other.confidence &&
+          startIndex == other.startIndex &&
+          text == other.text;
+
+  @override
+  int get hashCode => Object.hash(confidence, startIndex, text);
+
+  @override
+  String toString() =>
+      'OcrConfidenceScore(confidence: $confidence, '
+      'startIndex: $startIndex, text: ${text.length} chars)';
+}

--- a/packages/mistralai_dart/lib/src/models/ocr/ocr_confidence_scores_granularity.dart
+++ b/packages/mistralai_dart/lib/src/models/ocr/ocr_confidence_scores_granularity.dart
@@ -1,0 +1,34 @@
+/// Granularity of confidence scores returned by the OCR API.
+///
+/// Used with `OcrRequest.confidenceScoresGranularity` to opt into
+/// confidence score reporting on the response.
+///
+/// Defaults (when the field is omitted) to no confidence scores returned —
+/// keeps payload small.
+enum OcrConfidenceScoresGranularity {
+  /// Per-word confidence scores (also includes page aggregates).
+  word('word'),
+
+  /// Page-level aggregate confidence scores only.
+  page('page'),
+
+  /// Unknown granularity (forward compatibility).
+  unknown('unknown');
+
+  const OcrConfidenceScoresGranularity(this.value);
+
+  /// The string value used in the API.
+  final String value;
+
+  /// Creates from a string value.
+  ///
+  /// Returns null if [value] is null.
+  /// Returns [unknown] if [value] does not match any known value.
+  static OcrConfidenceScoresGranularity? fromString(String? value) =>
+      switch (value) {
+        'word' => word,
+        'page' => page,
+        null => null,
+        _ => unknown,
+      };
+}

--- a/packages/mistralai_dart/lib/src/models/ocr/ocr_page.dart
+++ b/packages/mistralai_dart/lib/src/models/ocr/ocr_page.dart
@@ -3,6 +3,7 @@ import 'package:meta/meta.dart';
 import '../common/copy_with_sentinel.dart';
 import '../common/equality_helpers.dart';
 import 'ocr_image.dart';
+import 'ocr_page_confidence_scores.dart';
 import 'ocr_page_dimensions.dart';
 import 'ocr_table.dart';
 
@@ -37,6 +38,12 @@ class OcrPage {
   /// List of all hyperlinks in the page.
   final List<String> hyperlinks;
 
+  /// Aggregate (and optionally per-word) confidence scores for this page.
+  ///
+  /// Populated when the request was made with
+  /// `confidenceScoresGranularity` set. `null` otherwise.
+  final OcrPageConfidenceScores? confidenceScores;
+
   /// Creates an [OcrPage].
   const OcrPage({
     required this.index,
@@ -47,6 +54,7 @@ class OcrPage {
     this.header,
     this.footer,
     this.hyperlinks = const [],
+    this.confidenceScores,
   });
 
   /// Creates an [OcrPage] from JSON.
@@ -69,6 +77,11 @@ class OcrPage {
     header: json['header'] as String?,
     footer: json['footer'] as String?,
     hyperlinks: (json['hyperlinks'] as List?)?.cast<String>() ?? [],
+    confidenceScores: json['confidence_scores'] != null
+        ? OcrPageConfidenceScores.fromJson(
+            json['confidence_scores'] as Map<String, dynamic>,
+          )
+        : null,
   );
 
   /// Converts to JSON.
@@ -81,6 +94,8 @@ class OcrPage {
     if (header != null) 'header': header,
     if (footer != null) 'footer': footer,
     if (hyperlinks.isNotEmpty) 'hyperlinks': hyperlinks,
+    if (confidenceScores != null)
+      'confidence_scores': confidenceScores!.toJson(),
   };
 
   /// Creates a copy with the specified fields replaced.
@@ -95,6 +110,7 @@ class OcrPage {
     Object? header = unsetCopyWithValue,
     Object? footer = unsetCopyWithValue,
     List<String>? hyperlinks,
+    Object? confidenceScores = unsetCopyWithValue,
   }) => OcrPage(
     index: index ?? this.index,
     markdown: markdown ?? this.markdown,
@@ -106,6 +122,9 @@ class OcrPage {
     header: header == unsetCopyWithValue ? this.header : header as String?,
     footer: footer == unsetCopyWithValue ? this.footer : footer as String?,
     hyperlinks: hyperlinks ?? this.hyperlinks,
+    confidenceScores: confidenceScores == unsetCopyWithValue
+        ? this.confidenceScores
+        : confidenceScores as OcrPageConfidenceScores?,
   );
 
   @override
@@ -120,7 +139,8 @@ class OcrPage {
           listsEqual(tables, other.tables) &&
           header == other.header &&
           footer == other.footer &&
-          listsEqual(hyperlinks, other.hyperlinks);
+          listsEqual(hyperlinks, other.hyperlinks) &&
+          confidenceScores == other.confidenceScores;
 
   @override
   int get hashCode => Object.hash(
@@ -132,6 +152,7 @@ class OcrPage {
     header,
     footer,
     listHash(hyperlinks),
+    confidenceScores,
   );
 
   @override

--- a/packages/mistralai_dart/lib/src/models/ocr/ocr_page.dart
+++ b/packages/mistralai_dart/lib/src/models/ocr/ocr_page.dart
@@ -40,8 +40,9 @@ class OcrPage {
 
   /// Aggregate (and optionally per-word) confidence scores for this page.
   ///
-  /// Populated when the request was made with
-  /// `confidenceScoresGranularity` set. `null` otherwise.
+  /// Populated when [OcrRequest.confidenceScoresGranularity] is set
+  /// (either [OcrConfidenceScoresGranularity.word] or
+  /// [OcrConfidenceScoresGranularity.page]); `null` otherwise.
   final OcrPageConfidenceScores? confidenceScores;
 
   /// Creates an [OcrPage].

--- a/packages/mistralai_dart/lib/src/models/ocr/ocr_page_confidence_scores.dart
+++ b/packages/mistralai_dart/lib/src/models/ocr/ocr_page_confidence_scores.dart
@@ -24,8 +24,8 @@ class OcrPageConfidenceScores {
 
   /// Per-span confidence scores for the page's extracted text.
   ///
-  /// Populated when the request was made with `word` granularity; `null`
-  /// otherwise.
+  /// Populated when [OcrRequest.confidenceScoresGranularity] is set to
+  /// [OcrConfidenceScoresGranularity.word]; `null` otherwise.
   final List<OcrConfidenceScore>? wordConfidenceScores;
 
   /// Creates an [OcrPageConfidenceScores].

--- a/packages/mistralai_dart/lib/src/models/ocr/ocr_page_confidence_scores.dart
+++ b/packages/mistralai_dart/lib/src/models/ocr/ocr_page_confidence_scores.dart
@@ -1,0 +1,115 @@
+import 'package:meta/meta.dart';
+
+import '../common/copy_with_sentinel.dart';
+import '../common/equality_helpers.dart';
+import 'ocr_confidence_score.dart';
+
+/// Aggregate confidence scores for an OCR-processed page.
+///
+/// Returned on `OcrPage.confidenceScores` when the request was made with
+/// `confidenceScoresGranularity` set to `word` or `page`.
+///
+/// [averagePageConfidenceScore] and [minimumPageConfidenceScore] are always
+/// populated. [wordConfidenceScores] is only populated when granularity is
+/// `word`.
+@immutable
+class OcrPageConfidenceScores {
+  /// Average reliability score across all OCR-extracted text on the page
+  /// (0.0 to 1.0).
+  final double averagePageConfidenceScore;
+
+  /// Minimum reliability score across all OCR-extracted text on the page
+  /// (0.0 to 1.0).
+  final double minimumPageConfidenceScore;
+
+  /// Per-span confidence scores for the page's extracted text.
+  ///
+  /// Populated when the request was made with `word` granularity; `null`
+  /// otherwise.
+  final List<OcrConfidenceScore>? wordConfidenceScores;
+
+  /// Creates an [OcrPageConfidenceScores].
+  const OcrPageConfidenceScores({
+    required this.averagePageConfidenceScore,
+    required this.minimumPageConfidenceScore,
+    this.wordConfidenceScores,
+  });
+
+  /// Creates an [OcrPageConfidenceScores] from JSON.
+  ///
+  /// Throws a [FormatException] if either of the required aggregate scores
+  /// is missing or null.
+  factory OcrPageConfidenceScores.fromJson(Map<String, dynamic> json) {
+    final avg = json['average_page_confidence_score'];
+    if (avg is! num) {
+      throw const FormatException(
+        'OcrPageConfidenceScores: missing required field '
+        '"average_page_confidence_score"',
+      );
+    }
+    final min = json['minimum_page_confidence_score'];
+    if (min is! num) {
+      throw const FormatException(
+        'OcrPageConfidenceScores: missing required field '
+        '"minimum_page_confidence_score"',
+      );
+    }
+    return OcrPageConfidenceScores(
+      averagePageConfidenceScore: avg.toDouble(),
+      minimumPageConfidenceScore: min.toDouble(),
+      wordConfidenceScores: (json['word_confidence_scores'] as List?)
+          ?.map((e) => OcrConfidenceScore.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'average_page_confidence_score': averagePageConfidenceScore,
+    'minimum_page_confidence_score': minimumPageConfidenceScore,
+    if (wordConfidenceScores != null)
+      'word_confidence_scores': wordConfidenceScores!
+          .map((e) => e.toJson())
+          .toList(),
+  };
+
+  /// Creates a copy with the specified fields replaced.
+  ///
+  /// Pass `null` explicitly to clear nullable fields.
+  OcrPageConfidenceScores copyWith({
+    double? averagePageConfidenceScore,
+    double? minimumPageConfidenceScore,
+    Object? wordConfidenceScores = unsetCopyWithValue,
+  }) => OcrPageConfidenceScores(
+    averagePageConfidenceScore:
+        averagePageConfidenceScore ?? this.averagePageConfidenceScore,
+    minimumPageConfidenceScore:
+        minimumPageConfidenceScore ?? this.minimumPageConfidenceScore,
+    wordConfidenceScores: wordConfidenceScores == unsetCopyWithValue
+        ? this.wordConfidenceScores
+        : wordConfidenceScores as List<OcrConfidenceScore>?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OcrPageConfidenceScores &&
+          runtimeType == other.runtimeType &&
+          averagePageConfidenceScore == other.averagePageConfidenceScore &&
+          minimumPageConfidenceScore == other.minimumPageConfidenceScore &&
+          listsEqual(wordConfidenceScores, other.wordConfidenceScores);
+
+  @override
+  int get hashCode => Object.hash(
+    averagePageConfidenceScore,
+    minimumPageConfidenceScore,
+    listHash(wordConfidenceScores),
+  );
+
+  @override
+  String toString() =>
+      'OcrPageConfidenceScores('
+      'average: $averagePageConfidenceScore, '
+      'minimum: $minimumPageConfidenceScore, '
+      'wordConfidenceScores: ${wordConfidenceScores?.length ?? 0} items)';
+}

--- a/packages/mistralai_dart/lib/src/models/ocr/ocr_request.dart
+++ b/packages/mistralai_dart/lib/src/models/ocr/ocr_request.dart
@@ -3,6 +3,7 @@ import 'package:meta/meta.dart';
 import '../common/copy_with_sentinel.dart';
 import '../common/equality_helpers.dart';
 import '../metadata/response_format.dart';
+import 'ocr_confidence_scores_granularity.dart';
 import 'ocr_document.dart';
 import 'ocr_table_format.dart';
 
@@ -56,6 +57,13 @@ class OcrRequest {
   /// document. Only json_schema is valid.
   final ResponseFormat? documentAnnotationFormat;
 
+  /// Granularity of confidence scores returned in the response.
+  ///
+  /// `word` returns per-word scores plus the page aggregate; `page` returns
+  /// only the page aggregate. When omitted, no confidence scores are
+  /// returned, which keeps the response payload small.
+  final OcrConfidenceScoresGranularity? confidenceScoresGranularity;
+
   /// Creates an [OcrRequest].
   const OcrRequest({
     this.model = 'mistral-ocr-latest',
@@ -71,6 +79,7 @@ class OcrRequest {
     this.extractFooter,
     this.bboxAnnotationFormat,
     this.documentAnnotationFormat,
+    this.confidenceScoresGranularity,
   });
 
   /// Creates an [OcrRequest] from a URL.
@@ -142,6 +151,9 @@ class OcrRequest {
             json['document_annotation_format'] as Map<String, dynamic>,
           )
         : null,
+    confidenceScoresGranularity: OcrConfidenceScoresGranularity.fromString(
+      json['confidence_scores_granularity'] as String?,
+    ),
   );
 
   /// Converts to JSON.
@@ -162,6 +174,8 @@ class OcrRequest {
       'bbox_annotation_format': bboxAnnotationFormat!.toJson(),
     if (documentAnnotationFormat != null)
       'document_annotation_format': documentAnnotationFormat!.toJson(),
+    if (confidenceScoresGranularity != null)
+      'confidence_scores_granularity': confidenceScoresGranularity!.value,
   };
 
   /// Creates a copy with the specified fields replaced.
@@ -181,6 +195,7 @@ class OcrRequest {
     Object? extractFooter = unsetCopyWithValue,
     Object? bboxAnnotationFormat = unsetCopyWithValue,
     Object? documentAnnotationFormat = unsetCopyWithValue,
+    Object? confidenceScoresGranularity = unsetCopyWithValue,
   }) => OcrRequest(
     model: model ?? this.model,
     document: document ?? this.document,
@@ -213,6 +228,10 @@ class OcrRequest {
     documentAnnotationFormat: documentAnnotationFormat == unsetCopyWithValue
         ? this.documentAnnotationFormat
         : documentAnnotationFormat as ResponseFormat?,
+    confidenceScoresGranularity:
+        confidenceScoresGranularity == unsetCopyWithValue
+        ? this.confidenceScoresGranularity
+        : confidenceScoresGranularity as OcrConfidenceScoresGranularity?,
   );
 
   @override
@@ -232,7 +251,8 @@ class OcrRequest {
           extractHeader == other.extractHeader &&
           extractFooter == other.extractFooter &&
           bboxAnnotationFormat == other.bboxAnnotationFormat &&
-          documentAnnotationFormat == other.documentAnnotationFormat;
+          documentAnnotationFormat == other.documentAnnotationFormat &&
+          confidenceScoresGranularity == other.confidenceScoresGranularity;
 
   @override
   int get hashCode => Object.hash(
@@ -249,6 +269,7 @@ class OcrRequest {
     extractFooter,
     bboxAnnotationFormat,
     documentAnnotationFormat,
+    confidenceScoresGranularity,
   );
 
   @override

--- a/packages/mistralai_dart/lib/src/models/ocr/ocr_table.dart
+++ b/packages/mistralai_dart/lib/src/models/ocr/ocr_table.dart
@@ -19,8 +19,8 @@ class OcrTable {
 
   /// Per-span confidence scores for the table's extracted text.
   ///
-  /// Populated when the request was made with `word`
-  /// `confidenceScoresGranularity`. `null` otherwise.
+  /// Populated when [OcrRequest.confidenceScoresGranularity] is set to
+  /// [OcrConfidenceScoresGranularity.word]; `null` otherwise.
   final List<OcrConfidenceScore>? wordConfidenceScores;
 
   /// Creates an [OcrTable].

--- a/packages/mistralai_dart/lib/src/models/ocr/ocr_table.dart
+++ b/packages/mistralai_dart/lib/src/models/ocr/ocr_table.dart
@@ -1,5 +1,8 @@
 import 'package:meta/meta.dart';
 
+import '../common/copy_with_sentinel.dart';
+import '../common/equality_helpers.dart';
+import 'ocr_confidence_score.dart';
 import 'ocr_table_format.dart';
 
 /// Represents a table extracted from a document page by OCR.
@@ -14,11 +17,18 @@ class OcrTable {
   /// Format of the table.
   final OcrTableFormat format;
 
+  /// Per-span confidence scores for the table's extracted text.
+  ///
+  /// Populated when the request was made with `word`
+  /// `confidenceScoresGranularity`. `null` otherwise.
+  final List<OcrConfidenceScore>? wordConfidenceScores;
+
   /// Creates an [OcrTable].
   const OcrTable({
     required this.id,
     required this.content,
     required this.format,
+    this.wordConfidenceScores,
   });
 
   /// Creates an [OcrTable] from JSON.
@@ -32,6 +42,9 @@ class OcrTable {
       id: json['id'] as String,
       content: json['content'] as String,
       format: format,
+      wordConfidenceScores: (json['word_confidence_scores'] as List?)
+          ?.map((e) => OcrConfidenceScore.fromJson(e as Map<String, dynamic>))
+          .toList(),
     );
   }
 
@@ -40,15 +53,28 @@ class OcrTable {
     'id': id,
     'content': content,
     'format': format.value,
+    if (wordConfidenceScores != null)
+      'word_confidence_scores': wordConfidenceScores!
+          .map((e) => e.toJson())
+          .toList(),
   };
 
   /// Creates a copy with the specified fields replaced.
-  OcrTable copyWith({String? id, String? content, OcrTableFormat? format}) =>
-      OcrTable(
-        id: id ?? this.id,
-        content: content ?? this.content,
-        format: format ?? this.format,
-      );
+  ///
+  /// Pass `null` explicitly to clear nullable fields.
+  OcrTable copyWith({
+    String? id,
+    String? content,
+    OcrTableFormat? format,
+    Object? wordConfidenceScores = unsetCopyWithValue,
+  }) => OcrTable(
+    id: id ?? this.id,
+    content: content ?? this.content,
+    format: format ?? this.format,
+    wordConfidenceScores: wordConfidenceScores == unsetCopyWithValue
+        ? this.wordConfidenceScores
+        : wordConfidenceScores as List<OcrConfidenceScore>?,
+  );
 
   @override
   bool operator ==(Object other) =>
@@ -57,10 +83,12 @@ class OcrTable {
           runtimeType == other.runtimeType &&
           id == other.id &&
           content == other.content &&
-          format == other.format;
+          format == other.format &&
+          listsEqual(wordConfidenceScores, other.wordConfidenceScores);
 
   @override
-  int get hashCode => Object.hash(id, content, format);
+  int get hashCode =>
+      Object.hash(id, content, format, listHash(wordConfidenceScores));
 
   @override
   String toString() =>

--- a/packages/mistralai_dart/specs/openapi.json
+++ b/packages/mistralai_dart/specs/openapi.json
@@ -1277,6 +1277,18 @@
             "title": "Presence Penalty",
             "type": "number"
           },
+          "prompt_cache_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "A cache key to enable prompt caching. When provided, the API will attempt to reuse previously computed tokens for requests sharing the same prefix (e.g. multi-turn conversations or requests with a similar system prompt). Cached tokens are billed at 10% of the standard input token price.",
+            "title": "Prompt Cache Key"
+          },
           "prompt_mode": {
             "anyOf": [
               {
@@ -3084,6 +3096,18 @@
             "minimum": -2,
             "title": "Presence Penalty",
             "type": "number"
+          },
+          "prompt_cache_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "A cache key to enable prompt caching. When provided, the API will attempt to reuse previously computed tokens for requests sharing the same prefix (e.g. multi-turn conversations or requests with a similar system prompt). Cached tokens are billed at 10% of the standard input token price.",
+            "title": "Prompt Cache Key"
           },
           "prompt_mode": {
             "anyOf": [
@@ -8121,6 +8145,18 @@
             "title": "Prompt",
             "type": "string"
           },
+          "prompt_cache_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "A cache key to enable prompt caching. When provided, the API will attempt to reuse previously computed tokens for requests sharing the same prefix (e.g. multi-turn conversations or requests with a similar system prompt). Cached tokens are billed at 10% of the standard input token price.",
+            "title": "Prompt Cache Key"
+          },
           "random_seed": {
             "anyOf": [
               {
@@ -11967,6 +12003,37 @@
         "title": "OAuth2TokenAuth",
         "type": "object"
       },
+      "OCRConfidenceScore": {
+        "additionalProperties": false,
+        "description": "Confidence score for a token or word in OCR output.",
+        "properties": {
+          "confidence": {
+            "description": "Confidence score (0-1)",
+            "maximum": 1,
+            "minimum": 0,
+            "title": "Confidence",
+            "type": "number"
+          },
+          "start_index": {
+            "description": "Start index of the text in the page markdown string",
+            "minimum": 0,
+            "title": "Start Index",
+            "type": "integer"
+          },
+          "text": {
+            "description": "The word or text segment",
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text",
+          "confidence",
+          "start_index"
+        ],
+        "title": "OCRConfidenceScore",
+        "type": "object"
+      },
       "OCRImageObject": {
         "additionalProperties": false,
         "properties": {
@@ -12062,6 +12129,40 @@
         "title": "OCRImageObject",
         "type": "object"
       },
+      "OCRPageConfidenceScores": {
+        "additionalProperties": false,
+        "description": "Confidence scores for an OCR page at various granularities.",
+        "properties": {
+          "average_page_confidence_score": {
+            "description": "Average confidence score for the page",
+            "maximum": 1,
+            "minimum": 0,
+            "title": "Average Page Confidence Score",
+            "type": "number"
+          },
+          "minimum_page_confidence_score": {
+            "description": "Minimum confidence score for the page",
+            "maximum": 1,
+            "minimum": 0,
+            "title": "Minimum Page Confidence Score",
+            "type": "number"
+          },
+          "word_confidence_scores": {
+            "description": "Word-level confidence scores (populated only for 'word' granularity)",
+            "items": {
+              "$ref": "#/components/schemas/OCRConfidenceScore"
+            },
+            "title": "Word Confidence Scores",
+            "type": "array"
+          }
+        },
+        "required": [
+          "average_page_confidence_score",
+          "minimum_page_confidence_score"
+        ],
+        "title": "OCRPageConfidenceScores",
+        "type": "object"
+      },
       "OCRPageDimensions": {
         "additionalProperties": false,
         "properties": {
@@ -12095,6 +12196,17 @@
       "OCRPageObject": {
         "additionalProperties": false,
         "properties": {
+          "confidence_scores": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OCRPageConfidenceScores"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Confidence scores for the OCR page (populated when confidence_scores_granularity is set)"
+          },
           "dimensions": {
             "anyOf": [
               {
@@ -12188,6 +12300,21 @@
               }
             ],
             "description": "Structured output class for extracting useful information from each extracted bounding box / image from document. Only json_schema is valid for this field"
+          },
+          "confidence_scores_granularity": {
+            "anyOf": [
+              {
+                "enum": [
+                  "word",
+                  "page"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Granularity for confidence scores: 'word' (per-word scores) or 'page' (aggregate only). Defaults to None (no confidence scores) to keep response payload small."
           },
           "document": {
             "anyOf": [
@@ -12388,6 +12515,21 @@
             "description": "Table ID for extracted table in a page",
             "title": "Id",
             "type": "string"
+          },
+          "word_confidence_scores": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/OCRConfidenceScore"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-word confidence scores for the table content. Returned when confidence_scores_granularity is set to 'word'.",
+            "title": "Word Confidence Scores"
           }
         },
         "required": [

--- a/packages/mistralai_dart/specs/spec_metadata.json
+++ b/packages/mistralai_dart/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "1.0.0",
-      "last_fetched": "2026-05-02T07:57:11.384628Z",
+      "last_fetched": "2026-05-09T16:23:18.351534Z",
       "source_url": "https://docs.mistral.ai/openapi.yaml",
       "title": "Mistral AI API",
       "version_history": []

--- a/packages/mistralai_dart/test/unit/models/agents/agent_completion_request_test.dart
+++ b/packages/mistralai_dart/test/unit/models/agents/agent_completion_request_test.dart
@@ -360,6 +360,78 @@ void main() {
         expect(str, contains('maxTokens: null'));
         expect(str, contains('frequencyPenalty: null'));
         expect(str, contains('reasoningEffort: null'));
+        expect(str, contains('promptCacheKey: null'));
+      });
+    });
+
+    group('promptCacheKey', () {
+      test('omits prompt_cache_key from JSON when null', () {
+        final request = AgentCompletionRequest(
+          agentId: 'agent-1',
+          messages: [ChatMessage.user('Hi')],
+        );
+
+        final json = request.toJson();
+
+        expect(json.containsKey('prompt_cache_key'), isFalse);
+      });
+
+      test('serializes prompt_cache_key when set', () {
+        final request = AgentCompletionRequest(
+          agentId: 'agent-1',
+          messages: [ChatMessage.user('Hi')],
+          promptCacheKey: 'tenant-42',
+        );
+
+        final json = request.toJson();
+
+        expect(json['prompt_cache_key'], 'tenant-42');
+      });
+
+      test('round-trips prompt_cache_key', () {
+        final original = AgentCompletionRequest(
+          agentId: 'agent-1',
+          messages: [ChatMessage.user('Hi')],
+          promptCacheKey: 'tenant-42',
+        );
+
+        final roundTripped = AgentCompletionRequest.fromJson(original.toJson());
+
+        expect(roundTripped.promptCacheKey, 'tenant-42');
+      });
+
+      test('copyWith clears with explicit null', () {
+        final original = AgentCompletionRequest(
+          agentId: 'agent-1',
+          messages: [ChatMessage.user('Hi')],
+          promptCacheKey: 'tenant-42',
+        );
+
+        final cleared = original.copyWith(promptCacheKey: null);
+
+        expect(cleared.promptCacheKey, isNull);
+      });
+
+      test('equality and hashCode include prompt_cache_key', () {
+        final a = AgentCompletionRequest(
+          agentId: 'agent-1',
+          messages: [ChatMessage.user('Hi')],
+          promptCacheKey: 'k1',
+        );
+        final b = AgentCompletionRequest(
+          agentId: 'agent-1',
+          messages: [ChatMessage.user('Hi')],
+          promptCacheKey: 'k1',
+        );
+        final c = AgentCompletionRequest(
+          agentId: 'agent-1',
+          messages: [ChatMessage.user('Hi')],
+          promptCacheKey: 'k2',
+        );
+
+        expect(a, equals(b));
+        expect(a.hashCode, b.hashCode);
+        expect(a, isNot(equals(c)));
       });
     });
   });

--- a/packages/mistralai_dart/test/unit/models/chat/chat_completion_request_test.dart
+++ b/packages/mistralai_dart/test/unit/models/chat/chat_completion_request_test.dart
@@ -366,6 +366,71 @@ void main() {
         expect(str, contains('promptMode: null'));
         expect(str, contains('reasoningEffort: null'));
         expect(str, contains('guardrails: null'));
+        expect(str, contains('promptCacheKey: null'));
+      });
+    });
+
+    group('promptCacheKey', () {
+      test('omits prompt_cache_key from JSON when null', () {
+        final request = ChatCompletionRequest(
+          model: 'mistral-small-latest',
+          messages: [ChatMessage.user('Hi')],
+        );
+
+        final json = request.toJson();
+
+        expect(json.containsKey('prompt_cache_key'), isFalse);
+      });
+
+      test('serializes prompt_cache_key when set', () {
+        final request = ChatCompletionRequest(
+          model: 'mistral-small-latest',
+          messages: [ChatMessage.user('Hi')],
+          promptCacheKey: 'tenant-42',
+        );
+
+        final json = request.toJson();
+
+        expect(json['prompt_cache_key'], 'tenant-42');
+      });
+
+      test('round-trips prompt_cache_key', () {
+        final original = ChatCompletionRequest(
+          model: 'mistral-small-latest',
+          messages: [ChatMessage.user('Hi')],
+          promptCacheKey: 'tenant-42',
+        );
+
+        final roundTripped = ChatCompletionRequest.fromJson(original.toJson());
+
+        expect(roundTripped.promptCacheKey, 'tenant-42');
+      });
+
+      test('copyWith clears with explicit null', () {
+        final original = ChatCompletionRequest(
+          model: 'mistral-small-latest',
+          messages: [ChatMessage.user('Hi')],
+          promptCacheKey: 'tenant-42',
+        );
+
+        final cleared = original.copyWith(promptCacheKey: null);
+
+        expect(cleared.promptCacheKey, isNull);
+      });
+
+      test('equality includes promptCacheKey', () {
+        final a = ChatCompletionRequest(
+          model: 'm',
+          messages: [ChatMessage.user('Hi')],
+          promptCacheKey: 'k1',
+        );
+        final b = ChatCompletionRequest(
+          model: 'm',
+          messages: [ChatMessage.user('Hi')],
+          promptCacheKey: 'k2',
+        );
+
+        expect(a, isNot(equals(b)));
       });
     });
   });

--- a/packages/mistralai_dart/test/unit/models/fim/fim_completion_request_test.dart
+++ b/packages/mistralai_dart/test/unit/models/fim/fim_completion_request_test.dart
@@ -172,6 +172,49 @@ void main() {
       expect(request1.hashCode, request2.hashCode);
     });
 
+    test('equality covers all generation parameters', () {
+      const base = FimCompletionRequest(model: 'codestral-latest', prompt: 'p');
+
+      // Each variant should be distinct from the base.
+      const variants = [
+        FimCompletionRequest(
+          model: 'codestral-latest',
+          prompt: 'p',
+          temperature: 0.5,
+        ),
+        FimCompletionRequest(model: 'codestral-latest', prompt: 'p', topP: 0.9),
+        FimCompletionRequest(
+          model: 'codestral-latest',
+          prompt: 'p',
+          maxTokens: 100,
+        ),
+        FimCompletionRequest(
+          model: 'codestral-latest',
+          prompt: 'p',
+          minTokens: 1,
+        ),
+        FimCompletionRequest(
+          model: 'codestral-latest',
+          prompt: 'p',
+          stream: true,
+        ),
+        FimCompletionRequest(
+          model: 'codestral-latest',
+          prompt: 'p',
+          stop: StopSequence.single('END'),
+        ),
+        FimCompletionRequest(
+          model: 'codestral-latest',
+          prompt: 'p',
+          randomSeed: 42,
+        ),
+      ];
+
+      for (final v in variants) {
+        expect(v, isNot(equals(base)), reason: 'variant $v should differ');
+      }
+    });
+
     test('toString provides useful representation', () {
       const request = FimCompletionRequest(
         model: 'codestral-latest',

--- a/packages/mistralai_dart/test/unit/models/fim/fim_completion_request_test.dart
+++ b/packages/mistralai_dart/test/unit/models/fim/fim_completion_request_test.dart
@@ -181,5 +181,102 @@ void main() {
       expect(request.toString(), contains('FimCompletionRequest'));
       expect(request.toString(), contains('codestral-latest'));
     });
+
+    group('metadata', () {
+      test('omitted from JSON when null', () {
+        const request = FimCompletionRequest(
+          model: 'codestral-latest',
+          prompt: 'def f():',
+        );
+
+        expect(request.toJson().containsKey('metadata'), isFalse);
+      });
+
+      test('round-trips metadata', () {
+        const original = FimCompletionRequest(
+          model: 'codestral-latest',
+          prompt: 'def f():',
+          metadata: {'tenant': 'acme', 'job': 42},
+        );
+
+        final roundTripped = FimCompletionRequest.fromJson(original.toJson());
+
+        expect(roundTripped.metadata, {'tenant': 'acme', 'job': 42});
+      });
+
+      test('copyWith clears with explicit null', () {
+        const original = FimCompletionRequest(
+          model: 'codestral-latest',
+          prompt: 'def f():',
+          metadata: {'k': 'v'},
+        );
+
+        expect(original.copyWith(metadata: null).metadata, isNull);
+      });
+    });
+
+    group('promptCacheKey', () {
+      test('omits prompt_cache_key from JSON when null', () {
+        const request = FimCompletionRequest(
+          model: 'codestral-latest',
+          prompt: 'def f():',
+        );
+
+        final json = request.toJson();
+
+        expect(json.containsKey('prompt_cache_key'), isFalse);
+      });
+
+      test('serializes prompt_cache_key when set', () {
+        const request = FimCompletionRequest(
+          model: 'codestral-latest',
+          prompt: 'def f():',
+          promptCacheKey: 'tenant-42',
+        );
+
+        final json = request.toJson();
+
+        expect(json['prompt_cache_key'], 'tenant-42');
+      });
+
+      test('round-trips prompt_cache_key', () {
+        const original = FimCompletionRequest(
+          model: 'codestral-latest',
+          prompt: 'def f():',
+          promptCacheKey: 'tenant-42',
+        );
+
+        final roundTripped = FimCompletionRequest.fromJson(original.toJson());
+
+        expect(roundTripped.promptCacheKey, 'tenant-42');
+      });
+
+      test('copyWith clears with explicit null', () {
+        const original = FimCompletionRequest(
+          model: 'codestral-latest',
+          prompt: 'def f():',
+          promptCacheKey: 'tenant-42',
+        );
+
+        final cleared = original.copyWith(promptCacheKey: null);
+
+        expect(cleared.promptCacheKey, isNull);
+      });
+
+      test('equality includes prompt_cache_key', () {
+        const a = FimCompletionRequest(
+          model: 'codestral-latest',
+          prompt: 'p',
+          promptCacheKey: 'k1',
+        );
+        const b = FimCompletionRequest(
+          model: 'codestral-latest',
+          prompt: 'p',
+          promptCacheKey: 'k2',
+        );
+
+        expect(a, isNot(equals(b)));
+      });
+    });
   });
 }

--- a/packages/mistralai_dart/test/unit/models/ocr/ocr_confidence_score_test.dart
+++ b/packages/mistralai_dart/test/unit/models/ocr/ocr_confidence_score_test.dart
@@ -1,0 +1,173 @@
+import 'package:mistralai_dart/mistralai_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OcrConfidenceScore', () {
+    group('fromJson', () {
+      test('parses required fields', () {
+        final score = OcrConfidenceScore.fromJson(const {
+          'confidence': 0.92,
+          'start_index': 12,
+          'text': 'hello world',
+        });
+
+        expect(score.confidence, 0.92);
+        expect(score.startIndex, 12);
+        expect(score.text, 'hello world');
+      });
+
+      test('parses confidence as integer', () {
+        final score = OcrConfidenceScore.fromJson(const {
+          'confidence': 1,
+          'start_index': 0,
+          'text': 'x',
+        });
+
+        expect(score.confidence, 1.0);
+      });
+
+      test('throws FormatException when confidence missing', () {
+        expect(
+          () => OcrConfidenceScore.fromJson(const {
+            'start_index': 0,
+            'text': 'x',
+          }),
+          throwsFormatException,
+        );
+      });
+
+      test('throws FormatException when start_index missing', () {
+        expect(
+          () => OcrConfidenceScore.fromJson(const {
+            'confidence': 0.5,
+            'text': 'x',
+          }),
+          throwsFormatException,
+        );
+      });
+
+      test('throws FormatException when text missing', () {
+        expect(
+          () => OcrConfidenceScore.fromJson(const {
+            'confidence': 0.5,
+            'start_index': 0,
+          }),
+          throwsFormatException,
+        );
+      });
+
+      test('throws FormatException when a required field is null', () {
+        expect(
+          () => OcrConfidenceScore.fromJson(const {
+            'confidence': null,
+            'start_index': 0,
+            'text': 'x',
+          }),
+          throwsFormatException,
+        );
+      });
+    });
+
+    group('toJson', () {
+      test('serializes all fields', () {
+        const score = OcrConfidenceScore(
+          confidence: 0.5,
+          startIndex: 4,
+          text: 'foo',
+        );
+
+        expect(score.toJson(), {
+          'confidence': 0.5,
+          'start_index': 4,
+          'text': 'foo',
+        });
+      });
+    });
+
+    group('round-trip', () {
+      test('fromJson/toJson preserves data', () {
+        const original = OcrConfidenceScore(
+          confidence: 0.83,
+          startIndex: 7,
+          text: 'sample',
+        );
+
+        final roundTripped = OcrConfidenceScore.fromJson(original.toJson());
+
+        expect(roundTripped, equals(original));
+      });
+    });
+
+    group('copyWith', () {
+      test('copies with new values', () {
+        const original = OcrConfidenceScore(
+          confidence: 0.5,
+          startIndex: 0,
+          text: 'old',
+        );
+
+        final copy = original.copyWith(confidence: 0.9, text: 'new');
+
+        expect(copy.confidence, 0.9);
+        expect(copy.startIndex, 0);
+        expect(copy.text, 'new');
+      });
+
+      test('preserves values when not specified', () {
+        const original = OcrConfidenceScore(
+          confidence: 0.5,
+          startIndex: 1,
+          text: 'foo',
+        );
+
+        expect(original.copyWith(), equals(original));
+      });
+    });
+
+    group('equality', () {
+      test('equal when all fields match', () {
+        const a = OcrConfidenceScore(confidence: 0.5, startIndex: 0, text: 'x');
+        const b = OcrConfidenceScore(confidence: 0.5, startIndex: 0, text: 'x');
+
+        expect(a, equals(b));
+        expect(a.hashCode, equals(b.hashCode));
+      });
+
+      test('not equal when confidence differs', () {
+        const a = OcrConfidenceScore(confidence: 0.5, startIndex: 0, text: 'x');
+        const b = OcrConfidenceScore(confidence: 0.6, startIndex: 0, text: 'x');
+
+        expect(a, isNot(equals(b)));
+      });
+
+      test('not equal when startIndex differs', () {
+        const a = OcrConfidenceScore(confidence: 0.5, startIndex: 0, text: 'x');
+        const b = OcrConfidenceScore(confidence: 0.5, startIndex: 1, text: 'x');
+
+        expect(a, isNot(equals(b)));
+      });
+
+      test('not equal when text differs', () {
+        const a = OcrConfidenceScore(confidence: 0.5, startIndex: 0, text: 'x');
+        const b = OcrConfidenceScore(confidence: 0.5, startIndex: 0, text: 'y');
+
+        expect(a, isNot(equals(b)));
+      });
+    });
+
+    test('toString includes summary', () {
+      const score = OcrConfidenceScore(
+        confidence: 0.42,
+        startIndex: 3,
+        text: 'hello',
+      );
+
+      final str = score.toString();
+
+      expect(str, contains('OcrConfidenceScore'));
+      expect(str, contains('0.42'));
+      expect(str, contains('startIndex: 3'));
+      expect(str, contains('chars'));
+    });
+  });
+}

--- a/packages/mistralai_dart/test/unit/models/ocr/ocr_page_confidence_scores_test.dart
+++ b/packages/mistralai_dart/test/unit/models/ocr/ocr_page_confidence_scores_test.dart
@@ -1,0 +1,186 @@
+import 'package:mistralai_dart/mistralai_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OcrPageConfidenceScores', () {
+    group('fromJson', () {
+      test('parses required aggregate scores', () {
+        final scores = OcrPageConfidenceScores.fromJson(const {
+          'average_page_confidence_score': 0.91,
+          'minimum_page_confidence_score': 0.42,
+        });
+
+        expect(scores.averagePageConfidenceScore, 0.91);
+        expect(scores.minimumPageConfidenceScore, 0.42);
+        expect(scores.wordConfidenceScores, isNull);
+      });
+
+      test('parses word_confidence_scores when present', () {
+        final scores = OcrPageConfidenceScores.fromJson(const {
+          'average_page_confidence_score': 0.8,
+          'minimum_page_confidence_score': 0.5,
+          'word_confidence_scores': [
+            {'confidence': 0.95, 'start_index': 0, 'text': 'foo'},
+            {'confidence': 0.6, 'start_index': 4, 'text': 'bar'},
+          ],
+        });
+
+        expect(scores.wordConfidenceScores, hasLength(2));
+        expect(scores.wordConfidenceScores![0].confidence, 0.95);
+        expect(scores.wordConfidenceScores![0].text, 'foo');
+        expect(scores.wordConfidenceScores![1].startIndex, 4);
+      });
+
+      test('throws FormatException when average missing', () {
+        expect(
+          () => OcrPageConfidenceScores.fromJson(const {
+            'minimum_page_confidence_score': 0.5,
+          }),
+          throwsFormatException,
+        );
+      });
+
+      test('throws FormatException when minimum missing', () {
+        expect(
+          () => OcrPageConfidenceScores.fromJson(const {
+            'average_page_confidence_score': 0.5,
+          }),
+          throwsFormatException,
+        );
+      });
+    });
+
+    group('toJson', () {
+      test('omits word_confidence_scores when null', () {
+        const scores = OcrPageConfidenceScores(
+          averagePageConfidenceScore: 0.8,
+          minimumPageConfidenceScore: 0.4,
+        );
+
+        final json = scores.toJson();
+
+        expect(json['average_page_confidence_score'], 0.8);
+        expect(json['minimum_page_confidence_score'], 0.4);
+        expect(json.containsKey('word_confidence_scores'), isFalse);
+      });
+
+      test('serializes word_confidence_scores when set', () {
+        const scores = OcrPageConfidenceScores(
+          averagePageConfidenceScore: 0.8,
+          minimumPageConfidenceScore: 0.4,
+          wordConfidenceScores: [
+            OcrConfidenceScore(confidence: 0.5, startIndex: 0, text: 'a'),
+          ],
+        );
+
+        final json = scores.toJson();
+
+        expect(json['word_confidence_scores'], hasLength(1));
+        final entry =
+            (json['word_confidence_scores'] as List).first
+                as Map<String, dynamic>;
+        expect(entry['confidence'], 0.5);
+        expect(entry['start_index'], 0);
+        expect(entry['text'], 'a');
+      });
+    });
+
+    group('round-trip', () {
+      test('with nested word_confidence_scores', () {
+        const original = OcrPageConfidenceScores(
+          averagePageConfidenceScore: 0.77,
+          minimumPageConfidenceScore: 0.21,
+          wordConfidenceScores: [
+            OcrConfidenceScore(confidence: 0.9, startIndex: 0, text: 'lorem'),
+            OcrConfidenceScore(confidence: 0.3, startIndex: 6, text: 'ipsum'),
+          ],
+        );
+
+        final roundTripped = OcrPageConfidenceScores.fromJson(
+          original.toJson(),
+        );
+
+        expect(roundTripped, equals(original));
+        expect(
+          roundTripped.wordConfidenceScores,
+          equals(original.wordConfidenceScores),
+        );
+      });
+    });
+
+    group('copyWith', () {
+      test('clears wordConfidenceScores when explicitly null', () {
+        const original = OcrPageConfidenceScores(
+          averagePageConfidenceScore: 0.8,
+          minimumPageConfidenceScore: 0.4,
+          wordConfidenceScores: [
+            OcrConfidenceScore(confidence: 0.5, startIndex: 0, text: 'a'),
+          ],
+        );
+
+        final copy = original.copyWith(wordConfidenceScores: null);
+
+        expect(copy.wordConfidenceScores, isNull);
+        expect(copy.averagePageConfidenceScore, 0.8);
+      });
+
+      test('preserves wordConfidenceScores when not specified', () {
+        const original = OcrPageConfidenceScores(
+          averagePageConfidenceScore: 0.8,
+          minimumPageConfidenceScore: 0.4,
+          wordConfidenceScores: [
+            OcrConfidenceScore(confidence: 0.5, startIndex: 0, text: 'a'),
+          ],
+        );
+
+        final copy = original.copyWith();
+
+        expect(copy, equals(original));
+      });
+    });
+
+    group('equality', () {
+      test('equal when nested word lists match element-wise', () {
+        const a = OcrPageConfidenceScores(
+          averagePageConfidenceScore: 0.8,
+          minimumPageConfidenceScore: 0.4,
+          wordConfidenceScores: [
+            OcrConfidenceScore(confidence: 0.5, startIndex: 0, text: 'foo'),
+          ],
+        );
+        const b = OcrPageConfidenceScores(
+          averagePageConfidenceScore: 0.8,
+          minimumPageConfidenceScore: 0.4,
+          wordConfidenceScores: [
+            OcrConfidenceScore(confidence: 0.5, startIndex: 0, text: 'foo'),
+          ],
+        );
+
+        expect(a, equals(b));
+        expect(a.hashCode, equals(b.hashCode));
+      });
+
+      test(
+        'not equal when nested entry text differs (full-fidelity check)',
+        () {
+          const a = OcrPageConfidenceScores(
+            averagePageConfidenceScore: 0.8,
+            minimumPageConfidenceScore: 0.4,
+            wordConfidenceScores: [
+              OcrConfidenceScore(confidence: 0.5, startIndex: 0, text: 'foo'),
+            ],
+          );
+          const b = OcrPageConfidenceScores(
+            averagePageConfidenceScore: 0.8,
+            minimumPageConfidenceScore: 0.4,
+            wordConfidenceScores: [
+              OcrConfidenceScore(confidence: 0.5, startIndex: 0, text: 'bar'),
+            ],
+          );
+
+          expect(a, isNot(equals(b)));
+        },
+      );
+    });
+  });
+}

--- a/packages/mistralai_dart/test/unit/models/ocr/ocr_page_test.dart
+++ b/packages/mistralai_dart/test/unit/models/ocr/ocr_page_test.dart
@@ -237,5 +237,77 @@ void main() {
       expect(page.toString(), contains('chars'));
       expect(page.toString(), contains('tables: 1'));
     });
+
+    group('confidenceScores', () {
+      test('parses confidence_scores when present', () {
+        final page = OcrPage.fromJson(const {
+          'index': 0,
+          'markdown': 'text',
+          'confidence_scores': {
+            'average_page_confidence_score': 0.9,
+            'minimum_page_confidence_score': 0.5,
+            'word_confidence_scores': [
+              {'confidence': 0.5, 'start_index': 0, 'text': 'text'},
+            ],
+          },
+        });
+
+        expect(page.confidenceScores, isNotNull);
+        expect(page.confidenceScores!.averagePageConfidenceScore, 0.9);
+        expect(page.confidenceScores!.minimumPageConfidenceScore, 0.5);
+        expect(page.confidenceScores!.wordConfidenceScores, hasLength(1));
+      });
+
+      test('omits confidence_scores from JSON when null', () {
+        const page = OcrPage(index: 0, markdown: 'text');
+
+        final json = page.toJson();
+
+        expect(json.containsKey('confidence_scores'), isFalse);
+      });
+
+      test('round-trips a populated confidenceScores', () {
+        const original = OcrPage(
+          index: 1,
+          markdown: 'lorem ipsum',
+          confidenceScores: OcrPageConfidenceScores(
+            averagePageConfidenceScore: 0.88,
+            minimumPageConfidenceScore: 0.31,
+            wordConfidenceScores: [
+              OcrConfidenceScore(
+                confidence: 0.88,
+                startIndex: 0,
+                text: 'lorem',
+              ),
+              OcrConfidenceScore(
+                confidence: 0.31,
+                startIndex: 6,
+                text: 'ipsum',
+              ),
+            ],
+          ),
+        );
+
+        final roundTripped = OcrPage.fromJson(original.toJson());
+
+        expect(roundTripped, equals(original));
+      });
+
+      test('copyWith clears confidenceScores with explicit null', () {
+        const original = OcrPage(
+          index: 0,
+          markdown: 'text',
+          confidenceScores: OcrPageConfidenceScores(
+            averagePageConfidenceScore: 0.9,
+            minimumPageConfidenceScore: 0.5,
+          ),
+        );
+
+        final cleared = original.copyWith(confidenceScores: null);
+
+        expect(cleared.confidenceScores, isNull);
+        expect(cleared.markdown, 'text');
+      });
+    });
   });
 }

--- a/packages/mistralai_dart/test/unit/models/ocr/ocr_request_test.dart
+++ b/packages/mistralai_dart/test/unit/models/ocr/ocr_request_test.dart
@@ -350,5 +350,113 @@ void main() {
         expect(request1, isNot(equals(request2)));
       });
     });
+
+    group('confidenceScoresGranularity', () {
+      test('omitted from JSON when null', () {
+        const request = OcrRequest(
+          document: UrlDocument('https://example.com/doc.pdf'),
+        );
+
+        final json = request.toJson();
+
+        expect(json.containsKey('confidence_scores_granularity'), isFalse);
+      });
+
+      test('serializes as "word"', () {
+        const request = OcrRequest(
+          document: UrlDocument('https://example.com/doc.pdf'),
+          confidenceScoresGranularity: OcrConfidenceScoresGranularity.word,
+        );
+
+        expect(request.toJson()['confidence_scores_granularity'], 'word');
+      });
+
+      test('serializes as "page"', () {
+        const request = OcrRequest(
+          document: UrlDocument('https://example.com/doc.pdf'),
+          confidenceScoresGranularity: OcrConfidenceScoresGranularity.page,
+        );
+
+        expect(request.toJson()['confidence_scores_granularity'], 'page');
+      });
+
+      test('round-trips word granularity', () {
+        const original = OcrRequest(
+          document: UrlDocument('https://example.com/doc.pdf'),
+          confidenceScoresGranularity: OcrConfidenceScoresGranularity.word,
+        );
+
+        final roundTripped = OcrRequest.fromJson(original.toJson());
+
+        expect(
+          roundTripped.confidenceScoresGranularity,
+          OcrConfidenceScoresGranularity.word,
+        );
+      });
+
+      test('round-trips page granularity', () {
+        const original = OcrRequest(
+          document: UrlDocument('https://example.com/doc.pdf'),
+          confidenceScoresGranularity: OcrConfidenceScoresGranularity.page,
+        );
+
+        final roundTripped = OcrRequest.fromJson(original.toJson());
+
+        expect(
+          roundTripped.confidenceScoresGranularity,
+          OcrConfidenceScoresGranularity.page,
+        );
+      });
+
+      test('fromJson maps unknown granularity value to unknown sentinel', () {
+        final request = OcrRequest.fromJson(const {
+          'document': {
+            'type': 'document_url',
+            'document_url': 'https://example.com/doc.pdf',
+          },
+          'confidence_scores_granularity': 'sentence',
+        });
+
+        expect(
+          request.confidenceScoresGranularity,
+          OcrConfidenceScoresGranularity.unknown,
+        );
+      });
+
+      test('copyWith clears with explicit null', () {
+        const original = OcrRequest(
+          document: UrlDocument('https://example.com/doc.pdf'),
+          confidenceScoresGranularity: OcrConfidenceScoresGranularity.word,
+        );
+
+        final cleared = original.copyWith(confidenceScoresGranularity: null);
+
+        expect(cleared.confidenceScoresGranularity, isNull);
+      });
+    });
+
+    group('OcrConfidenceScoresGranularity.fromString', () {
+      test('parses known values', () {
+        expect(
+          OcrConfidenceScoresGranularity.fromString('word'),
+          OcrConfidenceScoresGranularity.word,
+        );
+        expect(
+          OcrConfidenceScoresGranularity.fromString('page'),
+          OcrConfidenceScoresGranularity.page,
+        );
+      });
+
+      test('returns null for null input', () {
+        expect(OcrConfidenceScoresGranularity.fromString(null), isNull);
+      });
+
+      test('returns unknown for unrecognized values', () {
+        expect(
+          OcrConfidenceScoresGranularity.fromString('character'),
+          OcrConfidenceScoresGranularity.unknown,
+        );
+      });
+    });
   });
 }

--- a/packages/mistralai_dart/test/unit/models/ocr/ocr_table_test.dart
+++ b/packages/mistralai_dart/test/unit/models/ocr/ocr_table_test.dart
@@ -138,5 +138,85 @@ void main() {
       expect(str, contains('markdown'));
       expect(str, contains('chars'));
     });
+
+    group('wordConfidenceScores', () {
+      test('omitted when null', () {
+        const table = OcrTable(
+          id: 't',
+          content: 'c',
+          format: OcrTableFormat.markdown,
+        );
+
+        final json = table.toJson();
+
+        expect(json.containsKey('word_confidence_scores'), isFalse);
+      });
+
+      test('parses an empty list', () {
+        final table = OcrTable.fromJson(const {
+          'id': 't',
+          'content': 'c',
+          'format': 'markdown',
+          'word_confidence_scores': <Map<String, dynamic>>[],
+        });
+
+        expect(table.wordConfidenceScores, isEmpty);
+      });
+
+      test('round-trips a populated list', () {
+        const original = OcrTable(
+          id: 't',
+          content: '| A |\n|---|',
+          format: OcrTableFormat.markdown,
+          wordConfidenceScores: [
+            OcrConfidenceScore(confidence: 0.95, startIndex: 2, text: 'A'),
+            OcrConfidenceScore(confidence: 0.5, startIndex: 4, text: '|'),
+          ],
+        );
+
+        final roundTripped = OcrTable.fromJson(original.toJson());
+
+        expect(roundTripped, equals(original));
+        expect(roundTripped.wordConfidenceScores, hasLength(2));
+        expect(roundTripped.wordConfidenceScores![1].text, '|');
+      });
+
+      test('not equal when scores differ', () {
+        const a = OcrTable(
+          id: 't',
+          content: 'c',
+          format: OcrTableFormat.markdown,
+          wordConfidenceScores: [
+            OcrConfidenceScore(confidence: 0.5, startIndex: 0, text: 'a'),
+          ],
+        );
+        const b = OcrTable(
+          id: 't',
+          content: 'c',
+          format: OcrTableFormat.markdown,
+          wordConfidenceScores: [
+            OcrConfidenceScore(confidence: 0.5, startIndex: 0, text: 'b'),
+          ],
+        );
+
+        expect(a, isNot(equals(b)));
+      });
+
+      test('copyWith clears with explicit null', () {
+        const original = OcrTable(
+          id: 't',
+          content: 'c',
+          format: OcrTableFormat.markdown,
+          wordConfidenceScores: [
+            OcrConfidenceScore(confidence: 0.5, startIndex: 0, text: 'a'),
+          ],
+        );
+
+        final cleared = original.copyWith(wordConfidenceScores: null);
+
+        expect(cleared.wordConfidenceScores, isNull);
+        expect(cleared.id, 't');
+      });
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Add `promptCacheKey` to `AgentCompletionRequest`, `ChatCompletionRequest`, and `FimCompletionRequest`. Tokens hit by a cached prefix are billed at 10% of the standard input token price.
- Add OCR confidence scores: new `OcrConfidenceScore` and `OcrPageConfidenceScores` models, new `OcrConfidenceScoresGranularity` enum (`word` / `page`), plus `confidenceScoresGranularity` on `OcrRequest`, `confidenceScores` on `OcrPage`, and `wordConfidenceScores` on `OcrTable`.
- Add the previously-missing `metadata` field on `FimCompletionRequest` (parity with `ChatCompletionRequest` / `AgentCompletionRequest`).
- Refresh the committed `mistralai_dart` OpenAPI spec to its 2026-05-09 fetch.

All changes are additive. No public API breaks.

## Details

### Prompt cache key

Send `promptCacheKey` to opt requests into Mistral's prefix cache. Requests sharing the same key and matching prefix tokens reuse a cached prefix; cached prefix tokens are billed at 10% of standard input price.

```dart
final response = await client.chat.create(
  request: ChatCompletionRequest(
    model: 'mistral-large-latest',
    messages: [ChatMessage.user('Hello')],
    promptCacheKey: 'tenant-42',
  ),
);
```

### OCR confidence scores

Pass `confidenceScoresGranularity` on the request to opt into per-word or per-page reliability data. Defaults to `null` (no scores returned, smaller payload).

```dart
final response = await client.ocr.process(
  request: OcrRequest.fromUrl(
    url: 'https://example.com/doc.pdf',
    // confidenceScoresGranularity: OcrConfidenceScoresGranularity.word,
  ).copyWith(
    confidenceScoresGranularity: OcrConfidenceScoresGranularity.word,
  ),
);

for (final page in response.pages) {
  final scores = page.confidenceScores;
  if (scores != null) {
    print('avg=${scores.averagePageConfidenceScore} '
          'min=${scores.minimumPageConfidenceScore}');
    for (final span in scores.wordConfidenceScores ?? const []) {
      print('  ${span.text} @ ${span.startIndex}: ${span.confidence}');
    }
  }
}
```

The granularity enum follows the project's forward-compatibility pattern: unknown server values map to `OcrConfidenceScoresGranularity.unknown` rather than throwing.

### FIM `metadata`

`FimCompletionRequest` now accepts a `Map<String, dynamic>? metadata` field, matching the sibling completion requests. This was a pre-existing gap in our spec coverage that surfaced when registering `FIMCompletionRequest` in the openapi-mistral toolkit manifest.

## References

- [Mistral AI OpenAPI](https://docs.mistral.ai/openapi.yaml) — upstream spec source

## Test Plan

- [x] `dart analyze --fatal-infos` — clean
- [x] `dart format --set-exit-if-changed .` — clean
- [x] Unit tests pass (1494 passing, 3 skipped — pre-existing env-key skips)
- [x] Integration tests pass (22/22) against live Mistral API
- [x] Toolkit verify (`api_toolkit.py verify --checks all`) — 0 errors
- [x] `fromJson`/`toJson` round-trip covered for every new field, including null-omit
- [x] `copyWith` null-clear via `unsetCopyWithValue` covered for every new nullable field
- [x] `==`/`hashCode` cover every new field; nested-list equality verified for `OcrConfidenceScore` lists
- [x] `OcrConfidenceScore.fromJson` throws `FormatException` on missing/null required fields
- [x] `OcrConfidenceScoresGranularity.fromString` returns `unknown` (not `null`/throw) for unrecognized values — forward compatibility
- [x] Three new manifest entries (`FIMCompletionRequest`, `OCRConfidenceScore`, `OCRPageConfidenceScores`); granularity enum intentionally not registered (matches `OcrTableFormat` precedent)
- [x] Three new exports in `lib/mistralai_dart.dart`
- [x] Committed spec is byte-identical to fetched upstream