### PR TITLE
feat(anthropic_sdk_dart)!: spec refresh, relationship + thread IDs

### DIFF
--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
@@ -2557,6 +2557,13 @@
       "file": "lib/src/models/user_profiles/user_profile_list_order.dart",
       "schema": "BetaUserProfileListOrder"
     },
+    "BetaUserProfileRelationship": {
+      "spec": "main",
+      "kind": "enum",
+      "dart_class": "BetaUserProfileRelationship",
+      "file": "lib/src/models/user_profiles/user_profile_relationship.dart",
+      "schema": "BetaUserProfileRelationship"
+    },
     "EnrollmentUrl": {
       "spec": "main",
       "kind": "object",

--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/specs.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/specs.json
@@ -27,9 +27,9 @@
       "fetch_mode": "remote",
       "local_file": "openapi.yaml",
       "name": "Anthropic API",
-      "pinned_hash": "6811827071199207cf69c4e64cae1b41e7e74cdb14048e9c748701e474c694a7",
+      "pinned_hash": "0df2c793ea4c3ad955e8e488be39d7041a0a95e2fe144dd69ae4d9fb72835190",
       "requires_auth": false,
-      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic%2Fanthropic-6811827071199207cf69c4e64cae1b41e7e74cdb14048e9c748701e474c694a7.yml"
+      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-0df2c793ea4c3ad955e8e488be39d7041a0a95e2fe144dd69ae4d9fb72835190.yml"
     }
   },
   "specs_dir": "packages/anthropic_sdk_dart/specs"

--- a/packages/anthropic_sdk_dart/README.md
+++ b/packages/anthropic_sdk_dart/README.md
@@ -47,7 +47,7 @@ Dart client for the **[Anthropic API](https://docs.anthropic.com/en/api)** to bu
 - Model discovery, files (beta), and skills (beta)
 - Managed agents with sessions, vaults, and streaming events (beta)
 - Memory stores for persistent agent memories with versioning and redaction (beta)
-- User profiles with trust-grant tracking and enrollment URLs (beta)
+- User profiles with relationship classification (`external`/`resold`/`internal`), trust-grant tracking, and enrollment URLs (beta)
 
 ## Quickstart
 

--- a/packages/anthropic_sdk_dart/lib/anthropic_sdk_dart.dart
+++ b/packages/anthropic_sdk_dart/lib/anthropic_sdk_dart.dart
@@ -72,6 +72,9 @@ export 'src/models/beta/config/token_task_budget.dart';
 // since they extend BuiltInTool (sealed class)
 export 'src/models/beta/tools/code_execution_tool.dart';
 
+// Models - Beta Common
+export 'src/models/beta_timestamp.dart';
+
 // Models - Completions (Legacy)
 export 'src/models/completions/completion.dart';
 
@@ -184,6 +187,7 @@ export 'src/models/user_profiles/list_user_profiles_response.dart';
 export 'src/models/user_profiles/update_user_profile_request.dart';
 export 'src/models/user_profiles/user_profile.dart';
 export 'src/models/user_profiles/user_profile_list_order.dart';
+export 'src/models/user_profiles/user_profile_relationship.dart';
 export 'src/models/user_profiles/user_profile_trust_grant.dart';
 
 // Resources

--- a/packages/anthropic_sdk_dart/lib/src/models/beta_timestamp.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/beta_timestamp.dart
@@ -1,0 +1,2 @@
+/// A timestamp in RFC 3339 format.
+typedef BetaTimestamp = DateTime;

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/agents/agent.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/agents/agent.dart
@@ -1,5 +1,6 @@
 import 'package:meta/meta.dart';
 
+import '../../beta_timestamp.dart';
 import '../../common/copy_with_sentinel.dart';
 import '../../common/equality_helpers.dart';
 import '../config/agent_skill.dart';
@@ -44,13 +45,13 @@ class Agent {
   final Map<String, String>? metadata;
 
   /// ISO 8601 timestamp of when the agent was created.
-  final DateTime createdAt;
+  final BetaTimestamp createdAt;
 
   /// ISO 8601 timestamp of when the agent was last updated.
-  final DateTime updatedAt;
+  final BetaTimestamp updatedAt;
 
   /// ISO 8601 timestamp of when the agent was archived, or null.
-  final DateTime? archivedAt;
+  final BetaTimestamp? archivedAt;
 
   /// Creates an [Agent].
   const Agent({
@@ -133,8 +134,8 @@ class Agent {
     List<MCPServer>? mcpServers,
     List<AgentSkill>? skills,
     Object? metadata = unsetCopyWithValue,
-    DateTime? createdAt,
-    DateTime? updatedAt,
+    BetaTimestamp? createdAt,
+    BetaTimestamp? updatedAt,
     Object? archivedAt = unsetCopyWithValue,
   }) {
     return Agent(
@@ -157,7 +158,7 @@ class Agent {
       updatedAt: updatedAt ?? this.updatedAt,
       archivedAt: archivedAt == unsetCopyWithValue
           ? this.archivedAt
-          : archivedAt as DateTime?,
+          : archivedAt as BetaTimestamp?,
     );
   }
 

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/events/send_event_params.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/events/send_event_params.dart
@@ -126,27 +126,53 @@ class UserInterruptEventParams extends EventParams {
   /// The event type, always 'user.interrupt'.
   String get type => 'user.interrupt';
 
+  /// ID of the session thread to interrupt, if any.
+  final String? sessionThreadId;
+
   /// Creates a [UserInterruptEventParams].
-  const UserInterruptEventParams();
+  const UserInterruptEventParams({this.sessionThreadId});
 
   /// Creates a [UserInterruptEventParams] from JSON.
-  factory UserInterruptEventParams.fromJson(Map<String, dynamic> _) {
-    return const UserInterruptEventParams();
+  factory UserInterruptEventParams.fromJson(Map<String, dynamic> json) {
+    return UserInterruptEventParams(
+      sessionThreadId: json['session_thread_id'] as String?,
+    );
   }
 
   @override
-  Map<String, dynamic> toJson() => {'type': type};
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (sessionThreadId != null) 'session_thread_id': sessionThreadId,
+  };
+
+  /// Creates a copy with replaced values.
+  ///
+  /// For nullable fields ([sessionThreadId]), pass the sentinel value
+  /// [unsetCopyWithValue] (or omit) to keep the original value, or pass
+  /// `null` explicitly to set the field to null.
+  UserInterruptEventParams copyWith({
+    Object? sessionThreadId = unsetCopyWithValue,
+  }) {
+    return UserInterruptEventParams(
+      sessionThreadId: sessionThreadId == unsetCopyWithValue
+          ? this.sessionThreadId
+          : sessionThreadId as String?,
+    );
+  }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is UserInterruptEventParams && runtimeType == other.runtimeType;
+      other is UserInterruptEventParams &&
+          runtimeType == other.runtimeType &&
+          sessionThreadId == other.sessionThreadId;
 
   @override
-  int get hashCode => runtimeType.hashCode;
+  int get hashCode => sessionThreadId.hashCode;
 
   @override
-  String toString() => 'UserInterruptEventParams()';
+  String toString() =>
+      'UserInterruptEventParams(sessionThreadId: $sessionThreadId)';
 }
 
 /// Parameters for confirming or denying a tool execution request.

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/events/session_event.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/events/session_event.dart
@@ -1,5 +1,6 @@
 import 'package:meta/meta.dart';
 
+import '../../beta_timestamp.dart';
 import '../../common/copy_with_sentinel.dart';
 import '../../common/equality_helpers.dart';
 import '../config/agent_tool.dart' show AgentEvaluatedPermission;
@@ -86,7 +87,7 @@ class AgentMessageEvent extends SessionEvent {
   final List<Map<String, dynamic>> content;
 
   /// Timestamp when this response was generated.
-  final DateTime processedAt;
+  final BetaTimestamp processedAt;
 
   /// Creates an [AgentMessageEvent].
   const AgentMessageEvent({
@@ -118,7 +119,7 @@ class AgentMessageEvent extends SessionEvent {
   AgentMessageEvent copyWith({
     String? id,
     List<Map<String, dynamic>>? content,
-    DateTime? processedAt,
+    BetaTimestamp? processedAt,
   }) {
     return AgentMessageEvent(
       id: id ?? this.id,
@@ -155,7 +156,7 @@ class AgentThinkingEvent extends SessionEvent {
   final String id;
 
   /// Timestamp when this thinking was produced.
-  final DateTime processedAt;
+  final BetaTimestamp processedAt;
 
   /// Creates an [AgentThinkingEvent].
   const AgentThinkingEvent({required this.id, required this.processedAt});
@@ -176,7 +177,7 @@ class AgentThinkingEvent extends SessionEvent {
   };
 
   /// Creates a copy with replaced values.
-  AgentThinkingEvent copyWith({String? id, DateTime? processedAt}) {
+  AgentThinkingEvent copyWith({String? id, BetaTimestamp? processedAt}) {
     return AgentThinkingEvent(
       id: id ?? this.id,
       processedAt: processedAt ?? this.processedAt,
@@ -217,7 +218,10 @@ class AgentToolUseEvent extends SessionEvent {
   final AgentEvaluatedPermission? evaluatedPermission;
 
   /// Timestamp when this event was processed.
-  final DateTime processedAt;
+  final BetaTimestamp processedAt;
+
+  /// ID of the session thread this event belongs to, if any.
+  final String? sessionThreadId;
 
   /// Creates an [AgentToolUseEvent].
   const AgentToolUseEvent({
@@ -226,6 +230,7 @@ class AgentToolUseEvent extends SessionEvent {
     required this.input,
     this.evaluatedPermission,
     required this.processedAt,
+    this.sessionThreadId,
   });
 
   /// Creates an [AgentToolUseEvent] from JSON.
@@ -240,6 +245,7 @@ class AgentToolUseEvent extends SessionEvent {
             )
           : null,
       processedAt: DateTime.parse(json['processed_at'] as String),
+      sessionThreadId: json['session_thread_id'] as String?,
     );
   }
 
@@ -252,6 +258,7 @@ class AgentToolUseEvent extends SessionEvent {
     if (evaluatedPermission != null)
       'evaluated_permission': evaluatedPermission!.toJson(),
     'processed_at': processedAt.toUtc().toIso8601String(),
+    if (sessionThreadId != null) 'session_thread_id': sessionThreadId,
   };
 
   /// Creates a copy with replaced values.
@@ -260,7 +267,8 @@ class AgentToolUseEvent extends SessionEvent {
     String? name,
     Map<String, dynamic>? input,
     Object? evaluatedPermission = unsetCopyWithValue,
-    DateTime? processedAt,
+    BetaTimestamp? processedAt,
+    Object? sessionThreadId = unsetCopyWithValue,
   }) {
     return AgentToolUseEvent(
       id: id ?? this.id,
@@ -270,6 +278,9 @@ class AgentToolUseEvent extends SessionEvent {
           ? this.evaluatedPermission
           : evaluatedPermission as AgentEvaluatedPermission?,
       processedAt: processedAt ?? this.processedAt,
+      sessionThreadId: sessionThreadId == unsetCopyWithValue
+          ? this.sessionThreadId
+          : sessionThreadId as String?,
     );
   }
 
@@ -282,7 +293,8 @@ class AgentToolUseEvent extends SessionEvent {
           name == other.name &&
           mapsDeepEqual(input, other.input) &&
           evaluatedPermission == other.evaluatedPermission &&
-          processedAt == other.processedAt;
+          processedAt == other.processedAt &&
+          sessionThreadId == other.sessionThreadId;
 
   @override
   int get hashCode => Object.hash(
@@ -291,13 +303,15 @@ class AgentToolUseEvent extends SessionEvent {
     mapDeepHashCode(input),
     evaluatedPermission,
     processedAt,
+    sessionThreadId,
   );
 
   @override
   String toString() =>
       'AgentToolUseEvent(id: $id, name: $name, input: $input, '
       'evaluatedPermission: $evaluatedPermission, '
-      'processedAt: $processedAt)';
+      'processedAt: $processedAt, '
+      'sessionThreadId: $sessionThreadId)';
 }
 
 /// Result of a built-in agent tool execution.
@@ -319,7 +333,7 @@ class AgentToolResultEvent extends SessionEvent {
   final bool? isError;
 
   /// Timestamp when this event was processed.
-  final DateTime processedAt;
+  final BetaTimestamp processedAt;
 
   /// Creates an [AgentToolResultEvent].
   const AgentToolResultEvent({
@@ -359,7 +373,7 @@ class AgentToolResultEvent extends SessionEvent {
     String? toolUseId,
     Object? content = unsetCopyWithValue,
     Object? isError = unsetCopyWithValue,
-    DateTime? processedAt,
+    BetaTimestamp? processedAt,
   }) {
     return AgentToolResultEvent(
       id: id ?? this.id,
@@ -420,7 +434,10 @@ class AgentMcpToolUseEvent extends SessionEvent {
   final AgentEvaluatedPermission? evaluatedPermission;
 
   /// Timestamp when this event was processed.
-  final DateTime processedAt;
+  final BetaTimestamp processedAt;
+
+  /// ID of the session thread this event belongs to, if any.
+  final String? sessionThreadId;
 
   /// Creates an [AgentMcpToolUseEvent].
   const AgentMcpToolUseEvent({
@@ -430,6 +447,7 @@ class AgentMcpToolUseEvent extends SessionEvent {
     required this.input,
     this.evaluatedPermission,
     required this.processedAt,
+    this.sessionThreadId,
   });
 
   /// Creates an [AgentMcpToolUseEvent] from JSON.
@@ -445,6 +463,7 @@ class AgentMcpToolUseEvent extends SessionEvent {
             )
           : null,
       processedAt: DateTime.parse(json['processed_at'] as String),
+      sessionThreadId: json['session_thread_id'] as String?,
     );
   }
 
@@ -458,6 +477,7 @@ class AgentMcpToolUseEvent extends SessionEvent {
     if (evaluatedPermission != null)
       'evaluated_permission': evaluatedPermission!.toJson(),
     'processed_at': processedAt.toUtc().toIso8601String(),
+    if (sessionThreadId != null) 'session_thread_id': sessionThreadId,
   };
 
   /// Creates a copy with replaced values.
@@ -467,7 +487,8 @@ class AgentMcpToolUseEvent extends SessionEvent {
     String? name,
     Map<String, dynamic>? input,
     Object? evaluatedPermission = unsetCopyWithValue,
-    DateTime? processedAt,
+    BetaTimestamp? processedAt,
+    Object? sessionThreadId = unsetCopyWithValue,
   }) {
     return AgentMcpToolUseEvent(
       id: id ?? this.id,
@@ -478,6 +499,9 @@ class AgentMcpToolUseEvent extends SessionEvent {
           ? this.evaluatedPermission
           : evaluatedPermission as AgentEvaluatedPermission?,
       processedAt: processedAt ?? this.processedAt,
+      sessionThreadId: sessionThreadId == unsetCopyWithValue
+          ? this.sessionThreadId
+          : sessionThreadId as String?,
     );
   }
 
@@ -491,7 +515,8 @@ class AgentMcpToolUseEvent extends SessionEvent {
           name == other.name &&
           mapsDeepEqual(input, other.input) &&
           evaluatedPermission == other.evaluatedPermission &&
-          processedAt == other.processedAt;
+          processedAt == other.processedAt &&
+          sessionThreadId == other.sessionThreadId;
 
   @override
   int get hashCode => Object.hash(
@@ -501,6 +526,7 @@ class AgentMcpToolUseEvent extends SessionEvent {
     mapDeepHashCode(input),
     evaluatedPermission,
     processedAt,
+    sessionThreadId,
   );
 
   @override
@@ -508,7 +534,8 @@ class AgentMcpToolUseEvent extends SessionEvent {
       'AgentMcpToolUseEvent(id: $id, mcpServerName: $mcpServerName, '
       'name: $name, input: $input, '
       'evaluatedPermission: $evaluatedPermission, '
-      'processedAt: $processedAt)';
+      'processedAt: $processedAt, '
+      'sessionThreadId: $sessionThreadId)';
 }
 
 /// Result of an MCP tool execution.
@@ -530,7 +557,7 @@ class AgentMcpToolResultEvent extends SessionEvent {
   final bool? isError;
 
   /// Timestamp when this event was processed.
-  final DateTime processedAt;
+  final BetaTimestamp processedAt;
 
   /// Creates an [AgentMcpToolResultEvent].
   const AgentMcpToolResultEvent({
@@ -570,7 +597,7 @@ class AgentMcpToolResultEvent extends SessionEvent {
     String? mcpToolUseId,
     Object? content = unsetCopyWithValue,
     Object? isError = unsetCopyWithValue,
-    DateTime? processedAt,
+    BetaTimestamp? processedAt,
   }) {
     return AgentMcpToolResultEvent(
       id: id ?? this.id,
@@ -625,7 +652,10 @@ class AgentCustomToolUseEvent extends SessionEvent {
   final Map<String, dynamic> input;
 
   /// Timestamp when this tool use was processed.
-  final DateTime processedAt;
+  final BetaTimestamp processedAt;
+
+  /// ID of the session thread this event belongs to, if any.
+  final String? sessionThreadId;
 
   /// Creates an [AgentCustomToolUseEvent].
   const AgentCustomToolUseEvent({
@@ -633,6 +663,7 @@ class AgentCustomToolUseEvent extends SessionEvent {
     required this.name,
     required this.input,
     required this.processedAt,
+    this.sessionThreadId,
   });
 
   /// Creates an [AgentCustomToolUseEvent] from JSON.
@@ -642,6 +673,7 @@ class AgentCustomToolUseEvent extends SessionEvent {
       name: json['name'] as String,
       input: json['input'] as Map<String, dynamic>,
       processedAt: DateTime.parse(json['processed_at'] as String),
+      sessionThreadId: json['session_thread_id'] as String?,
     );
   }
 
@@ -652,6 +684,7 @@ class AgentCustomToolUseEvent extends SessionEvent {
     'name': name,
     'input': input,
     'processed_at': processedAt.toUtc().toIso8601String(),
+    if (sessionThreadId != null) 'session_thread_id': sessionThreadId,
   };
 
   /// Creates a copy with replaced values.
@@ -659,13 +692,17 @@ class AgentCustomToolUseEvent extends SessionEvent {
     String? id,
     String? name,
     Map<String, dynamic>? input,
-    DateTime? processedAt,
+    BetaTimestamp? processedAt,
+    Object? sessionThreadId = unsetCopyWithValue,
   }) {
     return AgentCustomToolUseEvent(
       id: id ?? this.id,
       name: name ?? this.name,
       input: input ?? this.input,
       processedAt: processedAt ?? this.processedAt,
+      sessionThreadId: sessionThreadId == unsetCopyWithValue
+          ? this.sessionThreadId
+          : sessionThreadId as String?,
     );
   }
 
@@ -677,16 +714,22 @@ class AgentCustomToolUseEvent extends SessionEvent {
           id == other.id &&
           name == other.name &&
           mapsDeepEqual(input, other.input) &&
-          processedAt == other.processedAt;
+          processedAt == other.processedAt &&
+          sessionThreadId == other.sessionThreadId;
 
   @override
-  int get hashCode =>
-      Object.hash(id, name, mapDeepHashCode(input), processedAt);
+  int get hashCode => Object.hash(
+    id,
+    name,
+    mapDeepHashCode(input),
+    processedAt,
+    sessionThreadId,
+  );
 
   @override
   String toString() =>
       'AgentCustomToolUseEvent(id: $id, name: $name, input: $input, '
-      'processedAt: $processedAt)';
+      'processedAt: $processedAt, sessionThreadId: $sessionThreadId)';
 }
 
 /// Context compaction (summarization) occurred during the session.
@@ -699,7 +742,7 @@ class AgentThreadContextCompactedEvent extends SessionEvent {
   final String id;
 
   /// Timestamp when compaction was processed.
-  final DateTime processedAt;
+  final BetaTimestamp processedAt;
 
   /// Creates an [AgentThreadContextCompactedEvent].
   const AgentThreadContextCompactedEvent({
@@ -725,7 +768,7 @@ class AgentThreadContextCompactedEvent extends SessionEvent {
   /// Creates a copy with replaced values.
   AgentThreadContextCompactedEvent copyWith({
     String? id,
-    DateTime? processedAt,
+    BetaTimestamp? processedAt,
   }) {
     return AgentThreadContextCompactedEvent(
       id: id ?? this.id,
@@ -767,7 +810,7 @@ class UserMessageEvent extends SessionEvent {
   final List<Map<String, dynamic>> content;
 
   /// Timestamp when the agent finished processing this message.
-  final DateTime? processedAt;
+  final BetaTimestamp? processedAt;
 
   /// Creates a [UserMessageEvent].
   const UserMessageEvent({
@@ -809,7 +852,7 @@ class UserMessageEvent extends SessionEvent {
       content: content ?? this.content,
       processedAt: processedAt == unsetCopyWithValue
           ? this.processedAt
-          : processedAt as DateTime?,
+          : processedAt as BetaTimestamp?,
     );
   }
 
@@ -841,10 +884,17 @@ class UserInterruptEvent extends SessionEvent {
   final String id;
 
   /// Timestamp when the interrupt was processed.
-  final DateTime? processedAt;
+  final BetaTimestamp? processedAt;
+
+  /// ID of the session thread this event belongs to, if any.
+  final String? sessionThreadId;
 
   /// Creates a [UserInterruptEvent].
-  const UserInterruptEvent({required this.id, this.processedAt});
+  const UserInterruptEvent({
+    required this.id,
+    this.processedAt,
+    this.sessionThreadId,
+  });
 
   /// Creates a [UserInterruptEvent] from JSON.
   factory UserInterruptEvent.fromJson(Map<String, dynamic> json) {
@@ -853,6 +903,7 @@ class UserInterruptEvent extends SessionEvent {
       processedAt: json['processed_at'] != null
           ? DateTime.parse(json['processed_at'] as String)
           : null,
+      sessionThreadId: json['session_thread_id'] as String?,
     );
   }
 
@@ -862,18 +913,23 @@ class UserInterruptEvent extends SessionEvent {
     'id': id,
     if (processedAt != null)
       'processed_at': processedAt!.toUtc().toIso8601String(),
+    if (sessionThreadId != null) 'session_thread_id': sessionThreadId,
   };
 
   /// Creates a copy with replaced values.
   UserInterruptEvent copyWith({
     String? id,
     Object? processedAt = unsetCopyWithValue,
+    Object? sessionThreadId = unsetCopyWithValue,
   }) {
     return UserInterruptEvent(
       id: id ?? this.id,
       processedAt: processedAt == unsetCopyWithValue
           ? this.processedAt
-          : processedAt as DateTime?,
+          : processedAt as BetaTimestamp?,
+      sessionThreadId: sessionThreadId == unsetCopyWithValue
+          ? this.sessionThreadId
+          : sessionThreadId as String?,
     );
   }
 
@@ -883,13 +939,16 @@ class UserInterruptEvent extends SessionEvent {
       other is UserInterruptEvent &&
           runtimeType == other.runtimeType &&
           id == other.id &&
-          processedAt == other.processedAt;
+          processedAt == other.processedAt &&
+          sessionThreadId == other.sessionThreadId;
 
   @override
-  int get hashCode => Object.hash(id, processedAt);
+  int get hashCode => Object.hash(id, processedAt, sessionThreadId);
 
   @override
-  String toString() => 'UserInterruptEvent(id: $id, processedAt: $processedAt)';
+  String toString() =>
+      'UserInterruptEvent(id: $id, processedAt: $processedAt, '
+      'sessionThreadId: $sessionThreadId)';
 }
 
 /// Confirmation result for tool execution.
@@ -938,7 +997,10 @@ class UserToolConfirmationEvent extends SessionEvent {
   final String? denyMessage;
 
   /// Timestamp when the confirmation was processed.
-  final DateTime? processedAt;
+  final BetaTimestamp? processedAt;
+
+  /// ID of the session thread this event belongs to, if any.
+  final String? sessionThreadId;
 
   /// Creates a [UserToolConfirmationEvent].
   const UserToolConfirmationEvent({
@@ -947,6 +1009,7 @@ class UserToolConfirmationEvent extends SessionEvent {
     required this.result,
     this.denyMessage,
     this.processedAt,
+    this.sessionThreadId,
   });
 
   /// Creates a [UserToolConfirmationEvent] from JSON.
@@ -959,6 +1022,7 @@ class UserToolConfirmationEvent extends SessionEvent {
       processedAt: json['processed_at'] != null
           ? DateTime.parse(json['processed_at'] as String)
           : null,
+      sessionThreadId: json['session_thread_id'] as String?,
     );
   }
 
@@ -971,6 +1035,7 @@ class UserToolConfirmationEvent extends SessionEvent {
     if (denyMessage != null) 'deny_message': denyMessage,
     if (processedAt != null)
       'processed_at': processedAt!.toUtc().toIso8601String(),
+    if (sessionThreadId != null) 'session_thread_id': sessionThreadId,
   };
 
   /// Creates a copy with replaced values.
@@ -980,6 +1045,7 @@ class UserToolConfirmationEvent extends SessionEvent {
     UserToolConfirmationResult? result,
     Object? denyMessage = unsetCopyWithValue,
     Object? processedAt = unsetCopyWithValue,
+    Object? sessionThreadId = unsetCopyWithValue,
   }) {
     return UserToolConfirmationEvent(
       id: id ?? this.id,
@@ -990,7 +1056,10 @@ class UserToolConfirmationEvent extends SessionEvent {
           : denyMessage as String?,
       processedAt: processedAt == unsetCopyWithValue
           ? this.processedAt
-          : processedAt as DateTime?,
+          : processedAt as BetaTimestamp?,
+      sessionThreadId: sessionThreadId == unsetCopyWithValue
+          ? this.sessionThreadId
+          : sessionThreadId as String?,
     );
   }
 
@@ -1003,17 +1072,24 @@ class UserToolConfirmationEvent extends SessionEvent {
           toolUseId == other.toolUseId &&
           result == other.result &&
           denyMessage == other.denyMessage &&
-          processedAt == other.processedAt;
+          processedAt == other.processedAt &&
+          sessionThreadId == other.sessionThreadId;
 
   @override
-  int get hashCode =>
-      Object.hash(id, toolUseId, result, denyMessage, processedAt);
+  int get hashCode => Object.hash(
+    id,
+    toolUseId,
+    result,
+    denyMessage,
+    processedAt,
+    sessionThreadId,
+  );
 
   @override
   String toString() =>
       'UserToolConfirmationEvent(id: $id, toolUseId: $toolUseId, '
       'result: $result, denyMessage: $denyMessage, '
-      'processedAt: $processedAt)';
+      'processedAt: $processedAt, sessionThreadId: $sessionThreadId)';
 }
 
 /// Custom tool result event sent by the client.
@@ -1035,7 +1111,10 @@ class UserCustomToolResultEvent extends SessionEvent {
   final bool? isError;
 
   /// Timestamp when this result was processed.
-  final DateTime? processedAt;
+  final BetaTimestamp? processedAt;
+
+  /// ID of the session thread this event belongs to, if any.
+  final String? sessionThreadId;
 
   /// Creates a [UserCustomToolResultEvent].
   const UserCustomToolResultEvent({
@@ -1044,6 +1123,7 @@ class UserCustomToolResultEvent extends SessionEvent {
     this.content,
     this.isError,
     this.processedAt,
+    this.sessionThreadId,
   });
 
   /// Creates a [UserCustomToolResultEvent] from JSON.
@@ -1058,6 +1138,7 @@ class UserCustomToolResultEvent extends SessionEvent {
       processedAt: json['processed_at'] != null
           ? DateTime.parse(json['processed_at'] as String)
           : null,
+      sessionThreadId: json['session_thread_id'] as String?,
     );
   }
 
@@ -1070,6 +1151,7 @@ class UserCustomToolResultEvent extends SessionEvent {
     if (isError != null) 'is_error': isError,
     if (processedAt != null)
       'processed_at': processedAt!.toUtc().toIso8601String(),
+    if (sessionThreadId != null) 'session_thread_id': sessionThreadId,
   };
 
   /// Creates a copy with replaced values.
@@ -1079,6 +1161,7 @@ class UserCustomToolResultEvent extends SessionEvent {
     Object? content = unsetCopyWithValue,
     Object? isError = unsetCopyWithValue,
     Object? processedAt = unsetCopyWithValue,
+    Object? sessionThreadId = unsetCopyWithValue,
   }) {
     return UserCustomToolResultEvent(
       id: id ?? this.id,
@@ -1089,7 +1172,10 @@ class UserCustomToolResultEvent extends SessionEvent {
       isError: isError == unsetCopyWithValue ? this.isError : isError as bool?,
       processedAt: processedAt == unsetCopyWithValue
           ? this.processedAt
-          : processedAt as DateTime?,
+          : processedAt as BetaTimestamp?,
+      sessionThreadId: sessionThreadId == unsetCopyWithValue
+          ? this.sessionThreadId
+          : sessionThreadId as String?,
     );
   }
 
@@ -1102,7 +1188,8 @@ class UserCustomToolResultEvent extends SessionEvent {
           customToolUseId == other.customToolUseId &&
           listOfMapsDeepEqual(content, other.content) &&
           isError == other.isError &&
-          processedAt == other.processedAt;
+          processedAt == other.processedAt &&
+          sessionThreadId == other.sessionThreadId;
 
   @override
   int get hashCode => Object.hash(
@@ -1111,13 +1198,15 @@ class UserCustomToolResultEvent extends SessionEvent {
     listOfMapsHashCode(content),
     isError,
     processedAt,
+    sessionThreadId,
   );
 
   @override
   String toString() =>
       'UserCustomToolResultEvent(id: $id, '
       'customToolUseId: $customToolUseId, content: $content, '
-      'isError: $isError, processedAt: $processedAt)';
+      'isError: $isError, processedAt: $processedAt, '
+      'sessionThreadId: $sessionThreadId)';
 }
 
 // ---------------------------------------------------------------------------
@@ -1134,7 +1223,7 @@ class SessionStatusRunningEvent extends SessionEvent {
   final String id;
 
   /// Timestamp of status change.
-  final DateTime processedAt;
+  final BetaTimestamp processedAt;
 
   /// Creates a [SessionStatusRunningEvent].
   const SessionStatusRunningEvent({
@@ -1158,7 +1247,7 @@ class SessionStatusRunningEvent extends SessionEvent {
   };
 
   /// Creates a copy with replaced values.
-  SessionStatusRunningEvent copyWith({String? id, DateTime? processedAt}) {
+  SessionStatusRunningEvent copyWith({String? id, BetaTimestamp? processedAt}) {
     return SessionStatusRunningEvent(
       id: id ?? this.id,
       processedAt: processedAt ?? this.processedAt,
@@ -1344,7 +1433,7 @@ class SessionStatusIdleEvent extends SessionEvent {
   final SessionStopReason stopReason;
 
   /// Timestamp of status change.
-  final DateTime processedAt;
+  final BetaTimestamp processedAt;
 
   /// Creates a [SessionStatusIdleEvent].
   const SessionStatusIdleEvent({
@@ -1376,7 +1465,7 @@ class SessionStatusIdleEvent extends SessionEvent {
   SessionStatusIdleEvent copyWith({
     String? id,
     SessionStopReason? stopReason,
-    DateTime? processedAt,
+    BetaTimestamp? processedAt,
   }) {
     return SessionStatusIdleEvent(
       id: id ?? this.id,
@@ -1413,7 +1502,7 @@ class SessionStatusRescheduledEvent extends SessionEvent {
   final String id;
 
   /// Timestamp of status change.
-  final DateTime processedAt;
+  final BetaTimestamp processedAt;
 
   /// Creates a [SessionStatusRescheduledEvent].
   const SessionStatusRescheduledEvent({
@@ -1437,7 +1526,10 @@ class SessionStatusRescheduledEvent extends SessionEvent {
   };
 
   /// Creates a copy with replaced values.
-  SessionStatusRescheduledEvent copyWith({String? id, DateTime? processedAt}) {
+  SessionStatusRescheduledEvent copyWith({
+    String? id,
+    BetaTimestamp? processedAt,
+  }) {
     return SessionStatusRescheduledEvent(
       id: id ?? this.id,
       processedAt: processedAt ?? this.processedAt,
@@ -1470,7 +1562,7 @@ class SessionStatusTerminatedEvent extends SessionEvent {
   final String id;
 
   /// Timestamp of status change.
-  final DateTime processedAt;
+  final BetaTimestamp processedAt;
 
   /// Creates a [SessionStatusTerminatedEvent].
   const SessionStatusTerminatedEvent({
@@ -1494,7 +1586,10 @@ class SessionStatusTerminatedEvent extends SessionEvent {
   };
 
   /// Creates a copy with replaced values.
-  SessionStatusTerminatedEvent copyWith({String? id, DateTime? processedAt}) {
+  SessionStatusTerminatedEvent copyWith({
+    String? id,
+    BetaTimestamp? processedAt,
+  }) {
     return SessionStatusTerminatedEvent(
       id: id ?? this.id,
       processedAt: processedAt ?? this.processedAt,
@@ -1530,7 +1625,7 @@ class SessionErrorEvent extends SessionEvent {
   final Map<String, dynamic> error;
 
   /// Timestamp when the error occurred.
-  final DateTime processedAt;
+  final BetaTimestamp processedAt;
 
   /// Creates a [SessionErrorEvent].
   const SessionErrorEvent({
@@ -1560,7 +1655,7 @@ class SessionErrorEvent extends SessionEvent {
   SessionErrorEvent copyWith({
     String? id,
     Map<String, dynamic>? error,
-    DateTime? processedAt,
+    BetaTimestamp? processedAt,
   }) {
     return SessionErrorEvent(
       id: id ?? this.id,
@@ -1597,7 +1692,7 @@ class SessionDeletedEvent extends SessionEvent {
   final String id;
 
   /// Timestamp when the session was deleted.
-  final DateTime processedAt;
+  final BetaTimestamp processedAt;
 
   /// Creates a [SessionDeletedEvent].
   const SessionDeletedEvent({required this.id, required this.processedAt});
@@ -1618,7 +1713,7 @@ class SessionDeletedEvent extends SessionEvent {
   };
 
   /// Creates a copy with replaced values.
-  SessionDeletedEvent copyWith({String? id, DateTime? processedAt}) {
+  SessionDeletedEvent copyWith({String? id, BetaTimestamp? processedAt}) {
     return SessionDeletedEvent(
       id: id ?? this.id,
       processedAt: processedAt ?? this.processedAt,
@@ -1655,7 +1750,7 @@ class SpanModelRequestStartEvent extends SessionEvent {
   final String id;
 
   /// Timestamp when the model request started.
-  final DateTime processedAt;
+  final BetaTimestamp processedAt;
 
   /// Creates a [SpanModelRequestStartEvent].
   const SpanModelRequestStartEvent({
@@ -1679,7 +1774,10 @@ class SpanModelRequestStartEvent extends SessionEvent {
   };
 
   /// Creates a copy with replaced values.
-  SpanModelRequestStartEvent copyWith({String? id, DateTime? processedAt}) {
+  SpanModelRequestStartEvent copyWith({
+    String? id,
+    BetaTimestamp? processedAt,
+  }) {
     return SpanModelRequestStartEvent(
       id: id ?? this.id,
       processedAt: processedAt ?? this.processedAt,
@@ -1721,7 +1819,7 @@ class SpanModelRequestEndEvent extends SessionEvent {
   final String modelRequestStartId;
 
   /// Timestamp when the model request completed.
-  final DateTime processedAt;
+  final BetaTimestamp processedAt;
 
   /// Creates a [SpanModelRequestEndEvent].
   const SpanModelRequestEndEvent({
@@ -1761,7 +1859,7 @@ class SpanModelRequestEndEvent extends SessionEvent {
     Object? isError = unsetCopyWithValue,
     Object? modelUsage = unsetCopyWithValue,
     String? modelRequestStartId,
-    DateTime? processedAt,
+    BetaTimestamp? processedAt,
   }) {
     return SpanModelRequestEndEvent(
       id: id ?? this.id,

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/session.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/session.dart
@@ -1,5 +1,6 @@
 import 'package:meta/meta.dart';
 
+import '../../beta_timestamp.dart';
 import '../../common/copy_with_sentinel.dart';
 import '../../common/equality_helpers.dart';
 import '../config/agent_skill.dart';
@@ -81,13 +82,13 @@ class Session {
   final SessionUsage usage;
 
   /// When the session was created.
-  final DateTime createdAt;
+  final BetaTimestamp createdAt;
 
   /// When the session was last updated.
-  final DateTime updatedAt;
+  final BetaTimestamp updatedAt;
 
   /// When the session was archived. Null if not archived.
-  final DateTime? archivedAt;
+  final BetaTimestamp? archivedAt;
 
   /// Creates a [Session].
   const Session({
@@ -164,8 +165,8 @@ class Session {
     List<String>? vaultIds,
     SessionStats? stats,
     SessionUsage? usage,
-    DateTime? createdAt,
-    DateTime? updatedAt,
+    BetaTimestamp? createdAt,
+    BetaTimestamp? updatedAt,
     Object? archivedAt = unsetCopyWithValue,
   }) {
     return Session(
@@ -184,7 +185,7 @@ class Session {
       updatedAt: updatedAt ?? this.updatedAt,
       archivedAt: archivedAt == unsetCopyWithValue
           ? this.archivedAt
-          : archivedAt as DateTime?,
+          : archivedAt as BetaTimestamp?,
     );
   }
 

--- a/packages/anthropic_sdk_dart/lib/src/models/user_profiles/create_user_profile_request.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/user_profiles/create_user_profile_request.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../common/copy_with_sentinel.dart';
 import '../common/equality_helpers.dart';
+import 'user_profile_relationship.dart';
 
 /// Request parameters for creating a user profile.
 @immutable
@@ -10,6 +11,18 @@ class CreateUserProfileRequest {
   /// Maximum 255 characters.
   final String? externalId;
 
+  /// Display name of the entity this profile represents.
+  ///
+  /// Required when [relationship] is `resold` (the resold-to company's name);
+  /// optional otherwise. Maximum 255 characters.
+  final String? name;
+
+  /// How the entity relates to the platform.
+  ///
+  /// `external` (default): an individual end-user. `resold`: a company the
+  /// platform resells Claude access to. `internal`: the platform's own usage.
+  final BetaUserProfileRelationship? relationship;
+
   /// Free-form key-value metadata to attach to this user profile.
   ///
   /// Maximum 16 keys, keys up to 64 chars, and values must be non-empty
@@ -17,12 +30,21 @@ class CreateUserProfileRequest {
   final Map<String, String>? metadata;
 
   /// Creates a [CreateUserProfileRequest].
-  const CreateUserProfileRequest({this.externalId, this.metadata});
+  const CreateUserProfileRequest({
+    this.externalId,
+    this.name,
+    this.relationship,
+    this.metadata,
+  });
 
   /// Creates a [CreateUserProfileRequest] from JSON.
   factory CreateUserProfileRequest.fromJson(Map<String, dynamic> json) {
     return CreateUserProfileRequest(
       externalId: json['external_id'] as String?,
+      name: json['name'] as String?,
+      relationship: json['relationship'] != null
+          ? BetaUserProfileRelationship.fromJson(json['relationship'] as String)
+          : null,
       metadata: (json['metadata'] as Map<String, dynamic>?)?.map(
         (k, v) => MapEntry(k, v as String),
       ),
@@ -32,22 +54,30 @@ class CreateUserProfileRequest {
   /// Converts to JSON.
   Map<String, dynamic> toJson() => {
     if (externalId != null) 'external_id': externalId,
+    if (name != null) 'name': name,
+    if (relationship != null) 'relationship': relationship!.toJson(),
     if (metadata != null) 'metadata': metadata,
   };
 
   /// Creates a copy with replaced values.
   ///
-  /// For nullable fields ([externalId], [metadata]), pass the sentinel value
-  /// [unsetCopyWithValue] (or omit) to keep the original value, or pass
-  /// `null` explicitly to set the field to null.
+  /// For nullable fields ([externalId], [name], [relationship], [metadata]),
+  /// pass the sentinel value [unsetCopyWithValue] (or omit) to keep the
+  /// original value, or pass `null` explicitly to set the field to null.
   CreateUserProfileRequest copyWith({
     Object? externalId = unsetCopyWithValue,
+    Object? name = unsetCopyWithValue,
+    Object? relationship = unsetCopyWithValue,
     Object? metadata = unsetCopyWithValue,
   }) {
     return CreateUserProfileRequest(
       externalId: externalId == unsetCopyWithValue
           ? this.externalId
           : externalId as String?,
+      name: name == unsetCopyWithValue ? this.name : name as String?,
+      relationship: relationship == unsetCopyWithValue
+          ? this.relationship
+          : relationship as BetaUserProfileRelationship?,
       metadata: metadata == unsetCopyWithValue
           ? this.metadata
           : metadata as Map<String, String>?,
@@ -60,14 +90,19 @@ class CreateUserProfileRequest {
       other is CreateUserProfileRequest &&
           runtimeType == other.runtimeType &&
           externalId == other.externalId &&
+          name == other.name &&
+          relationship == other.relationship &&
           mapsEqual(metadata, other.metadata);
 
   @override
-  int get hashCode => Object.hash(externalId, mapHash(metadata));
+  int get hashCode =>
+      Object.hash(externalId, name, relationship, mapHash(metadata));
 
   @override
   String toString() =>
       'CreateUserProfileRequest('
       'externalId: $externalId, '
+      'name: $name, '
+      'relationship: $relationship, '
       'metadata: $metadata)';
 }

--- a/packages/anthropic_sdk_dart/lib/src/models/user_profiles/update_user_profile_request.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/user_profiles/update_user_profile_request.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../common/copy_with_sentinel.dart';
 import '../common/equality_helpers.dart';
+import 'user_profile_relationship.dart';
 
 /// Private sentinel to distinguish "not provided" from explicit `null`.
 const Object _notSet = Object();
@@ -27,6 +28,27 @@ class UpdateUserProfileRequest {
   bool get hasExternalId => _externalId != _notSet;
   final Object? _externalId;
 
+  /// Updated display name, or `null` to clear it.
+  ///
+  /// Returns `null` both when omitted and when explicitly set to `null`.
+  /// Use [hasName] to disambiguate if needed.
+  String? get name => _name == _notSet ? null : _name as String?;
+
+  /// Whether a name update was provided (set to a value or to null).
+  bool get hasName => _name != _notSet;
+  final Object? _name;
+
+  /// Updated relationship to the platform.
+  ///
+  /// Returns `null` when omitted. Use [hasRelationship] to disambiguate.
+  BetaUserProfileRelationship? get relationship => _relationship == _notSet
+      ? null
+      : _relationship as BetaUserProfileRelationship?;
+
+  /// Whether a relationship update was provided.
+  bool get hasRelationship => _relationship != _notSet;
+  final Object? _relationship;
+
   /// Metadata patch: keys to upsert into the stored metadata.
   ///
   /// Set a key's value to the empty string to delete it server-side.
@@ -41,17 +63,22 @@ class UpdateUserProfileRequest {
   /// Creates an [UpdateUserProfileRequest].
   ///
   /// Omit a field to leave its stored value unchanged. Pass `null` explicitly
-  /// for [externalId] to clear it. [metadata] is not nullable per the spec —
-  /// to delete a stored key, include it in [metadata] with an empty-string
-  /// value; to leave metadata entirely unchanged, omit the parameter.
+  /// for [externalId], [name], or [relationship] to clear them. [metadata] is
+  /// not nullable per the spec — to delete a stored key, include it in
+  /// [metadata] with an empty-string value; to leave metadata entirely
+  /// unchanged, omit the parameter.
   const UpdateUserProfileRequest({
     Object? externalId = _notSet,
+    Object? name = _notSet,
+    Object? relationship = _notSet,
     Object? metadata = _notSet,
   }) : assert(
          metadata == _notSet || metadata is Map<String, String>,
          'metadata must be a Map<String, String> when provided; use empty-string values to remove keys, or omit the metadata parameter to leave it unchanged',
        ),
        _externalId = externalId,
+       _name = name,
+       _relationship = relationship,
        _metadata = metadata;
 
   /// Creates an [UpdateUserProfileRequest] from JSON.
@@ -59,6 +86,14 @@ class UpdateUserProfileRequest {
     return UpdateUserProfileRequest(
       externalId: json.containsKey('external_id')
           ? json['external_id'] as String?
+          : _notSet,
+      name: json.containsKey('name') ? json['name'] as String? : _notSet,
+      relationship: json.containsKey('relationship')
+          ? (json['relationship'] != null
+                ? BetaUserProfileRelationship.fromJson(
+                    json['relationship'] as String,
+                  )
+                : null)
           : _notSet,
       metadata: json.containsKey('metadata')
           ? (json['metadata'] as Map<String, dynamic>?)?.map(
@@ -75,6 +110,9 @@ class UpdateUserProfileRequest {
   /// on the server.
   Map<String, dynamic> toJson() => {
     if (_externalId != _notSet) 'external_id': _externalId,
+    if (_name != _notSet) 'name': _name,
+    if (_relationship != _notSet)
+      'relationship': (_relationship as BetaUserProfileRelationship?)?.toJson(),
     if (_metadata != _notSet) 'metadata': _metadata,
   };
 
@@ -84,10 +122,16 @@ class UpdateUserProfileRequest {
   /// original value, or pass `null` explicitly to set the field to null.
   UpdateUserProfileRequest copyWith({
     Object? externalId = unsetCopyWithValue,
+    Object? name = unsetCopyWithValue,
+    Object? relationship = unsetCopyWithValue,
     Object? metadata = unsetCopyWithValue,
   }) {
     return UpdateUserProfileRequest(
       externalId: externalId == unsetCopyWithValue ? _externalId : externalId,
+      name: name == unsetCopyWithValue ? _name : name,
+      relationship: relationship == unsetCopyWithValue
+          ? _relationship
+          : relationship,
       metadata: metadata == unsetCopyWithValue ? _metadata : metadata,
     );
   }
@@ -98,11 +142,15 @@ class UpdateUserProfileRequest {
       other is UpdateUserProfileRequest &&
           runtimeType == other.runtimeType &&
           _externalId == other._externalId &&
+          _name == other._name &&
+          _relationship == other._relationship &&
           _mapsEqualOrBothSentinel(_metadata, other._metadata);
 
   @override
   int get hashCode => Object.hash(
     _externalId,
+    _name,
+    _relationship,
     _metadata == _notSet ? _notSet : mapHash(metadata),
   );
 
@@ -110,6 +158,8 @@ class UpdateUserProfileRequest {
   String toString() =>
       'UpdateUserProfileRequest('
       'externalId: $externalId, '
+      'name: $name, '
+      'relationship: $relationship, '
       'metadata: $metadata)';
 }
 

--- a/packages/anthropic_sdk_dart/lib/src/models/user_profiles/user_profile.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/user_profiles/user_profile.dart
@@ -1,7 +1,9 @@
 import 'package:meta/meta.dart';
 
+import '../beta_timestamp.dart';
 import '../common/copy_with_sentinel.dart';
 import '../common/equality_helpers.dart';
+import 'user_profile_relationship.dart';
 import 'user_profile_trust_grant.dart';
 
 /// A user profile representing an end-user of a platform built on Claude.
@@ -20,6 +22,18 @@ class UserProfile {
   /// Platform's own identifier for this user. Not enforced unique.
   final String? externalId;
 
+  /// Display name of the entity this profile represents.
+  ///
+  /// Required when [relationship] is `resold` (the resold-to company's name);
+  /// optional otherwise. Maximum 255 characters.
+  final String? name;
+
+  /// How the entity relates to the platform.
+  ///
+  /// `external` (default): an individual end-user. `resold`: a company the
+  /// platform resells Claude access to. `internal`: the platform's own usage.
+  final BetaUserProfileRelationship relationship;
+
   /// Arbitrary key-value metadata. Maximum 16 pairs, keys up to 64 chars,
   /// values up to 512 chars. Always present; may be empty.
   final Map<String, String> metadata;
@@ -30,18 +44,20 @@ class UserProfile {
   final Map<String, UserProfileTrustGrant> trustGrants;
 
   /// When this user profile was created.
-  final DateTime createdAt;
+  final BetaTimestamp createdAt;
 
   /// When this user profile was last updated.
   ///
   /// Bumped when trust grants change or metadata is updated.
-  final DateTime updatedAt;
+  final BetaTimestamp updatedAt;
 
   /// Creates a [UserProfile].
   const UserProfile({
     required this.id,
     this.type = 'user_profile',
     this.externalId,
+    this.name,
+    required this.relationship,
     required this.metadata,
     required this.trustGrants,
     required this.createdAt,
@@ -55,6 +71,10 @@ class UserProfile {
       id: json['id'] as String,
       type: json['type'] as String? ?? 'user_profile',
       externalId: json['external_id'] as String?,
+      name: json['name'] as String?,
+      relationship: BetaUserProfileRelationship.fromJson(
+        json['relationship'] as String,
+      ),
       metadata:
           (json['metadata'] as Map<String, dynamic>?)?.map(
             (k, v) => MapEntry(k, v as String),
@@ -78,6 +98,8 @@ class UserProfile {
     'id': id,
     'type': type,
     'external_id': externalId,
+    'name': name,
+    'relationship': relationship.toJson(),
     'metadata': metadata,
     'trust_grants': trustGrants.map((k, v) => MapEntry(k, v.toJson())),
     'created_at': createdAt.toUtc().toIso8601String(),
@@ -86,17 +108,19 @@ class UserProfile {
 
   /// Creates a copy with replaced values.
   ///
-  /// For nullable fields ([externalId]), pass the sentinel value
+  /// For nullable fields ([externalId], [name]), pass the sentinel value
   /// [unsetCopyWithValue] (or omit) to keep the original value, or pass
   /// `null` explicitly to set the field to null.
   UserProfile copyWith({
     String? id,
     String? type,
     Object? externalId = unsetCopyWithValue,
+    Object? name = unsetCopyWithValue,
+    BetaUserProfileRelationship? relationship,
     Map<String, String>? metadata,
     Map<String, UserProfileTrustGrant>? trustGrants,
-    DateTime? createdAt,
-    DateTime? updatedAt,
+    BetaTimestamp? createdAt,
+    BetaTimestamp? updatedAt,
   }) {
     return UserProfile(
       id: id ?? this.id,
@@ -104,6 +128,8 @@ class UserProfile {
       externalId: externalId == unsetCopyWithValue
           ? this.externalId
           : externalId as String?,
+      name: name == unsetCopyWithValue ? this.name : name as String?,
+      relationship: relationship ?? this.relationship,
       metadata: metadata ?? this.metadata,
       trustGrants: trustGrants ?? this.trustGrants,
       createdAt: createdAt ?? this.createdAt,
@@ -119,6 +145,8 @@ class UserProfile {
           id == other.id &&
           type == other.type &&
           externalId == other.externalId &&
+          name == other.name &&
+          relationship == other.relationship &&
           mapsEqual(metadata, other.metadata) &&
           mapsEqual(trustGrants, other.trustGrants) &&
           createdAt == other.createdAt &&
@@ -129,6 +157,8 @@ class UserProfile {
     id,
     type,
     externalId,
+    name,
+    relationship,
     mapHash(metadata),
     mapHash(trustGrants),
     createdAt,
@@ -141,6 +171,8 @@ class UserProfile {
       'id: $id, '
       'type: $type, '
       'externalId: $externalId, '
+      'name: $name, '
+      'relationship: $relationship, '
       'metadata: $metadata, '
       'trustGrants: $trustGrants, '
       'createdAt: $createdAt, '

--- a/packages/anthropic_sdk_dart/lib/src/models/user_profiles/user_profile_relationship.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/user_profiles/user_profile_relationship.dart
@@ -1,0 +1,30 @@
+/// How a user profile relates to the platform.
+enum BetaUserProfileRelationship {
+  /// An individual end-user (default).
+  external('external'),
+
+  /// A company the platform resells Claude access to.
+  resold('resold'),
+
+  /// The platform's own usage.
+  internal('internal'),
+
+  /// Unknown relationship — fallback for forward compatibility.
+  unknown('unknown');
+
+  const BetaUserProfileRelationship(this.value);
+
+  /// JSON value for this relationship.
+  final String value;
+
+  /// Parses a [BetaUserProfileRelationship] from JSON.
+  static BetaUserProfileRelationship fromJson(String value) => switch (value) {
+    'external' => BetaUserProfileRelationship.external,
+    'resold' => BetaUserProfileRelationship.resold,
+    'internal' => BetaUserProfileRelationship.internal,
+    _ => BetaUserProfileRelationship.unknown,
+  };
+
+  /// Converts this relationship to JSON.
+  String toJson() => value;
+}

--- a/packages/anthropic_sdk_dart/lib/src/resources/session_events_resource.dart
+++ b/packages/anthropic_sdk_dart/lib/src/resources/session_events_resource.dart
@@ -35,11 +35,22 @@ class SessionEventsResource extends ResourceBase with StreamingResource {
   /// - [limit]: Maximum number of events to return.
   /// - [order]: Sort order.
   /// - [page]: Pagination token from a previous response.
+  /// - [createdAtGt]: Filter events created after this ISO 8601 timestamp.
+  /// - [createdAtGte]: Filter events created at or after this timestamp.
+  /// - [createdAtLt]: Filter events created before this timestamp.
+  /// - [createdAtLte]: Filter events created at or before this timestamp.
+  /// - [types]: Filter by event types (e.g. `agent.message`,
+  ///   `user.interrupt`). Multiple values are OR-ed.
   /// - [abortTrigger]: Allows canceling the request.
   Future<ListSessionEventsResponse> list({
     int? limit,
     ListOrder? order,
     String? page,
+    String? createdAtGt,
+    String? createdAtGte,
+    String? createdAtLt,
+    String? createdAtLte,
+    List<String>? types,
     Future<void>? abortTrigger,
   }) async {
     ensureNotClosed?.call();
@@ -47,6 +58,11 @@ class SessionEventsResource extends ResourceBase with StreamingResource {
       'limit': ?limit?.toString(),
       'order': ?order?.toJson(),
       'page': ?page,
+      'created_at[gt]': ?createdAtGt,
+      'created_at[gte]': ?createdAtGte,
+      'created_at[lt]': ?createdAtLt,
+      'created_at[lte]': ?createdAtLte,
+      'types[]': ?types,
     };
 
     final url = requestBuilder.buildUrl(

--- a/packages/anthropic_sdk_dart/lib/src/resources/sessions_resource.dart
+++ b/packages/anthropic_sdk_dart/lib/src/resources/sessions_resource.dart
@@ -90,6 +90,8 @@ class SessionsResource extends ResourceBase {
   /// - [createdAtLt]: Filter sessions created before this timestamp.
   /// - [createdAtLte]: Filter sessions created at or before this timestamp.
   /// - [includeArchived]: Whether to include archived sessions.
+  /// - [memoryStoreId]: Filter sessions by memory store ID.
+  /// - [statuses]: Filter sessions by status. Multiple values are OR-ed.
   /// - [abortTrigger]: Allows canceling the request.
   Future<ListSessionsResponse> list({
     String? agentId,
@@ -102,6 +104,8 @@ class SessionsResource extends ResourceBase {
     String? createdAtLt,
     String? createdAtLte,
     bool? includeArchived,
+    String? memoryStoreId,
+    List<SessionStatus>? statuses,
     Future<void>? abortTrigger,
   }) async {
     ensureNotClosed?.call();
@@ -116,6 +120,8 @@ class SessionsResource extends ResourceBase {
       'created_at[lt]': ?createdAtLt,
       'created_at[lte]': ?createdAtLte,
       'include_archived': ?includeArchived?.toString(),
+      'memory_store_id': ?memoryStoreId,
+      'statuses[]': ?statuses?.map((s) => s.toJson()).toList(),
     };
 
     final url = requestBuilder.buildUrl(

--- a/packages/anthropic_sdk_dart/specs/openapi.yaml
+++ b/packages/anthropic_sdk_dart/specs/openapi.yaml
@@ -61,7 +61,8 @@
               "fast-mode-2026-02-01",
               "output-300k-2026-03-24",
               "user-profiles-2026-03-24",
-              "advisor-tool-2026-03-01"
+              "advisor-tool-2026-03-01",
+              "managed-agents-2026-04-01"
             ],
             "type": "string",
             "x-stainless-nominal": false
@@ -2679,11 +2680,11 @@
             "title": "Inference Geo"
           },
           "max_tokens": {
-            "description": "The maximum number of tokens to generate before stopping.\n\nNote that our models may stop _before_ reaching this maximum. This parameter only specifies the absolute maximum number of tokens to generate.\n\nDifferent models have different maximum values for this parameter.  See [models](https://docs.claude.com/en/docs/models-overview) for details.",
+            "description": "The maximum number of tokens to generate before stopping.\n\nNote that our models may stop _before_ reaching this maximum. This parameter only specifies the absolute maximum number of tokens to generate.\n\nSet to `0` to populate the [prompt cache](https://docs.claude.com/en/docs/build-with-claude/prompt-caching#pre-warming-the-cache) without generating a response.\n\nDifferent models have different maximum values for this parameter.  See [models](https://docs.claude.com/en/docs/models-overview) for details.",
             "examples": [
               1024
             ],
-            "minimum": 1,
+            "minimum": 0,
             "title": "Max Tokens",
             "type": "integer"
           },
@@ -3136,6 +3137,21 @@
               {}
             ],
             "type": "object"
+          },
+          "name": {
+            "description": "Display name of the entity this profile represents. Required when relationship is `resold` (the resold-to company's name); optional otherwise. Maximum 255 characters.",
+            "maxLength": 255,
+            "minLength": 1,
+            "nullable": true,
+            "type": "string"
+          },
+          "relationship": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaUserProfileRelationship"
+              }
+            ],
+            "description": "How the entity relates to the platform. `external` (default): an individual end-user. `resold`: a company the platform resells Claude access to. `internal`: the platform's own usage."
           }
         },
         "type": "object"
@@ -3333,7 +3349,7 @@
         "type": "object"
       },
       "BetaEnvironment": {
-        "description": "Unified Environment resource for both cloud and BYOC environments.",
+        "description": "Unified Environment resource for both cloud and self-hosted environments.",
         "example": {
           "archived_at": null,
           "config": {
@@ -3384,7 +3400,7 @@
             "title": "Archived At"
           },
           "config": {
-            "description": "Environment configuration (either Anthropic Cloud or BYOC)",
+            "description": "Environment configuration (either Anthropic Cloud or self-hosted)",
             "discriminator": {
               "mapping": {
                 "cloud": "#/components/schemas/BetaCloudConfig"
@@ -4730,6 +4746,8 @@
               "external_id": "user_12345",
               "id": "uprof_011CZkZCu8hGbp5mYRQgUmz9",
               "metadata": {},
+              "name": "Example User",
+              "relationship": "external",
               "trust_grants": {
                 "cyber": {
                   "status": "active"
@@ -4751,6 +4769,8 @@
                   "external_id": "user_12345",
                   "id": "uprof_011CZkZCu8hGbp5mYRQgUmz9",
                   "metadata": {},
+                  "name": "Example User",
+                  "relationship": "external",
                   "trust_grants": {
                     "cyber": {
                       "status": "active"
@@ -4776,7 +4796,8 @@
           }
         },
         "required": [
-          "data"
+          "data",
+          "next_page"
         ],
         "type": "object"
       },
@@ -4878,6 +4899,7 @@
         "type": "object"
       },
       "BetaManagedAgentsActor": {
+        "description": "Identifies who performed a write or redact operation. Captured at write time on the `memory_version` row. The API key that created a session is not recorded on agent writes; attribution answers who made the write, not who is ultimately responsible. Look up session provenance separately via the [Sessions API](/en/api/sessions-retrieve).",
         "discriminator": {
           "mapping": {
             "api_actor": "#/components/schemas/BetaManagedAgentsApiActor",
@@ -4956,6 +4978,7 @@
             "id": "claude-sonnet-4-6",
             "speed": "standard"
           },
+          "multiagent": null,
           "name": "My First Agent",
           "skills": [
             {
@@ -5053,6 +5076,18 @@
               }
             ]
           },
+          "multiagent": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsMultiagent"
+              }
+            ],
+            "description": "Multiagent orchestration configuration. Null when the agent is single-threaded.",
+            "examples": [
+              null
+            ],
+            "nullable": true
+          },
           "name": {
             "examples": [
               "My First Agent"
@@ -5144,7 +5179,8 @@
           "metadata",
           "created_at",
           "updated_at",
-          "archived_at"
+          "archived_at",
+          "multiagent"
         ],
         "type": "object"
       },
@@ -5175,6 +5211,11 @@
               }
             ],
             "description": "Timestamp when this tool use was processed."
+          },
+          "session_thread_id": {
+            "description": "When set, this event was cross-posted from a subagent's thread to surface its custom tool use on the primary thread's stream. Empty on the thread's own events. Echo this on a `user.custom_tool_result` event to route the result back.",
+            "nullable": true,
+            "type": "string"
           },
           "type": {
             "enum": [
@@ -5288,6 +5329,11 @@
             ],
             "description": "Timestamp when this event was processed."
           },
+          "session_thread_id": {
+            "description": "When set, this event was cross-posted from a subagent's thread to surface its permission request on the primary thread's stream. Empty on the thread's own events. Echo this on a `user.tool_confirmation` event to route the approval back.",
+            "nullable": true,
+            "type": "string"
+          },
           "type": {
             "enum": [
               "agent.mcp_tool_use"
@@ -5399,6 +5445,45 @@
         ],
         "type": "object"
       },
+      "BetaManagedAgentsAgentReference": {
+        "additionalProperties": false,
+        "description": "A resolved agent reference with a concrete version.",
+        "example": {
+          "id": "agent_011CZkYqphY8vELVzwCUpqiQ",
+          "type": "agent",
+          "version": 1
+        },
+        "properties": {
+          "id": {
+            "examples": [
+              "agent_011CZkYqphY8vELVzwCUpqiQ"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "agent"
+            ],
+            "examples": [
+              "agent"
+            ],
+            "type": "string"
+          },
+          "version": {
+            "examples": [
+              1
+            ],
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "version"
+        ],
+        "type": "object"
+      },
       "BetaManagedAgentsAgentThinkingEvent": {
         "additionalProperties": false,
         "description": "Indicates the agent is making forward progress via extended thinking. A progress signal, not a content carrier.",
@@ -5456,6 +5541,102 @@
           "type",
           "id",
           "processed_at"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsAgentThreadMessageReceivedEvent": {
+        "additionalProperties": false,
+        "description": "Delivery event written to the target thread's input stream when an agent-to-agent message arrives.",
+        "properties": {
+          "content": {
+            "description": "Message content blocks.",
+            "items": {
+              "$ref": "#/components/schemas/BetaManagedAgentsUserContentBlock"
+            },
+            "type": "array"
+          },
+          "from_agent_name": {
+            "description": "Name of the callable agent this message came from. Absent when received from the primary agent.",
+            "nullable": true,
+            "type": "string"
+          },
+          "from_session_thread_id": {
+            "description": "Public `sthr_` ID of the thread that sent the message.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for this event.",
+            "type": "string"
+          },
+          "processed_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "Timestamp when the message was received."
+          },
+          "type": {
+            "enum": [
+              "agent.thread_message_received"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "processed_at",
+          "content",
+          "from_session_thread_id"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsAgentThreadMessageSentEvent": {
+        "additionalProperties": false,
+        "description": "Observability event emitted to the sender's output stream when an agent-to-agent message is sent.",
+        "properties": {
+          "content": {
+            "description": "Message content blocks.",
+            "items": {
+              "$ref": "#/components/schemas/BetaManagedAgentsUserContentBlock"
+            },
+            "type": "array"
+          },
+          "id": {
+            "description": "Unique identifier for this event.",
+            "type": "string"
+          },
+          "processed_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "Timestamp when the message was sent."
+          },
+          "to_agent_name": {
+            "description": "Name of the callable agent this message was sent to. Absent when sent to the primary agent.",
+            "nullable": true,
+            "type": "string"
+          },
+          "to_session_thread_id": {
+            "description": "Public `sthr_` ID of the thread the message was sent to.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "agent.thread_message_sent"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "processed_at",
+          "content",
+          "to_session_thread_id"
         ],
         "type": "object"
       },
@@ -5649,6 +5830,11 @@
               }
             ],
             "description": "Timestamp when this event was processed."
+          },
+          "session_thread_id": {
+            "description": "When set, this event was cross-posted from a subagent's thread to surface its permission request on the primary thread's stream. Empty on the thread's own events. Echo this on a `user.tool_confirmation` event to route the approval back.",
+            "nullable": true,
+            "type": "string"
           },
           "type": {
             "enum": [
@@ -5898,8 +6084,10 @@
       },
       "BetaManagedAgentsApiActor": {
         "additionalProperties": false,
+        "description": "Attribution for a write made directly via the public API (outside of any session).",
         "properties": {
           "api_key_id": {
+            "description": "ID of the API key that performed the write. This identifies the key, not the secret.",
             "minLength": 1,
             "type": "string"
           },
@@ -5917,6 +6105,7 @@
         "type": "object"
       },
       "BetaManagedAgentsArchiveMemoryStoreResponse": {
+        "description": "Response from archiving a `memory_store`. Returns the store with `archived_at` set.",
         "discriminator": {
           "mapping": {
             "memory_store": "#/components/schemas/BetaManagedAgentsMemoryStore"
@@ -6107,8 +6296,10 @@
       },
       "BetaManagedAgentsContentSha256Precondition": {
         "additionalProperties": false,
+        "description": "Optimistic-concurrency precondition: the update applies only if the memory's stored `content_sha256` equals the supplied value. On mismatch, the request returns `memory_precondition_failed_error` (HTTP 409); re-read the memory and retry against the fresh state. If the precondition fails but the stored state already exactly matches the requested `content` and `path`, the server returns 200 instead of 409.",
         "properties": {
           "content_sha256": {
+            "description": "Expected `content_sha256` of the stored memory (64 lowercase hexadecimal characters). Typically the `content_sha256` returned by a prior read or list call. Because the server applies no content normalization, clients can also compute this locally as the SHA-256 of the UTF-8 content bytes.",
             "type": "string"
           },
           "type": {
@@ -6179,6 +6370,15 @@
             "examples": [
               "claude-sonnet-4-6"
             ]
+          },
+          "multiagent": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsMultiagentParams"
+              }
+            ],
+            "description": "Multiagent orchestration configuration. Currently supports the `coordinator` topology with a roster of 1-20 agents.",
+            "nullable": true
           },
           "name": {
             "description": "Human-readable name for the agent. 1-256 characters.",
@@ -6284,12 +6484,15 @@
       },
       "BetaManagedAgentsCreateMemoryParams": {
         "additionalProperties": false,
+        "description": "Request parameters for [Create a memory](/en/api/beta/memory_stores/memories/create). The path must be unoccupied: if a memory already exists at the path, or the path is an ancestor or descendant of an existing memory's path, the request returns `memory_path_conflict_error` (HTTP 409). Create never overwrites; to modify an existing memory, use [Update a memory](/en/api/beta/memory_stores/memories/update).",
         "properties": {
           "content": {
+            "description": "UTF-8 text content for the new memory. Maximum 100 kB (102,400 bytes). Required; pass `\"\"` explicitly to create an empty memory.",
             "nullable": true,
             "type": "string"
           },
           "path": {
+            "description": "Hierarchical path for the new memory, e.g. `/projects/foo/notes.md`. Must start with `/`, contain at least one non-empty segment, and be at most 1,024 bytes. Must not contain empty segments, `.` or `..` segments, control or format characters, and must be NFC-normalized. Paths are case-sensitive.",
             "maxLength": 1024,
             "minLength": 2,
             "type": "string"
@@ -6303,8 +6506,10 @@
       },
       "BetaManagedAgentsCreateMemoryStoreRequest": {
         "additionalProperties": false,
+        "description": "Request parameters for creating a `memory_store`.",
         "properties": {
           "description": {
+            "description": "Free-text description of what the store contains, up to 1024 characters. Included in the agent's system prompt when the store is attached, so word it to be useful to the agent.",
             "maxLength": 1024,
             "type": "string"
           },
@@ -6312,9 +6517,11 @@
             "additionalProperties": {
               "type": "string"
             },
+            "description": "Arbitrary key-value tags for your own bookkeeping (such as the end user a store belongs to). Up to 16 pairs; keys 1\u201364 characters; values up to 512 characters. Not visible to the agent.",
             "type": "object"
           },
           "name": {
+            "description": "Human-readable name for the store. Required; 1\u2013255 characters; no control characters. The mount-path slug under `/mnt/memory/` is derived from this name (lowercased, non-alphanumeric runs collapsed to a hyphen). Names need not be unique within a workspace.",
             "maxLength": 255,
             "minLength": 1,
             "type": "string"
@@ -6326,6 +6533,7 @@
         "type": "object"
       },
       "BetaManagedAgentsCreateMemoryStoreResponse": {
+        "description": "Response from creating a `memory_store`. Returns the created store.",
         "discriminator": {
           "mapping": {
             "memory_store": "#/components/schemas/BetaManagedAgentsMemoryStore"
@@ -6603,6 +6811,16 @@
         ],
         "type": "object"
       },
+      "BetaManagedAgentsCredentialRefreshStatus": {
+        "description": "Outcome of a refresh-token exchange attempted during credential validation.",
+        "enum": [
+          "succeeded",
+          "failed",
+          "connect_error",
+          "no_refresh_token"
+        ],
+        "type": "string"
+      },
       "BetaManagedAgentsCredentialUpdateAuth": {
         "description": "Updated authentication details for a credential.",
         "discriminator": {
@@ -6621,6 +6839,118 @@
           }
         ],
         "type": "object"
+      },
+      "BetaManagedAgentsCredentialValidation": {
+        "additionalProperties": false,
+        "description": "Result of live-probing a credential against its configured MCP server.",
+        "example": {
+          "credential_id": "vcrd_011CZkZEMt8gZan2iYOQfSkw",
+          "has_refresh_token": true,
+          "mcp_probe": null,
+          "refresh": null,
+          "status": "valid",
+          "type": "vault_credential_validation",
+          "validated_at": "2026-03-15T10:00:00Z",
+          "vault_id": "vlt_011CZkZDLs7fYzm1hXNPeRjv"
+        },
+        "properties": {
+          "credential_id": {
+            "description": "Unique identifier of the credential that was validated.",
+            "examples": [
+              "vcrd_011CZkZEMt8gZan2iYOQfSkw"
+            ],
+            "type": "string"
+          },
+          "has_refresh_token": {
+            "description": "Whether the credential has a refresh token configured.",
+            "examples": [
+              true
+            ],
+            "type": "boolean"
+          },
+          "mcp_probe": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsMcpProbe"
+              }
+            ],
+            "description": "Details of the failing MCP probe step. Null when the probe succeeded.",
+            "examples": [
+              null
+            ],
+            "nullable": true
+          },
+          "refresh": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsRefreshObject"
+              }
+            ],
+            "description": "Details of the refresh-token exchange attempted on a 401. Null when no refresh was attempted.",
+            "examples": [
+              null
+            ],
+            "nullable": true
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsCredentialValidationStatus"
+              }
+            ],
+            "description": "Overall verdict of the validation probe.",
+            "examples": [
+              "valid"
+            ]
+          },
+          "type": {
+            "enum": [
+              "vault_credential_validation"
+            ],
+            "examples": [
+              "vault_credential_validation"
+            ],
+            "type": "string"
+          },
+          "validated_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "When the validation probe was performed.",
+            "examples": [
+              "2026-03-15T10:00:00Z"
+            ]
+          },
+          "vault_id": {
+            "description": "Identifier of the vault containing the credential.",
+            "examples": [
+              "vlt_011CZkZDLs7fYzm1hXNPeRjv"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "credential_id",
+          "vault_id",
+          "status",
+          "validated_at",
+          "has_refresh_token",
+          "mcp_probe",
+          "refresh"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsCredentialValidationStatus": {
+        "description": "Overall verdict of a credential validation probe.",
+        "enum": [
+          "valid",
+          "invalid",
+          "unknown"
+        ],
+        "type": "string"
       },
       "BetaManagedAgentsCustomSkill": {
         "additionalProperties": false,
@@ -6805,6 +7135,7 @@
         "type": "object"
       },
       "BetaManagedAgentsDeleteMemoryStoreResponse": {
+        "description": "Response from deleting a `memory_store`. Confirms the deleted ID.",
         "discriminator": {
           "mapping": {
             "memory_store_deleted": "#/components/schemas/BetaManagedAgentsDeletedMemoryStore"
@@ -6881,8 +7212,10 @@
       },
       "BetaManagedAgentsDeletedMemory": {
         "additionalProperties": false,
+        "description": "Tombstone returned by [Delete a memory](/en/api/beta/memory_stores/memories/delete). The memory's version history persists and remains listable via [List memory versions](/en/api/beta/memory_stores/memory_versions/list) until the store itself is deleted.",
         "properties": {
           "id": {
+            "description": "ID of the deleted memory (a `mem_...` value).",
             "type": "string"
           },
           "type": {
@@ -6900,8 +7233,10 @@
       },
       "BetaManagedAgentsDeletedMemoryStore": {
         "additionalProperties": false,
+        "description": "Confirmation that a `memory_store` was deleted.",
         "properties": {
           "id": {
+            "description": "ID of the deleted memory store (a `memstore_...` identifier). The store and all its memories and versions are no longer retrievable.",
             "type": "string"
           },
           "type": {
@@ -7121,6 +7456,7 @@
         "discriminator": {
           "mapping": {
             "user.custom_tool_result": "#/components/schemas/BetaManagedAgentsUserCustomToolResultEventParams",
+            "user.define_outcome": "#/components/schemas/BetaManagedAgentsUserDefineOutcomeEventParams",
             "user.interrupt": "#/components/schemas/BetaManagedAgentsUserInterruptEventParams",
             "user.message": "#/components/schemas/BetaManagedAgentsUserMessageEventParams",
             "user.tool_confirmation": "#/components/schemas/BetaManagedAgentsUserToolConfirmationEventParams"
@@ -7139,6 +7475,9 @@
           },
           {
             "$ref": "#/components/schemas/BetaManagedAgentsUserCustomToolResultEventParams"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsUserDefineOutcomeEventParams"
           }
         ],
         "type": "object"
@@ -7292,7 +7631,60 @@
         ],
         "type": "object"
       },
+      "BetaManagedAgentsFileRubric": {
+        "additionalProperties": false,
+        "description": "Rubric referenced by a file uploaded via the Files API.",
+        "properties": {
+          "file_id": {
+            "description": "ID of the rubric file.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "file"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "file_id"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsFileRubricParams": {
+        "additionalProperties": false,
+        "description": "Rubric referenced by a file uploaded via the Files API.",
+        "example": {
+          "file_id": "file_011CNha8iCJcU1wXNR6q4V8w",
+          "type": "file"
+        },
+        "properties": {
+          "file_id": {
+            "description": "ID of the rubric file.",
+            "examples": [
+              "file_011CNha8iCJcU1wXNR6q4V8w"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "file"
+            ],
+            "examples": [
+              "file"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "file_id"
+        ],
+        "type": "object"
+      },
       "BetaManagedAgentsGetMemoryStoreResponse": {
+        "description": "Response from retrieving a `memory_store`. Returns the store, including archived stores.",
         "discriminator": {
           "mapping": {
             "memory_store": "#/components/schemas/BetaManagedAgentsMemoryStore"
@@ -7517,6 +7909,7 @@
         "discriminator": {
           "mapping": {
             "user.custom_tool_result": "#/components/schemas/BetaManagedAgentsUserCustomToolResultEvent",
+            "user.define_outcome": "#/components/schemas/BetaManagedAgentsUserDefineOutcomeEvent",
             "user.interrupt": "#/components/schemas/BetaManagedAgentsUserInterruptEvent",
             "user.message": "#/components/schemas/BetaManagedAgentsUserMessageEvent",
             "user.tool_confirmation": "#/components/schemas/BetaManagedAgentsUserToolConfirmationEvent"
@@ -7535,6 +7928,9 @@
           },
           {
             "$ref": "#/components/schemas/BetaManagedAgentsUserCustomToolResultEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsUserDefineOutcomeEvent"
           }
         ],
         "type": "object"
@@ -7654,14 +8050,17 @@
       },
       "BetaManagedAgentsListMemoriesResult": {
         "additionalProperties": false,
+        "description": "Response payload for [List memories](/en/api/beta/memory_stores/memories/list).",
         "properties": {
           "data": {
+            "description": "One page of results. Each item is either a `memory` object or, when `depth` was set, a `memory_prefix` rollup marker. Items appear in the requested `order_by`/`order`.",
             "items": {
               "$ref": "#/components/schemas/BetaManagedAgentsMemoryListItem"
             },
             "type": "array"
           },
           "next_page": {
+            "description": "Opaque cursor for the next page (a `page_...` value), or `null` if there are no more results. Pass as `page` on the next request.",
             "nullable": true,
             "type": "string"
           }
@@ -7670,14 +8069,17 @@
       },
       "BetaManagedAgentsListMemoryStoresResponse": {
         "additionalProperties": false,
+        "description": "A page of `memory_store` results, ordered by `created_at` descending (newest first).",
         "properties": {
           "data": {
+            "description": "Memory stores on this page, newest first. Empty when there are no stores matching the filters.",
             "items": {
               "$ref": "#/components/schemas/BetaManagedAgentsMemoryStore"
             },
             "type": "array"
           },
           "next_page": {
+            "description": "Opaque cursor for the next page (a `page_...` value). Pass as `page` on the next request. `null` when there are no more results.",
             "nullable": true,
             "type": "string"
           }
@@ -7686,14 +8088,17 @@
       },
       "BetaManagedAgentsListMemoryVersionsResult": {
         "additionalProperties": false,
+        "description": "Response payload for [List memory versions](/en/api/beta/memory_stores/memory_versions/list).",
         "properties": {
           "data": {
+            "description": "One page of `memory_version` objects, ordered by `created_at` descending (newest first), with `id` as tiebreak.",
             "items": {
               "$ref": "#/components/schemas/BetaManagedAgentsMemoryVersion"
             },
             "type": "array"
           },
           "next_page": {
+            "description": "Opaque cursor for the next page (a `page_...` value), or `null` if there are no more results. Pass as `page` on the next request.",
             "nullable": true,
             "type": "string"
           }
@@ -7867,6 +8272,168 @@
         "required": [
           "data"
         ],
+        "type": "object"
+      },
+      "BetaManagedAgentsListSessionThreadEvents": {
+        "additionalProperties": false,
+        "description": "Paginated list of events for a single thread within a `session`.",
+        "properties": {
+          "data": {
+            "description": "Events for the thread, ordered by `created_at`.",
+            "items": {
+              "$ref": "#/components/schemas/BetaManagedAgentsSessionEvent"
+            },
+            "type": "array",
+            "x-stainless-pagination-property": {
+              "purpose": "items"
+            }
+          },
+          "next_page": {
+            "description": "Opaque cursor for the next page. Null when no more results.",
+            "nullable": true,
+            "type": "string",
+            "x-stainless-pagination-property": {
+              "purpose": "next_cursor_field"
+            }
+          }
+        },
+        "type": "object"
+      },
+      "BetaManagedAgentsListSessionThreads": {
+        "additionalProperties": false,
+        "description": "Paginated list of threads within a `session`.",
+        "example": {
+          "data": [
+            {
+              "agent": {
+                "description": "A focused research subagent.",
+                "id": "agent_011CZkYqphY8vELVzwCUpqiQ",
+                "mcp_servers": [],
+                "model": {
+                  "id": "claude-sonnet-4-6",
+                  "speed": "standard"
+                },
+                "name": "Researcher",
+                "skills": [],
+                "system": "You are a research subagent that gathers and summarises sources for the coordinating agent.",
+                "tools": [
+                  {
+                    "configs": [],
+                    "default_config": {
+                      "enabled": true,
+                      "permission_policy": {
+                        "type": "always_ask"
+                      }
+                    },
+                    "type": "agent_toolset_20260401"
+                  }
+                ],
+                "type": "agent",
+                "version": 1
+              },
+              "archived_at": null,
+              "created_at": "2026-03-15T10:00:00Z",
+              "id": "sthr_011CZkZVWa6oIjw0rgXZpnBt",
+              "parent_thread_id": null,
+              "session_id": "sesn_011CZkZAtmR3yMPDzynEDxu7",
+              "stats": {
+                "active_seconds": 0,
+                "duration_seconds": 0,
+                "startup_seconds": 0
+              },
+              "status": "idle",
+              "type": "session_thread",
+              "updated_at": "2026-03-15T10:00:00Z",
+              "usage": {
+                "cache_creation": {
+                  "ephemeral_1h_input_tokens": 0,
+                  "ephemeral_5m_input_tokens": 0
+                },
+                "cache_read_input_tokens": 0,
+                "input_tokens": 0,
+                "output_tokens": 0
+              }
+            }
+          ],
+          "next_page": "page_MjAyNS0wNS0xNFQwMDowMDowMFo="
+        },
+        "properties": {
+          "data": {
+            "description": "Threads in the session, primary first then children in spawn order.",
+            "examples": [
+              [
+                {
+                  "agent": {
+                    "description": "A focused research subagent.",
+                    "id": "agent_011CZkYqphY8vELVzwCUpqiQ",
+                    "mcp_servers": [],
+                    "model": {
+                      "id": "claude-sonnet-4-6",
+                      "speed": "standard"
+                    },
+                    "name": "Researcher",
+                    "skills": [],
+                    "system": "You are a research subagent that gathers and summarises sources for the coordinating agent.",
+                    "tools": [
+                      {
+                        "configs": [],
+                        "default_config": {
+                          "enabled": true,
+                          "permission_policy": {
+                            "type": "always_ask"
+                          }
+                        },
+                        "type": "agent_toolset_20260401"
+                      }
+                    ],
+                    "type": "agent",
+                    "version": 1
+                  },
+                  "archived_at": null,
+                  "created_at": "2026-03-15T10:00:00Z",
+                  "id": "sthr_011CZkZVWa6oIjw0rgXZpnBt",
+                  "parent_thread_id": null,
+                  "session_id": "sesn_011CZkZAtmR3yMPDzynEDxu7",
+                  "stats": {
+                    "active_seconds": 0,
+                    "duration_seconds": 0,
+                    "startup_seconds": 0
+                  },
+                  "status": "idle",
+                  "type": "session_thread",
+                  "updated_at": "2026-03-15T10:00:00Z",
+                  "usage": {
+                    "cache_creation": {
+                      "ephemeral_1h_input_tokens": 0,
+                      "ephemeral_5m_input_tokens": 0
+                    },
+                    "cache_read_input_tokens": 0,
+                    "input_tokens": 0,
+                    "output_tokens": 0
+                  }
+                }
+              ]
+            ],
+            "items": {
+              "$ref": "#/components/schemas/BetaManagedAgentsSessionThread"
+            },
+            "type": "array",
+            "x-stainless-pagination-property": {
+              "purpose": "items"
+            }
+          },
+          "next_page": {
+            "description": "Opaque cursor for the next page. Null when no more results.",
+            "examples": [
+              "page_MjAyNS0wNS0xNFQwMDowMDowMFo="
+            ],
+            "nullable": true,
+            "type": "string",
+            "x-stainless-pagination-property": {
+              "purpose": "next_cursor_field"
+            }
+          }
+        },
         "type": "object"
       },
       "BetaManagedAgentsListSessions": {
@@ -8523,33 +9090,70 @@
         ],
         "type": "object"
       },
+      "BetaManagedAgentsMcpProbe": {
+        "additionalProperties": false,
+        "description": "The failing step of an MCP validation probe.",
+        "properties": {
+          "http_response": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsRefreshHttpResponse"
+              }
+            ],
+            "description": "The captured HTTP error response. Null when no HTTP response was received (timeout, DNS, TLS).",
+            "nullable": true
+          },
+          "method": {
+            "description": "The MCP method that failed (for example `initialize` or `tools/list`).",
+            "type": "string"
+          }
+        },
+        "required": [
+          "method",
+          "http_response"
+        ],
+        "type": "object"
+      },
       "BetaManagedAgentsMemory": {
         "additionalProperties": false,
+        "description": "A `memory` object: a single text document at a hierarchical path inside a memory store. The `content` field is populated when `view=full` and `null` when `view=basic`; the `content_size_bytes` and `content_sha256` fields are always populated so sync clients can diff without fetching content. Memories are addressed by their `mem_...` ID; the path is the create key and can be changed via update.",
         "properties": {
           "content": {
+            "description": "The memory's UTF-8 text content. Populated when `view=full`; `null` when `view=basic`. Maximum 100 kB (102,400 bytes).",
             "nullable": true,
             "type": "string"
           },
           "content_sha256": {
+            "description": "Lowercase hex SHA-256 digest of the UTF-8 `content` bytes (64 characters). The server applies no normalization, so clients can compute the same hash locally for staleness checks and as the value for a `content_sha256` precondition on update. Always populated, regardless of `view`.",
             "type": "string"
           },
           "content_size_bytes": {
+            "description": "Size of `content` in bytes (the UTF-8 plaintext length). Always populated, regardless of `view`.",
             "format": "int32",
             "type": "integer"
           },
           "created_at": {
-            "$ref": "#/components/schemas/BetaTimestamp"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "When this memory was created, in RFC 3339 format."
           },
           "id": {
+            "description": "Unique identifier for this memory (a `mem_...` value). Stable across renames; use this ID, not the path, to read, update, or delete the memory.",
             "type": "string"
           },
           "memory_store_id": {
+            "description": "ID of the memory store this memory belongs to (a `memstore_...` value).",
             "type": "string"
           },
           "memory_version_id": {
+            "description": "ID of the `memory_version` representing this memory's current content (a `memver_...` value). This is the authoritative head pointer; `memory_version` objects do not carry an `is_latest` flag, so compare against this field instead. Enumerate the full history via [List memory versions](/en/api/beta/memory_stores/memory_versions/list).",
             "type": "string"
           },
           "path": {
+            "description": "Hierarchical path of the memory within the store, e.g. `/projects/foo/notes.md`. Always starts with `/`. Paths are case-sensitive and unique within a store. Maximum 1,024 bytes.",
             "type": "string"
           },
           "type": {
@@ -8559,7 +9163,12 @@
             "type": "string"
           },
           "updated_at": {
-            "$ref": "#/components/schemas/BetaTimestamp"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "When this memory was last modified, in RFC 3339 format. Use this as a cheap freshness signal; for who made the change, look up the head version's `created_by` via [List memory versions](/en/api/beta/memory_stores/memory_versions/list)."
           }
         },
         "required": [
@@ -8576,6 +9185,7 @@
         "type": "object"
       },
       "BetaManagedAgentsMemoryListItem": {
+        "description": "One item in a [List memories](/en/api/beta/memory_stores/memories/list) response: either a `memory` object or, when `depth` is set, a `memory_prefix` rollup marker.",
         "discriminator": {
           "mapping": {
             "memory": "#/components/schemas/BetaManagedAgentsMemory",
@@ -8637,8 +9247,10 @@
       },
       "BetaManagedAgentsMemoryPrefix": {
         "additionalProperties": false,
+        "description": "A rolled-up directory marker returned by [List memories](/en/api/beta/memory_stores/memories/list) when `depth` is set. Indicates that one or more memories exist deeper than the requested depth under this prefix. This is a list-time rollup, not a stored resource; it has no ID and no lifecycle. Each prefix counts toward the page `limit` and interleaves with `memory` items in path order.",
         "properties": {
           "path": {
+            "description": "The rolled-up path prefix, including a trailing `/` (e.g. `/projects/foo/`). Pass this value as `path_prefix` on a subsequent list call to drill into the directory.",
             "type": "string"
           },
           "type": {
@@ -8656,27 +9268,42 @@
       },
       "BetaManagedAgentsMemoryStore": {
         "additionalProperties": false,
+        "description": "A `memory_store`: a named container for agent memories, scoped to a workspace. Attach a store to a session via `resources[]` to mount it as a directory the agent can read and write.",
         "properties": {
           "archived_at": {
-            "$ref": "#/components/schemas/BetaTimestamp",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "Timestamp when the store was archived, or `null` if active. Set once and never cleared; archiving is one-way. Archived stores are read-only and cannot be attached to new sessions.",
             "nullable": true
           },
           "created_at": {
-            "$ref": "#/components/schemas/BetaTimestamp"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "Timestamp when the store was created."
           },
           "description": {
+            "description": "Free-text description of what the store contains, up to 1024 characters. Included in the agent's system prompt when the store is attached, so word it to be useful to the agent. Empty string when unset.",
             "type": "string"
           },
           "id": {
+            "description": "Unique identifier for the memory store (a `memstore_...` tagged ID). Use this when attaching the store to a session, or in the `{memory_store_id}` path parameter of subsequent calls.",
             "type": "string"
           },
           "metadata": {
             "additionalProperties": {
               "type": "string"
             },
+            "description": "Arbitrary key-value tags for your own bookkeeping (such as the end user a store belongs to). Up to 16 pairs; keys 1\u201364 characters; values up to 512 characters. Returned on retrieve/list but not filterable.",
             "type": "object"
           },
           "name": {
+            "description": "Human-readable name for the store. 1\u2013255 characters. The store's mount-path slug under `/mnt/memory/` is derived from this name.",
             "type": "string"
           },
           "type": {
@@ -8686,7 +9313,12 @@
             "type": "string"
           },
           "updated_at": {
-            "$ref": "#/components/schemas/BetaTimestamp"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "Timestamp when the store's `name`, `description`, or `metadata` was last modified. Memory writes inside the store do not advance this."
           }
         },
         "required": [
@@ -8786,48 +9418,81 @@
       },
       "BetaManagedAgentsMemoryVersion": {
         "additionalProperties": false,
+        "description": "A `memory_version` object: one immutable, attributed row in a memory's append-only history. Every non-no-op mutation to a memory produces a new version. Versions belong to the store (not the individual memory) and persist after the memory is deleted. Retrieving a redacted version returns 200 with `content`, `path`, `content_size_bytes`, and `content_sha256` set to `null`; branch on `redacted_at`, not HTTP status.",
         "properties": {
           "content": {
+            "description": "The memory's UTF-8 text content as of this version. `null` when `view=basic`, when `operation` is `deleted`, or when `redacted_at` is set.",
             "nullable": true,
             "type": "string"
           },
           "content_sha256": {
+            "description": "Lowercase hex SHA-256 digest of `content` as of this version (64 characters). `null` when `redacted_at` is set or `operation` is `deleted`. Populated regardless of `view` otherwise.",
             "nullable": true,
             "type": "string"
           },
           "content_size_bytes": {
+            "description": "Size of `content` in bytes as of this version. `null` when `redacted_at` is set or `operation` is `deleted`. Populated regardless of `view` otherwise.",
             "format": "int32",
             "nullable": true,
             "type": "integer"
           },
           "created_at": {
-            "$ref": "#/components/schemas/BetaTimestamp"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "When this version was written, in RFC 3339 format."
           },
           "created_by": {
-            "$ref": "#/components/schemas/BetaManagedAgentsActor"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsActor"
+              }
+            ],
+            "description": "Who performed this write: a `session_actor`, `api_actor`, or `user_actor`. Captured at write time and preserved through redaction."
           },
           "id": {
+            "description": "Unique identifier for this version (a `memver_...` value).",
             "type": "string"
           },
           "memory_id": {
+            "description": "ID of the memory this version snapshots (a `mem_...` value). Remains valid after the memory is deleted; pass it as `memory_id` to [List memory versions](/en/api/beta/memory_stores/memory_versions/list) to retrieve the full lineage including the `deleted` row.",
             "type": "string"
           },
           "memory_store_id": {
+            "description": "ID of the memory store this version belongs to (a `memstore_...` value).",
             "type": "string"
           },
           "operation": {
-            "$ref": "#/components/schemas/BetaManagedAgentsMemoryVersionOperation"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsMemoryVersionOperation"
+              }
+            ],
+            "description": "The kind of mutation this version records: `created`, `modified`, or `deleted`."
           },
           "path": {
+            "description": "The memory's path at the time of this write. `null` if and only if `redacted_at` is set.",
             "nullable": true,
             "type": "string"
           },
           "redacted_at": {
-            "$ref": "#/components/schemas/BetaTimestamp",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "When this version was redacted, in RFC 3339 format, or `null` if it has not been redacted. When set, `content`, `path`, `content_size_bytes`, and `content_sha256` are all `null`. See [Redact a memory version](/en/api/beta/memory_stores/memory_versions/redact).",
             "nullable": true
           },
           "redacted_by": {
-            "$ref": "#/components/schemas/BetaManagedAgentsActor"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsActor"
+              }
+            ],
+            "description": "Who redacted this version, or `null` if it has not been redacted. In practice always an `api_actor` or `user_actor` (agents do not have a redact capability)."
           },
           "type": {
             "enum": [
@@ -8847,7 +9512,7 @@
         "type": "object"
       },
       "BetaManagedAgentsMemoryVersionOperation": {
-        "description": "MemoryVersionOperation enum",
+        "description": "The kind of mutation a `memory_version` records. Every non-no-op mutation to a memory appends exactly one version row with one of these values.",
         "enum": [
           "created",
           "modified",
@@ -8856,7 +9521,7 @@
         "type": "string"
       },
       "BetaManagedAgentsMemoryView": {
-        "description": "MemoryView enum",
+        "description": "Selects which projection of a `memory` or `memory_version` the server returns. `basic` returns the object with `content` set to `null`; `full` populates `content`. When omitted, the default is endpoint-specific: retrieve operations default to `full`; list, create, and update operations default to `basic`. Listing with `view=full` caps `limit` at 20.",
         "enum": [
           "basic",
           "full"
@@ -9087,6 +9752,232 @@
         ],
         "type": "string"
       },
+      "BetaManagedAgentsMultiagent": {
+        "description": "Resolved multiagent orchestration configuration as returned in API responses.",
+        "discriminator": {
+          "mapping": {
+            "coordinator": "#/components/schemas/BetaManagedAgentsMultiagentCoordinator"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsMultiagentCoordinator"
+          }
+        ]
+      },
+      "BetaManagedAgentsMultiagentCoordinator": {
+        "additionalProperties": false,
+        "description": "Resolved coordinator topology with a concrete agent roster.",
+        "properties": {
+          "agents": {
+            "description": "Agents the coordinator may spawn as session threads, each resolved to a specific version.",
+            "items": {
+              "$ref": "#/components/schemas/BetaManagedAgentsAgentReference"
+            },
+            "type": "array"
+          },
+          "type": {
+            "enum": [
+              "coordinator"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "agents"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsMultiagentCoordinatorParams": {
+        "additionalProperties": false,
+        "description": "A coordinator topology: the session's primary thread orchestrates work by spawning session threads, each running an agent drawn from the `agents` roster.",
+        "example": {
+          "agents": [
+            "agent_011CZkYqphY8vELVzwCUpqiQ",
+            {
+              "type": "self"
+            }
+          ],
+          "type": "coordinator"
+        },
+        "properties": {
+          "agents": {
+            "description": "Agents the coordinator may spawn as session threads. 1\u201320 entries. Each entry is an agent ID string, a versioned `{\"type\":\"agent\",\"id\",\"version\"}` reference, or `{\"type\":\"self\"}` to allow recursive self-invocation. Entries must reference distinct agents (after resolving `self` and string forms); at most one `self`. Referenced agents must exist, must not be archived, and must not themselves have `multiagent` set (depth limit 1).",
+            "examples": [
+              [
+                "agent_011CZkYqphY8vELVzwCUpqiQ",
+                {
+                  "type": "self"
+                }
+              ]
+            ],
+            "items": {
+              "$ref": "#/components/schemas/BetaManagedAgentsMultiagentRosterEntryParams"
+            },
+            "type": "array"
+          },
+          "type": {
+            "enum": [
+              "coordinator"
+            ],
+            "examples": [
+              "coordinator"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "agents"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsMultiagentParams": {
+        "description": "Multiagent orchestration configuration. Currently supports the `coordinator` topology.",
+        "discriminator": {
+          "mapping": {
+            "coordinator": "#/components/schemas/BetaManagedAgentsMultiagentCoordinatorParams"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsMultiagentCoordinatorParams"
+          }
+        ]
+      },
+      "BetaManagedAgentsMultiagentRosterEntryParams": {
+        "description": "An entry in a multiagent roster: an agent ID string, a versioned agent reference, or `self`.",
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "discriminator": {
+              "mapping": {
+                "agent": "#/components/schemas/BetaManagedAgentsAgentParams",
+                "self": "#/components/schemas/BetaManagedAgentsMultiagentSelfParams"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsAgentParams"
+              },
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsMultiagentSelfParams"
+              }
+            ]
+          }
+        ]
+      },
+      "BetaManagedAgentsMultiagentSelfParams": {
+        "additionalProperties": false,
+        "description": "Sentinel roster entry meaning \"the agent that owns this configuration\". Resolved server-side to a concrete agent reference.",
+        "example": {
+          "type": "self"
+        },
+        "properties": {
+          "type": {
+            "enum": [
+              "self"
+            ],
+            "examples": [
+              "self"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsOutcomeEvaluationResource": {
+        "additionalProperties": false,
+        "description": "Evaluation state for a single outcome defined via a define_outcome event.",
+        "example": {
+          "completed_at": "2026-03-15T10:02:31Z",
+          "description": "Produce a 2-page summary as summary.md",
+          "explanation": "All five sections present with inline citations.",
+          "iteration": 0,
+          "outcome_id": "outc_011CZkZRSw2kEfs6ncTVljxP",
+          "result": "satisfied",
+          "type": "outcome_evaluation"
+        },
+        "properties": {
+          "completed_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "When the outcome reached a terminal result. Null while pending/running/evaluating.",
+            "examples": [
+              "2026-03-15T10:02:31Z"
+            ],
+            "nullable": true
+          },
+          "description": {
+            "description": "What the agent should produce.",
+            "examples": [
+              "Produce a 2-page summary as summary.md"
+            ],
+            "type": "string"
+          },
+          "explanation": {
+            "description": "Grader's verdict text from the most recent evaluation. For satisfied, explains why criteria are met; for needs_revision (intermediate), what's missing; for failed, why unrecoverable.",
+            "examples": [
+              "All five sections present with inline citations."
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "iteration": {
+            "description": "0-indexed revision cycle the outcome is currently on.",
+            "examples": [
+              0
+            ],
+            "format": "int32",
+            "type": "integer"
+          },
+          "outcome_id": {
+            "description": "Server-generated outc_ ID for this outcome.",
+            "examples": [
+              "outc_011CZkZRSw2kEfs6ncTVljxP"
+            ],
+            "type": "string"
+          },
+          "result": {
+            "description": "Current evaluation state. 'pending' before the agent begins work; 'running' while producing or revising; 'evaluating' while the grader scores; 'satisfied'/'max_iterations_reached'/'failed'/'interrupted' are terminal.",
+            "examples": [
+              "satisfied"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "outcome_evaluation"
+            ],
+            "examples": [
+              "outcome_evaluation"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "outcome_id",
+          "description",
+          "result",
+          "iteration",
+          "completed_at",
+          "explanation"
+        ],
+        "type": "object"
+      },
       "BetaManagedAgentsPermissionPolicy": {
         "description": "Permission policy for tool execution.",
         "discriminator": {
@@ -9137,6 +10028,7 @@
         "type": "object"
       },
       "BetaManagedAgentsPrecondition": {
+        "description": "Optional condition that must hold for an update to apply. When omitted, the update is unconditional. Asserts the current state of the memory being updated. When an update changes `path`, the precondition still refers to the memory's current content, not the destination path. Currently the only supported variant is `content_sha256`.",
         "discriminator": {
           "mapping": {
             "content_sha256": "#/components/schemas/BetaManagedAgentsContentSha256Precondition"
@@ -9147,6 +10039,64 @@
           {
             "$ref": "#/components/schemas/BetaManagedAgentsContentSha256Precondition"
           }
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsRefreshHttpResponse": {
+        "additionalProperties": false,
+        "description": "An HTTP response captured during a credential validation probe.",
+        "properties": {
+          "body": {
+            "description": "Response body. May be truncated and has sensitive values scrubbed.",
+            "type": "string"
+          },
+          "body_truncated": {
+            "description": "Whether `body` was truncated.",
+            "type": "boolean"
+          },
+          "content_type": {
+            "description": "Value of the `Content-Type` response header.",
+            "type": "string"
+          },
+          "status_code": {
+            "description": "HTTP status code.",
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "status_code",
+          "content_type",
+          "body",
+          "body_truncated"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsRefreshObject": {
+        "additionalProperties": false,
+        "description": "Outcome of a refresh-token exchange attempted during credential validation.",
+        "properties": {
+          "http_response": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsRefreshHttpResponse"
+              }
+            ],
+            "description": "The captured HTTP error response from the token endpoint. Populated only when `status` is `failed`.",
+            "nullable": true
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsCredentialRefreshStatus"
+              }
+            ],
+            "description": "Outcome of the refresh attempt."
+          }
+        },
+        "required": [
+          "status",
+          "http_response"
         ],
         "type": "object"
       },
@@ -9239,6 +10189,42 @@
         ],
         "type": "object"
       },
+      "BetaManagedAgentsRubric": {
+        "description": "Rubric for grading the quality of an outcome.",
+        "discriminator": {
+          "mapping": {
+            "file": "#/components/schemas/BetaManagedAgentsFileRubric",
+            "text": "#/components/schemas/BetaManagedAgentsTextRubric"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsFileRubric"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsTextRubric"
+          }
+        ]
+      },
+      "BetaManagedAgentsRubricParams": {
+        "description": "Rubric for grading the quality of an outcome.",
+        "discriminator": {
+          "mapping": {
+            "file": "#/components/schemas/BetaManagedAgentsFileRubricParams",
+            "text": "#/components/schemas/BetaManagedAgentsTextRubricParams"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsFileRubricParams"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsTextRubricParams"
+          }
+        ]
+      },
       "BetaManagedAgentsSendSessionEvents": {
         "additionalProperties": false,
         "description": "Events that were successfully sent to the session.",
@@ -9314,6 +10300,7 @@
               "id": "claude-sonnet-4-6",
               "speed": "standard"
             },
+            "multiagent": null,
             "name": "My First Agent",
             "skills": [
               {
@@ -9348,6 +10335,17 @@
           "environment_id": "env_011CZkZ9X2dpNyB7HsEFoRfW",
           "id": "sesn_011CZkZAtmR3yMPDzynEDxu7",
           "metadata": {},
+          "outcome_evaluations": [
+            {
+              "completed_at": "2026-03-15T10:02:31Z",
+              "description": "Produce a 2-page summary as summary.md",
+              "explanation": "All five sections present with inline citations.",
+              "iteration": 0,
+              "outcome_id": "outc_011CZkZRSw2kEfs6ncTVljxP",
+              "result": "satisfied",
+              "type": "outcome_evaluation"
+            }
+          ],
           "resources": [
             {
               "created_at": "2026-03-15T10:00:00Z",
@@ -9405,6 +10403,7 @@
                   "id": "claude-sonnet-4-6",
                   "speed": "standard"
                 },
+                "multiagent": null,
                 "name": "My First Agent",
                 "skills": [
                   {
@@ -9476,6 +10475,26 @@
               }
             ],
             "type": "object"
+          },
+          "outcome_evaluations": {
+            "description": "Per-outcome evaluation state. One entry per define_outcome event sent to the session.",
+            "examples": [
+              [
+                {
+                  "completed_at": "2026-03-15T10:02:31Z",
+                  "description": "Produce a 2-page summary as summary.md",
+                  "explanation": "All five sections present with inline citations.",
+                  "iteration": 0,
+                  "outcome_id": "outc_011CZkZRSw2kEfs6ncTVljxP",
+                  "result": "satisfied",
+                  "type": "outcome_evaluation"
+                }
+              ]
+            ],
+            "items": {
+              "$ref": "#/components/schemas/BetaManagedAgentsOutcomeEvaluationResource"
+            },
+            "type": "array"
           },
           "resources": {
             "examples": [
@@ -9589,6 +10608,7 @@
           "agent",
           "resources",
           "vault_ids",
+          "outcome_evaluations",
           "usage",
           "stats",
           "archived_at"
@@ -9597,8 +10617,10 @@
       },
       "BetaManagedAgentsSessionActor": {
         "additionalProperties": false,
+        "description": "Attribution for a write made by an agent during a session, through the mounted filesystem at `/mnt/memory/`.",
         "properties": {
           "session_id": {
+            "description": "ID of the session that performed the write (a `sesn_...` value). Look up the session via [Retrieve a session](/en/api/sessions-retrieve) for further provenance.",
             "minLength": 1,
             "type": "string"
           },
@@ -9632,6 +10654,7 @@
             "id": "claude-sonnet-4-6",
             "speed": "standard"
           },
+          "multiagent": null,
           "name": "My First Agent",
           "skills": [
             {
@@ -9698,6 +10721,18 @@
                 "speed": "standard"
               }
             ]
+          },
+          "multiagent": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsSessionMultiagent"
+              }
+            ],
+            "description": "Resolved multiagent orchestration configuration. Null when the agent is single-threaded.",
+            "examples": [
+              null
+            ],
+            "nullable": true
           },
           "name": {
             "examples": [
@@ -9779,7 +10814,8 @@
           "system",
           "tools",
           "mcp_servers",
-          "skills"
+          "skills",
+          "multiagent"
         ],
         "type": "object"
       },
@@ -9908,6 +10944,8 @@
             "agent.message": "#/components/schemas/BetaManagedAgentsAgentMessageEvent",
             "agent.thinking": "#/components/schemas/BetaManagedAgentsAgentThinkingEvent",
             "agent.thread_context_compacted": "#/components/schemas/BetaManagedAgentsAgentThreadContextCompactedEvent",
+            "agent.thread_message_received": "#/components/schemas/BetaManagedAgentsAgentThreadMessageReceivedEvent",
+            "agent.thread_message_sent": "#/components/schemas/BetaManagedAgentsAgentThreadMessageSentEvent",
             "agent.tool_result": "#/components/schemas/BetaManagedAgentsAgentToolResultEvent",
             "agent.tool_use": "#/components/schemas/BetaManagedAgentsAgentToolUseEvent",
             "session.deleted": "#/components/schemas/BetaManagedAgentsSessionDeletedEvent",
@@ -9916,9 +10954,18 @@
             "session.status_rescheduled": "#/components/schemas/BetaManagedAgentsSessionStatusRescheduledEvent",
             "session.status_running": "#/components/schemas/BetaManagedAgentsSessionStatusRunningEvent",
             "session.status_terminated": "#/components/schemas/BetaManagedAgentsSessionStatusTerminatedEvent",
+            "session.thread_created": "#/components/schemas/BetaManagedAgentsSessionThreadCreatedEvent",
+            "session.thread_status_idle": "#/components/schemas/BetaManagedAgentsSessionThreadStatusIdleEvent",
+            "session.thread_status_rescheduled": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRescheduledEvent",
+            "session.thread_status_running": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRunningEvent",
+            "session.thread_status_terminated": "#/components/schemas/BetaManagedAgentsSessionThreadStatusTerminatedEvent",
             "span.model_request_end": "#/components/schemas/BetaManagedAgentsSpanModelRequestEndEvent",
             "span.model_request_start": "#/components/schemas/BetaManagedAgentsSpanModelRequestStartEvent",
+            "span.outcome_evaluation_end": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationEndEvent",
+            "span.outcome_evaluation_ongoing": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationOngoingEvent",
+            "span.outcome_evaluation_start": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationStartEvent",
             "user.custom_tool_result": "#/components/schemas/BetaManagedAgentsUserCustomToolResultEvent",
+            "user.define_outcome": "#/components/schemas/BetaManagedAgentsUserDefineOutcomeEvent",
             "user.interrupt": "#/components/schemas/BetaManagedAgentsUserInterruptEvent",
             "user.message": "#/components/schemas/BetaManagedAgentsUserMessageEvent",
             "user.tool_confirmation": "#/components/schemas/BetaManagedAgentsUserToolConfirmationEvent"
@@ -9960,6 +11007,12 @@
             "$ref": "#/components/schemas/BetaManagedAgentsAgentToolResultEvent"
           },
           {
+            "$ref": "#/components/schemas/BetaManagedAgentsAgentThreadMessageReceivedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsAgentThreadMessageSentEvent"
+          },
+          {
             "$ref": "#/components/schemas/BetaManagedAgentsAgentThreadContextCompactedEvent"
           },
           {
@@ -9978,14 +11031,79 @@
             "$ref": "#/components/schemas/BetaManagedAgentsSessionStatusTerminatedEvent"
           },
           {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadCreatedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationStartEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationEndEvent"
+          },
+          {
             "$ref": "#/components/schemas/BetaManagedAgentsSpanModelRequestStartEvent"
           },
           {
             "$ref": "#/components/schemas/BetaManagedAgentsSpanModelRequestEndEvent"
           },
           {
+            "$ref": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationOngoingEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsUserDefineOutcomeEvent"
+          },
+          {
             "$ref": "#/components/schemas/BetaManagedAgentsSessionDeletedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRunningEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadStatusIdleEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadStatusTerminatedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRescheduledEvent"
           }
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsSessionMultiagent": {
+        "description": "Resolved multiagent orchestration configuration as returned on a `session`.",
+        "discriminator": {
+          "mapping": {
+            "coordinator": "#/components/schemas/BetaManagedAgentsSessionMultiagentCoordinator"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionMultiagentCoordinator"
+          }
+        ]
+      },
+      "BetaManagedAgentsSessionMultiagentCoordinator": {
+        "additionalProperties": false,
+        "description": "Resolved coordinator topology with full agent definitions for each roster member.",
+        "properties": {
+          "agents": {
+            "description": "Full `agent` definitions the coordinator may spawn as session threads.",
+            "items": {
+              "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadAgent"
+            },
+            "type": "array"
+          },
+          "type": {
+            "enum": [
+              "coordinator"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "agents"
         ],
         "type": "object"
       },
@@ -10249,6 +11367,695 @@
         ],
         "type": "object"
       },
+      "BetaManagedAgentsSessionThread": {
+        "additionalProperties": false,
+        "description": "An execution thread within a `session`. Each session has one primary thread plus zero or more child threads spawned by the coordinator.",
+        "example": {
+          "agent": {
+            "description": "A focused research subagent.",
+            "id": "agent_011CZkYqphY8vELVzwCUpqiQ",
+            "mcp_servers": [],
+            "model": {
+              "id": "claude-sonnet-4-6",
+              "speed": "standard"
+            },
+            "name": "Researcher",
+            "skills": [],
+            "system": "You are a research subagent that gathers and summarises sources for the coordinating agent.",
+            "tools": [
+              {
+                "configs": [],
+                "default_config": {
+                  "enabled": true,
+                  "permission_policy": {
+                    "type": "always_ask"
+                  }
+                },
+                "type": "agent_toolset_20260401"
+              }
+            ],
+            "type": "agent",
+            "version": 1
+          },
+          "archived_at": null,
+          "created_at": "2026-03-15T10:00:00Z",
+          "id": "sthr_011CZkZVWa6oIjw0rgXZpnBt",
+          "parent_thread_id": null,
+          "session_id": "sesn_011CZkZAtmR3yMPDzynEDxu7",
+          "stats": {
+            "active_seconds": 0,
+            "duration_seconds": 0,
+            "startup_seconds": 0
+          },
+          "status": "idle",
+          "type": "session_thread",
+          "updated_at": "2026-03-15T10:00:00Z",
+          "usage": {
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 0
+            },
+            "cache_read_input_tokens": 0,
+            "input_tokens": 0,
+            "output_tokens": 0
+          }
+        },
+        "properties": {
+          "agent": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadAgent"
+              }
+            ],
+            "description": "Resolved agent definition for this thread. Snapshot of the agent at thread creation time.",
+            "examples": [
+              {
+                "description": "A focused research subagent.",
+                "id": "agent_011CZkYqphY8vELVzwCUpqiQ",
+                "mcp_servers": [],
+                "model": {
+                  "id": "claude-sonnet-4-6",
+                  "speed": "standard"
+                },
+                "name": "Researcher",
+                "skills": [],
+                "system": "You are a research subagent that gathers and summarises sources for the coordinating agent.",
+                "tools": [
+                  {
+                    "configs": [],
+                    "default_config": {
+                      "enabled": true,
+                      "permission_policy": {
+                        "type": "always_ask"
+                      }
+                    },
+                    "type": "agent_toolset_20260401"
+                  }
+                ],
+                "type": "agent",
+                "version": 1
+              }
+            ]
+          },
+          "archived_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "When the thread was archived. Null if not archived.",
+            "examples": [
+              null
+            ],
+            "nullable": true
+          },
+          "created_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "When the thread was created.",
+            "examples": [
+              "2026-03-15T10:00:00Z"
+            ]
+          },
+          "id": {
+            "description": "Unique identifier for this thread.",
+            "examples": [
+              "sthr_011CZkZVWa6oIjw0rgXZpnBt"
+            ],
+            "type": "string"
+          },
+          "parent_thread_id": {
+            "description": "Parent thread that spawned this thread. Null for the primary thread.",
+            "examples": [
+              null
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "session_id": {
+            "description": "The session this thread belongs to.",
+            "examples": [
+              "sesn_011CZkZAtmR3yMPDzynEDxu7"
+            ],
+            "type": "string"
+          },
+          "stats": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadStats"
+              }
+            ],
+            "description": "Timing statistics for this thread. Null until the thread's first status transition.",
+            "examples": [
+              {
+                "active_seconds": 0,
+                "duration_seconds": 0,
+                "startup_seconds": 0
+              }
+            ],
+            "nullable": true
+          },
+          "status": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadStatus"
+              }
+            ],
+            "description": "Current execution status of the thread.",
+            "examples": [
+              "idle"
+            ]
+          },
+          "type": {
+            "enum": [
+              "session_thread"
+            ],
+            "examples": [
+              "session_thread"
+            ],
+            "type": "string"
+          },
+          "updated_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "When the thread was last updated.",
+            "examples": [
+              "2026-03-15T10:00:00Z"
+            ]
+          },
+          "usage": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadUsage"
+              }
+            ],
+            "description": "Cumulative token usage for this thread. Null until the thread's first idle transition.",
+            "examples": [
+              {
+                "cache_creation": {
+                  "ephemeral_1h_input_tokens": 0,
+                  "ephemeral_5m_input_tokens": 0
+                },
+                "cache_read_input_tokens": 0,
+                "input_tokens": 0,
+                "output_tokens": 0
+              }
+            ],
+            "nullable": true
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "session_id",
+          "status",
+          "agent",
+          "parent_thread_id",
+          "created_at",
+          "updated_at",
+          "archived_at",
+          "usage",
+          "stats"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsSessionThreadAgent": {
+        "additionalProperties": false,
+        "description": "Resolved `agent` definition for a single `session_thread`. Snapshot of the agent at thread creation time. The multiagent roster is not repeated here; read it from `Session.agent`.",
+        "example": {
+          "description": "A focused research subagent.",
+          "id": "agent_011CZkYqphY8vELVzwCUpqiQ",
+          "mcp_servers": [],
+          "model": {
+            "id": "claude-sonnet-4-6",
+            "speed": "standard"
+          },
+          "name": "Researcher",
+          "skills": [],
+          "system": "You are a research subagent that gathers and summarises sources for the coordinating agent.",
+          "tools": [
+            {
+              "configs": [],
+              "default_config": {
+                "enabled": true,
+                "permission_policy": {
+                  "type": "always_ask"
+                }
+              },
+              "type": "agent_toolset_20260401"
+            }
+          ],
+          "type": "agent",
+          "version": 1
+        },
+        "properties": {
+          "description": {
+            "examples": [
+              "A focused research subagent."
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "examples": [
+              "agent_011CZkYqphY8vELVzwCUpqiQ"
+            ],
+            "type": "string"
+          },
+          "mcp_servers": {
+            "examples": [
+              []
+            ],
+            "items": {
+              "$ref": "#/components/schemas/BetaManagedAgentsMCPServer"
+            },
+            "type": "array"
+          },
+          "model": {
+            "$ref": "#/components/schemas/BetaManagedAgentsModelConfig",
+            "examples": [
+              {
+                "id": "claude-sonnet-4-6",
+                "speed": "standard"
+              }
+            ]
+          },
+          "name": {
+            "examples": [
+              "Researcher"
+            ],
+            "type": "string"
+          },
+          "skills": {
+            "examples": [
+              []
+            ],
+            "items": {
+              "$ref": "#/components/schemas/BetaManagedAgentsSkill"
+            },
+            "type": "array"
+          },
+          "system": {
+            "examples": [
+              "You are a research subagent that gathers and summarises sources for the coordinating agent."
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "tools": {
+            "examples": [
+              [
+                {
+                  "configs": [],
+                  "default_config": {
+                    "enabled": true,
+                    "permission_policy": {
+                      "type": "always_ask"
+                    }
+                  },
+                  "type": "agent_toolset_20260401"
+                }
+              ]
+            ],
+            "items": {
+              "$ref": "#/components/schemas/BetaManagedAgentsAgentTool"
+            },
+            "type": "array"
+          },
+          "type": {
+            "enum": [
+              "agent"
+            ],
+            "examples": [
+              "agent"
+            ],
+            "type": "string"
+          },
+          "version": {
+            "examples": [
+              1
+            ],
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "version",
+          "name",
+          "description",
+          "model",
+          "system",
+          "tools",
+          "mcp_servers",
+          "skills"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsSessionThreadCreatedEvent": {
+        "additionalProperties": false,
+        "description": "Emitted when a subagent is spawned as a new thread. Written to the parent thread's output stream so clients observing the session see child creation.",
+        "example": {
+          "agent_name": "Researcher",
+          "id": "sevt_011CZkZWXb7pJkx1shYaqoCu",
+          "processed_at": "2026-03-15T10:00:00Z",
+          "session_thread_id": "sthr_011CZkZVWa6oIjw0rgXZpnBt",
+          "type": "session.thread_created"
+        },
+        "properties": {
+          "agent_name": {
+            "description": "Name of the callable agent the thread runs.",
+            "examples": [
+              "Researcher"
+            ],
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for this event.",
+            "examples": [
+              "sevt_011CZkZWXb7pJkx1shYaqoCu"
+            ],
+            "type": "string"
+          },
+          "processed_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "Timestamp when the thread was created.",
+            "examples": [
+              "2026-03-15T10:00:00Z"
+            ]
+          },
+          "session_thread_id": {
+            "description": "Public `sthr_` ID of the newly created thread.",
+            "examples": [
+              "sthr_011CZkZVWa6oIjw0rgXZpnBt"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "session.thread_created"
+            ],
+            "examples": [
+              "session.thread_created"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "processed_at",
+          "agent_name",
+          "session_thread_id"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsSessionThreadStats": {
+        "additionalProperties": false,
+        "description": "Timing statistics for a session thread.",
+        "properties": {
+          "active_seconds": {
+            "description": "Cumulative time in seconds the thread spent actively running. Excludes idle time.",
+            "format": "double",
+            "type": "number"
+          },
+          "duration_seconds": {
+            "description": "Elapsed time since thread creation in seconds. For archived threads, frozen at the final update.",
+            "format": "double",
+            "type": "number"
+          },
+          "startup_seconds": {
+            "description": "Time in seconds for the thread to begin running. Zero for child threads, which start immediately.",
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "type": "object"
+      },
+      "BetaManagedAgentsSessionThreadStatus": {
+        "description": "SessionThreadStatus enum",
+        "enum": [
+          "running",
+          "idle",
+          "rescheduling",
+          "terminated"
+        ],
+        "type": "string"
+      },
+      "BetaManagedAgentsSessionThreadStatusIdleEvent": {
+        "additionalProperties": false,
+        "description": "A session thread has yielded and is awaiting input. Emitted on the thread's own stream and cross-posted to the primary stream for child threads.",
+        "example": {
+          "agent_name": "Researcher",
+          "id": "sevt_011CZkZXYc8qKly2tiZbrpDv",
+          "processed_at": "2026-03-15T10:00:00Z",
+          "session_thread_id": "sthr_011CZkZVWa6oIjw0rgXZpnBt",
+          "stop_reason": {
+            "type": "end_turn"
+          },
+          "type": "session.thread_status_idle"
+        },
+        "properties": {
+          "agent_name": {
+            "description": "Name of the agent the thread runs.",
+            "examples": [
+              "Researcher"
+            ],
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for this event.",
+            "examples": [
+              "sevt_011CZkZXYc8qKly2tiZbrpDv"
+            ],
+            "type": "string"
+          },
+          "processed_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "Timestamp of the status transition.",
+            "examples": [
+              "2026-03-15T10:00:00Z"
+            ]
+          },
+          "session_thread_id": {
+            "description": "Public sthr_ ID of the thread that went idle.",
+            "examples": [
+              "sthr_011CZkZVWa6oIjw0rgXZpnBt"
+            ],
+            "type": "string"
+          },
+          "stop_reason": {
+            "discriminator": {
+              "mapping": {
+                "end_turn": "#/components/schemas/BetaManagedAgentsSessionEndTurn",
+                "requires_action": "#/components/schemas/BetaManagedAgentsSessionRequiresAction",
+                "retries_exhausted": "#/components/schemas/BetaManagedAgentsSessionRetriesExhausted"
+              },
+              "propertyName": "type"
+            },
+            "examples": [
+              {
+                "type": "end_turn"
+              }
+            ],
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsSessionEndTurn"
+              },
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsSessionRequiresAction"
+              },
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsSessionRetriesExhausted"
+              }
+            ],
+            "type": "object"
+          },
+          "type": {
+            "enum": [
+              "session.thread_status_idle"
+            ],
+            "examples": [
+              "session.thread_status_idle"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "session_thread_id",
+          "processed_at",
+          "agent_name",
+          "stop_reason"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsSessionThreadStatusRescheduledEvent": {
+        "additionalProperties": false,
+        "description": "A session thread hit a transient error and is retrying automatically. Emitted on the thread's own stream and cross-posted to the primary stream for child threads.",
+        "properties": {
+          "agent_name": {
+            "description": "Name of the agent the thread runs.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for this event.",
+            "type": "string"
+          },
+          "processed_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "Timestamp of the status transition."
+          },
+          "session_thread_id": {
+            "description": "Public sthr_ ID of the thread that is retrying.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "session.thread_status_rescheduled"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "session_thread_id",
+          "processed_at",
+          "agent_name"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsSessionThreadStatusRunningEvent": {
+        "additionalProperties": false,
+        "description": "A session thread has begun executing. Emitted on the thread's own stream and cross-posted to the primary stream for child threads.",
+        "properties": {
+          "agent_name": {
+            "description": "Name of the agent the thread runs.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for this event.",
+            "type": "string"
+          },
+          "processed_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "Timestamp of the status transition."
+          },
+          "session_thread_id": {
+            "description": "Public sthr_ ID of the thread that started running.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "session.thread_status_running"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "session_thread_id",
+          "processed_at",
+          "agent_name"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsSessionThreadStatusTerminatedEvent": {
+        "additionalProperties": false,
+        "description": "A session thread has terminated and will accept no further input. Emitted on the thread's own stream and cross-posted to the primary stream for child threads.",
+        "properties": {
+          "agent_name": {
+            "description": "Name of the agent the thread runs.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for this event.",
+            "type": "string"
+          },
+          "processed_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "Timestamp of the status transition."
+          },
+          "session_thread_id": {
+            "description": "Public sthr_ ID of the thread that terminated.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "session.thread_status_terminated"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "session_thread_id",
+          "processed_at",
+          "agent_name"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsSessionThreadUsage": {
+        "additionalProperties": false,
+        "description": "Cumulative token usage for a session thread across all turns.",
+        "properties": {
+          "cache_creation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsCacheCreationUsage"
+              }
+            ],
+            "description": "Tokens used to create prompt cache entries, broken down by cache TTL."
+          },
+          "cache_read_input_tokens": {
+            "description": "Total tokens read from prompt cache.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "input_tokens": {
+            "description": "Total input tokens consumed across all turns.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "output_tokens": {
+            "description": "Total output tokens generated across all turns.",
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
       "BetaManagedAgentsSessionUsage": {
         "additionalProperties": false,
         "description": "Cumulative token usage for a session across all turns.",
@@ -10437,6 +12244,245 @@
         ],
         "type": "object"
       },
+      "BetaManagedAgentsSpanOutcomeEvaluationEndEvent": {
+        "additionalProperties": false,
+        "description": "Emitted when an outcome evaluation cycle completes. Carries the verdict and aggregate token usage. A verdict of `needs_revision` means another evaluation cycle follows; `satisfied`, `max_iterations_reached`, `failed`, or `interrupted` are terminal \u2014 no further evaluation cycles follow.",
+        "example": {
+          "explanation": "All five sections present with inline citations.",
+          "id": "sevt_011CZkZUVz5nHiv9qfWYomas",
+          "iteration": 0,
+          "outcome_evaluation_start_id": "sevt_011CZkZTUy4mGhu8peVXnlzr",
+          "outcome_id": "outc_011CZkZRSw2kEfs6ncTVljxP",
+          "processed_at": "2026-03-15T10:02:31Z",
+          "result": "satisfied",
+          "type": "span.outcome_evaluation_end",
+          "usage": {
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 1536,
+            "input_tokens": 1842,
+            "output_tokens": 213
+          }
+        },
+        "properties": {
+          "explanation": {
+            "description": "Human-readable explanation of the verdict. For `needs_revision`, describes which criteria failed and why.",
+            "examples": [
+              "All five sections present with inline citations."
+            ],
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for this event.",
+            "examples": [
+              "sevt_011CZkZUVz5nHiv9qfWYomas"
+            ],
+            "type": "string"
+          },
+          "iteration": {
+            "description": "0-indexed revision cycle, matching the corresponding `span.outcome_evaluation_start`.",
+            "examples": [
+              0
+            ],
+            "format": "int32",
+            "type": "integer"
+          },
+          "outcome_evaluation_start_id": {
+            "description": "The id of the corresponding `span.outcome_evaluation_start` event.",
+            "examples": [
+              "sevt_011CZkZTUy4mGhu8peVXnlzr"
+            ],
+            "type": "string"
+          },
+          "outcome_id": {
+            "description": "The `outc_` ID of the outcome being evaluated.",
+            "examples": [
+              "outc_011CZkZRSw2kEfs6ncTVljxP"
+            ],
+            "type": "string"
+          },
+          "processed_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "Timestamp when outcome evaluation ended.",
+            "examples": [
+              "2026-03-15T10:02:31Z"
+            ]
+          },
+          "result": {
+            "description": "Evaluation verdict. 'satisfied': criteria met, session goes idle. 'needs_revision': criteria not met, another revision cycle follows. 'max_iterations_reached': evaluation budget exhausted with criteria still unmet \u2014 one final acknowledgment turn follows before the session goes idle, but no further evaluation runs. 'failed': grader determined the rubric does not apply to the deliverables. 'interrupted': user sent an interrupt while evaluation was in progress.",
+            "examples": [
+              "satisfied"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "span.outcome_evaluation_end"
+            ],
+            "examples": [
+              "span.outcome_evaluation_end"
+            ],
+            "type": "string"
+          },
+          "usage": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsSpanModelUsage"
+              }
+            ],
+            "description": "Aggregate token usage for this evaluation cycle. Sums across all grader model requests within the cycle.",
+            "examples": [
+              {
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 1536,
+                "input_tokens": 1842,
+                "output_tokens": 213
+              }
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "processed_at",
+          "outcome_evaluation_start_id",
+          "iteration",
+          "result",
+          "explanation",
+          "usage",
+          "outcome_id"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsSpanOutcomeEvaluationOngoingEvent": {
+        "additionalProperties": false,
+        "description": "Periodic heartbeat emitted while an outcome evaluation cycle is in progress. Distinguishes 'evaluation is actively running' from 'evaluation is stuck' between the corresponding `span.outcome_evaluation_start` and `span.outcome_evaluation_end` events.",
+        "example": {
+          "id": "sevt_011CZkZbCG2uOpc6xmDfvTzh",
+          "iteration": 0,
+          "outcome_id": "outc_011CZkZRSw2kEfs6ncTVljxP",
+          "processed_at": "2026-03-15T10:02:14Z",
+          "type": "span.outcome_evaluation_ongoing"
+        },
+        "properties": {
+          "id": {
+            "description": "Unique identifier for this event.",
+            "examples": [
+              "sevt_011CZkZbCG2uOpc6xmDfvTzh"
+            ],
+            "type": "string"
+          },
+          "iteration": {
+            "description": "0-indexed revision cycle, matching the corresponding `span.outcome_evaluation_start`.",
+            "examples": [
+              0
+            ],
+            "format": "int32",
+            "type": "integer"
+          },
+          "outcome_id": {
+            "description": "The `outc_` ID of the outcome being evaluated.",
+            "examples": [
+              "outc_011CZkZRSw2kEfs6ncTVljxP"
+            ],
+            "type": "string"
+          },
+          "processed_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "Timestamp when this heartbeat was emitted.",
+            "examples": [
+              "2026-03-15T10:02:14Z"
+            ]
+          },
+          "type": {
+            "enum": [
+              "span.outcome_evaluation_ongoing"
+            ],
+            "examples": [
+              "span.outcome_evaluation_ongoing"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "processed_at",
+          "iteration",
+          "outcome_id"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsSpanOutcomeEvaluationStartEvent": {
+        "additionalProperties": false,
+        "description": "Emitted when an outcome evaluation cycle begins.",
+        "example": {
+          "id": "sevt_011CZkZTUy4mGhu8peVXnlzr",
+          "iteration": 0,
+          "outcome_id": "outc_011CZkZRSw2kEfs6ncTVljxP",
+          "processed_at": "2026-03-15T10:02:14Z",
+          "type": "span.outcome_evaluation_start"
+        },
+        "properties": {
+          "id": {
+            "description": "Unique identifier for this event.",
+            "examples": [
+              "sevt_011CZkZTUy4mGhu8peVXnlzr"
+            ],
+            "type": "string"
+          },
+          "iteration": {
+            "description": "0-indexed revision cycle. 0 is the first evaluation; 1 is the re-evaluation after the first revision; etc.",
+            "examples": [
+              0
+            ],
+            "format": "int32",
+            "type": "integer"
+          },
+          "outcome_id": {
+            "description": "The `outc_` ID of the outcome being evaluated.",
+            "examples": [
+              "outc_011CZkZRSw2kEfs6ncTVljxP"
+            ],
+            "type": "string"
+          },
+          "processed_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "Timestamp when outcome evaluation started.",
+            "examples": [
+              "2026-03-15T10:02:14Z"
+            ]
+          },
+          "type": {
+            "enum": [
+              "span.outcome_evaluation_start"
+            ],
+            "examples": [
+              "span.outcome_evaluation_start"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "processed_at",
+          "iteration",
+          "outcome_id"
+        ],
+        "type": "object"
+      },
       "BetaManagedAgentsSpeed": {
         "description": "Inference speed mode. `fast` provides significantly faster output token generation at premium pricing. Not all models support `fast`; invalid combinations are rejected at create time.",
         "enum": [
@@ -10553,6 +12599,8 @@
             "agent.message": "#/components/schemas/BetaManagedAgentsAgentMessageEvent",
             "agent.thinking": "#/components/schemas/BetaManagedAgentsAgentThinkingEvent",
             "agent.thread_context_compacted": "#/components/schemas/BetaManagedAgentsAgentThreadContextCompactedEvent",
+            "agent.thread_message_received": "#/components/schemas/BetaManagedAgentsAgentThreadMessageReceivedEvent",
+            "agent.thread_message_sent": "#/components/schemas/BetaManagedAgentsAgentThreadMessageSentEvent",
             "agent.tool_result": "#/components/schemas/BetaManagedAgentsAgentToolResultEvent",
             "agent.tool_use": "#/components/schemas/BetaManagedAgentsAgentToolUseEvent",
             "session.deleted": "#/components/schemas/BetaManagedAgentsSessionDeletedEvent",
@@ -10561,9 +12609,18 @@
             "session.status_rescheduled": "#/components/schemas/BetaManagedAgentsSessionStatusRescheduledEvent",
             "session.status_running": "#/components/schemas/BetaManagedAgentsSessionStatusRunningEvent",
             "session.status_terminated": "#/components/schemas/BetaManagedAgentsSessionStatusTerminatedEvent",
+            "session.thread_created": "#/components/schemas/BetaManagedAgentsSessionThreadCreatedEvent",
+            "session.thread_status_idle": "#/components/schemas/BetaManagedAgentsSessionThreadStatusIdleEvent",
+            "session.thread_status_rescheduled": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRescheduledEvent",
+            "session.thread_status_running": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRunningEvent",
+            "session.thread_status_terminated": "#/components/schemas/BetaManagedAgentsSessionThreadStatusTerminatedEvent",
             "span.model_request_end": "#/components/schemas/BetaManagedAgentsSpanModelRequestEndEvent",
             "span.model_request_start": "#/components/schemas/BetaManagedAgentsSpanModelRequestStartEvent",
+            "span.outcome_evaluation_end": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationEndEvent",
+            "span.outcome_evaluation_ongoing": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationOngoingEvent",
+            "span.outcome_evaluation_start": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationStartEvent",
             "user.custom_tool_result": "#/components/schemas/BetaManagedAgentsUserCustomToolResultEvent",
+            "user.define_outcome": "#/components/schemas/BetaManagedAgentsUserDefineOutcomeEvent",
             "user.interrupt": "#/components/schemas/BetaManagedAgentsUserInterruptEvent",
             "user.message": "#/components/schemas/BetaManagedAgentsUserMessageEvent",
             "user.tool_confirmation": "#/components/schemas/BetaManagedAgentsUserToolConfirmationEvent"
@@ -10605,6 +12662,12 @@
             "$ref": "#/components/schemas/BetaManagedAgentsAgentToolResultEvent"
           },
           {
+            "$ref": "#/components/schemas/BetaManagedAgentsAgentThreadMessageReceivedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsAgentThreadMessageSentEvent"
+          },
+          {
             "$ref": "#/components/schemas/BetaManagedAgentsAgentThreadContextCompactedEvent"
           },
           {
@@ -10623,13 +12686,175 @@
             "$ref": "#/components/schemas/BetaManagedAgentsSessionStatusTerminatedEvent"
           },
           {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadCreatedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationStartEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationEndEvent"
+          },
+          {
             "$ref": "#/components/schemas/BetaManagedAgentsSpanModelRequestStartEvent"
           },
           {
             "$ref": "#/components/schemas/BetaManagedAgentsSpanModelRequestEndEvent"
           },
           {
+            "$ref": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationOngoingEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsUserDefineOutcomeEvent"
+          },
+          {
             "$ref": "#/components/schemas/BetaManagedAgentsSessionDeletedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRunningEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadStatusIdleEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadStatusTerminatedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRescheduledEvent"
+          }
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsStreamSessionThreadEvents": {
+        "description": "Server-sent event in a single thread's stream.",
+        "discriminator": {
+          "mapping": {
+            "agent.custom_tool_use": "#/components/schemas/BetaManagedAgentsAgentCustomToolUseEvent",
+            "agent.mcp_tool_result": "#/components/schemas/BetaManagedAgentsAgentMcpToolResultEvent",
+            "agent.mcp_tool_use": "#/components/schemas/BetaManagedAgentsAgentMcpToolUseEvent",
+            "agent.message": "#/components/schemas/BetaManagedAgentsAgentMessageEvent",
+            "agent.thinking": "#/components/schemas/BetaManagedAgentsAgentThinkingEvent",
+            "agent.thread_context_compacted": "#/components/schemas/BetaManagedAgentsAgentThreadContextCompactedEvent",
+            "agent.thread_message_received": "#/components/schemas/BetaManagedAgentsAgentThreadMessageReceivedEvent",
+            "agent.thread_message_sent": "#/components/schemas/BetaManagedAgentsAgentThreadMessageSentEvent",
+            "agent.tool_result": "#/components/schemas/BetaManagedAgentsAgentToolResultEvent",
+            "agent.tool_use": "#/components/schemas/BetaManagedAgentsAgentToolUseEvent",
+            "session.deleted": "#/components/schemas/BetaManagedAgentsSessionDeletedEvent",
+            "session.error": "#/components/schemas/BetaManagedAgentsSessionErrorEvent",
+            "session.status_idle": "#/components/schemas/BetaManagedAgentsSessionStatusIdleEvent",
+            "session.status_rescheduled": "#/components/schemas/BetaManagedAgentsSessionStatusRescheduledEvent",
+            "session.status_running": "#/components/schemas/BetaManagedAgentsSessionStatusRunningEvent",
+            "session.status_terminated": "#/components/schemas/BetaManagedAgentsSessionStatusTerminatedEvent",
+            "session.thread_created": "#/components/schemas/BetaManagedAgentsSessionThreadCreatedEvent",
+            "session.thread_status_idle": "#/components/schemas/BetaManagedAgentsSessionThreadStatusIdleEvent",
+            "session.thread_status_rescheduled": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRescheduledEvent",
+            "session.thread_status_running": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRunningEvent",
+            "session.thread_status_terminated": "#/components/schemas/BetaManagedAgentsSessionThreadStatusTerminatedEvent",
+            "span.model_request_end": "#/components/schemas/BetaManagedAgentsSpanModelRequestEndEvent",
+            "span.model_request_start": "#/components/schemas/BetaManagedAgentsSpanModelRequestStartEvent",
+            "span.outcome_evaluation_end": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationEndEvent",
+            "span.outcome_evaluation_ongoing": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationOngoingEvent",
+            "span.outcome_evaluation_start": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationStartEvent",
+            "user.custom_tool_result": "#/components/schemas/BetaManagedAgentsUserCustomToolResultEvent",
+            "user.define_outcome": "#/components/schemas/BetaManagedAgentsUserDefineOutcomeEvent",
+            "user.interrupt": "#/components/schemas/BetaManagedAgentsUserInterruptEvent",
+            "user.message": "#/components/schemas/BetaManagedAgentsUserMessageEvent",
+            "user.tool_confirmation": "#/components/schemas/BetaManagedAgentsUserToolConfirmationEvent"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsUserMessageEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsUserInterruptEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsUserToolConfirmationEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsUserCustomToolResultEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsAgentCustomToolUseEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsAgentMessageEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsAgentThinkingEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsAgentMcpToolUseEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsAgentMcpToolResultEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsAgentToolUseEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsAgentToolResultEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsAgentThreadMessageReceivedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsAgentThreadMessageSentEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsAgentThreadContextCompactedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionErrorEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionStatusRescheduledEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionStatusRunningEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionStatusIdleEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionStatusTerminatedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadCreatedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationStartEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationEndEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSpanModelRequestStartEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSpanModelRequestEndEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationOngoingEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsUserDefineOutcomeEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionDeletedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRunningEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadStatusIdleEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadStatusTerminatedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRescheduledEvent"
           }
         ],
         "type": "object"
@@ -10667,6 +12892,59 @@
         "required": [
           "type",
           "text"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsTextRubric": {
+        "additionalProperties": false,
+        "description": "Rubric content provided inline as text.",
+        "properties": {
+          "content": {
+            "description": "Rubric content. Plain text or markdown \u2014 the grader treats it as freeform text.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "content"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsTextRubricParams": {
+        "additionalProperties": false,
+        "description": "Rubric content provided inline as text.",
+        "example": {
+          "content": "Must cover all five sections; cite sources inline.",
+          "type": "text"
+        },
+        "properties": {
+          "content": {
+            "description": "Rubric content. Plain text or markdown \u2014 the grader treats it as freeform text. Maximum 262144 characters.",
+            "examples": [
+              "Must cover all five sections; cite sources inline."
+            ],
+            "maxLength": 262144,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "text"
+            ],
+            "examples": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "content"
         ],
         "type": "object"
       },
@@ -11005,6 +13283,15 @@
             ],
             "description": "Model identifier. Accepts the [model string](https://platform.claude.com/docs/en/about-claude/models/overview#latest-models-comparison), e.g. `claude-opus-4-6`, or a `model_config` object for additional configuration control. Omit to preserve. Cannot be cleared."
           },
+          "multiagent": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsMultiagentParams"
+              }
+            ],
+            "description": "Multiagent orchestration configuration. Full replacement. Omit to preserve; send null to clear.",
+            "nullable": true
+          },
           "name": {
             "description": "Human-readable name. 1-256 characters. Omit to preserve. Cannot be cleared.",
             "maxLength": 256,
@@ -11095,19 +13382,27 @@
       },
       "BetaManagedAgentsUpdateMemoryParams": {
         "additionalProperties": false,
+        "description": "Request parameters for [Update a memory](/en/api/beta/memory_stores/memories/update). At least one of `content` or `path` must be provided. Renaming onto a path occupied by a different memory returns `memory_path_conflict_error` (HTTP 409). Rename never overwrites; delete or rename the blocking memory first. An update where every supplied field already matches the stored value is a no-op: it returns 200 with the existing memory and writes no new version.",
         "properties": {
           "content": {
+            "description": "New UTF-8 text content for the memory. Maximum 100 kB (102,400 bytes). Omit to leave the content unchanged (e.g., for a rename-only update).",
             "nullable": true,
             "type": "string"
           },
           "path": {
+            "description": "New path for the memory (a rename). Must start with `/`, contain at least one non-empty segment, and be at most 1,024 bytes. Must not contain empty segments, `.` or `..` segments, control or format characters, and must be NFC-normalized. Paths are case-sensitive. The memory's `id` is preserved across renames. Omit to leave the path unchanged.",
             "maxLength": 1024,
             "minLength": 2,
             "nullable": true,
             "type": "string"
           },
           "precondition": {
-            "$ref": "#/components/schemas/BetaManagedAgentsPrecondition"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsPrecondition"
+              }
+            ],
+            "description": "Optional optimistic-concurrency precondition. When supplied, the update applies only if the memory's current state matches; on mismatch the request returns `memory_precondition_failed_error` (HTTP 409). When omitted, the update is unconditional."
           }
         },
         "type": "object"
@@ -11116,6 +13411,7 @@
         "additionalProperties": false,
         "properties": {
           "description": {
+            "description": "New description for the store, up to 1024 characters. Pass an empty string to clear it.",
             "maxLength": 1024,
             "nullable": true,
             "type": "string"
@@ -11130,6 +13426,7 @@
             "type": "object"
           },
           "name": {
+            "description": "New human-readable name for the store. 1\u2013255 characters; no control characters. Renaming changes the slug used for the store's `mount_path` in sessions created after the update.",
             "maxLength": 255,
             "minLength": 1,
             "nullable": true,
@@ -11139,6 +13436,7 @@
         "type": "object"
       },
       "BetaManagedAgentsUpdateMemoryStoreResponse": {
+        "description": "Response from updating a `memory_store`. Returns the store with the changes applied.",
         "discriminator": {
           "mapping": {
             "memory_store": "#/components/schemas/BetaManagedAgentsMemoryStore"
@@ -11271,6 +13569,7 @@
       },
       "BetaManagedAgentsUserActor": {
         "additionalProperties": false,
+        "description": "Attribution for a write made by a human user through the Anthropic Console.",
         "properties": {
           "type": {
             "enum": [
@@ -11279,6 +13578,7 @@
             "type": "string"
           },
           "user_id": {
+            "description": "ID of the user who performed the write (a `user_...` value).",
             "minLength": 1,
             "type": "string"
           }
@@ -11345,6 +13645,11 @@
             "description": "Timestamp when this result was processed.",
             "nullable": true
           },
+          "session_thread_id": {
+            "description": "Routes this result to a subagent thread. Copy from the `agent.custom_tool_use` event's `session_thread_id`.",
+            "nullable": true,
+            "type": "string"
+          },
           "type": {
             "enum": [
               "user.custom_tool_result"
@@ -11394,6 +13699,158 @@
         ],
         "type": "object"
       },
+      "BetaManagedAgentsUserDefineOutcomeEvent": {
+        "additionalProperties": false,
+        "description": "Echo of a `user.define_outcome` input event. Carries the server-generated `outcome_id` that subsequent `span.outcome_evaluation_*` events reference.",
+        "example": {
+          "description": "Produce a 2-page summary as summary.md",
+          "id": "sevt_011CZkZSTx3lFgt7odUWmkyq",
+          "max_iterations": 3,
+          "outcome_id": "outc_011CZkZRSw2kEfs6ncTVljxP",
+          "processed_at": "2026-03-15T10:02:14Z",
+          "rubric": {
+            "content": "Must cover all five sections; cite sources inline.",
+            "type": "text"
+          },
+          "type": "user.define_outcome"
+        },
+        "properties": {
+          "description": {
+            "description": "What the agent should produce. Copied from the input event.",
+            "examples": [
+              "Produce a 2-page summary as summary.md"
+            ],
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for this event.",
+            "examples": [
+              "sevt_011CZkZSTx3lFgt7odUWmkyq"
+            ],
+            "type": "string"
+          },
+          "max_iterations": {
+            "description": "Evaluate-then-revise cycles before giving up. Default 3, max 20.",
+            "examples": [
+              3
+            ],
+            "format": "int32",
+            "nullable": true,
+            "type": "integer"
+          },
+          "outcome_id": {
+            "description": "Server-generated `outc_` ID for this outcome. Referenced by `span.outcome_evaluation_*` events and the session's `outcome_evaluations` list.",
+            "examples": [
+              "outc_011CZkZRSw2kEfs6ncTVljxP"
+            ],
+            "type": "string"
+          },
+          "processed_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "Timestamp when the outcome was accepted.",
+            "examples": [
+              "2026-03-15T10:02:14Z"
+            ]
+          },
+          "rubric": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsRubric"
+              }
+            ],
+            "description": "How to grade the outcome. File rubrics are currently resolved to their text content; clients should handle both variants.",
+            "examples": [
+              {
+                "content": "Must cover all five sections; cite sources inline.",
+                "type": "text"
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "user.define_outcome"
+            ],
+            "examples": [
+              "user.define_outcome"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "processed_at",
+          "outcome_id",
+          "description",
+          "max_iterations",
+          "rubric"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsUserDefineOutcomeEventParams": {
+        "additionalProperties": false,
+        "description": "Parameters for defining an outcome the agent should work toward. The agent begins work on receipt.",
+        "example": {
+          "description": "Produce a 2-page summary as summary.md",
+          "max_iterations": 3,
+          "rubric": {
+            "content": "Must cover all five sections; cite sources inline.",
+            "type": "text"
+          },
+          "type": "user.define_outcome"
+        },
+        "properties": {
+          "description": {
+            "description": "What the agent should produce. This is the task specification.",
+            "examples": [
+              "Produce a 2-page summary as summary.md"
+            ],
+            "type": "string"
+          },
+          "max_iterations": {
+            "description": "Eval\u2192revision cycles before giving up. Default 3, max 20.",
+            "examples": [
+              3
+            ],
+            "format": "int32",
+            "nullable": true,
+            "type": "integer"
+          },
+          "rubric": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsRubricParams"
+              }
+            ],
+            "description": "How to grade the outcome. Text or file reference.",
+            "examples": [
+              {
+                "content": "Must cover all five sections; cite sources inline.",
+                "type": "text"
+              }
+            ]
+          },
+          "type": {
+            "enum": [
+              "user.define_outcome"
+            ],
+            "examples": [
+              "user.define_outcome"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "description",
+          "rubric"
+        ],
+        "type": "object"
+      },
       "BetaManagedAgentsUserInterruptEvent": {
         "additionalProperties": false,
         "description": "An interrupt event that pauses agent execution and returns control to the user.",
@@ -11410,6 +13867,11 @@
             ],
             "description": "Timestamp when the interrupt was processed.",
             "nullable": true
+          },
+          "session_thread_id": {
+            "description": "If absent, interrupts every non-archived thread in a multiagent session (or the primary alone in a single-agent session). If present, interrupts only the named thread.",
+            "nullable": true,
+            "type": "string"
           },
           "type": {
             "enum": [
@@ -11428,6 +13890,11 @@
         "additionalProperties": false,
         "description": "Parameters for sending an interrupt to pause the agent.",
         "properties": {
+          "session_thread_id": {
+            "description": "If absent, interrupts every non-archived thread in a multiagent session (or the primary alone in a single-agent session). If present, interrupts only the named thread.",
+            "nullable": true,
+            "type": "string"
+          },
           "type": {
             "enum": [
               "user.interrupt"
@@ -11580,6 +14047,11 @@
               }
             ],
             "description": "The confirmation result: 'allow' or 'deny'."
+          },
+          "session_thread_id": {
+            "description": "When set, the confirmation routes to this subagent's thread rather than the primary. Echo this from the `session_thread_id` on the `agent.tool_use` or `agent.mcp_tool_use` event that prompted the approval.",
+            "nullable": true,
+            "type": "string"
           },
           "tool_use_id": {
             "description": "The id of the `agent.tool_use` or `agent.mcp_tool_use` event this result corresponds to, which can be found in the last `session.status_idle` [event's](https://platform.claude.com/docs/en/api/beta/sessions/events/list#beta_managed_agents_session_requires_action.event_ids) `stop_reason.event_ids` field.",
@@ -12894,7 +15366,7 @@
                 "type": "null"
               }
             ],
-            "description": "How much effort the model should put into its response. Higher effort levels may result in more thorough analysis but take longer.\n\nValid values are `low`, `medium`, `high`, or `max`."
+            "description": "How much effort the model should put into its response. Higher effort levels may result in more thorough analysis but take longer.\n\nValid values are `low`, `medium`, `high`, `xhigh`, or `max`."
           },
           "format": {
             "anyOf": [
@@ -13979,6 +16451,7 @@
         "additionalProperties": false,
         "properties": {
           "cited_text": {
+            "description": "The full text of the cited block range, concatenated.\n\nAlways equals the contents of `content[start_block_index:end_block_index]` joined together. The text block is the minimal citable unit; this field is never a substring of a single block. Not counted toward output tokens, and not counted toward input tokens when sent back in subsequent turns.",
             "title": "Cited Text",
             "type": "string"
           },
@@ -14001,10 +16474,12 @@
             "title": "Document Title"
           },
           "end_block_index": {
+            "description": "Exclusive 0-based end index of the cited block range in the source's `content` array.\n\nAlways greater than `start_block_index`; a single-block citation has `end_block_index = start_block_index + 1`.",
             "title": "End Block Index",
             "type": "integer"
           },
           "start_block_index": {
+            "description": "0-based index of the first cited block in the source's `content` array.",
             "minimum": 0,
             "title": "Start Block Index",
             "type": "integer"
@@ -14620,14 +17095,17 @@
         "additionalProperties": false,
         "properties": {
           "cited_text": {
+            "description": "The full text of the cited block range, concatenated.\n\nAlways equals the contents of `content[start_block_index:end_block_index]` joined together. The text block is the minimal citable unit; this field is never a substring of a single block. Not counted toward output tokens, and not counted toward input tokens when sent back in subsequent turns.",
             "title": "Cited Text",
             "type": "string"
           },
           "end_block_index": {
+            "description": "Exclusive 0-based end index of the cited block range in the source's `content` array.\n\nAlways greater than `start_block_index`; a single-block citation has `end_block_index = start_block_index + 1`.",
             "title": "End Block Index",
             "type": "integer"
           },
           "search_result_index": {
+            "description": "0-based index of the cited search result among all `search_result` content blocks in the request, in the order they appear across messages and tool results.\n\nCounted separately from `document_index`; server-side web search results are not included in this count.",
             "minimum": 0,
             "title": "Search Result Index",
             "type": "integer"
@@ -14637,6 +17115,7 @@
             "type": "string"
           },
           "start_block_index": {
+            "description": "0-based index of the first cited block in the source's `content` array.",
             "minimum": 0,
             "title": "Start Block Index",
             "type": "integer"
@@ -16282,6 +18761,7 @@
       "BetaResponseContentBlockLocationCitation": {
         "properties": {
           "cited_text": {
+            "description": "The full text of the cited block range, concatenated.\n\nAlways equals the contents of `content[start_block_index:end_block_index]` joined together. The text block is the minimal citable unit; this field is never a substring of a single block. Not counted toward output tokens, and not counted toward input tokens when sent back in subsequent turns.",
             "title": "Cited Text",
             "type": "string"
           },
@@ -16302,6 +18782,7 @@
             "title": "Document Title"
           },
           "end_block_index": {
+            "description": "Exclusive 0-based end index of the cited block range in the source's `content` array.\n\nAlways greater than `start_block_index`; a single-block citation has `end_block_index = start_block_index + 1`.",
             "title": "End Block Index",
             "type": "integer"
           },
@@ -16318,6 +18799,7 @@
             "title": "File Id"
           },
           "start_block_index": {
+            "description": "0-based index of the first cited block in the source's `content` array.",
             "minimum": 0,
             "title": "Start Block Index",
             "type": "integer"
@@ -16640,14 +19122,17 @@
       "BetaResponseSearchResultLocationCitation": {
         "properties": {
           "cited_text": {
+            "description": "The full text of the cited block range, concatenated.\n\nAlways equals the contents of `content[start_block_index:end_block_index]` joined together. The text block is the minimal citable unit; this field is never a substring of a single block. Not counted toward output tokens, and not counted toward input tokens when sent back in subsequent turns.",
             "title": "Cited Text",
             "type": "string"
           },
           "end_block_index": {
+            "description": "Exclusive 0-based end index of the cited block range in the source's `content` array.\n\nAlways greater than `start_block_index`; a single-block citation has `end_block_index = start_block_index + 1`.",
             "title": "End Block Index",
             "type": "integer"
           },
           "search_result_index": {
+            "description": "0-based index of the cited search result among all `search_result` content blocks in the request, in the order they appear across messages and tool results.\n\nCounted separately from `document_index`; server-side web search results are not included in this count.",
             "minimum": 0,
             "title": "Search Result Index",
             "type": "integer"
@@ -16657,6 +19142,7 @@
             "type": "string"
           },
           "start_block_index": {
+            "description": "0-based index of the first cited block in the source's `content` array.",
             "minimum": 0,
             "title": "Start Block Index",
             "type": "integer"
@@ -18884,6 +21370,22 @@
             },
             "description": "Key-value pairs to merge into the stored metadata. Keys provided overwrite existing values. To remove a key, set its value to an empty string. Keys not provided are left unchanged. Maximum 16 keys, with keys up to 64 characters and values up to 512 characters.",
             "type": "object"
+          },
+          "name": {
+            "description": "If present, replaces the stored name. Omit to leave unchanged. Maximum 255 characters.",
+            "maxLength": 255,
+            "minLength": 1,
+            "nullable": true,
+            "type": "string"
+          },
+          "relationship": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaUserProfileRelationship"
+              }
+            ],
+            "description": "If present, replaces the stored relationship. Omit to leave unchanged.",
+            "nullable": true
           }
         },
         "type": "object"
@@ -19126,6 +21628,8 @@
           "external_id": "user_12345",
           "id": "uprof_011CZkZCu8hGbp5mYRQgUmz9",
           "metadata": {},
+          "name": "Example User",
+          "relationship": "external",
           "trust_grants": {
             "cyber": {
               "status": "active"
@@ -19171,6 +21675,25 @@
             ],
             "type": "object"
           },
+          "name": {
+            "description": "Display name of the entity this profile represents. For `resold` this is the resold-to company's name.",
+            "examples": [
+              "Example User"
+            ],
+            "nullable": true,
+            "type": "string"
+          },
+          "relationship": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaUserProfileRelationship"
+              }
+            ],
+            "description": "How the entity relates to the platform. `external` (default), `resold`, or `internal`.",
+            "examples": [
+              "external"
+            ]
+          },
           "trust_grants": {
             "additionalProperties": {
               "$ref": "#/components/schemas/BetaUserProfileTrustGrant"
@@ -19210,6 +21733,7 @@
         "required": [
           "id",
           "type",
+          "relationship",
           "trust_grants",
           "created_at",
           "metadata",
@@ -19222,6 +21746,15 @@
         "enum": [
           "asc",
           "desc"
+        ],
+        "type": "string"
+      },
+      "BetaUserProfileRelationship": {
+        "description": "How the entity behind a user profile relates to the platform that owns the API key. `external`: an individual end-user of the platform. `resold`: a company the platform resells Claude access to. `internal`: the platform's own usage.",
+        "enum": [
+          "external",
+          "resold",
+          "internal"
         ],
         "type": "string"
       },
@@ -19895,6 +22428,789 @@
         "title": "WebSearchTool_20260209",
         "type": "object"
       },
+      "BetaWebhookEvent": {
+        "example": {
+          "created_at": "2026-03-15T10:00:00Z",
+          "data": {
+            "id": "sesn_011CZkZAtmR3yMPDzynEDxu7",
+            "organization_id": "org_011CZkZZAe0sMna4vkBdtrfx",
+            "type": "session.status_idled",
+            "workspace_id": "wrkspc_011CZkZaBF1tNoB5wlCeusgy"
+          },
+          "id": "wevt_011CZkZYZd9rLmz3ujAcsqEw",
+          "type": "event"
+        },
+        "properties": {
+          "created_at": {
+            "description": "RFC 3339 timestamp when the event occurred.",
+            "examples": [
+              "2026-03-15T10:00:00Z"
+            ],
+            "format": "date-time",
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/components/schemas/BetaWebhookEventData",
+            "examples": [
+              {
+                "id": "sesn_011CZkZAtmR3yMPDzynEDxu7",
+                "organization_id": "org_011CZkZZAe0sMna4vkBdtrfx",
+                "type": "session.status_idled",
+                "workspace_id": "wrkspc_011CZkZaBF1tNoB5wlCeusgy"
+              }
+            ]
+          },
+          "id": {
+            "description": "Unique event identifier for idempotency.",
+            "examples": [
+              "wevt_011CZkZYZd9rLmz3ujAcsqEw"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "const": "event",
+            "description": "Object type. Always `event` for webhook payloads.",
+            "examples": [
+              "event"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "created_at",
+          "data"
+        ],
+        "title": "BetaWebhookEvent",
+        "type": "object"
+      },
+      "BetaWebhookEventData": {
+        "discriminator": {
+          "mapping": {
+            "session.archived": "#/components/schemas/BetaWebhookSessionArchivedEventData",
+            "session.created": "#/components/schemas/BetaWebhookSessionCreatedEventData",
+            "session.deleted": "#/components/schemas/BetaWebhookSessionDeletedEventData",
+            "session.idled": "#/components/schemas/BetaWebhookSessionIdledEventData",
+            "session.outcome_evaluation_ended": "#/components/schemas/BetaWebhookSessionOutcomeEvaluationEndedEventData",
+            "session.pending": "#/components/schemas/BetaWebhookSessionPendingEventData",
+            "session.requires_action": "#/components/schemas/BetaWebhookSessionRequiresActionEventData",
+            "session.running": "#/components/schemas/BetaWebhookSessionRunningEventData",
+            "session.status_idled": "#/components/schemas/BetaWebhookSessionStatusIdledEventData",
+            "session.status_rescheduled": "#/components/schemas/BetaWebhookSessionStatusRescheduledEventData",
+            "session.status_run_started": "#/components/schemas/BetaWebhookSessionStatusRunStartedEventData",
+            "session.status_terminated": "#/components/schemas/BetaWebhookSessionStatusTerminatedEventData",
+            "session.thread_created": "#/components/schemas/BetaWebhookSessionThreadCreatedEventData",
+            "session.thread_idled": "#/components/schemas/BetaWebhookSessionThreadIdledEventData",
+            "session.thread_terminated": "#/components/schemas/BetaWebhookSessionThreadTerminatedEventData",
+            "vault.archived": "#/components/schemas/BetaWebhookVaultArchivedEventData",
+            "vault.created": "#/components/schemas/BetaWebhookVaultCreatedEventData",
+            "vault.deleted": "#/components/schemas/BetaWebhookVaultDeletedEventData",
+            "vault_credential.archived": "#/components/schemas/BetaWebhookVaultCredentialArchivedEventData",
+            "vault_credential.created": "#/components/schemas/BetaWebhookVaultCredentialCreatedEventData",
+            "vault_credential.deleted": "#/components/schemas/BetaWebhookVaultCredentialDeletedEventData",
+            "vault_credential.refresh_failed": "#/components/schemas/BetaWebhookVaultCredentialRefreshFailedEventData"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BetaWebhookSessionCreatedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookSessionPendingEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookSessionRunningEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookSessionIdledEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookSessionRequiresActionEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookSessionArchivedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookSessionDeletedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookSessionStatusRescheduledEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookSessionStatusRunStartedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookSessionStatusIdledEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookSessionStatusTerminatedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookSessionThreadCreatedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookSessionThreadIdledEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookSessionThreadTerminatedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookSessionOutcomeEvaluationEndedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookVaultCreatedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookVaultArchivedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookVaultDeletedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookVaultCredentialCreatedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookVaultCredentialArchivedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookVaultCredentialDeletedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookVaultCredentialRefreshFailedEventData"
+          }
+        ],
+        "title": "BetaWebhookEventData"
+      },
+      "BetaWebhookSessionArchivedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "session.archived",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookSessionArchivedEventData",
+        "type": "object"
+      },
+      "BetaWebhookSessionCreatedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "session.created",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookSessionCreatedEventData",
+        "type": "object"
+      },
+      "BetaWebhookSessionDeletedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "session.deleted",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookSessionDeletedEventData",
+        "type": "object"
+      },
+      "BetaWebhookSessionIdledEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "session.idled",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookSessionIdledEventData",
+        "type": "object"
+      },
+      "BetaWebhookSessionOutcomeEvaluationEndedEventData": {
+        "example": {
+          "id": "sesn_011CZkZAtmR3yMPDzynEDxu7",
+          "organization_id": "org_011CZkZZAe0sMna4vkBdtrfx",
+          "type": "session.outcome_evaluation_ended",
+          "workspace_id": "wrkspc_011CZkZaBF1tNoB5wlCeusgy"
+        },
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "examples": [
+              "sesn_011CZkZAtmR3yMPDzynEDxu7"
+            ],
+            "type": "string"
+          },
+          "organization_id": {
+            "examples": [
+              "org_011CZkZZAe0sMna4vkBdtrfx"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "const": "session.outcome_evaluation_ended",
+            "examples": [
+              "session.outcome_evaluation_ended"
+            ],
+            "type": "string"
+          },
+          "workspace_id": {
+            "examples": [
+              "wrkspc_011CZkZaBF1tNoB5wlCeusgy"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookSessionOutcomeEvaluationEndedEventData",
+        "type": "object"
+      },
+      "BetaWebhookSessionPendingEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "session.pending",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookSessionPendingEventData",
+        "type": "object"
+      },
+      "BetaWebhookSessionRequiresActionEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "session.requires_action",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookSessionRequiresActionEventData",
+        "type": "object"
+      },
+      "BetaWebhookSessionRunningEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "session.running",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookSessionRunningEventData",
+        "type": "object"
+      },
+      "BetaWebhookSessionStatusIdledEventData": {
+        "example": {
+          "id": "sesn_011CZkZAtmR3yMPDzynEDxu7",
+          "organization_id": "org_011CZkZZAe0sMna4vkBdtrfx",
+          "type": "session.status_idled",
+          "workspace_id": "wrkspc_011CZkZaBF1tNoB5wlCeusgy"
+        },
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "examples": [
+              "sesn_011CZkZAtmR3yMPDzynEDxu7"
+            ],
+            "type": "string"
+          },
+          "organization_id": {
+            "examples": [
+              "org_011CZkZZAe0sMna4vkBdtrfx"
+            ],
+            "type": "string"
+          },
+          "type": {
+            "const": "session.status_idled",
+            "examples": [
+              "session.status_idled"
+            ],
+            "type": "string"
+          },
+          "workspace_id": {
+            "examples": [
+              "wrkspc_011CZkZaBF1tNoB5wlCeusgy"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookSessionStatusIdledEventData",
+        "type": "object"
+      },
+      "BetaWebhookSessionStatusRescheduledEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "session.status_rescheduled",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookSessionStatusRescheduledEventData",
+        "type": "object"
+      },
+      "BetaWebhookSessionStatusRunStartedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "session.status_run_started",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookSessionStatusRunStartedEventData",
+        "type": "object"
+      },
+      "BetaWebhookSessionStatusTerminatedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "session.status_terminated",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookSessionStatusTerminatedEventData",
+        "type": "object"
+      },
+      "BetaWebhookSessionThreadCreatedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "session.thread_created",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookSessionThreadCreatedEventData",
+        "type": "object"
+      },
+      "BetaWebhookSessionThreadIdledEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "session.thread_idled",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookSessionThreadIdledEventData",
+        "type": "object"
+      },
+      "BetaWebhookSessionThreadTerminatedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "session.thread_terminated",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookSessionThreadTerminatedEventData",
+        "type": "object"
+      },
+      "BetaWebhookVaultArchivedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "vault.archived",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookVaultArchivedEventData",
+        "type": "object"
+      },
+      "BetaWebhookVaultCreatedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "vault.created",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookVaultCreatedEventData",
+        "type": "object"
+      },
+      "BetaWebhookVaultCredentialArchivedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "vault_credential.archived",
+            "type": "string"
+          },
+          "vault_id": {
+            "description": "ID of the vault that owns this credential.",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id",
+          "vault_id"
+        ],
+        "title": "BetaWebhookVaultCredentialArchivedEventData",
+        "type": "object"
+      },
+      "BetaWebhookVaultCredentialCreatedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "vault_credential.created",
+            "type": "string"
+          },
+          "vault_id": {
+            "description": "ID of the vault that owns this credential.",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id",
+          "vault_id"
+        ],
+        "title": "BetaWebhookVaultCredentialCreatedEventData",
+        "type": "object"
+      },
+      "BetaWebhookVaultCredentialDeletedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "vault_credential.deleted",
+            "type": "string"
+          },
+          "vault_id": {
+            "description": "ID of the vault that owns this credential.",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id",
+          "vault_id"
+        ],
+        "title": "BetaWebhookVaultCredentialDeletedEventData",
+        "type": "object"
+      },
+      "BetaWebhookVaultCredentialRefreshFailedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "vault_credential.refresh_failed",
+            "type": "string"
+          },
+          "vault_id": {
+            "description": "ID of the vault that owns this credential.",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id",
+          "vault_id"
+        ],
+        "title": "BetaWebhookVaultCredentialRefreshFailedEventData",
+        "type": "object"
+      },
+      "BetaWebhookVaultDeletedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the resource that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "vault.deleted",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookVaultDeletedEventData",
+        "type": "object"
+      },
       "Betaapi__schemas__skills__Skill": {
         "properties": {
           "created_at": {
@@ -19997,68 +23313,6 @@
           "type"
         ],
         "title": "BillingError",
-        "type": "object"
-      },
-      "Body_create_skill_v1_skills_post": {
-        "properties": {
-          "display_title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Display title for the skill.\n\nThis is a human-readable label that is not included in the prompt sent to the model.",
-            "title": "Display Title"
-          },
-          "files": {
-            "anyOf": [
-              {
-                "items": {
-                  "format": "binary",
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null",
-                "x-stainless-skip": [
-                  "cli"
-                ]
-              }
-            ],
-            "description": "Files to upload for the skill.\n\nAll files must be in the same top-level directory and must include a SKILL.md file at the root of that directory.",
-            "title": "Files"
-          }
-        },
-        "title": "Body_create_skill_v1_skills_post",
-        "type": "object"
-      },
-      "Body_create_skill_version_v1_skills__skill_id__versions_post": {
-        "properties": {
-          "files": {
-            "anyOf": [
-              {
-                "items": {
-                  "format": "binary",
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null",
-                "x-stainless-skip": [
-                  "cli"
-                ]
-              }
-            ],
-            "description": "Files to upload for the skill.\n\nAll files must be in the same top-level directory and must include a SKILL.md file at the root of that directory.",
-            "title": "Files"
-          }
-        },
-        "title": "Body_create_skill_version_v1_skills__skill_id__versions_post",
         "type": "object"
       },
       "CacheControlEphemeral": {
@@ -21150,11 +24404,11 @@
             "title": "Inference Geo"
           },
           "max_tokens": {
-            "description": "The maximum number of tokens to generate before stopping.\n\nNote that our models may stop _before_ reaching this maximum. This parameter only specifies the absolute maximum number of tokens to generate.\n\nDifferent models have different maximum values for this parameter.  See [models](https://docs.claude.com/en/docs/models-overview) for details.",
+            "description": "The maximum number of tokens to generate before stopping.\n\nNote that our models may stop _before_ reaching this maximum. This parameter only specifies the absolute maximum number of tokens to generate.\n\nSet to `0` to populate the [prompt cache](https://docs.claude.com/en/docs/build-with-claude/prompt-caching#pre-warming-the-cache) without generating a response.\n\nDifferent models have different maximum values for this parameter.  See [models](https://docs.claude.com/en/docs/models-overview) for details.",
             "examples": [
               1024
             ],
-            "minimum": 1,
+            "minimum": 0,
             "title": "Max Tokens",
             "type": "integer"
           },
@@ -21415,11 +24669,11 @@
             "title": "Inference Geo"
           },
           "max_tokens": {
-            "description": "The maximum number of tokens to generate before stopping.\n\nNote that our models may stop _before_ reaching this maximum. This parameter only specifies the absolute maximum number of tokens to generate.\n\nDifferent models have different maximum values for this parameter.  See [models](https://docs.claude.com/en/docs/models-overview) for details.",
+            "description": "The maximum number of tokens to generate before stopping.\n\nNote that our models may stop _before_ reaching this maximum. This parameter only specifies the absolute maximum number of tokens to generate.\n\nSet to `0` to populate the [prompt cache](https://docs.claude.com/en/docs/build-with-claude/prompt-caching#pre-warming-the-cache) without generating a response.\n\nDifferent models have different maximum values for this parameter.  See [models](https://docs.claude.com/en/docs/models-overview) for details.",
             "examples": [
               1024
             ],
-            "minimum": 1,
+            "minimum": 0,
             "title": "Max Tokens",
             "type": "integer"
           },
@@ -21612,167 +24866,6 @@
         "title": "CreateMessageParams",
         "type": "object"
       },
-      "CreateSkillResponse": {
-        "properties": {
-          "created_at": {
-            "description": "ISO 8601 timestamp of when the skill was created.",
-            "examples": [
-              "2024-10-30T23:58:27.427722Z"
-            ],
-            "title": "Created At",
-            "type": "string"
-          },
-          "display_title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Display title for the skill.\n\nThis is a human-readable label that is not included in the prompt sent to the model.",
-            "examples": [
-              "My Custom Skill"
-            ],
-            "title": "Display Title"
-          },
-          "id": {
-            "description": "Unique identifier for the skill.\n\nThe format and length of IDs may change over time.",
-            "examples": [
-              "skill_01JAbcdefghijklmnopqrstuvw"
-            ],
-            "title": "Id",
-            "type": "string"
-          },
-          "latest_version": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The latest version identifier for the skill.\n\nThis represents the most recent version of the skill that has been created.",
-            "examples": [
-              "1759178010641129"
-            ],
-            "title": "Latest Version"
-          },
-          "source": {
-            "description": "Source of the skill.\n\nThis may be one of the following values:\n* `\"custom\"`: the skill was created by a user\n* `\"anthropic\"`: the skill was created by Anthropic",
-            "examples": [
-              "custom"
-            ],
-            "title": "Source",
-            "type": "string"
-          },
-          "type": {
-            "default": "skill",
-            "description": "Object type.\n\nFor Skills, this is always `\"skill\"`.",
-            "title": "Type",
-            "type": "string"
-          },
-          "updated_at": {
-            "description": "ISO 8601 timestamp of when the skill was last updated.",
-            "examples": [
-              "2024-10-30T23:58:27.427722Z"
-            ],
-            "title": "Updated At",
-            "type": "string"
-          }
-        },
-        "required": [
-          "created_at",
-          "display_title",
-          "id",
-          "latest_version",
-          "source",
-          "type",
-          "updated_at"
-        ],
-        "title": "CreateSkillResponse",
-        "type": "object"
-      },
-      "CreateSkillVersionResponse": {
-        "properties": {
-          "created_at": {
-            "description": "ISO 8601 timestamp of when the skill version was created.",
-            "examples": [
-              "2024-10-30T23:58:27.427722Z"
-            ],
-            "title": "Created At",
-            "type": "string"
-          },
-          "description": {
-            "description": "Description of the skill version.\n\nThis is extracted from the SKILL.md file in the skill upload.",
-            "examples": [
-              "A custom skill for doing something useful"
-            ],
-            "title": "Description",
-            "type": "string"
-          },
-          "directory": {
-            "description": "Directory name of the skill version.\n\nThis is the top-level directory name that was extracted from the uploaded files.",
-            "examples": [
-              "my-skill"
-            ],
-            "title": "Directory",
-            "type": "string"
-          },
-          "id": {
-            "description": "Unique identifier for the skill version.\n\nThe format and length of IDs may change over time.",
-            "examples": [
-              "skillver_01JAbcdefghijklmnopqrstuvw"
-            ],
-            "title": "Id",
-            "type": "string"
-          },
-          "name": {
-            "description": "Human-readable name of the skill version.\n\nThis is extracted from the SKILL.md file in the skill upload.",
-            "examples": [
-              "my-skill"
-            ],
-            "title": "Name",
-            "type": "string"
-          },
-          "skill_id": {
-            "description": "Identifier for the skill that this version belongs to.",
-            "examples": [
-              "skill_01JAbcdefghijklmnopqrstuvw"
-            ],
-            "title": "Skill Id",
-            "type": "string"
-          },
-          "type": {
-            "default": "skill_version",
-            "description": "Object type.\n\nFor Skill Versions, this is always `\"skill_version\"`.",
-            "title": "Type",
-            "type": "string"
-          },
-          "version": {
-            "description": "Version identifier for the skill.\n\nEach version is identified by a Unix epoch timestamp (e.g., \"1759178010641129\").",
-            "examples": [
-              "1759178010641129"
-            ],
-            "title": "Version",
-            "type": "string"
-          }
-        },
-        "required": [
-          "created_at",
-          "description",
-          "directory",
-          "id",
-          "name",
-          "skill_id",
-          "type",
-          "version"
-        ],
-        "title": "CreateSkillVersionResponse",
-        "type": "object"
-      },
       "DeleteMessageBatchResponse": {
         "properties": {
           "id": {
@@ -21796,54 +24889,6 @@
           "type"
         ],
         "title": "DeleteMessageBatchResponse",
-        "type": "object"
-      },
-      "DeleteSkillResponse": {
-        "properties": {
-          "id": {
-            "description": "Unique identifier for the skill.\n\nThe format and length of IDs may change over time.",
-            "examples": [
-              "skill_01JAbcdefghijklmnopqrstuvw"
-            ],
-            "title": "Id",
-            "type": "string"
-          },
-          "type": {
-            "default": "skill_deleted",
-            "description": "Deleted object type.\n\nFor Skills, this is always `\"skill_deleted\"`.",
-            "title": "Type",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "type"
-        ],
-        "title": "DeleteSkillResponse",
-        "type": "object"
-      },
-      "DeleteSkillVersionResponse": {
-        "properties": {
-          "id": {
-            "description": "Version identifier for the skill.\n\nEach version is identified by a Unix epoch timestamp (e.g., \"1759178010641129\").",
-            "examples": [
-              "1759178010641129"
-            ],
-            "title": "Id",
-            "type": "string"
-          },
-          "type": {
-            "default": "skill_version_deleted",
-            "description": "Deleted object type.\n\nFor Skill Versions, this is always `\"skill_version_deleted\"`.",
-            "title": "Type",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "type"
-        ],
-        "title": "DeleteSkillVersionResponse",
         "type": "object"
       },
       "DirectCaller": {
@@ -22045,158 +25090,6 @@
         "title": "ExpiredResult",
         "type": "object"
       },
-      "FileDeleteResponse": {
-        "properties": {
-          "id": {
-            "description": "ID of the deleted file.",
-            "examples": [
-              "file_011CNha8iCJcU1wXNR6q4V8w"
-            ],
-            "title": "Id",
-            "type": "string"
-          },
-          "type": {
-            "const": "file_deleted",
-            "default": "file_deleted",
-            "description": "Deleted object type.\n\nFor file deletion, this is always `\"file_deleted\"`.",
-            "title": "Type",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id"
-        ],
-        "title": "FileDeleteResponse",
-        "type": "object"
-      },
-      "FileListResponse": {
-        "properties": {
-          "data": {
-            "description": "List of file metadata objects.",
-            "items": {
-              "$ref": "#/components/schemas/FileMetadataSchema"
-            },
-            "title": "Data",
-            "type": "array"
-          },
-          "first_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "ID of the first file in this page of results.",
-            "examples": [
-              "file_011CNha8iCJcU1wXNR6q4V8w"
-            ],
-            "title": "First Id"
-          },
-          "has_more": {
-            "default": false,
-            "description": "Whether there are more results available.",
-            "title": "Has More",
-            "type": "boolean"
-          },
-          "last_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "ID of the last file in this page of results.",
-            "examples": [
-              "file_013Zva2CMHLNnXjNJJKqJ2EF"
-            ],
-            "title": "Last Id"
-          }
-        },
-        "required": [
-          "data"
-        ],
-        "title": "FileListResponse",
-        "type": "object"
-      },
-      "FileMetadataSchema": {
-        "properties": {
-          "created_at": {
-            "description": "RFC 3339 datetime string representing when the file was created.",
-            "examples": [
-              "2025-04-15T18:37:24.100435Z"
-            ],
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "downloadable": {
-            "default": false,
-            "description": "Whether the file can be downloaded.",
-            "examples": [
-              false
-            ],
-            "title": "Downloadable",
-            "type": "boolean"
-          },
-          "filename": {
-            "description": "Original filename of the uploaded file.",
-            "examples": [
-              "document.pdf"
-            ],
-            "maxLength": 500,
-            "minLength": 1,
-            "title": "Filename",
-            "type": "string"
-          },
-          "id": {
-            "description": "Unique object identifier.\n\nThe format and length of IDs may change over time.",
-            "examples": [
-              "file_011CNha8iCJcU1wXNR6q4V8w"
-            ],
-            "title": "Id",
-            "type": "string"
-          },
-          "mime_type": {
-            "description": "MIME type of the file.",
-            "examples": [
-              "application/pdf"
-            ],
-            "maxLength": 255,
-            "minLength": 1,
-            "title": "Mime Type",
-            "type": "string"
-          },
-          "size_bytes": {
-            "description": "Size of the file in bytes.",
-            "examples": [
-              102400
-            ],
-            "minimum": 0,
-            "title": "Size Bytes",
-            "type": "integer"
-          },
-          "type": {
-            "const": "file",
-            "description": "Object type.\n\nFor files, this is always `\"file\"`.",
-            "title": "Type",
-            "type": "string"
-          }
-        },
-        "required": [
-          "created_at",
-          "filename",
-          "id",
-          "mime_type",
-          "size_bytes",
-          "type"
-        ],
-        "title": "FileMetadataSchema",
-        "type": "object"
-      },
       "GatewayTimeoutError": {
         "properties": {
           "message": {
@@ -22216,167 +25109,6 @@
           "type"
         ],
         "title": "GatewayTimeoutError",
-        "type": "object"
-      },
-      "GetSkillResponse": {
-        "properties": {
-          "created_at": {
-            "description": "ISO 8601 timestamp of when the skill was created.",
-            "examples": [
-              "2024-10-30T23:58:27.427722Z"
-            ],
-            "title": "Created At",
-            "type": "string"
-          },
-          "display_title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Display title for the skill.\n\nThis is a human-readable label that is not included in the prompt sent to the model.",
-            "examples": [
-              "My Custom Skill"
-            ],
-            "title": "Display Title"
-          },
-          "id": {
-            "description": "Unique identifier for the skill.\n\nThe format and length of IDs may change over time.",
-            "examples": [
-              "skill_01JAbcdefghijklmnopqrstuvw"
-            ],
-            "title": "Id",
-            "type": "string"
-          },
-          "latest_version": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The latest version identifier for the skill.\n\nThis represents the most recent version of the skill that has been created.",
-            "examples": [
-              "1759178010641129"
-            ],
-            "title": "Latest Version"
-          },
-          "source": {
-            "description": "Source of the skill.\n\nThis may be one of the following values:\n* `\"custom\"`: the skill was created by a user\n* `\"anthropic\"`: the skill was created by Anthropic",
-            "examples": [
-              "custom"
-            ],
-            "title": "Source",
-            "type": "string"
-          },
-          "type": {
-            "default": "skill",
-            "description": "Object type.\n\nFor Skills, this is always `\"skill\"`.",
-            "title": "Type",
-            "type": "string"
-          },
-          "updated_at": {
-            "description": "ISO 8601 timestamp of when the skill was last updated.",
-            "examples": [
-              "2024-10-30T23:58:27.427722Z"
-            ],
-            "title": "Updated At",
-            "type": "string"
-          }
-        },
-        "required": [
-          "created_at",
-          "display_title",
-          "id",
-          "latest_version",
-          "source",
-          "type",
-          "updated_at"
-        ],
-        "title": "GetSkillResponse",
-        "type": "object"
-      },
-      "GetSkillVersionResponse": {
-        "properties": {
-          "created_at": {
-            "description": "ISO 8601 timestamp of when the skill version was created.",
-            "examples": [
-              "2024-10-30T23:58:27.427722Z"
-            ],
-            "title": "Created At",
-            "type": "string"
-          },
-          "description": {
-            "description": "Description of the skill version.\n\nThis is extracted from the SKILL.md file in the skill upload.",
-            "examples": [
-              "A custom skill for doing something useful"
-            ],
-            "title": "Description",
-            "type": "string"
-          },
-          "directory": {
-            "description": "Directory name of the skill version.\n\nThis is the top-level directory name that was extracted from the uploaded files.",
-            "examples": [
-              "my-skill"
-            ],
-            "title": "Directory",
-            "type": "string"
-          },
-          "id": {
-            "description": "Unique identifier for the skill version.\n\nThe format and length of IDs may change over time.",
-            "examples": [
-              "skillver_01JAbcdefghijklmnopqrstuvw"
-            ],
-            "title": "Id",
-            "type": "string"
-          },
-          "name": {
-            "description": "Human-readable name of the skill version.\n\nThis is extracted from the SKILL.md file in the skill upload.",
-            "examples": [
-              "my-skill"
-            ],
-            "title": "Name",
-            "type": "string"
-          },
-          "skill_id": {
-            "description": "Identifier for the skill that this version belongs to.",
-            "examples": [
-              "skill_01JAbcdefghijklmnopqrstuvw"
-            ],
-            "title": "Skill Id",
-            "type": "string"
-          },
-          "type": {
-            "default": "skill_version",
-            "description": "Object type.\n\nFor Skill Versions, this is always `\"skill_version\"`.",
-            "title": "Type",
-            "type": "string"
-          },
-          "version": {
-            "description": "Version identifier for the skill.\n\nEach version is identified by a Unix epoch timestamp (e.g., \"1759178010641129\").",
-            "examples": [
-              "1759178010641129"
-            ],
-            "title": "Version",
-            "type": "string"
-          }
-        },
-        "required": [
-          "created_at",
-          "description",
-          "directory",
-          "id",
-          "name",
-          "skill_id",
-          "type",
-          "version"
-        ],
-        "title": "GetSkillVersionResponse",
         "type": "object"
       },
       "InputContentBlock": {
@@ -22714,98 +25446,6 @@
           "last_id"
         ],
         "title": "ListResponse[ModelInfo]",
-        "type": "object"
-      },
-      "ListSkillVersionsResponse": {
-        "properties": {
-          "data": {
-            "description": "List of skill versions.",
-            "items": {
-              "$ref": "#/components/schemas/SkillVersion"
-            },
-            "title": "Data",
-            "type": "array",
-            "x-stainless-pagination-property": {
-              "purpose": "items"
-            }
-          },
-          "has_more": {
-            "description": "Indicates if there are more results in the requested page direction.",
-            "title": "Has More",
-            "type": "boolean"
-          },
-          "next_page": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Token to provide in as `page` in the subsequent request to retrieve the next page of data.",
-            "examples": [
-              "page_MjAyNS0wNS0xNFQwMDowMDowMFo=",
-              null
-            ],
-            "title": "Next Page",
-            "x-stainless-pagination-property": {
-              "purpose": "next_cursor_field"
-            }
-          }
-        },
-        "required": [
-          "data",
-          "has_more",
-          "next_page"
-        ],
-        "title": "ListSkillVersionsResponse",
-        "type": "object"
-      },
-      "ListSkillsResponse": {
-        "properties": {
-          "data": {
-            "description": "List of skills.",
-            "items": {
-              "$ref": "#/components/schemas/Skill"
-            },
-            "title": "Data",
-            "type": "array",
-            "x-stainless-pagination-property": {
-              "purpose": "items"
-            }
-          },
-          "has_more": {
-            "description": "Whether there are more results available.\n\nIf `true`, there are additional results that can be fetched using the `next_page` token.",
-            "title": "Has More",
-            "type": "boolean"
-          },
-          "next_page": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Token for fetching the next page of results.\n\nIf `null`, there are no more results available. Pass this value to the `page_token` parameter in the next request to get the next page.",
-            "examples": [
-              "page_MjAyNS0wNS0xNFQwMDowMDowMFo=",
-              null
-            ],
-            "title": "Next Page",
-            "x-stainless-pagination-property": {
-              "purpose": "next_cursor_field"
-            }
-          }
-        },
-        "required": [
-          "data",
-          "has_more",
-          "next_page"
-        ],
-        "title": "ListSkillsResponse",
         "type": "object"
       },
       "MemoryTool_20250818": {
@@ -23783,7 +26423,7 @@
                 "type": "null"
               }
             ],
-            "description": "How much effort the model should put into its response. Higher effort levels may result in more thorough analysis but take longer.\n\nValid values are `low`, `medium`, `high`, or `max`."
+            "description": "How much effort the model should put into its response. Higher effort levels may result in more thorough analysis but take longer.\n\nValid values are `low`, `medium`, `high`, `xhigh`, or `max`."
           },
           "format": {
             "anyOf": [
@@ -24313,6 +26953,7 @@
         "additionalProperties": false,
         "properties": {
           "cited_text": {
+            "description": "The full text of the cited block range, concatenated.\n\nAlways equals the contents of `content[start_block_index:end_block_index]` joined together. The text block is the minimal citable unit; this field is never a substring of a single block. Not counted toward output tokens, and not counted toward input tokens when sent back in subsequent turns.",
             "title": "Cited Text",
             "type": "string"
           },
@@ -24335,10 +26976,12 @@
             "title": "Document Title"
           },
           "end_block_index": {
+            "description": "Exclusive 0-based end index of the cited block range in the source's `content` array.\n\nAlways greater than `start_block_index`; a single-block citation has `end_block_index = start_block_index + 1`.",
             "title": "End Block Index",
             "type": "integer"
           },
           "start_block_index": {
+            "description": "0-based index of the first cited block in the source's `content` array.",
             "minimum": 0,
             "title": "Start Block Index",
             "type": "integer"
@@ -24745,14 +27388,17 @@
         "additionalProperties": false,
         "properties": {
           "cited_text": {
+            "description": "The full text of the cited block range, concatenated.\n\nAlways equals the contents of `content[start_block_index:end_block_index]` joined together. The text block is the minimal citable unit; this field is never a substring of a single block. Not counted toward output tokens, and not counted toward input tokens when sent back in subsequent turns.",
             "title": "Cited Text",
             "type": "string"
           },
           "end_block_index": {
+            "description": "Exclusive 0-based end index of the cited block range in the source's `content` array.\n\nAlways greater than `start_block_index`; a single-block citation has `end_block_index = start_block_index + 1`.",
             "title": "End Block Index",
             "type": "integer"
           },
           "search_result_index": {
+            "description": "0-based index of the cited search result among all `search_result` content blocks in the request, in the order they appear across messages and tool results.\n\nCounted separately from `document_index`; server-side web search results are not included in this count.",
             "minimum": 0,
             "title": "Search Result Index",
             "type": "integer"
@@ -24762,6 +27408,7 @@
             "type": "string"
           },
           "start_block_index": {
+            "description": "0-based index of the first cited block in the source's `content` array.",
             "minimum": 0,
             "title": "Start Block Index",
             "type": "integer"
@@ -26207,6 +28854,7 @@
       "ResponseContentBlockLocationCitation": {
         "properties": {
           "cited_text": {
+            "description": "The full text of the cited block range, concatenated.\n\nAlways equals the contents of `content[start_block_index:end_block_index]` joined together. The text block is the minimal citable unit; this field is never a substring of a single block. Not counted toward output tokens, and not counted toward input tokens when sent back in subsequent turns.",
             "title": "Cited Text",
             "type": "string"
           },
@@ -26227,6 +28875,7 @@
             "title": "Document Title"
           },
           "end_block_index": {
+            "description": "Exclusive 0-based end index of the cited block range in the source's `content` array.\n\nAlways greater than `start_block_index`; a single-block citation has `end_block_index = start_block_index + 1`.",
             "title": "End Block Index",
             "type": "integer"
           },
@@ -26243,6 +28892,7 @@
             "title": "File Id"
           },
           "start_block_index": {
+            "description": "0-based index of the first cited block in the source's `content` array.",
             "minimum": 0,
             "title": "Start Block Index",
             "type": "integer"
@@ -26451,14 +29101,17 @@
       "ResponseSearchResultLocationCitation": {
         "properties": {
           "cited_text": {
+            "description": "The full text of the cited block range, concatenated.\n\nAlways equals the contents of `content[start_block_index:end_block_index]` joined together. The text block is the minimal citable unit; this field is never a substring of a single block. Not counted toward output tokens, and not counted toward input tokens when sent back in subsequent turns.",
             "title": "Cited Text",
             "type": "string"
           },
           "end_block_index": {
+            "description": "Exclusive 0-based end index of the cited block range in the source's `content` array.\n\nAlways greater than `start_block_index`; a single-block citation has `end_block_index = start_block_index + 1`.",
             "title": "End Block Index",
             "type": "integer"
           },
           "search_result_index": {
+            "description": "0-based index of the cited search result among all `search_result` content blocks in the request, in the order they appear across messages and tool results.\n\nCounted separately from `document_index`; server-side web search results are not included in this count.",
             "minimum": 0,
             "title": "Search Result Index",
             "type": "integer"
@@ -26468,6 +29121,7 @@
             "type": "string"
           },
           "start_block_index": {
+            "description": "0-based index of the first cited block in the source's `content` array.",
             "minimum": 0,
             "title": "Start Block Index",
             "type": "integer"
@@ -27447,167 +30101,6 @@
           "type"
         ],
         "title": "SignatureContentBlockDelta",
-        "type": "object"
-      },
-      "Skill": {
-        "properties": {
-          "created_at": {
-            "description": "ISO 8601 timestamp of when the skill was created.",
-            "examples": [
-              "2024-10-30T23:58:27.427722Z"
-            ],
-            "title": "Created At",
-            "type": "string"
-          },
-          "display_title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Display title for the skill.\n\nThis is a human-readable label that is not included in the prompt sent to the model.",
-            "examples": [
-              "My Custom Skill"
-            ],
-            "title": "Display Title"
-          },
-          "id": {
-            "description": "Unique identifier for the skill.\n\nThe format and length of IDs may change over time.",
-            "examples": [
-              "skill_01JAbcdefghijklmnopqrstuvw"
-            ],
-            "title": "Id",
-            "type": "string"
-          },
-          "latest_version": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The latest version identifier for the skill.\n\nThis represents the most recent version of the skill that has been created.",
-            "examples": [
-              "1759178010641129"
-            ],
-            "title": "Latest Version"
-          },
-          "source": {
-            "description": "Source of the skill.\n\nThis may be one of the following values:\n* `\"custom\"`: the skill was created by a user\n* `\"anthropic\"`: the skill was created by Anthropic",
-            "examples": [
-              "custom"
-            ],
-            "title": "Source",
-            "type": "string"
-          },
-          "type": {
-            "default": "skill",
-            "description": "Object type.\n\nFor Skills, this is always `\"skill\"`.",
-            "title": "Type",
-            "type": "string"
-          },
-          "updated_at": {
-            "description": "ISO 8601 timestamp of when the skill was last updated.",
-            "examples": [
-              "2024-10-30T23:58:27.427722Z"
-            ],
-            "title": "Updated At",
-            "type": "string"
-          }
-        },
-        "required": [
-          "created_at",
-          "display_title",
-          "id",
-          "latest_version",
-          "source",
-          "type",
-          "updated_at"
-        ],
-        "title": "Skill",
-        "type": "object"
-      },
-      "SkillVersion": {
-        "properties": {
-          "created_at": {
-            "description": "ISO 8601 timestamp of when the skill version was created.",
-            "examples": [
-              "2024-10-30T23:58:27.427722Z"
-            ],
-            "title": "Created At",
-            "type": "string"
-          },
-          "description": {
-            "description": "Description of the skill version.\n\nThis is extracted from the SKILL.md file in the skill upload.",
-            "examples": [
-              "A custom skill for doing something useful"
-            ],
-            "title": "Description",
-            "type": "string"
-          },
-          "directory": {
-            "description": "Directory name of the skill version.\n\nThis is the top-level directory name that was extracted from the uploaded files.",
-            "examples": [
-              "my-skill"
-            ],
-            "title": "Directory",
-            "type": "string"
-          },
-          "id": {
-            "description": "Unique identifier for the skill version.\n\nThe format and length of IDs may change over time.",
-            "examples": [
-              "skillver_01JAbcdefghijklmnopqrstuvw"
-            ],
-            "title": "Id",
-            "type": "string"
-          },
-          "name": {
-            "description": "Human-readable name of the skill version.\n\nThis is extracted from the SKILL.md file in the skill upload.",
-            "examples": [
-              "my-skill"
-            ],
-            "title": "Name",
-            "type": "string"
-          },
-          "skill_id": {
-            "description": "Identifier for the skill that this version belongs to.",
-            "examples": [
-              "skill_01JAbcdefghijklmnopqrstuvw"
-            ],
-            "title": "Skill Id",
-            "type": "string"
-          },
-          "type": {
-            "default": "skill_version",
-            "description": "Object type.\n\nFor Skill Versions, this is always `\"skill_version\"`.",
-            "title": "Type",
-            "type": "string"
-          },
-          "version": {
-            "description": "Version identifier for the skill.\n\nEach version is identified by a Unix epoch timestamp (e.g., \"1759178010641129\").",
-            "examples": [
-              "1759178010641129"
-            ],
-            "title": "Version",
-            "type": "string"
-          }
-        },
-        "required": [
-          "created_at",
-          "description",
-          "directory",
-          "id",
-          "name",
-          "skill_id",
-          "type",
-          "version"
-        ],
-        "title": "SkillVersion",
         "type": "object"
       },
       "StopReason": {
@@ -30055,7 +32548,8 @@
             "name": "agent_id",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-stainless-cli-data-alias": "id"
             }
           }
         ],
@@ -31035,7 +33529,8 @@
             "required": true,
             "schema": {
               "title": "Environment Id",
-              "type": "string"
+              "type": "string",
+              "x-stainless-cli-data-alias": "id"
             }
           },
           {
@@ -31307,455 +33802,6 @@
           }
         },
         "summary": "Create Environment"
-      }
-    },
-    "/v1/files": {
-      "get": {
-        "operationId": "list_files_v1_files_get",
-        "parameters": [
-          {
-            "description": "ID of the object to use as a cursor for pagination. When provided, returns the page of results immediately before this object.",
-            "in": "query",
-            "name": "before_id",
-            "required": false,
-            "schema": {
-              "description": "ID of the object to use as a cursor for pagination. When provided, returns the page of results immediately before this object.",
-              "title": "Before Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "ID of the object to use as a cursor for pagination. When provided, returns the page of results immediately after this object.",
-            "in": "query",
-            "name": "after_id",
-            "required": false,
-            "schema": {
-              "description": "ID of the object to use as a cursor for pagination. When provided, returns the page of results immediately after this object.",
-              "title": "After Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Number of items to return per page.\n\nDefaults to `20`. Ranges from `1` to `1000`.",
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 20,
-              "description": "Number of items to return per page.\n\nDefaults to `20`. Ranges from `1` to `1000`.",
-              "maximum": 1000,
-              "minimum": 1,
-              "title": "Limit",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-            "in": "header",
-            "name": "anthropic-beta",
-            "required": false,
-            "schema": {
-              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-              "items": {
-                "type": "string"
-              },
-              "title": "Anthropic-Beta",
-              "type": "string",
-              "x-stainless-override-schema": {
-                "description": "Optional header to specify the beta version(s) you want to use.",
-                "items": {
-                  "$ref": "#/components/schemas/AnthropicBeta"
-                },
-                "type": "array",
-                "x-stainless-extend-default": true,
-                "x-stainless-param": "betas"
-              }
-            }
-          },
-          {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-            "in": "header",
-            "name": "anthropic-version",
-            "required": false,
-            "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-              "title": "Anthropic-Version",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
-            "in": "header",
-            "name": "x-api-key",
-            "required": false,
-            "schema": {
-              "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
-              "title": "X-Api-Key",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FileListResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
-          }
-        },
-        "summary": "List Files"
-      },
-      "post": {
-        "operationId": "upload_file_v1_files_post",
-        "parameters": [
-          {
-            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-            "in": "header",
-            "name": "anthropic-beta",
-            "required": false,
-            "schema": {
-              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-              "items": {
-                "type": "string"
-              },
-              "title": "Anthropic-Beta",
-              "type": "string",
-              "x-stainless-override-schema": {
-                "description": "Optional header to specify the beta version(s) you want to use.",
-                "items": {
-                  "$ref": "#/components/schemas/AnthropicBeta"
-                },
-                "type": "array",
-                "x-stainless-extend-default": true,
-                "x-stainless-param": "betas"
-              }
-            }
-          },
-          {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-            "in": "header",
-            "name": "anthropic-version",
-            "required": false,
-            "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-              "title": "Anthropic-Version",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "properties": {
-                  "file": {
-                    "description": "The file to upload",
-                    "format": "binary",
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "file"
-                ],
-                "type": "object"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FileMetadataSchema"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
-          }
-        },
-        "summary": "Upload File"
-      }
-    },
-    "/v1/files/{file_id}": {
-      "delete": {
-        "operationId": "delete_file_v1_files__file_id__delete",
-        "parameters": [
-          {
-            "description": "ID of the File.",
-            "in": "path",
-            "name": "file_id",
-            "required": true,
-            "schema": {
-              "description": "ID of the File.",
-              "title": "File Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-            "in": "header",
-            "name": "anthropic-beta",
-            "required": false,
-            "schema": {
-              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-              "items": {
-                "type": "string"
-              },
-              "title": "Anthropic-Beta",
-              "type": "string",
-              "x-stainless-override-schema": {
-                "description": "Optional header to specify the beta version(s) you want to use.",
-                "items": {
-                  "$ref": "#/components/schemas/AnthropicBeta"
-                },
-                "type": "array",
-                "x-stainless-extend-default": true,
-                "x-stainless-param": "betas"
-              }
-            }
-          },
-          {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-            "in": "header",
-            "name": "anthropic-version",
-            "required": false,
-            "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-              "title": "Anthropic-Version",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
-            "in": "header",
-            "name": "x-api-key",
-            "required": false,
-            "schema": {
-              "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
-              "title": "X-Api-Key",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FileDeleteResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
-          }
-        },
-        "summary": "Delete File"
-      },
-      "get": {
-        "operationId": "get_file_metadata_v1_files__file_id__get",
-        "parameters": [
-          {
-            "description": "ID of the File.",
-            "in": "path",
-            "name": "file_id",
-            "required": true,
-            "schema": {
-              "description": "ID of the File.",
-              "title": "File Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-            "in": "header",
-            "name": "anthropic-beta",
-            "required": false,
-            "schema": {
-              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-              "items": {
-                "type": "string"
-              },
-              "title": "Anthropic-Beta",
-              "type": "string",
-              "x-stainless-override-schema": {
-                "description": "Optional header to specify the beta version(s) you want to use.",
-                "items": {
-                  "$ref": "#/components/schemas/AnthropicBeta"
-                },
-                "type": "array",
-                "x-stainless-extend-default": true,
-                "x-stainless-param": "betas"
-              }
-            }
-          },
-          {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-            "in": "header",
-            "name": "anthropic-version",
-            "required": false,
-            "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-              "title": "Anthropic-Version",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
-            "in": "header",
-            "name": "x-api-key",
-            "required": false,
-            "schema": {
-              "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
-              "title": "X-Api-Key",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FileMetadataSchema"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
-          }
-        },
-        "summary": "Get File Metadata"
-      }
-    },
-    "/v1/files/{file_id}/content": {
-      "get": {
-        "operationId": "download_file_v1_files__file_id__content_get",
-        "parameters": [
-          {
-            "description": "ID of the File.",
-            "in": "path",
-            "name": "file_id",
-            "required": true,
-            "schema": {
-              "description": "ID of the File.",
-              "title": "File Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-            "in": "header",
-            "name": "anthropic-beta",
-            "required": false,
-            "schema": {
-              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-              "items": {
-                "type": "string"
-              },
-              "title": "Anthropic-Beta",
-              "type": "string",
-              "x-stainless-override-schema": {
-                "description": "Optional header to specify the beta version(s) you want to use.",
-                "items": {
-                  "$ref": "#/components/schemas/AnthropicBeta"
-                },
-                "type": "array",
-                "x-stainless-extend-default": true,
-                "x-stainless-param": "betas"
-              }
-            }
-          },
-          {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-            "in": "header",
-            "name": "anthropic-version",
-            "required": false,
-            "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-              "title": "Anthropic-Version",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
-            "in": "header",
-            "name": "x-api-key",
-            "required": false,
-            "schema": {
-              "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
-              "title": "X-Api-Key",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/octet-stream": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "4XX": {
-            "content": {
-              "application/octet-stream": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
-          }
-        },
-        "summary": "Download File"
       }
     },
     "/v1/files/{file_id}/content?beta=true": {
@@ -32422,7 +34468,7 @@
             "description": "Deadline exceeded - Upstream service did not respond in time"
           }
         },
-        "summary": "ArchiveMemoryStore"
+        "summary": "Archive a memory store"
       }
     },
     "/v1/memory_stores/{memory_store_id}/memories/{memory_id}?beta=true": {
@@ -32655,7 +34701,7 @@
             "description": "Deadline exceeded - Upstream service did not respond in time"
           }
         },
-        "summary": "DeleteMemory"
+        "summary": "Delete a memory"
       },
       "get": {
         "operationId": "BetaGetMemory",
@@ -32886,7 +34932,7 @@
             "description": "Deadline exceeded - Upstream service did not respond in time"
           }
         },
-        "summary": "GetMemory"
+        "summary": "Retrieve a memory"
       },
       "post": {
         "operationId": "BetaUpdateMemory",
@@ -32934,7 +34980,8 @@
             "name": "memory_id",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-stainless-cli-data-alias": "id"
             }
           },
           {
@@ -33119,7 +35166,7 @@
             "description": "Deadline exceeded - Upstream service did not respond in time"
           }
         },
-        "summary": "UpdateMemory"
+        "summary": "Update a memory"
       }
     },
     "/v1/memory_stores/{memory_store_id}/memories?beta=true": {
@@ -33399,7 +35446,7 @@
             "description": "Deadline exceeded - Upstream service did not respond in time"
           }
         },
-        "summary": "ListMemories"
+        "summary": "List memories"
       },
       "post": {
         "operationId": "BetaCreateMemory",
@@ -33623,7 +35670,7 @@
             "description": "Deadline exceeded - Upstream service did not respond in time"
           }
         },
-        "summary": "CreateMemory"
+        "summary": "Create a memory"
       }
     },
     "/v1/memory_stores/{memory_store_id}/memory_versions/{memory_version_id}/redact?beta=true": {
@@ -33839,7 +35886,7 @@
             "description": "Deadline exceeded - Upstream service did not respond in time"
           }
         },
-        "summary": "RedactMemoryVersion"
+        "summary": "Redact a memory version"
       }
     },
     "/v1/memory_stores/{memory_store_id}/memory_versions/{memory_version_id}?beta=true": {
@@ -34072,7 +36119,7 @@
             "description": "Deadline exceeded - Upstream service did not respond in time"
           }
         },
-        "summary": "GetMemoryVersion"
+        "summary": "Retrieve a memory version"
       }
     },
     "/v1/memory_stores/{memory_store_id}/memory_versions?beta=true": {
@@ -34369,7 +36416,7 @@
             "description": "Deadline exceeded - Upstream service did not respond in time"
           }
         },
-        "summary": "ListMemoryVersions"
+        "summary": "List memory versions"
       }
     },
     "/v1/memory_stores/{memory_store_id}?beta=true": {
@@ -34584,7 +36631,7 @@
             "description": "Deadline exceeded - Upstream service did not respond in time"
           }
         },
-        "summary": "DeleteMemoryStore"
+        "summary": "Delete a memory store"
       },
       "get": {
         "operationId": "BetaGetMemoryStore",
@@ -34797,7 +36844,7 @@
             "description": "Deadline exceeded - Upstream service did not respond in time"
           }
         },
-        "summary": "GetMemoryStore"
+        "summary": "Retrieve a memory store"
       },
       "post": {
         "operationId": "BetaUpdateMemoryStore",
@@ -34836,7 +36883,8 @@
             "name": "memory_store_id",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-stainless-cli-data-alias": "id"
             }
           }
         ],
@@ -35012,7 +37060,7 @@
             "description": "Deadline exceeded - Upstream service did not respond in time"
           }
         },
-        "summary": "UpdateMemoryStore"
+        "summary": "Update a memory store"
       }
     },
     "/v1/memory_stores?beta=true": {
@@ -35056,7 +37104,7 @@
             }
           },
           {
-            "description": "Query parameter for limit",
+            "description": "Maximum number of stores to return per page. Must be between 1 and 100. Defaults to 20 when omitted.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -35066,7 +37114,7 @@
             }
           },
           {
-            "description": "Query parameter for page",
+            "description": "Opaque pagination cursor (a `page_...` value). Pass the `next_page` value from a previous response to fetch the next page; omit for the first page.",
             "in": "query",
             "name": "page",
             "required": false,
@@ -35075,7 +37123,7 @@
             }
           },
           {
-            "description": "Query parameter for include_archived",
+            "description": "When `true`, archived stores are included in the results. Defaults to `false` (archived stores are excluded).",
             "in": "query",
             "name": "include_archived",
             "required": false,
@@ -35084,7 +37132,7 @@
             }
           },
           {
-            "description": "Return stores created at or after this time (inclusive).",
+            "description": "Return only stores whose `created_at` is at or after this time (inclusive). Sent on the wire as `created_at[gte]`.",
             "in": "query",
             "name": "created_at[gte]",
             "required": false,
@@ -35093,7 +37141,7 @@
             }
           },
           {
-            "description": "Return stores created at or before this time (inclusive).",
+            "description": "Return only stores whose `created_at` is at or before this time (inclusive). Sent on the wire as `created_at[lte]`.",
             "in": "query",
             "name": "created_at[lte]",
             "required": false,
@@ -35264,7 +37312,7 @@
             "description": "Deadline exceeded - Upstream service did not respond in time"
           }
         },
-        "summary": "ListMemoryStores"
+        "summary": "List memory stores"
       },
       "post": {
         "operationId": "BetaCreateMemoryStore",
@@ -35470,7 +37518,7 @@
             "description": "Deadline exceeded - Upstream service did not respond in time"
           }
         },
-        "summary": "CreateMemoryStore"
+        "summary": "Create a memory store"
       }
     },
     "/v1/messages": {
@@ -37528,6 +39576,56 @@
             "schema": {
               "$ref": "#/components/schemas/BetaManagedAgentsListOrder"
             }
+          },
+          {
+            "description": "Filter by event type. Values match the `type` field on returned events (for example, `user.message` or `agent.tool_use`). Omit to return all event types.",
+            "explode": true,
+            "in": "query",
+            "name": "types[]",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "style": "form"
+          },
+          {
+            "description": "Return events created at or after this time (inclusive).",
+            "in": "query",
+            "name": "created_at[gte]",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/BetaTimestamp"
+            }
+          },
+          {
+            "description": "Return events created after this time (exclusive).",
+            "in": "query",
+            "name": "created_at[gt]",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/BetaTimestamp"
+            }
+          },
+          {
+            "description": "Return events created at or before this time (inclusive).",
+            "in": "query",
+            "name": "created_at[lte]",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/BetaTimestamp"
+            }
+          },
+          {
+            "description": "Return events created before this time (exclusive).",
+            "in": "query",
+            "name": "created_at[lt]",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/BetaTimestamp"
+            }
           }
         ],
         "responses": {
@@ -38408,7 +40506,8 @@
             "name": "resource_id",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-stainless-cli-data-alias": "id"
             }
           }
         ],
@@ -39038,6 +41137,1156 @@
         "summary": "Add Session Resource"
       }
     },
+    "/v1/sessions/{session_id}/threads/{thread_id}/archive?beta=true": {
+      "post": {
+        "operationId": "BetaArchiveSessionThread",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Path parameter session_id",
+            "example": "sesn_011CZkZAtmR3yMPDzynEDxu7",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Path parameter thread_id",
+            "example": "sthr_011CZkZVWa6oIjw0rgXZpnBt",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaManagedAgentsSessionThread"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "Archive Session Thread"
+      }
+    },
+    "/v1/sessions/{session_id}/threads/{thread_id}/events?beta=true": {
+      "get": {
+        "operationId": "BetaListSessionThreadEvents",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Path parameter session_id",
+            "example": "sesn_011CZkZAtmR3yMPDzynEDxu7",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Path parameter thread_id",
+            "example": "sthr_011CZkZVWa6oIjw0rgXZpnBt",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Query parameter for limit",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Query parameter for page",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaManagedAgentsListSessionThreadEvents"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "List Session Thread Events"
+      }
+    },
+    "/v1/sessions/{session_id}/threads/{thread_id}/stream?beta=true": {
+      "get": {
+        "operationId": "BetaStreamSessionThreadEvents",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Path parameter session_id",
+            "example": "sesn_011CZkZAtmR3yMPDzynEDxu7",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Path parameter thread_id",
+            "example": "sthr_011CZkZVWa6oIjw0rgXZpnBt",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaManagedAgentsStreamSessionThreadEvents"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "Stream Session Thread Events"
+      }
+    },
+    "/v1/sessions/{session_id}/threads/{thread_id}?beta=true": {
+      "get": {
+        "operationId": "BetaGetSessionThread",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Path parameter session_id",
+            "example": "sesn_011CZkZAtmR3yMPDzynEDxu7",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Path parameter thread_id",
+            "example": "sthr_011CZkZVWa6oIjw0rgXZpnBt",
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaManagedAgentsSessionThread"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "Get Session Thread"
+      }
+    },
+    "/v1/sessions/{session_id}/threads?beta=true": {
+      "get": {
+        "operationId": "BetaListSessionThreads",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Path parameter session_id",
+            "example": "sesn_011CZkZAtmR3yMPDzynEDxu7",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum results per page. Defaults to 1000.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Opaque pagination cursor from a previous response's next_page. Forward-only.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaManagedAgentsListSessionThreads"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "List Session Threads"
+      }
+    },
     "/v1/sessions/{session_id}?beta=true": {
       "delete": {
         "operationId": "BetaDeleteSession",
@@ -39505,7 +42754,8 @@
             "name": "session_id",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-stainless-cli-data-alias": "id"
             }
           }
         ],
@@ -39815,6 +43065,29 @@
             "schema": {
               "$ref": "#/components/schemas/BetaManagedAgentsListOrder"
             }
+          },
+          {
+            "description": "Filter sessions whose resources contain a memory_store with this memory store ID.",
+            "in": "query",
+            "name": "memory_store_id",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by session status. Repeat the parameter to match any of multiple statuses.",
+            "explode": true,
+            "in": "query",
+            "name": "statuses[]",
+            "required": false,
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/BetaManagedAgentsSessionStatus"
+              },
+              "type": "array"
+            },
+            "style": "form"
           }
         ],
         "responses": {
@@ -40186,772 +43459,6 @@
           }
         },
         "summary": "Create Session"
-      }
-    },
-    "/v1/skills": {
-      "get": {
-        "operationId": "list_skills_v1_skills_get",
-        "parameters": [
-          {
-            "description": "Pagination token for fetching a specific page of results.\n\nPass the value from a previous response's `next_page` field to get the next page of results.",
-            "in": "query",
-            "name": "page",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Pagination token for fetching a specific page of results.\n\nPass the value from a previous response's `next_page` field to get the next page of results.",
-              "title": "Page",
-              "x-stainless-pagination-property": {
-                "purpose": "next_cursor_param"
-              }
-            }
-          },
-          {
-            "description": "Number of results to return per page.\n\nMaximum value is 100. Defaults to 20.",
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 20,
-              "description": "Number of results to return per page.\n\nMaximum value is 100. Defaults to 20.",
-              "title": "Limit",
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Filter skills by source.\n\nIf provided, only skills from the specified source will be returned:\n* `\"custom\"`: only return user-created skills\n* `\"anthropic\"`: only return Anthropic-created skills",
-            "in": "query",
-            "name": "source",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Filter skills by source.\n\nIf provided, only skills from the specified source will be returned:\n* `\"custom\"`: only return user-created skills\n* `\"anthropic\"`: only return Anthropic-created skills",
-              "title": "Source"
-            }
-          },
-          {
-            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-            "in": "header",
-            "name": "anthropic-beta",
-            "required": false,
-            "schema": {
-              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-              "items": {
-                "type": "string"
-              },
-              "title": "Anthropic-Beta",
-              "type": "string",
-              "x-stainless-override-schema": {
-                "description": "Optional header to specify the beta version(s) you want to use.",
-                "items": {
-                  "$ref": "#/components/schemas/AnthropicBeta"
-                },
-                "type": "array",
-                "x-stainless-extend-default": true,
-                "x-stainless-param": "betas"
-              }
-            }
-          },
-          {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-            "in": "header",
-            "name": "anthropic-version",
-            "required": false,
-            "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-              "title": "Anthropic-Version",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
-            "in": "header",
-            "name": "x-api-key",
-            "required": false,
-            "schema": {
-              "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
-              "title": "X-Api-Key",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListSkillsResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
-          }
-        },
-        "summary": "List Skills"
-      },
-      "post": {
-        "operationId": "create_skill_v1_skills_post",
-        "parameters": [
-          {
-            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-            "in": "header",
-            "name": "anthropic-beta",
-            "required": false,
-            "schema": {
-              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-              "items": {
-                "type": "string"
-              },
-              "title": "Anthropic-Beta",
-              "type": "string",
-              "x-stainless-override-schema": {
-                "description": "Optional header to specify the beta version(s) you want to use.",
-                "items": {
-                  "$ref": "#/components/schemas/AnthropicBeta"
-                },
-                "type": "array",
-                "x-stainless-extend-default": true,
-                "x-stainless-param": "betas"
-              }
-            }
-          },
-          {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-            "in": "header",
-            "name": "anthropic-version",
-            "required": false,
-            "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-              "title": "Anthropic-Version",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_create_skill_v1_skills_post"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreateSkillResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
-          }
-        },
-        "summary": "Create Skill"
-      }
-    },
-    "/v1/skills/{skill_id}": {
-      "delete": {
-        "operationId": "delete_skill_v1_skills__skill_id__delete",
-        "parameters": [
-          {
-            "description": "Unique identifier for the skill.\n\nThe format and length of IDs may change over time.",
-            "in": "path",
-            "name": "skill_id",
-            "required": true,
-            "schema": {
-              "description": "Unique identifier for the skill.\n\nThe format and length of IDs may change over time.",
-              "title": "Skill Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-            "in": "header",
-            "name": "anthropic-beta",
-            "required": false,
-            "schema": {
-              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-              "items": {
-                "type": "string"
-              },
-              "title": "Anthropic-Beta",
-              "type": "string",
-              "x-stainless-override-schema": {
-                "description": "Optional header to specify the beta version(s) you want to use.",
-                "items": {
-                  "$ref": "#/components/schemas/AnthropicBeta"
-                },
-                "type": "array",
-                "x-stainless-extend-default": true,
-                "x-stainless-param": "betas"
-              }
-            }
-          },
-          {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-            "in": "header",
-            "name": "anthropic-version",
-            "required": false,
-            "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-              "title": "Anthropic-Version",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
-            "in": "header",
-            "name": "x-api-key",
-            "required": false,
-            "schema": {
-              "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
-              "title": "X-Api-Key",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DeleteSkillResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
-          }
-        },
-        "summary": "Delete Skill"
-      },
-      "get": {
-        "operationId": "get_skill_v1_skills__skill_id__get",
-        "parameters": [
-          {
-            "description": "Unique identifier for the skill.\n\nThe format and length of IDs may change over time.",
-            "in": "path",
-            "name": "skill_id",
-            "required": true,
-            "schema": {
-              "description": "Unique identifier for the skill.\n\nThe format and length of IDs may change over time.",
-              "title": "Skill Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-            "in": "header",
-            "name": "anthropic-beta",
-            "required": false,
-            "schema": {
-              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-              "items": {
-                "type": "string"
-              },
-              "title": "Anthropic-Beta",
-              "type": "string",
-              "x-stainless-override-schema": {
-                "description": "Optional header to specify the beta version(s) you want to use.",
-                "items": {
-                  "$ref": "#/components/schemas/AnthropicBeta"
-                },
-                "type": "array",
-                "x-stainless-extend-default": true,
-                "x-stainless-param": "betas"
-              }
-            }
-          },
-          {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-            "in": "header",
-            "name": "anthropic-version",
-            "required": false,
-            "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-              "title": "Anthropic-Version",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
-            "in": "header",
-            "name": "x-api-key",
-            "required": false,
-            "schema": {
-              "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
-              "title": "X-Api-Key",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetSkillResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
-          }
-        },
-        "summary": "Get Skill"
-      }
-    },
-    "/v1/skills/{skill_id}/versions": {
-      "get": {
-        "operationId": "list_skill_versions_v1_skills__skill_id__versions_get",
-        "parameters": [
-          {
-            "description": "Unique identifier for the skill.\n\nThe format and length of IDs may change over time.",
-            "in": "path",
-            "name": "skill_id",
-            "required": true,
-            "schema": {
-              "description": "Unique identifier for the skill.\n\nThe format and length of IDs may change over time.",
-              "title": "Skill Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Optionally set to the `next_page` token from the previous response.",
-            "in": "query",
-            "name": "page",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Optionally set to the `next_page` token from the previous response.",
-              "title": "Page",
-              "x-stainless-pagination-property": {
-                "purpose": "next_cursor_param"
-              }
-            }
-          },
-          {
-            "description": "Number of items to return per page.\n\nDefaults to `20`. Ranges from `1` to `1000`.",
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "Number of items to return per page.\n\nDefaults to `20`. Ranges from `1` to `1000`.",
-              "title": "Limit"
-            }
-          },
-          {
-            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-            "in": "header",
-            "name": "anthropic-beta",
-            "required": false,
-            "schema": {
-              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-              "items": {
-                "type": "string"
-              },
-              "title": "Anthropic-Beta",
-              "type": "string",
-              "x-stainless-override-schema": {
-                "description": "Optional header to specify the beta version(s) you want to use.",
-                "items": {
-                  "$ref": "#/components/schemas/AnthropicBeta"
-                },
-                "type": "array",
-                "x-stainless-extend-default": true,
-                "x-stainless-param": "betas"
-              }
-            }
-          },
-          {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-            "in": "header",
-            "name": "anthropic-version",
-            "required": false,
-            "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-              "title": "Anthropic-Version",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
-            "in": "header",
-            "name": "x-api-key",
-            "required": false,
-            "schema": {
-              "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
-              "title": "X-Api-Key",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListSkillVersionsResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
-          }
-        },
-        "summary": "List Skill Versions"
-      },
-      "post": {
-        "operationId": "create_skill_version_v1_skills__skill_id__versions_post",
-        "parameters": [
-          {
-            "description": "Unique identifier for the skill.\n\nThe format and length of IDs may change over time.",
-            "in": "path",
-            "name": "skill_id",
-            "required": true,
-            "schema": {
-              "description": "Unique identifier for the skill.\n\nThe format and length of IDs may change over time.",
-              "title": "Skill Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-            "in": "header",
-            "name": "anthropic-beta",
-            "required": false,
-            "schema": {
-              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-              "items": {
-                "type": "string"
-              },
-              "title": "Anthropic-Beta",
-              "type": "string",
-              "x-stainless-override-schema": {
-                "description": "Optional header to specify the beta version(s) you want to use.",
-                "items": {
-                  "$ref": "#/components/schemas/AnthropicBeta"
-                },
-                "type": "array",
-                "x-stainless-extend-default": true,
-                "x-stainless-param": "betas"
-              }
-            }
-          },
-          {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-            "in": "header",
-            "name": "anthropic-version",
-            "required": false,
-            "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-              "title": "Anthropic-Version",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "$ref": "#/components/schemas/Body_create_skill_version_v1_skills__skill_id__versions_post"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CreateSkillVersionResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
-          }
-        },
-        "summary": "Create Skill Version"
-      }
-    },
-    "/v1/skills/{skill_id}/versions/{version}": {
-      "delete": {
-        "operationId": "delete_skill_version_v1_skills__skill_id__versions__version__delete",
-        "parameters": [
-          {
-            "description": "Unique identifier for the skill.\n\nThe format and length of IDs may change over time.",
-            "in": "path",
-            "name": "skill_id",
-            "required": true,
-            "schema": {
-              "description": "Unique identifier for the skill.\n\nThe format and length of IDs may change over time.",
-              "title": "Skill Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Version identifier for the skill.\n\nEach version is identified by a Unix epoch timestamp (e.g., \"1759178010641129\").",
-            "in": "path",
-            "name": "version",
-            "required": true,
-            "schema": {
-              "description": "Version identifier for the skill.\n\nEach version is identified by a Unix epoch timestamp (e.g., \"1759178010641129\").",
-              "title": "Version",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-            "in": "header",
-            "name": "anthropic-beta",
-            "required": false,
-            "schema": {
-              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-              "items": {
-                "type": "string"
-              },
-              "title": "Anthropic-Beta",
-              "type": "string",
-              "x-stainless-override-schema": {
-                "description": "Optional header to specify the beta version(s) you want to use.",
-                "items": {
-                  "$ref": "#/components/schemas/AnthropicBeta"
-                },
-                "type": "array",
-                "x-stainless-extend-default": true,
-                "x-stainless-param": "betas"
-              }
-            }
-          },
-          {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-            "in": "header",
-            "name": "anthropic-version",
-            "required": false,
-            "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-              "title": "Anthropic-Version",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
-            "in": "header",
-            "name": "x-api-key",
-            "required": false,
-            "schema": {
-              "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
-              "title": "X-Api-Key",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DeleteSkillVersionResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
-          }
-        },
-        "summary": "Delete Skill Version"
-      },
-      "get": {
-        "operationId": "get_skill_version_v1_skills__skill_id__versions__version__get",
-        "parameters": [
-          {
-            "description": "Unique identifier for the skill.\n\nThe format and length of IDs may change over time.",
-            "in": "path",
-            "name": "skill_id",
-            "required": true,
-            "schema": {
-              "description": "Unique identifier for the skill.\n\nThe format and length of IDs may change over time.",
-              "title": "Skill Id",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Version identifier for the skill.\n\nEach version is identified by a Unix epoch timestamp (e.g., \"1759178010641129\").",
-            "in": "path",
-            "name": "version",
-            "required": true,
-            "schema": {
-              "description": "Version identifier for the skill.\n\nEach version is identified by a Unix epoch timestamp (e.g., \"1759178010641129\").",
-              "title": "Version",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-            "in": "header",
-            "name": "anthropic-beta",
-            "required": false,
-            "schema": {
-              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
-              "items": {
-                "type": "string"
-              },
-              "title": "Anthropic-Beta",
-              "type": "string",
-              "x-stainless-override-schema": {
-                "description": "Optional header to specify the beta version(s) you want to use.",
-                "items": {
-                  "$ref": "#/components/schemas/AnthropicBeta"
-                },
-                "type": "array",
-                "x-stainless-extend-default": true,
-                "x-stainless-param": "betas"
-              }
-            }
-          },
-          {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-            "in": "header",
-            "name": "anthropic-version",
-            "required": false,
-            "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
-              "title": "Anthropic-Version",
-              "type": "string"
-            }
-          },
-          {
-            "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
-            "in": "header",
-            "name": "x-api-key",
-            "required": false,
-            "schema": {
-              "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
-              "title": "X-Api-Key",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/GetSkillVersionResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "4XX": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
-          }
-        },
-        "summary": "Get Skill Version"
       }
     },
     "/v1/skills/{skill_id}/versions/{version}?beta=true": {
@@ -43226,6 +45733,224 @@
         "summary": "Archive Credential"
       }
     },
+    "/v1/vaults/{vault_id}/credentials/{credential_id}/mcp_oauth_validate?beta=true": {
+      "post": {
+        "operationId": "BetaValidateCredential",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Path parameter vault_id",
+            "example": "vlt_011CZkZDLs7fYzm1hXNPeRjv",
+            "in": "path",
+            "name": "vault_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Path parameter credential_id",
+            "example": "vcrd_011CZkZEMt8gZan2iYOQfSkw",
+            "in": "path",
+            "name": "credential_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaManagedAgentsCredentialValidation"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "Validate Credential"
+      }
+    },
     "/v1/vaults/{vault_id}/credentials/{credential_id}?beta=true": {
       "delete": {
         "operationId": "BetaDeleteCredential",
@@ -43723,7 +46448,8 @@
             "name": "credential_id",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-stainless-cli-data-alias": "id"
             }
           }
         ],
@@ -44829,7 +47555,8 @@
             "name": "vault_id",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "x-stainless-cli-data-alias": "id"
             }
           }
         ],
@@ -45453,5 +48180,469 @@
     {
       "url": "https://api.anthropic.com"
     }
-  ]
+  ],
+  "webhooks": {
+    "session.archived": {
+      "post": {
+        "operationId": "BetaSessionArchivedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "session.archived webhook"
+      }
+    },
+    "session.created": {
+      "post": {
+        "operationId": "BetaSessionCreatedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "session.created webhook"
+      }
+    },
+    "session.deleted": {
+      "post": {
+        "operationId": "BetaSessionDeletedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "session.deleted webhook"
+      }
+    },
+    "session.idled": {
+      "post": {
+        "operationId": "BetaSessionIdledWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "session.idled webhook"
+      }
+    },
+    "session.outcome_evaluation_ended": {
+      "post": {
+        "operationId": "BetaSessionOutcomeEvaluationEndedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "session.outcome_evaluation_ended webhook"
+      }
+    },
+    "session.pending": {
+      "post": {
+        "operationId": "BetaSessionPendingWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "session.pending webhook"
+      }
+    },
+    "session.requires_action": {
+      "post": {
+        "operationId": "BetaSessionRequiresActionWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "session.requires_action webhook"
+      }
+    },
+    "session.running": {
+      "post": {
+        "operationId": "BetaSessionRunningWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "session.running webhook"
+      }
+    },
+    "session.status_idled": {
+      "post": {
+        "operationId": "BetaSessionStatusIdledWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "session.status_idled webhook"
+      }
+    },
+    "session.status_rescheduled": {
+      "post": {
+        "operationId": "BetaSessionStatusRescheduledWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "session.status_rescheduled webhook"
+      }
+    },
+    "session.status_run_started": {
+      "post": {
+        "operationId": "BetaSessionStatusRunStartedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "session.status_run_started webhook"
+      }
+    },
+    "session.status_terminated": {
+      "post": {
+        "operationId": "BetaSessionStatusTerminatedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "session.status_terminated webhook"
+      }
+    },
+    "session.thread_created": {
+      "post": {
+        "operationId": "BetaSessionThreadCreatedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "session.thread_created webhook"
+      }
+    },
+    "session.thread_idled": {
+      "post": {
+        "operationId": "BetaSessionThreadIdledWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "session.thread_idled webhook"
+      }
+    },
+    "session.thread_terminated": {
+      "post": {
+        "operationId": "BetaSessionThreadTerminatedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "session.thread_terminated webhook"
+      }
+    },
+    "vault.archived": {
+      "post": {
+        "operationId": "BetaVaultArchivedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "vault.archived webhook"
+      }
+    },
+    "vault.created": {
+      "post": {
+        "operationId": "BetaVaultCreatedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "vault.created webhook"
+      }
+    },
+    "vault.deleted": {
+      "post": {
+        "operationId": "BetaVaultDeletedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "vault.deleted webhook"
+      }
+    },
+    "vault_credential.archived": {
+      "post": {
+        "operationId": "BetaVaultCredentialArchivedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "vault_credential.archived webhook"
+      }
+    },
+    "vault_credential.created": {
+      "post": {
+        "operationId": "BetaVaultCredentialCreatedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "vault_credential.created webhook"
+      }
+    },
+    "vault_credential.deleted": {
+      "post": {
+        "operationId": "BetaVaultCredentialDeletedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "vault_credential.deleted webhook"
+      }
+    },
+    "vault_credential.refresh_failed": {
+      "post": {
+        "operationId": "BetaVaultCredentialRefreshFailedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "vault_credential.refresh_failed webhook"
+      }
+    }
+  }
 }

--- a/packages/anthropic_sdk_dart/specs/spec_metadata.json
+++ b/packages/anthropic_sdk_dart/specs/spec_metadata.json
@@ -2,8 +2,8 @@
   "specs": {
     "main": {
       "current_version": "unknown",
-      "last_fetched": "2026-04-25T21:04:00.718243Z",
-      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic%2Fanthropic-6811827071199207cf69c4e64cae1b41e7e74cdb14048e9c748701e474c694a7.yml",
+      "last_fetched": "2026-05-09T16:05:44.690295Z",
+      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-0df2c793ea4c3ad955e8e488be39d7041a0a95e2fe144dd69ae4d9fb72835190.yml",
       "title": "Anthropic API",
       "version_history": [
         {

--- a/packages/anthropic_sdk_dart/test/unit/models/session_event_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/session_event_test.dart
@@ -1,0 +1,119 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SessionEvent.sessionThreadId', () {
+    test('AgentToolUseEvent round-trips session_thread_id', () {
+      final json = <String, dynamic>{
+        'type': 'agent.tool_use',
+        'id': 'event_001',
+        'name': 'agent_toolset_20260401',
+        'input': {'query': 'lookup'},
+        'processed_at': '2026-04-01T12:00:00Z',
+        'session_thread_id': 'thread_abc',
+      };
+
+      final parsed = SessionEvent.fromJson(json) as AgentToolUseEvent;
+      expect(parsed.sessionThreadId, 'thread_abc');
+      expect(parsed.toJson()['session_thread_id'], 'thread_abc');
+    });
+
+    test('AgentMcpToolUseEvent omits session_thread_id when null', () {
+      final json = <String, dynamic>{
+        'type': 'agent.mcp_tool_use',
+        'id': 'event_002',
+        'mcp_server_name': 'github',
+        'name': 'list_repos',
+        'input': <String, dynamic>{},
+        'processed_at': '2026-04-01T12:00:00Z',
+      };
+
+      final parsed = SessionEvent.fromJson(json) as AgentMcpToolUseEvent;
+      expect(parsed.sessionThreadId, isNull);
+      expect(parsed.toJson().containsKey('session_thread_id'), isFalse);
+    });
+
+    test('AgentCustomToolUseEvent copyWith updates and clears the id', () {
+      final original = AgentCustomToolUseEvent(
+        id: 'event_003',
+        name: 'my_tool',
+        input: const {},
+        processedAt: DateTime.utc(2026, 4, 1, 12),
+      );
+
+      final updated = original.copyWith(sessionThreadId: 'thread_x');
+      expect(updated.sessionThreadId, 'thread_x');
+
+      final cleared = updated.copyWith(sessionThreadId: null);
+      expect(cleared.sessionThreadId, isNull);
+    });
+
+    test('UserInterruptEvent round-trips session_thread_id', () {
+      final json = <String, dynamic>{
+        'type': 'user.interrupt',
+        'id': 'event_004',
+        'session_thread_id': 'thread_42',
+      };
+
+      final parsed = SessionEvent.fromJson(json) as UserInterruptEvent;
+      expect(parsed.sessionThreadId, 'thread_42');
+    });
+
+    test('UserToolConfirmationEvent round-trips session_thread_id', () {
+      final json = <String, dynamic>{
+        'type': 'user.tool_confirmation',
+        'id': 'event_005',
+        'tool_use_id': 'event_001',
+        'result': 'allow',
+        'session_thread_id': 'thread_42',
+      };
+
+      final parsed = SessionEvent.fromJson(json) as UserToolConfirmationEvent;
+      expect(parsed.sessionThreadId, 'thread_42');
+      expect(parsed.toJson()['session_thread_id'], 'thread_42');
+    });
+
+    test('UserCustomToolResultEvent round-trips session_thread_id', () {
+      final json = <String, dynamic>{
+        'type': 'user.custom_tool_result',
+        'id': 'event_006',
+        'custom_tool_use_id': 'event_003',
+        'session_thread_id': 'thread_42',
+      };
+
+      final parsed = SessionEvent.fromJson(json) as UserCustomToolResultEvent;
+      expect(parsed.sessionThreadId, 'thread_42');
+    });
+  });
+
+  group('UserInterruptEventParams', () {
+    test('serializes session_thread_id when set', () {
+      const params = UserInterruptEventParams(sessionThreadId: 'thread_77');
+      expect(params.toJson(), {
+        'type': 'user.interrupt',
+        'session_thread_id': 'thread_77',
+      });
+    });
+
+    test('omits session_thread_id when null', () {
+      const params = UserInterruptEventParams();
+      expect(params.toJson(), {'type': 'user.interrupt'});
+    });
+
+    test('round-trips through EventParams.fromJson dispatch', () {
+      const params = UserInterruptEventParams(sessionThreadId: 'thread_77');
+      final parsed = EventParams.fromJson(params.toJson());
+      expect(parsed, isA<UserInterruptEventParams>());
+      expect((parsed as UserInterruptEventParams).sessionThreadId, 'thread_77');
+    });
+
+    test('copyWith preserves and clears sessionThreadId', () {
+      const original = UserInterruptEventParams(sessionThreadId: 'thread_77');
+      final preserved = original.copyWith();
+      expect(preserved.sessionThreadId, 'thread_77');
+
+      final cleared = original.copyWith(sessionThreadId: null);
+      expect(cleared.sessionThreadId, isNull);
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/user_profiles_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/user_profiles_test.dart
@@ -22,6 +22,26 @@ void main() {
     });
   });
 
+  group('BetaUserProfileRelationship', () {
+    test('round-trips known values', () {
+      for (final value in const [
+        BetaUserProfileRelationship.external,
+        BetaUserProfileRelationship.resold,
+        BetaUserProfileRelationship.internal,
+      ]) {
+        final parsed = BetaUserProfileRelationship.fromJson(value.toJson());
+        expect(parsed, value);
+      }
+    });
+
+    test('falls back to unknown for unrecognized values', () {
+      expect(
+        BetaUserProfileRelationship.fromJson('partner'),
+        BetaUserProfileRelationship.unknown,
+      );
+    });
+  });
+
   group('UserProfileListOrder', () {
     test('round-trips known values', () {
       expect(
@@ -84,11 +104,13 @@ void main() {
       String? externalId = 'user_12345',
       Map<String, String>? metadata,
       Map<String, dynamic>? trustGrants,
+      String relationship = 'external',
     }) {
       return {
         'id': 'uprof_011CZkZCu8hGbp5mYRQgUmz9',
         'type': 'user_profile',
         'external_id': externalId,
+        'relationship': relationship,
         'metadata': metadata ?? <String, String>{},
         'trust_grants':
             trustGrants ??
@@ -170,6 +192,32 @@ void main() {
 
       expect(copy.externalId, 'user_12345');
     });
+
+    test('round-trips name and resold relationship when present', () {
+      final json = profileJson(relationship: 'resold');
+      json['name'] = 'Acme Corp';
+
+      final parsed = UserProfile.fromJson(json);
+      expect(parsed.name, 'Acme Corp');
+      expect(parsed.relationship, BetaUserProfileRelationship.resold);
+
+      final reparsed = UserProfile.fromJson(parsed.toJson());
+      expect(reparsed, equals(parsed));
+    });
+
+    test('treats missing name as null and defaults relationship', () {
+      final parsed = UserProfile.fromJson(profileJson());
+      expect(parsed.name, isNull);
+      expect(parsed.relationship, BetaUserProfileRelationship.external);
+    });
+
+    test('copyWith updates relationship', () {
+      final original = UserProfile.fromJson(profileJson());
+      final updated = original.copyWith(
+        relationship: BetaUserProfileRelationship.internal,
+      );
+      expect(updated.relationship, BetaUserProfileRelationship.internal);
+    });
   });
 
   group('CreateUserProfileRequest', () {
@@ -199,6 +247,18 @@ void main() {
       final cleared = request.copyWith(externalId: null);
 
       expect(cleared.externalId, isNull);
+    });
+
+    test('serializes name and relationship when set', () {
+      const request = CreateUserProfileRequest(
+        name: 'Acme Corp',
+        relationship: BetaUserProfileRelationship.resold,
+      );
+
+      expect(request.toJson(), {'name': 'Acme Corp', 'relationship': 'resold'});
+
+      final parsed = CreateUserProfileRequest.fromJson(request.toJson());
+      expect(parsed, equals(request));
     });
   });
 
@@ -251,6 +311,39 @@ void main() {
         throwsA(isA<AssertionError>()),
       );
     });
+
+    test('serializes name and relationship updates', () {
+      const request = UpdateUserProfileRequest(
+        name: 'Acme Corp',
+        relationship: BetaUserProfileRelationship.internal,
+      );
+
+      final json = request.toJson();
+      expect(json['name'], 'Acme Corp');
+      expect(json['relationship'], 'internal');
+
+      final parsed = UpdateUserProfileRequest.fromJson(json);
+      expect(parsed.name, 'Acme Corp');
+      expect(parsed.relationship, BetaUserProfileRelationship.internal);
+      expect(parsed.hasName, isTrue);
+      expect(parsed.hasRelationship, isTrue);
+    });
+
+    test('clears name with explicit null', () {
+      const request = UpdateUserProfileRequest(name: null);
+      final json = request.toJson();
+      expect(json.containsKey('name'), isTrue);
+      expect(json['name'], isNull);
+      expect(request.hasName, isTrue);
+    });
+
+    test('omits name and relationship when unset', () {
+      const request = UpdateUserProfileRequest();
+      expect(request.hasName, isFalse);
+      expect(request.hasRelationship, isFalse);
+      expect(request.toJson().containsKey('name'), isFalse);
+      expect(request.toJson().containsKey('relationship'), isFalse);
+    });
   });
 
   group('ListUserProfilesResponse', () {
@@ -261,6 +354,7 @@ void main() {
             'id': 'uprof_1',
             'type': 'user_profile',
             'external_id': null,
+            'relationship': 'external',
             'trust_grants': <String, dynamic>{},
             'created_at': '2026-03-15T10:00:00Z',
             'updated_at': '2026-03-15T10:00:00Z',

--- a/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
@@ -299,6 +299,19 @@ void main() {
       expect(request.url.queryParameters['limit'], '10');
     });
 
+    test('list passes memory_store_id and statuses[] filters', () async {
+      mockHttpClient.queueJsonResponse({'data': <Map<String, dynamic>>[]});
+
+      await client.sessions.list(
+        memoryStoreId: 'memstore_abc',
+        statuses: const [SessionStatus.running, SessionStatus.idle],
+      );
+
+      final params = mockHttpClient.lastRequest!.url.queryParametersAll;
+      expect(params['memory_store_id'], ['memstore_abc']);
+      expect(params['statuses[]'], ['running', 'idle']);
+    });
+
     test('retrieve sends correct request', () async {
       mockHttpClient.queueJsonResponse(ManagedAgentsFixtures.session());
 
@@ -376,6 +389,23 @@ void main() {
       expect(request.url.path, '/v1/sessions/session_test123/events');
       expect(request.method, 'GET');
       expect(request.headers['anthropic-beta'], 'managed-agents-2026-04-01');
+    });
+
+    test('list passes created_at[*] and types[] filters', () async {
+      mockHttpClient.queueJsonResponse({'data': <Map<String, dynamic>>[]});
+
+      await client.sessions
+          .events('session_test123')
+          .list(
+            createdAtGt: '2026-04-01T00:00:00Z',
+            createdAtLte: '2026-04-30T23:59:59Z',
+            types: const ['agent.message', 'user.interrupt'],
+          );
+
+      final params = mockHttpClient.lastRequest!.url.queryParametersAll;
+      expect(params['created_at[gt]'], ['2026-04-01T00:00:00Z']);
+      expect(params['created_at[lte]'], ['2026-04-30T23:59:59Z']);
+      expect(params['types[]'], ['agent.message', 'user.interrupt']);
     });
 
     test('send sends correct request', () async {

--- a/packages/anthropic_sdk_dart/test/unit/resources/user_profiles_resource_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/resources/user_profiles_resource_test.dart
@@ -19,6 +19,7 @@ class UserProfilesFixtures {
       'id': id,
       'type': 'user_profile',
       'external_id': externalId,
+      'relationship': 'external',
       'metadata': metadata ?? <String, String>{},
       'trust_grants':
           trustGrants ??


### PR DESCRIPTION
## Summary

- Refresh Anthropic OpenAPI spec to `0df2c79…` (was `6811827…`).
- Add `BetaTimestamp` typedef and migrate timestamp fields on `Agent`, `Session`, `UserProfile`, and every `SessionEvent` subclass.
- Introduce `BetaUserProfileRelationship` enum and add `name` + `relationship` to user-profile types.
- Add `sessionThreadId` to seven session-event classes plus `UserInterruptEventParams` (which also gains a `copyWith`).
- Expand `sessions.list()` and `sessionEvents.list()` with new filter parameters (`memoryStoreId`, `statuses[]`, `created_at[gt|gte|lt|lte]`, `types[]`).

This is **PR 1 of a four-PR series** for the spec refresh. PR 2/3/4 will land Session Threads, Multiagent + Outcome Evaluations + Rubrics, and Webhook events + Credential validation respectively. The full plan lives at `.claude/plans/cached-weaving-galaxy.md`.

## Details

### New types

- **`BetaTimestamp`** (`typedef BetaTimestamp = DateTime`) — purely a rename so the spec mapping is explicit. Zero functional change. Added to barrel.
- **`BetaUserProfileRelationship`** enum with values `external`, `resold`, `internal`, plus an `unknown` forward-compat fallback (matching the codebase convention used by `TrustGrantStatus`/`SessionStatus`).

### Existing types updated

| Class | Change |
|---|---|
| `Agent`, `Session` | `createdAt`/`updatedAt`/`archivedAt` retyped to `BetaTimestamp` |
| `UserProfile` | `createdAt`/`updatedAt` retyped; added `name` (`String?`) and `relationship` (non-nullable, `required` in constructor) |
| `CreateUserProfileRequest` | added `name` and `relationship` (both nullable optional) |
| `UpdateUserProfileRequest` | added `name` and `relationship` using the existing tri-state `_notSet` sentinel pattern, with new `hasName` / `hasRelationship` getters |
| 6 session-event classes (`AgentToolUseEvent`, `AgentMcpToolUseEvent`, `AgentCustomToolUseEvent`, `UserInterruptEvent`, `UserToolConfirmationEvent`, `UserCustomToolResultEvent`) | added optional `sessionThreadId`; `processedAt` retyped to `BetaTimestamp` |
| `UserInterruptEventParams` | added optional `sessionThreadId` and a brand-new `copyWith` |

### New endpoint filters

- `sessions.list()` gains `memoryStoreId` (`String?`) and `statuses` (`List<SessionStatus>?` → `statuses[]`).
- `sessionEvents.list()` gains `createdAtGt`/`Gte`/`Lt`/`Lte` (`String?` ISO 8601 timestamps, matching the existing `sessions.list()` shape) and `types` (`List<String>?` → `types[]`).

### Deferred to follow-up PRs

The spec also adds Multiagent, Session Threads, Outcome Evaluations, Rubrics, Webhook events, Credential validation, and several other Beta surfaces. Those are intentionally **not** addressed here. As a result the `openapi-anthropic` toolkit's `verify` will continue to flag:

- `Missing property 'multiagent'` on `Agent` / `SessionAgent` / `Create/UpdateAgentParams` (PR 3).
- `Missing property 'outcome_evaluations'` on `Session` (PR 3).
- `Property 'title' is required in spec but nullable in Dart` on `Session` and the same error on `ListUserProfilesResponse.next_page` — both are spec `required: + nullable:true` combos that Dart can already represent correctly via `required this.X` of type `String?`. Verifier limitation; no code change.

## Breaking Changes

- **`UserProfile.relationship`** is now a required, non-nullable constructor parameter (the spec marks it required and non-nullable). Code that constructs `UserProfile` directly (rather than via `UserProfile.fromJson`) must now pass `relationship`.

  ```dart
  // Before
  final profile = UserProfile(
    id: 'uprof_…',
    metadata: {},
    trustGrants: {},
    createdAt: DateTime.now(),
    updatedAt: DateTime.now(),
  );

  // After — relationship is now required
  final profile = UserProfile(
    id: 'uprof_…',
    relationship: BetaUserProfileRelationship.external,
    metadata: {},
    trustGrants: {},
    createdAt: DateTime.now(),
    updatedAt: DateTime.now(),
  );
  ```

## Test Plan

- [x] `dart analyze .` — clean
- [x] `dart format --set-exit-if-changed .` — clean
- [x] `dart test --reporter=failures-only test/unit/` — 744 passed, 4 skipped (env-dependent), 0 failed
- [x] `api_toolkit verify` — only PR 2/3/4-deferred surfaces remaining
- [x] New unit tests cover: enum round-trip + `unknown` fallback; `UserProfile`/`CreateUserProfileRequest`/`UpdateUserProfileRequest` `name` + `relationship` round-trip; `sessionThreadId` round-trip across all 6 events + `UserInterruptEventParams`; `sessions.list()` and `sessionEvents.list()` query-param wiring with `MockClient`
- [x] `==`/`hashCode` parity verified for every changed class — every new field is referenced in both