### PR TITLE
feat(ollama_dart): make X-Request-ID header opt-in to fix browser CORS

### DIFF
--- a/packages/ollama_dart/README.md
+++ b/packages/ollama_dart/README.md
@@ -111,6 +111,8 @@ Environment variable:
 
 Use `BearerTokenProvider` when the Ollama server is exposed behind an authenticated reverse proxy or remote deployment.
 
+By default the client does **not** send an `X-Request-ID` header — Ollama's CORS allow-list excludes it, so sending it breaks the preflight in browser targets (Flutter Web / dart2wasm). A request ID is still generated internally for logging and error correlation. Set `OllamaConfig(sendRequestIdHeader: true)` to emit the header when talking to an intermediary (e.g. a reverse proxy) you've configured to accept it.
+
 </details>
 
 ## Usage

--- a/packages/ollama_dart/lib/src/client/config.dart
+++ b/packages/ollama_dart/lib/src/client/config.dart
@@ -68,6 +68,21 @@ class OllamaConfig {
   /// Fields to redact in logs (case-insensitive).
   final List<String> redactionList;
 
+  /// Whether to send the `X-Request-ID` header on outgoing requests.
+  ///
+  /// Defaults to `false`. A request ID is always generated internally for
+  /// logging and error correlation; this flag only controls whether that ID is
+  /// added to the outgoing HTTP request.
+  ///
+  /// It defaults to `false` because Ollama's CORS allow-list does not include
+  /// `X-Request-ID`, so sending it triggers a failed preflight in browser
+  /// targets (Flutter Web / dart2wasm). Enable it only when talking to an
+  /// intermediary (e.g. a reverse proxy) that you've configured to accept it.
+  ///
+  /// An `X-Request-ID` set explicitly by the caller (e.g. via [defaultHeaders])
+  /// is always sent, regardless of this flag.
+  final bool sendRequestIdHeader;
+
   /// Creates an [OllamaConfig].
   const OllamaConfig({
     this.baseUrl = 'http://localhost:11434',
@@ -84,6 +99,7 @@ class OllamaConfig {
       'secret',
       'bearer',
     ],
+    this.sendRequestIdHeader = false,
   });
 
   /// Creates an [OllamaConfig] using runtime environment variables.
@@ -111,6 +127,7 @@ class OllamaConfig {
     RetryPolicy? retryPolicy,
     Level? logLevel,
     List<String>? redactionList,
+    bool? sendRequestIdHeader,
   }) {
     return OllamaConfig(
       baseUrl: baseUrl ?? this.baseUrl,
@@ -121,6 +138,7 @@ class OllamaConfig {
       retryPolicy: retryPolicy ?? this.retryPolicy,
       logLevel: logLevel ?? this.logLevel,
       redactionList: redactionList ?? this.redactionList,
+      sendRequestIdHeader: sendRequestIdHeader ?? this.sendRequestIdHeader,
     );
   }
 }

--- a/packages/ollama_dart/lib/src/client/ollama_client.dart
+++ b/packages/ollama_dart/lib/src/client/ollama_client.dart
@@ -128,6 +128,7 @@ class OllamaClient {
       LoggingInterceptor(
         logLevel: this.config.logLevel,
         redactionList: this.config.redactionList,
+        sendRequestIdHeader: this.config.sendRequestIdHeader,
       ),
       // Error interceptor
       const ErrorInterceptor(),

--- a/packages/ollama_dart/lib/src/interceptors/logging_interceptor.dart
+++ b/packages/ollama_dart/lib/src/interceptors/logging_interceptor.dart
@@ -6,7 +6,9 @@ import 'interceptor.dart';
 
 /// Interceptor that logs HTTP requests and responses.
 ///
-/// Adds `X-Request-ID` header if not already present.
+/// A request ID is always generated for log/error correlation. The
+/// `X-Request-ID` header is only added to the outgoing request when
+/// [sendRequestIdHeader] is `true` (or the caller already supplied one).
 /// Logs request/response details based on configured log level.
 class LoggingInterceptor implements Interceptor {
   /// Logger instance.
@@ -18,9 +20,15 @@ class LoggingInterceptor implements Interceptor {
   /// Fields to redact in logs.
   final List<String> redactionList;
 
+  /// Whether to add the `X-Request-ID` header to the outgoing request.
+  final bool sendRequestIdHeader;
+
   /// Creates a [LoggingInterceptor].
-  LoggingInterceptor({required this.logLevel, required this.redactionList})
-    : _logger = Logger('ollama_dart');
+  LoggingInterceptor({
+    required this.logLevel,
+    required this.redactionList,
+    required this.sendRequestIdHeader,
+  }) : _logger = Logger('ollama_dart');
 
   @override
   Future<http.Response> intercept(
@@ -29,11 +37,14 @@ class LoggingInterceptor implements Interceptor {
   ) async {
     final startTime = DateTime.now();
 
-    // Add request ID if not present
+    // Always derive a request ID for log/error correlation. Only add it to the
+    // outgoing request when enabled; a caller-supplied header is preserved.
     final requestId =
         context.request.headers['X-Request-ID'] ?? generateRequestId();
 
-    final request = _ensureRequestId(context.request, requestId);
+    final request = sendRequestIdHeader
+        ? _ensureRequestId(context.request, requestId)
+        : context.request;
 
     // Store correlation ID in metadata
     final metadata = Map<String, dynamic>.from(context.metadata)

--- a/packages/ollama_dart/lib/src/resources/chat_resource.dart
+++ b/packages/ollama_dart/lib/src/resources/chat_resource.dart
@@ -62,13 +62,18 @@ class ChatResource extends ResourceBase with StreamingResource {
     // Ensure stream is true for streaming
     final requestData = request.copyWith(stream: true);
 
-    var httpRequest = http.Request('POST', url)
+    final httpRequest = http.Request('POST', url)
       ..headers.addAll(headers)
       ..body = jsonEncode(requestData.toJson());
 
     // Use mixin methods for streaming request handling
-    httpRequest = await prepareStreamingRequest(httpRequest);
-    final streamedResponse = await sendStreamingRequest(httpRequest);
+    final (preparedRequest, requestId) = await prepareStreamingRequest(
+      httpRequest,
+    );
+    final streamedResponse = await sendStreamingRequest(
+      preparedRequest,
+      requestId: requestId,
+    );
 
     // Parse NDJSON stream
     await for (final json in parseNDJSON(streamedResponse.stream)) {

--- a/packages/ollama_dart/lib/src/resources/completions_resource.dart
+++ b/packages/ollama_dart/lib/src/resources/completions_resource.dart
@@ -64,13 +64,18 @@ class CompletionsResource extends ResourceBase with StreamingResource {
     // Ensure stream is true for streaming
     final requestData = request.copyWith(stream: true);
 
-    var httpRequest = http.Request('POST', url)
+    final httpRequest = http.Request('POST', url)
       ..headers.addAll(headers)
       ..body = jsonEncode(requestData.toJson());
 
     // Use mixin methods for streaming request handling
-    httpRequest = await prepareStreamingRequest(httpRequest);
-    final streamedResponse = await sendStreamingRequest(httpRequest);
+    final (preparedRequest, requestId) = await prepareStreamingRequest(
+      httpRequest,
+    );
+    final streamedResponse = await sendStreamingRequest(
+      preparedRequest,
+      requestId: requestId,
+    );
 
     // Parse NDJSON stream
     await for (final json in parseNDJSON(streamedResponse.stream)) {

--- a/packages/ollama_dart/lib/src/resources/models_resource.dart
+++ b/packages/ollama_dart/lib/src/resources/models_resource.dart
@@ -123,13 +123,18 @@ class ModelsResource extends ResourceBase with StreamingResource {
     // Ensure stream is true for streaming
     final requestData = request.copyWith(stream: true);
 
-    var httpRequest = http.Request('POST', url)
+    final httpRequest = http.Request('POST', url)
       ..headers.addAll(headers)
       ..body = jsonEncode(requestData.toJson());
 
     // Use mixin methods for streaming request handling
-    httpRequest = await prepareStreamingRequest(httpRequest);
-    final streamedResponse = await sendStreamingRequest(httpRequest);
+    final (preparedRequest, requestId) = await prepareStreamingRequest(
+      httpRequest,
+    );
+    final streamedResponse = await sendStreamingRequest(
+      preparedRequest,
+      requestId: requestId,
+    );
 
     await for (final json in parseNDJSON(streamedResponse.stream)) {
       if (json['error'] != null) {
@@ -213,13 +218,18 @@ class ModelsResource extends ResourceBase with StreamingResource {
     // Ensure stream is true for streaming
     final requestData = request.copyWith(stream: true);
 
-    var httpRequest = http.Request('POST', url)
+    final httpRequest = http.Request('POST', url)
       ..headers.addAll(headers)
       ..body = jsonEncode(requestData.toJson());
 
     // Use mixin methods for streaming request handling
-    httpRequest = await prepareStreamingRequest(httpRequest);
-    final streamedResponse = await sendStreamingRequest(httpRequest);
+    final (preparedRequest, requestId) = await prepareStreamingRequest(
+      httpRequest,
+    );
+    final streamedResponse = await sendStreamingRequest(
+      preparedRequest,
+      requestId: requestId,
+    );
 
     await for (final json in parseNDJSON(streamedResponse.stream)) {
       if (json['error'] != null) {
@@ -269,13 +279,18 @@ class ModelsResource extends ResourceBase with StreamingResource {
     // Ensure stream is true for streaming
     final requestData = request.copyWith(stream: true);
 
-    var httpRequest = http.Request('POST', url)
+    final httpRequest = http.Request('POST', url)
       ..headers.addAll(headers)
       ..body = jsonEncode(requestData.toJson());
 
     // Use mixin methods for streaming request handling
-    httpRequest = await prepareStreamingRequest(httpRequest);
-    final streamedResponse = await sendStreamingRequest(httpRequest);
+    final (preparedRequest, requestId) = await prepareStreamingRequest(
+      httpRequest,
+    );
+    final streamedResponse = await sendStreamingRequest(
+      preparedRequest,
+      requestId: requestId,
+    );
 
     await for (final json in parseNDJSON(streamedResponse.stream)) {
       if (json['error'] != null) {

--- a/packages/ollama_dart/lib/src/resources/streaming_resource.dart
+++ b/packages/ollama_dart/lib/src/resources/streaming_resource.dart
@@ -44,8 +44,13 @@ mixin StreamingResource on ResourceBase {
   /// Prepares a streaming request by applying auth and logging.
   ///
   /// This applies the same auth and logging that the interceptor chain would
-  /// apply, but without buffering the response.
-  Future<http.Request> prepareStreamingRequest(http.Request request) async {
+  /// apply, but without buffering the response. Returns the prepared request
+  /// together with its request ID (for log/error correlation); the ID is only
+  /// added to the request as an `X-Request-ID` header when
+  /// [OllamaConfig.sendRequestIdHeader] is enabled.
+  Future<(http.Request, String)> prepareStreamingRequest(
+    http.Request request,
+  ) async {
     var req = request;
 
     // Apply auth
@@ -55,18 +60,18 @@ mixin StreamingResource on ResourceBase {
     req = _applyAuthToRequest(req, credentials);
 
     // Apply logging
-    req = _applyLoggingToRequest(req);
-
-    return req;
+    return _applyLoggingToRequest(req);
   }
 
   /// Sends a streaming request with error handling.
   ///
   /// Returns the [StreamedResponse] if successful, or throws an
-  /// [OllamaException] if the response indicates an error.
+  /// [OllamaException] if the response indicates an error. [requestId] is used
+  /// for error-log correlation.
   Future<http.StreamedResponse> sendStreamingRequest(
-    http.Request request,
-  ) async {
+    http.Request request, {
+    required String requestId,
+  }) async {
     ensureNotClosed?.call();
 
     http.StreamedResponse streamedResponse;
@@ -78,10 +83,7 @@ mixin StreamingResource on ResourceBase {
         throw mapHttpError(response);
       }
     } catch (e) {
-      _logStreamError(
-        e,
-        request.headers['X-Request-ID'] ?? generateRequestId(),
-      );
+      _logStreamError(e, requestId);
       rethrow;
     }
 
@@ -106,26 +108,33 @@ mixin StreamingResource on ResourceBase {
     };
   }
 
-  /// Applies logging to a request by adding a request ID.
-  http.Request _applyLoggingToRequest(http.Request request) {
-    if (!request.headers.containsKey('X-Request-ID')) {
-      final requestId = generateRequestId();
+  /// Derives a request ID for the request and logs it.
+  ///
+  /// Returns the request together with its ID. The `X-Request-ID` header is
+  /// only added to the outgoing request when
+  /// [OllamaConfig.sendRequestIdHeader] is enabled and the caller didn't
+  /// already supply one; otherwise the ID is used for logging only.
+  (http.Request, String) _applyLoggingToRequest(http.Request request) {
+    final requestId = request.headers['X-Request-ID'] ?? generateRequestId();
+
+    if (config.logLevel.value <= Level.INFO.value) {
+      Logger(
+        'Ollama.HTTP',
+      ).info('REQUEST [$requestId] ${request.method} ${request.url}');
+    }
+
+    if (config.sendRequestIdHeader &&
+        !request.headers.containsKey('X-Request-ID')) {
       final updatedRequest = http.Request(request.method, request.url)
         ..headers.addAll(request.headers)
         ..headers['X-Request-ID'] = requestId
         ..bodyBytes = request.bodyBytes
         ..encoding = request.encoding;
 
-      if (config.logLevel.value <= Level.INFO.value) {
-        Logger(
-          'Ollama.HTTP',
-        ).info('REQUEST [$requestId] ${request.method} ${request.url}');
-      }
-
-      return updatedRequest;
+      return (updatedRequest, requestId);
     }
 
-    return request;
+    return (request, requestId);
   }
 
   /// Maps an HTTP error response to an [OllamaException].

--- a/packages/ollama_dart/test/unit/client/config_test.dart
+++ b/packages/ollama_dart/test/unit/client/config_test.dart
@@ -1,0 +1,29 @@
+import 'package:ollama_dart/src/client/config.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OllamaConfig', () {
+    test('sendRequestIdHeader defaults to false', () {
+      const config = OllamaConfig();
+
+      expect(config.sendRequestIdHeader, isFalse);
+    });
+
+    test('copyWith overrides sendRequestIdHeader', () {
+      const config = OllamaConfig();
+
+      final updated = config.copyWith(sendRequestIdHeader: true);
+
+      expect(updated.sendRequestIdHeader, isTrue);
+    });
+
+    test('copyWith preserves sendRequestIdHeader when not provided', () {
+      const config = OllamaConfig(sendRequestIdHeader: true);
+
+      final updated = config.copyWith(baseUrl: 'http://example.com');
+
+      expect(updated.sendRequestIdHeader, isTrue);
+      expect(updated.baseUrl, 'http://example.com');
+    });
+  });
+}

--- a/packages/ollama_dart/test/unit/interceptors/logging_interceptor_test.dart
+++ b/packages/ollama_dart/test/unit/interceptors/logging_interceptor_test.dart
@@ -1,0 +1,87 @@
+import 'package:http/http.dart' as http;
+import 'package:logging/logging.dart';
+import 'package:ollama_dart/src/interceptors/interceptor.dart';
+import 'package:ollama_dart/src/interceptors/logging_interceptor.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LoggingInterceptor', () {
+    LoggingInterceptor createInterceptor({bool sendRequestIdHeader = false}) {
+      return LoggingInterceptor(
+        logLevel: Level.OFF,
+        redactionList: const [],
+        sendRequestIdHeader: sendRequestIdHeader,
+      );
+    }
+
+    /// Runs the interceptor and returns the context forwarded to `next`.
+    Future<RequestContext> run(
+      LoggingInterceptor interceptor,
+      http.BaseRequest request,
+    ) async {
+      late RequestContext forwarded;
+      await interceptor.intercept(RequestContext(request: request), (
+        context,
+      ) async {
+        forwarded = context;
+        return http.Response('', 200);
+      });
+      return forwarded;
+    }
+
+    test('does not send X-Request-ID header by default', () async {
+      final forwarded = await run(
+        createInterceptor(),
+        http.Request('POST', Uri.parse('http://localhost:11434/api/chat')),
+      );
+
+      // No header on the wire (browser/CORS-safe default)...
+      expect(forwarded.request.headers.containsKey('X-Request-ID'), isFalse);
+      // ...but correlation is still tracked internally.
+      expect(forwarded.metadata['correlationId'], isA<String>());
+      expect(forwarded.metadata['correlationId'], isNotEmpty);
+    });
+
+    test(
+      'sends X-Request-ID header when sendRequestIdHeader is true',
+      () async {
+        final forwarded = await run(
+          createInterceptor(sendRequestIdHeader: true),
+          http.Request('POST', Uri.parse('http://localhost:11434/api/chat')),
+        );
+
+        final header = forwarded.request.headers['X-Request-ID'];
+        expect(header, isNotEmpty);
+        // The wire header and the correlation ID match.
+        expect(forwarded.metadata['correlationId'], header);
+      },
+    );
+
+    test('preserves caller-supplied X-Request-ID when flag is off', () async {
+      final request = http.Request(
+        'POST',
+        Uri.parse('http://localhost:11434/api/chat'),
+      )..headers['X-Request-ID'] = 'caller-id';
+
+      final forwarded = await run(createInterceptor(), request);
+
+      expect(forwarded.request.headers['X-Request-ID'], 'caller-id');
+      expect(forwarded.metadata['correlationId'], 'caller-id');
+    });
+
+    test('preserves caller-supplied X-Request-ID when flag is on', () async {
+      final request = http.Request(
+        'POST',
+        Uri.parse('http://localhost:11434/api/chat'),
+      )..headers['X-Request-ID'] = 'caller-id';
+
+      final forwarded = await run(
+        createInterceptor(sendRequestIdHeader: true),
+        request,
+      );
+
+      expect(forwarded.request.headers['X-Request-ID'], 'caller-id');
+      expect(forwarded.metadata['correlationId'], 'caller-id');
+    });
+  });
+}

--- a/packages/ollama_dart/test/unit/resources/streaming_resource_test.dart
+++ b/packages/ollama_dart/test/unit/resources/streaming_resource_test.dart
@@ -46,11 +46,13 @@ void main() {
   TestStreamingResource createResource({
     AuthProvider? authProvider,
     Level logLevel = Level.OFF,
+    bool sendRequestIdHeader = false,
   }) {
     final config = OllamaConfig(
       baseUrl: 'http://localhost:11434',
       authProvider: authProvider,
       logLevel: logLevel,
+      sendRequestIdHeader: sendRequestIdHeader,
     );
     return TestStreamingResource(
       config: config,
@@ -153,7 +155,7 @@ void main() {
           Uri.parse('http://localhost:11434/api/chat'),
         );
 
-        final prepared = await resource.prepareStreamingRequest(request);
+        final (prepared, _) = await resource.prepareStreamingRequest(request);
 
         expect(prepared.headers['Authorization'], 'Bearer test-token');
       });
@@ -170,7 +172,7 @@ void main() {
           Uri.parse('http://localhost:11434/api/chat'),
         );
 
-        final prepared = await resource.prepareStreamingRequest(request);
+        final (prepared, _) = await resource.prepareStreamingRequest(request);
 
         expect(prepared.headers.containsKey('Authorization'), isFalse);
       });
@@ -182,34 +184,74 @@ void main() {
           Uri.parse('http://localhost:11434/api/chat'),
         );
 
-        final prepared = await resource.prepareStreamingRequest(request);
+        final (prepared, _) = await resource.prepareStreamingRequest(request);
 
         expect(prepared.headers.containsKey('Authorization'), isFalse);
       });
 
-      test('adds X-Request-ID header when not present', () async {
+      test('does not add X-Request-ID header by default', () async {
         resource = createResource();
         final request = http.Request(
           'POST',
           Uri.parse('http://localhost:11434/api/chat'),
         );
 
-        final prepared = await resource.prepareStreamingRequest(request);
+        final (prepared, requestId) = await resource.prepareStreamingRequest(
+          request,
+        );
 
-        expect(prepared.headers['X-Request-ID'], isNotNull);
-        expect(prepared.headers['X-Request-ID'], isNotEmpty);
+        // No header on the wire (browser/CORS-safe default)...
+        expect(prepared.headers.containsKey('X-Request-ID'), isFalse);
+        // ...but an ID is still generated for log/error correlation.
+        expect(requestId, isNotEmpty);
       });
 
-      test('preserves existing X-Request-ID header', () async {
+      test(
+        'adds X-Request-ID header when sendRequestIdHeader is true',
+        () async {
+          resource = createResource(sendRequestIdHeader: true);
+          final request = http.Request(
+            'POST',
+            Uri.parse('http://localhost:11434/api/chat'),
+          );
+
+          final (prepared, requestId) = await resource.prepareStreamingRequest(
+            request,
+          );
+
+          expect(prepared.headers['X-Request-ID'], isNotEmpty);
+          expect(prepared.headers['X-Request-ID'], requestId);
+        },
+      );
+
+      test('preserves caller-supplied X-Request-ID when flag is off', () async {
         resource = createResource();
         final request = http.Request(
           'POST',
           Uri.parse('http://localhost:11434/api/chat'),
         )..headers['X-Request-ID'] = 'existing-id';
 
-        final prepared = await resource.prepareStreamingRequest(request);
+        final (prepared, requestId) = await resource.prepareStreamingRequest(
+          request,
+        );
 
         expect(prepared.headers['X-Request-ID'], 'existing-id');
+        expect(requestId, 'existing-id');
+      });
+
+      test('preserves caller-supplied X-Request-ID when flag is on', () async {
+        resource = createResource(sendRequestIdHeader: true);
+        final request = http.Request(
+          'POST',
+          Uri.parse('http://localhost:11434/api/chat'),
+        )..headers['X-Request-ID'] = 'existing-id';
+
+        final (prepared, requestId) = await resource.prepareStreamingRequest(
+          request,
+        );
+
+        expect(prepared.headers['X-Request-ID'], 'existing-id');
+        expect(requestId, 'existing-id');
       });
     });
 
@@ -229,7 +271,10 @@ void main() {
           () => mockHttpClient.send(any()),
         ).thenAnswer((_) async => mockStreamedResponse);
 
-        final response = await resource.sendStreamingRequest(request);
+        final response = await resource.sendStreamingRequest(
+          request,
+          requestId: 'test-id',
+        );
 
         expect(response.statusCode, 200);
       });
@@ -250,7 +295,7 @@ void main() {
         ).thenAnswer((_) async => mockStreamedResponse);
 
         expect(
-          () => resource.sendStreamingRequest(request),
+          () => resource.sendStreamingRequest(request, requestId: 'test-id'),
           throwsA(isA<ApiException>()),
         );
       });
@@ -272,7 +317,7 @@ void main() {
         ).thenAnswer((_) async => mockStreamedResponse);
 
         expect(
-          () => resource.sendStreamingRequest(request),
+          () => resource.sendStreamingRequest(request, requestId: 'test-id'),
           throwsA(isA<RateLimitException>()),
         );
       });


### PR DESCRIPTION
## Summary
- `ollama_dart` no longer sends an `X-Request-ID` header by default. The header is not CORS-safelisted and Ollama's hard-coded `Access-Control-Allow-Headers` list excludes it, so the browser preflight failed and **all** browser usage (Flutter Web / dart2wasm) against a real Ollama server was blocked.
- A request ID is still generated internally for logging, error correlation, and retry/abort tracing — only the *wire header* is now gated. Behavior is identical across native and web.
- New `OllamaConfig(sendRequestIdHeader: true)` opt-in restores the header for callers talking to an intermediary (e.g. a reverse proxy) configured to accept it. An `X-Request-ID` set explicitly by the caller (e.g. via `defaultHeaders`) is always sent, regardless of the flag.

Closes #225.

## Details

The `X-Request-ID` header exists purely for client-side observability — Ollama never reads or echoes it. The root cause was that the code conflated a client-only correlation ID with an HTTP header and leaked it onto the wire unconditionally, on both the non-streaming path (`LoggingInterceptor`) and the streaming path (`StreamingResource`, which bypasses the interceptor chain).

The fix decouples the two concerns: the ID is always generated and tracked internally (the non-streaming path already carried it in `context.metadata['correlationId']`), while the header is now an opt-in transport detail.

```dart
// Default (browser/CORS-safe): no X-Request-ID on the wire,
// but logs and exceptions still carry a correlation id.
final client = OllamaClient();

// Opt in when an intermediary you control expects the header:
final client = OllamaClient(
  config: OllamaConfig(sendRequestIdHeader: true),
);
```

Implementation notes:
- `OllamaConfig` gains `sendRequestIdHeader` (default `false`), threaded through the constructor and `copyWith`.
- `LoggingInterceptor` only adds the header when the flag is on; `metadata['correlationId']` is still set unconditionally.
- On the streaming path, `prepareStreamingRequest` / `_applyLoggingToRequest` now return `(http.Request, String requestId)` and `sendStreamingRequest` takes the `requestId`, so the ID no longer rides on the header to stay consistent in logs. The 5 streaming call sites (chat, completions, models ×3) were updated. These mixin methods live under `lib/src/` (private), so the signature change is internal-only.

> [!NOTE]
> No public Dart API breaks, so this is a minor (`feat`) bump. It does change default on-the-wire behavior: `X-Request-ID` is no longer sent unless `sendRequestIdHeader: true` or the caller sets the header explicitly.

## Test Plan
- [x] Unit tests pass for `ollama_dart` (222 passed, 2 pre-existing env skips)
- [x] New tests added: `logging_interceptor_test.dart` (non-streaming regression guard — no test existed before), `config_test.dart` (default + `copyWith`)
- [x] `streaming_resource_test.dart` reworked into a matrix: default → no header, flag on → header present, caller-supplied header always preserved
- [x] `correlationId` verified present in all cases (correlation never depends on the header)
- [x] `dart format` (no changes), `dart fix` (nothing to fix), `dart analyze` (no errors/warnings)
- [ ] Manual browser confirmation by reporter: dart2wasm build completes the Ollama preflight with the default config