### PR TITLE
chore(ollama_dart): refresh spec metadata

### DIFF
--- a/packages/ollama_dart/specs/spec_metadata.json
+++ b/packages/ollama_dart/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "0.1.0",
-      "last_fetched": "2026-05-09T16:23:47.644511Z",
+      "last_fetched": "2026-05-23T06:45:12.934679Z",
       "source_url": "https://raw.githubusercontent.com/ollama/ollama/refs/heads/main/docs/openapi.yaml",
       "title": "Ollama API",
       "version_history": []


### PR DESCRIPTION
## Summary
- Re-fetched the upstream Ollama OpenAPI spec (`ollama/ollama@main`, version `0.1.0`, 12 endpoints / 34 schemas). The spec content is **unchanged** — no models, resources, or tests required updates.
- Only `packages/ollama_dart/specs/spec_metadata.json` changes: the `last_fetched` timestamp is bumped to record that we re-verified against upstream today.

## Details
The toolkit `review` reported zero changed types and zero added/modified/removed endpoints or schemas. The checked-in `specs/openapi.json` is byte-identical to the freshly fetched candidate after normalization.

This mirrors the established practice in #221 (*"chore: refresh spec metadata for unchanged clients"*) of recording fetch verification for unchanged clients.

```diff
-  "last_fetched": "2026-05-09T16:23:47.644511Z",
+  "last_fetched": "2026-05-23T06:45:12.934679Z",
```

## Test Plan
- [x] `api_toolkit.py review` — 0 changed types, 0 endpoint/schema diffs, 0 errors/warnings
- [x] `api_toolkit.py verify --checks all --scope all` — `failing_checks: []`, `warning_checks: []`
- [x] `dart analyze` (lib/) — no issues
- [x] `dart format --set-exit-if-changed .` — clean
- [x] `dart test test/unit/` — 222 passed, 2 skipped