### PR TITLE
feat(anthropic_sdk_dart): add webhook events & credential validation

### DIFF
--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
@@ -3437,6 +3437,248 @@
       "file": "lib/src/models/managed_agents/events/send_event_params.dart",
       "schema": "BetaManagedAgentsUserDefineOutcomeEventParams",
       "parent": "EventParams"
+    },
+    "WebhookEvent": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "WebhookEvent",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookEvent"
+    },
+    "WebhookEventData": {
+      "spec": "main",
+      "kind": "sealed_parent",
+      "dart_class": "WebhookEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookEventData"
+    },
+    "WebhookSessionArchivedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookSessionArchivedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookSessionArchivedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookSessionCreatedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookSessionCreatedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookSessionCreatedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookSessionDeletedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookSessionDeletedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookSessionDeletedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookSessionIdledEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookSessionIdledEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookSessionIdledEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookSessionOutcomeEvaluationEndedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookSessionOutcomeEvaluationEndedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookSessionOutcomeEvaluationEndedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookSessionPendingEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookSessionPendingEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookSessionPendingEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookSessionRequiresActionEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookSessionRequiresActionEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookSessionRequiresActionEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookSessionRunningEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookSessionRunningEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookSessionRunningEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookSessionStatusIdledEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookSessionStatusIdledEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookSessionStatusIdledEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookSessionStatusRescheduledEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookSessionStatusRescheduledEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookSessionStatusRescheduledEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookSessionStatusRunStartedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookSessionStatusRunStartedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookSessionStatusRunStartedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookSessionStatusTerminatedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookSessionStatusTerminatedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookSessionStatusTerminatedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookSessionThreadCreatedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookSessionThreadCreatedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookSessionThreadCreatedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookSessionThreadIdledEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookSessionThreadIdledEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookSessionThreadIdledEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookSessionThreadTerminatedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookSessionThreadTerminatedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookSessionThreadTerminatedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookVaultCreatedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookVaultCreatedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookVaultCreatedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookVaultArchivedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookVaultArchivedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookVaultArchivedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookVaultDeletedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookVaultDeletedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookVaultDeletedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookVaultCredentialCreatedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookVaultCredentialCreatedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookVaultCredentialCreatedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookVaultCredentialArchivedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookVaultCredentialArchivedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookVaultCredentialArchivedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookVaultCredentialDeletedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookVaultCredentialDeletedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookVaultCredentialDeletedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookVaultCredentialRefreshFailedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookVaultCredentialRefreshFailedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookVaultCredentialRefreshFailedEventData",
+      "parent": "WebhookEventData"
+    },
+    "CredentialValidation": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "CredentialValidation",
+      "file": "lib/src/models/managed_agents/credentials/credential_validation.dart",
+      "schema": "BetaManagedAgentsCredentialValidation",
+      "excluded_properties": [
+        "mcp_probe",
+        "refresh"
+      ]
+    },
+    "RefreshObject": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "RefreshObject",
+      "file": "lib/src/models/managed_agents/credentials/credential_validation.dart",
+      "schema": "BetaManagedAgentsRefreshObject",
+      "excluded_properties": [
+        "http_response"
+      ]
+    },
+    "McpProbe": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "McpProbe",
+      "file": "lib/src/models/managed_agents/credentials/credential_validation.dart",
+      "schema": "BetaManagedAgentsMcpProbe",
+      "excluded_properties": [
+        "http_response"
+      ]
+    },
+    "RefreshHttpResponse": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "RefreshHttpResponse",
+      "file": "lib/src/models/managed_agents/credentials/credential_validation.dart",
+      "schema": "BetaManagedAgentsRefreshHttpResponse"
+    },
+    "CredentialValidationStatus": {
+      "spec": "main",
+      "kind": "enum",
+      "dart_class": "CredentialValidationStatus",
+      "file": "lib/src/models/managed_agents/credentials/credential_validation.dart",
+      "schema": "BetaManagedAgentsCredentialValidationStatus"
+    },
+    "CredentialRefreshStatus": {
+      "spec": "main",
+      "kind": "enum",
+      "dart_class": "CredentialRefreshStatus",
+      "file": "lib/src/models/managed_agents/credentials/credential_validation.dart",
+      "schema": "BetaManagedAgentsCredentialRefreshStatus"
     }
   }
 }

--- a/packages/anthropic_sdk_dart/README.md
+++ b/packages/anthropic_sdk_dart/README.md
@@ -47,6 +47,7 @@ Dart client for the **[Anthropic API](https://docs.anthropic.com/en/api)** to bu
 - Model discovery, files (beta), and skills (beta)
 - Managed agents with sessions, threads, vaults, and streaming events (beta)
 - Multiagent coordinator orchestration and outcome evaluations with grading rubrics (beta)
+- Typed webhook event parsing and MCP-OAuth credential validation (beta)
 - Memory stores for persistent agent memories with versioning and redaction (beta)
 - User profiles with relationship classification (`external`/`resold`/`internal`), trust-grant tracking, and enrollment URLs (beta)
 
@@ -671,7 +672,7 @@ See the [example/](example/) directory for complete examples:
 | [`files_example.dart`](example/files_example.dart) | File management (beta) |
 | [`skills_example.dart`](example/skills_example.dart) | Skills management (beta) |
 | [`mcp_example.dart`](example/mcp_example.dart) | MCP tool integration |
-| [`managed_agents_example.dart`](example/managed_agents_example.dart) | Managed agents: agents, sessions, vaults, multiagent rosters, outcomes (beta) |
+| [`managed_agents_example.dart`](example/managed_agents_example.dart) | Managed agents: agents, sessions, vaults, multiagent rosters, outcomes, webhooks, credential validation (beta) |
 | [`session_threads_example.dart`](example/session_threads_example.dart) | Session threads: list, retrieve, stream events, archive (beta) |
 | [`memory_stores_example.dart`](example/memory_stores_example.dart) | Managed agents memory stores, memories, and versions (beta) |
 | [`user_profiles_example.dart`](example/user_profiles_example.dart) | User profiles and enrollment URLs (beta) |
@@ -693,6 +694,7 @@ See the [example/](example/) directory for complete examples:
 | Vaults (Beta) | ✅ Full |
 | Memory Stores (Beta) | ✅ Full |
 | User Profiles (Beta) | ✅ Full |
+| Webhooks (Beta) | ✅ Full |
 
 ## Official Documentation
 

--- a/packages/anthropic_sdk_dart/example/managed_agents_example.dart
+++ b/packages/anthropic_sdk_dart/example/managed_agents_example.dart
@@ -179,13 +179,15 @@ void main() async {
         print('Webhook: ${webhookEvent.data.runtimeType}');
     }
 
-    // Validate a vault credential's MCP-OAuth setup.
+    // Validate a vault credential's MCP-OAuth setup. The mcp_oauth_validate
+    // endpoint only accepts MCP-OAuth credentials (a static-bearer credential
+    // is rejected with a 400), so create one of those.
     final credential = await client.vaults
         .credentials(vault.id)
         .create(
           const CreateCredentialParams(
-            auth: StaticBearerCreateParams(
-              token: 'secret-token',
+            auth: McpOauthCreateParams(
+              accessToken: 'access-token',
               mcpServerUrl: 'https://mcp.example.com',
             ),
           ),

--- a/packages/anthropic_sdk_dart/example/managed_agents_example.dart
+++ b/packages/anthropic_sdk_dart/example/managed_agents_example.dart
@@ -152,7 +152,51 @@ void main() async {
     print('Defined an outcome for the session');
 
     // =========================================================================
-    // 5. Cleanup
+    // 5. Webhooks & credential validation
+    // =========================================================================
+    print('\n=== Webhooks & Credential Validation ===');
+
+    // Parse an inbound webhook payload (e.g. the body of your HTTP handler)
+    // into a typed event, then switch over the discriminated `data` union.
+    final samplePayload = <String, dynamic>{
+      'type': 'event',
+      'id': 'evt_123',
+      'created_at': '2026-04-01T00:00:00Z',
+      'data': <String, dynamic>{
+        'type': 'session.created',
+        'id': 'sesn_123',
+        'organization_id': 'org_123',
+        'workspace_id': 'wrkspc_123',
+      },
+    };
+    final webhookEvent = WebhookEvent.fromJson(samplePayload);
+    switch (webhookEvent.data) {
+      case WebhookSessionCreatedEventData(:final id):
+        print('Webhook: session $id created');
+      case WebhookVaultCredentialRefreshFailedEventData(:final id):
+        print('Webhook: credential $id refresh failed');
+      default:
+        print('Webhook: ${webhookEvent.data.runtimeType}');
+    }
+
+    // Validate a vault credential's MCP-OAuth setup.
+    final credential = await client.vaults
+        .credentials(vault.id)
+        .create(
+          const CreateCredentialParams(
+            auth: StaticBearerCreateParams(
+              token: 'secret-token',
+              mcpServerUrl: 'https://mcp.example.com',
+            ),
+          ),
+        );
+    final validation = await client.vaults
+        .credentials(vault.id)
+        .validateCredential(credential.id);
+    print('Credential validation status: ${validation.status.value}');
+
+    // =========================================================================
+    // 6. Cleanup
     // =========================================================================
     print('\n=== Cleanup ===');
 

--- a/packages/anthropic_sdk_dart/lib/anthropic_sdk_dart.dart
+++ b/packages/anthropic_sdk_dart/lib/anthropic_sdk_dart.dart
@@ -106,6 +106,7 @@ export 'src/models/managed_agents/credentials/create_credential_params.dart';
 export 'src/models/managed_agents/credentials/credential.dart';
 export 'src/models/managed_agents/credentials/credential_auth.dart';
 export 'src/models/managed_agents/credentials/credential_list_response.dart';
+export 'src/models/managed_agents/credentials/credential_validation.dart';
 export 'src/models/managed_agents/credentials/update_credential_params.dart';
 export 'src/models/managed_agents/errors/managed_agent_error.dart';
 export 'src/models/managed_agents/events/send_event_params.dart';
@@ -139,6 +140,7 @@ export 'src/models/managed_agents/vaults/create_vault_params.dart';
 export 'src/models/managed_agents/vaults/update_vault_params.dart';
 export 'src/models/managed_agents/vaults/vault.dart';
 export 'src/models/managed_agents/vaults/vault_list_response.dart';
+export 'src/models/managed_agents/webhooks/webhook_event.dart';
 
 // Models - Messages
 export 'src/models/messages/input_message.dart';

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/credentials/credential_validation.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/credentials/credential_validation.dart
@@ -1,0 +1,406 @@
+import 'package:meta/meta.dart';
+
+import '../../beta_timestamp.dart';
+import '../../common/copy_with_sentinel.dart';
+
+/// Overall result of validating a vault credential.
+enum CredentialValidationStatus {
+  /// The credential is valid and usable.
+  valid('valid'),
+
+  /// The credential is invalid.
+  invalid('invalid'),
+
+  /// The validation result could not be determined — also the fallback for
+  /// unrecognized values.
+  unknown('unknown');
+
+  const CredentialValidationStatus(this.value);
+
+  /// JSON value for this status.
+  final String value;
+
+  /// Parses a [CredentialValidationStatus] from JSON.
+  static CredentialValidationStatus fromJson(String value) => switch (value) {
+    'valid' => CredentialValidationStatus.valid,
+    'invalid' => CredentialValidationStatus.invalid,
+    _ => CredentialValidationStatus.unknown,
+  };
+
+  /// Converts this status to JSON.
+  String toJson() => value;
+}
+
+/// Outcome of attempting to refresh a credential's access token.
+enum CredentialRefreshStatus {
+  /// The refresh succeeded.
+  succeeded('succeeded'),
+
+  /// The refresh attempt failed.
+  failed('failed'),
+
+  /// Could not connect to the token endpoint.
+  connectError('connect_error'),
+
+  /// No refresh token is available for this credential.
+  noRefreshToken('no_refresh_token'),
+
+  /// Unrecognized refresh status — fallback for forward compatibility.
+  unknown('unknown');
+
+  const CredentialRefreshStatus(this.value);
+
+  /// JSON value for this status.
+  final String value;
+
+  /// Parses a [CredentialRefreshStatus] from JSON.
+  static CredentialRefreshStatus fromJson(String value) => switch (value) {
+    'succeeded' => CredentialRefreshStatus.succeeded,
+    'failed' => CredentialRefreshStatus.failed,
+    'connect_error' => CredentialRefreshStatus.connectError,
+    'no_refresh_token' => CredentialRefreshStatus.noRefreshToken,
+    _ => CredentialRefreshStatus.unknown,
+  };
+
+  /// Converts this status to JSON.
+  String toJson() => value;
+}
+
+/// A captured HTTP response from a credential refresh or MCP probe.
+///
+/// Sensitive values are scrubbed and the body may be truncated.
+@immutable
+class RefreshHttpResponse {
+  /// HTTP status code of the response.
+  final int statusCode;
+
+  /// Value of the response `Content-Type` header.
+  final String contentType;
+
+  /// Response body (may be truncated; sensitive values scrubbed).
+  final String body;
+
+  /// Whether [body] was truncated.
+  final bool bodyTruncated;
+
+  /// Creates a [RefreshHttpResponse].
+  const RefreshHttpResponse({
+    required this.statusCode,
+    required this.contentType,
+    required this.body,
+    required this.bodyTruncated,
+  });
+
+  /// Creates a [RefreshHttpResponse] from JSON.
+  factory RefreshHttpResponse.fromJson(Map<String, dynamic> json) {
+    return RefreshHttpResponse(
+      statusCode: json['status_code'] as int,
+      contentType: json['content_type'] as String,
+      body: json['body'] as String,
+      bodyTruncated: json['body_truncated'] as bool,
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'status_code': statusCode,
+    'content_type': contentType,
+    'body': body,
+    'body_truncated': bodyTruncated,
+  };
+
+  /// Creates a copy with replaced values.
+  RefreshHttpResponse copyWith({
+    int? statusCode,
+    String? contentType,
+    String? body,
+    bool? bodyTruncated,
+  }) {
+    return RefreshHttpResponse(
+      statusCode: statusCode ?? this.statusCode,
+      contentType: contentType ?? this.contentType,
+      body: body ?? this.body,
+      bodyTruncated: bodyTruncated ?? this.bodyTruncated,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RefreshHttpResponse &&
+          runtimeType == other.runtimeType &&
+          statusCode == other.statusCode &&
+          contentType == other.contentType &&
+          body == other.body &&
+          bodyTruncated == other.bodyTruncated;
+
+  @override
+  int get hashCode => Object.hash(statusCode, contentType, body, bodyTruncated);
+
+  @override
+  String toString() =>
+      'RefreshHttpResponse(statusCode: $statusCode, '
+      'contentType: $contentType, body: $body, '
+      'bodyTruncated: $bodyTruncated)';
+}
+
+/// Result of attempting to refresh a credential's access token during
+/// validation.
+@immutable
+class RefreshObject {
+  /// Outcome of the refresh attempt.
+  final CredentialRefreshStatus status;
+
+  /// Captured HTTP response. Populated only when [status] is
+  /// [CredentialRefreshStatus.failed]; otherwise null.
+  final RefreshHttpResponse? httpResponse;
+
+  /// Creates a [RefreshObject].
+  const RefreshObject({required this.status, this.httpResponse});
+
+  /// Creates a [RefreshObject] from JSON.
+  factory RefreshObject.fromJson(Map<String, dynamic> json) {
+    return RefreshObject(
+      status: CredentialRefreshStatus.fromJson(json['status'] as String),
+      httpResponse: json['http_response'] != null
+          ? RefreshHttpResponse.fromJson(
+              json['http_response'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'status': status.toJson(),
+    'http_response': httpResponse?.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  ///
+  /// For the nullable [httpResponse], pass [unsetCopyWithValue] (or omit) to
+  /// keep the original, or `null` explicitly to clear it.
+  RefreshObject copyWith({
+    CredentialRefreshStatus? status,
+    Object? httpResponse = unsetCopyWithValue,
+  }) {
+    return RefreshObject(
+      status: status ?? this.status,
+      httpResponse: httpResponse == unsetCopyWithValue
+          ? this.httpResponse
+          : httpResponse as RefreshHttpResponse?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RefreshObject &&
+          runtimeType == other.runtimeType &&
+          status == other.status &&
+          httpResponse == other.httpResponse;
+
+  @override
+  int get hashCode => Object.hash(status, httpResponse);
+
+  @override
+  String toString() =>
+      'RefreshObject(status: $status, httpResponse: $httpResponse)';
+}
+
+/// Result of probing an MCP server with a credential during validation.
+@immutable
+class McpProbe {
+  /// The MCP method that was probed (e.g. `initialize`, `tools/list`).
+  final String method;
+
+  /// Captured HTTP response from the probe. Null when no response was
+  /// received.
+  final RefreshHttpResponse? httpResponse;
+
+  /// Creates an [McpProbe].
+  const McpProbe({required this.method, this.httpResponse});
+
+  /// Creates an [McpProbe] from JSON.
+  factory McpProbe.fromJson(Map<String, dynamic> json) {
+    return McpProbe(
+      method: json['method'] as String,
+      httpResponse: json['http_response'] != null
+          ? RefreshHttpResponse.fromJson(
+              json['http_response'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'method': method,
+    'http_response': httpResponse?.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  ///
+  /// For the nullable [httpResponse], pass [unsetCopyWithValue] (or omit) to
+  /// keep the original, or `null` explicitly to clear it.
+  McpProbe copyWith({
+    String? method,
+    Object? httpResponse = unsetCopyWithValue,
+  }) {
+    return McpProbe(
+      method: method ?? this.method,
+      httpResponse: httpResponse == unsetCopyWithValue
+          ? this.httpResponse
+          : httpResponse as RefreshHttpResponse?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is McpProbe &&
+          runtimeType == other.runtimeType &&
+          method == other.method &&
+          httpResponse == other.httpResponse;
+
+  @override
+  int get hashCode => Object.hash(method, httpResponse);
+
+  @override
+  String toString() => 'McpProbe(method: $method, httpResponse: $httpResponse)';
+}
+
+/// Result of validating a vault credential against its MCP server.
+///
+/// Returned by the credential `mcp_oauth_validate` endpoint.
+@immutable
+class CredentialValidation {
+  /// Object type. Always 'vault_credential_validation'.
+  final String type;
+
+  /// ID of the credential that was validated.
+  final String credentialId;
+
+  /// ID of the vault the credential belongs to.
+  final String vaultId;
+
+  /// Overall validation status.
+  final CredentialValidationStatus status;
+
+  /// When the validation was performed.
+  final BetaTimestamp validatedAt;
+
+  /// Whether the credential has a refresh token.
+  final bool hasRefreshToken;
+
+  /// Result of probing the MCP server. Null when no probe was performed.
+  final McpProbe? mcpProbe;
+
+  /// Result of attempting a token refresh. Null when no refresh was attempted.
+  final RefreshObject? refresh;
+
+  /// Creates a [CredentialValidation].
+  const CredentialValidation({
+    this.type = 'vault_credential_validation',
+    required this.credentialId,
+    required this.vaultId,
+    required this.status,
+    required this.validatedAt,
+    required this.hasRefreshToken,
+    this.mcpProbe,
+    this.refresh,
+  });
+
+  /// Creates a [CredentialValidation] from JSON.
+  factory CredentialValidation.fromJson(Map<String, dynamic> json) {
+    return CredentialValidation(
+      type: json['type'] as String? ?? 'vault_credential_validation',
+      credentialId: json['credential_id'] as String,
+      vaultId: json['vault_id'] as String,
+      status: CredentialValidationStatus.fromJson(json['status'] as String),
+      validatedAt: DateTime.parse(json['validated_at'] as String),
+      hasRefreshToken: json['has_refresh_token'] as bool,
+      mcpProbe: json['mcp_probe'] != null
+          ? McpProbe.fromJson(json['mcp_probe'] as Map<String, dynamic>)
+          : null,
+      refresh: json['refresh'] != null
+          ? RefreshObject.fromJson(json['refresh'] as Map<String, dynamic>)
+          : null,
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'credential_id': credentialId,
+    'vault_id': vaultId,
+    'status': status.toJson(),
+    'validated_at': validatedAt.toUtc().toIso8601String(),
+    'has_refresh_token': hasRefreshToken,
+    'mcp_probe': mcpProbe?.toJson(),
+    'refresh': refresh?.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  ///
+  /// For the nullable [mcpProbe] and [refresh], pass [unsetCopyWithValue] (or
+  /// omit) to keep the original, or `null` explicitly to clear it.
+  CredentialValidation copyWith({
+    String? type,
+    String? credentialId,
+    String? vaultId,
+    CredentialValidationStatus? status,
+    BetaTimestamp? validatedAt,
+    bool? hasRefreshToken,
+    Object? mcpProbe = unsetCopyWithValue,
+    Object? refresh = unsetCopyWithValue,
+  }) {
+    return CredentialValidation(
+      type: type ?? this.type,
+      credentialId: credentialId ?? this.credentialId,
+      vaultId: vaultId ?? this.vaultId,
+      status: status ?? this.status,
+      validatedAt: validatedAt ?? this.validatedAt,
+      hasRefreshToken: hasRefreshToken ?? this.hasRefreshToken,
+      mcpProbe: mcpProbe == unsetCopyWithValue
+          ? this.mcpProbe
+          : mcpProbe as McpProbe?,
+      refresh: refresh == unsetCopyWithValue
+          ? this.refresh
+          : refresh as RefreshObject?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CredentialValidation &&
+          runtimeType == other.runtimeType &&
+          type == other.type &&
+          credentialId == other.credentialId &&
+          vaultId == other.vaultId &&
+          status == other.status &&
+          validatedAt == other.validatedAt &&
+          hasRefreshToken == other.hasRefreshToken &&
+          mcpProbe == other.mcpProbe &&
+          refresh == other.refresh;
+
+  @override
+  int get hashCode => Object.hash(
+    type,
+    credentialId,
+    vaultId,
+    status,
+    validatedAt,
+    hasRefreshToken,
+    mcpProbe,
+    refresh,
+  );
+
+  @override
+  String toString() =>
+      'CredentialValidation(type: $type, credentialId: $credentialId, '
+      'vaultId: $vaultId, status: $status, validatedAt: $validatedAt, '
+      'hasRefreshToken: $hasRefreshToken, mcpProbe: $mcpProbe, '
+      'refresh: $refresh)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/webhooks/webhook_event.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/webhooks/webhook_event.dart
@@ -1,0 +1,1793 @@
+import 'package:meta/meta.dart';
+
+import '../../beta_timestamp.dart';
+import '../../common/equality_helpers.dart';
+
+/// A webhook event delivered to a configured endpoint (Beta).
+///
+/// Parse an inbound webhook request body with [WebhookEvent.fromJson]; the
+/// typed payload is available via [data].
+@immutable
+class WebhookEvent {
+  /// Object type. Always 'event'.
+  final String type;
+
+  /// Unique identifier for this event.
+  final String id;
+
+  /// When the event was created.
+  final BetaTimestamp createdAt;
+
+  /// The typed event payload.
+  final WebhookEventData data;
+
+  /// Creates a [WebhookEvent].
+  const WebhookEvent({
+    this.type = 'event',
+    required this.id,
+    required this.createdAt,
+    required this.data,
+  });
+
+  /// Creates a [WebhookEvent] from JSON.
+  factory WebhookEvent.fromJson(Map<String, dynamic> json) {
+    return WebhookEvent(
+      type: json['type'] as String? ?? 'event',
+      id: json['id'] as String,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      data: WebhookEventData.fromJson(json['data'] as Map<String, dynamic>),
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'created_at': createdAt.toUtc().toIso8601String(),
+    'data': data.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookEvent copyWith({
+    String? type,
+    String? id,
+    BetaTimestamp? createdAt,
+    WebhookEventData? data,
+  }) {
+    return WebhookEvent(
+      type: type ?? this.type,
+      id: id ?? this.id,
+      createdAt: createdAt ?? this.createdAt,
+      data: data ?? this.data,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookEvent &&
+          runtimeType == other.runtimeType &&
+          type == other.type &&
+          id == other.id &&
+          createdAt == other.createdAt &&
+          data == other.data;
+
+  @override
+  int get hashCode => Object.hash(type, id, createdAt, data);
+
+  @override
+  String toString() =>
+      'WebhookEvent(type: $type, id: $id, createdAt: $createdAt, data: $data)';
+}
+
+/// Payload data for a [WebhookEvent], discriminated by `type`.
+///
+/// Variants:
+/// - [WebhookSessionArchivedEventData] — `session.archived`.
+/// - [WebhookSessionCreatedEventData] — `session.created`.
+/// - [WebhookSessionDeletedEventData] — `session.deleted`.
+/// - [WebhookSessionIdledEventData] — `session.idled`.
+/// - [WebhookSessionOutcomeEvaluationEndedEventData] — `session.outcome_evaluation_ended`.
+/// - [WebhookSessionPendingEventData] — `session.pending`.
+/// - [WebhookSessionRequiresActionEventData] — `session.requires_action`.
+/// - [WebhookSessionRunningEventData] — `session.running`.
+/// - [WebhookSessionStatusIdledEventData] — `session.status_idled`.
+/// - [WebhookSessionStatusRescheduledEventData] — `session.status_rescheduled`.
+/// - [WebhookSessionStatusRunStartedEventData] — `session.status_run_started`.
+/// - [WebhookSessionStatusTerminatedEventData] — `session.status_terminated`.
+/// - [WebhookSessionThreadCreatedEventData] — `session.thread_created`.
+/// - [WebhookSessionThreadIdledEventData] — `session.thread_idled`.
+/// - [WebhookSessionThreadTerminatedEventData] — `session.thread_terminated`.
+/// - [WebhookVaultCreatedEventData] — `vault.created`.
+/// - [WebhookVaultArchivedEventData] — `vault.archived`.
+/// - [WebhookVaultDeletedEventData] — `vault.deleted`.
+/// - [WebhookVaultCredentialCreatedEventData] — `vault_credential.created`.
+/// - [WebhookVaultCredentialArchivedEventData] — `vault_credential.archived`.
+/// - [WebhookVaultCredentialDeletedEventData] — `vault_credential.deleted`.
+/// - [WebhookVaultCredentialRefreshFailedEventData] — `vault_credential.refresh_failed`.
+/// - [UnknownWebhookEventData] — unrecognized event-data type, for forward
+///   compatibility.
+sealed class WebhookEventData {
+  const WebhookEventData();
+
+  /// Creates a [WebhookEventData] from JSON.
+  ///
+  /// Dispatches on the `type` discriminator; unrecognized values fall back to
+  /// [UnknownWebhookEventData].
+  factory WebhookEventData.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    return switch (type) {
+      'session.archived' => WebhookSessionArchivedEventData.fromJson(json),
+      'session.created' => WebhookSessionCreatedEventData.fromJson(json),
+      'session.deleted' => WebhookSessionDeletedEventData.fromJson(json),
+      'session.idled' => WebhookSessionIdledEventData.fromJson(json),
+      'session.outcome_evaluation_ended' =>
+        WebhookSessionOutcomeEvaluationEndedEventData.fromJson(json),
+      'session.pending' => WebhookSessionPendingEventData.fromJson(json),
+      'session.requires_action' =>
+        WebhookSessionRequiresActionEventData.fromJson(json),
+      'session.running' => WebhookSessionRunningEventData.fromJson(json),
+      'session.status_idled' => WebhookSessionStatusIdledEventData.fromJson(
+        json,
+      ),
+      'session.status_rescheduled' =>
+        WebhookSessionStatusRescheduledEventData.fromJson(json),
+      'session.status_run_started' =>
+        WebhookSessionStatusRunStartedEventData.fromJson(json),
+      'session.status_terminated' =>
+        WebhookSessionStatusTerminatedEventData.fromJson(json),
+      'session.thread_created' => WebhookSessionThreadCreatedEventData.fromJson(
+        json,
+      ),
+      'session.thread_idled' => WebhookSessionThreadIdledEventData.fromJson(
+        json,
+      ),
+      'session.thread_terminated' =>
+        WebhookSessionThreadTerminatedEventData.fromJson(json),
+      'vault.created' => WebhookVaultCreatedEventData.fromJson(json),
+      'vault.archived' => WebhookVaultArchivedEventData.fromJson(json),
+      'vault.deleted' => WebhookVaultDeletedEventData.fromJson(json),
+      'vault_credential.created' =>
+        WebhookVaultCredentialCreatedEventData.fromJson(json),
+      'vault_credential.archived' =>
+        WebhookVaultCredentialArchivedEventData.fromJson(json),
+      'vault_credential.deleted' =>
+        WebhookVaultCredentialDeletedEventData.fromJson(json),
+      'vault_credential.refresh_failed' =>
+        WebhookVaultCredentialRefreshFailedEventData.fromJson(json),
+      _ => UnknownWebhookEventData(rawJson: json),
+    };
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson();
+}
+
+/// Webhook event data signalling a session was archived.
+@immutable
+class WebhookSessionArchivedEventData extends WebhookEventData {
+  /// The event-data type, always 'session.archived'.
+  String get type => 'session.archived';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookSessionArchivedEventData].
+  const WebhookSessionArchivedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookSessionArchivedEventData] from JSON.
+  factory WebhookSessionArchivedEventData.fromJson(Map<String, dynamic> json) {
+    return WebhookSessionArchivedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookSessionArchivedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookSessionArchivedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookSessionArchivedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookSessionArchivedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a session was created.
+@immutable
+class WebhookSessionCreatedEventData extends WebhookEventData {
+  /// The event-data type, always 'session.created'.
+  String get type => 'session.created';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookSessionCreatedEventData].
+  const WebhookSessionCreatedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookSessionCreatedEventData] from JSON.
+  factory WebhookSessionCreatedEventData.fromJson(Map<String, dynamic> json) {
+    return WebhookSessionCreatedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookSessionCreatedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookSessionCreatedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookSessionCreatedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookSessionCreatedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a session was deleted.
+@immutable
+class WebhookSessionDeletedEventData extends WebhookEventData {
+  /// The event-data type, always 'session.deleted'.
+  String get type => 'session.deleted';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookSessionDeletedEventData].
+  const WebhookSessionDeletedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookSessionDeletedEventData] from JSON.
+  factory WebhookSessionDeletedEventData.fromJson(Map<String, dynamic> json) {
+    return WebhookSessionDeletedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookSessionDeletedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookSessionDeletedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookSessionDeletedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookSessionDeletedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a session went idle.
+@immutable
+class WebhookSessionIdledEventData extends WebhookEventData {
+  /// The event-data type, always 'session.idled'.
+  String get type => 'session.idled';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookSessionIdledEventData].
+  const WebhookSessionIdledEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookSessionIdledEventData] from JSON.
+  factory WebhookSessionIdledEventData.fromJson(Map<String, dynamic> json) {
+    return WebhookSessionIdledEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookSessionIdledEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookSessionIdledEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookSessionIdledEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookSessionIdledEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling an outcome evaluation finished for a session.
+@immutable
+class WebhookSessionOutcomeEvaluationEndedEventData extends WebhookEventData {
+  /// The event-data type, always 'session.outcome_evaluation_ended'.
+  String get type => 'session.outcome_evaluation_ended';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookSessionOutcomeEvaluationEndedEventData].
+  const WebhookSessionOutcomeEvaluationEndedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookSessionOutcomeEvaluationEndedEventData] from JSON.
+  factory WebhookSessionOutcomeEvaluationEndedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookSessionOutcomeEvaluationEndedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookSessionOutcomeEvaluationEndedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookSessionOutcomeEvaluationEndedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookSessionOutcomeEvaluationEndedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookSessionOutcomeEvaluationEndedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a session became pending.
+@immutable
+class WebhookSessionPendingEventData extends WebhookEventData {
+  /// The event-data type, always 'session.pending'.
+  String get type => 'session.pending';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookSessionPendingEventData].
+  const WebhookSessionPendingEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookSessionPendingEventData] from JSON.
+  factory WebhookSessionPendingEventData.fromJson(Map<String, dynamic> json) {
+    return WebhookSessionPendingEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookSessionPendingEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookSessionPendingEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookSessionPendingEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookSessionPendingEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a session requires action.
+@immutable
+class WebhookSessionRequiresActionEventData extends WebhookEventData {
+  /// The event-data type, always 'session.requires_action'.
+  String get type => 'session.requires_action';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookSessionRequiresActionEventData].
+  const WebhookSessionRequiresActionEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookSessionRequiresActionEventData] from JSON.
+  factory WebhookSessionRequiresActionEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookSessionRequiresActionEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookSessionRequiresActionEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookSessionRequiresActionEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookSessionRequiresActionEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookSessionRequiresActionEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a session started running.
+@immutable
+class WebhookSessionRunningEventData extends WebhookEventData {
+  /// The event-data type, always 'session.running'.
+  String get type => 'session.running';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookSessionRunningEventData].
+  const WebhookSessionRunningEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookSessionRunningEventData] from JSON.
+  factory WebhookSessionRunningEventData.fromJson(Map<String, dynamic> json) {
+    return WebhookSessionRunningEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookSessionRunningEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookSessionRunningEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookSessionRunningEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookSessionRunningEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a session run status changed to idled.
+@immutable
+class WebhookSessionStatusIdledEventData extends WebhookEventData {
+  /// The event-data type, always 'session.status_idled'.
+  String get type => 'session.status_idled';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookSessionStatusIdledEventData].
+  const WebhookSessionStatusIdledEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookSessionStatusIdledEventData] from JSON.
+  factory WebhookSessionStatusIdledEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookSessionStatusIdledEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookSessionStatusIdledEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookSessionStatusIdledEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookSessionStatusIdledEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookSessionStatusIdledEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a session run status changed to rescheduled.
+@immutable
+class WebhookSessionStatusRescheduledEventData extends WebhookEventData {
+  /// The event-data type, always 'session.status_rescheduled'.
+  String get type => 'session.status_rescheduled';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookSessionStatusRescheduledEventData].
+  const WebhookSessionStatusRescheduledEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookSessionStatusRescheduledEventData] from JSON.
+  factory WebhookSessionStatusRescheduledEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookSessionStatusRescheduledEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookSessionStatusRescheduledEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookSessionStatusRescheduledEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookSessionStatusRescheduledEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookSessionStatusRescheduledEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a session run status changed to run-started.
+@immutable
+class WebhookSessionStatusRunStartedEventData extends WebhookEventData {
+  /// The event-data type, always 'session.status_run_started'.
+  String get type => 'session.status_run_started';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookSessionStatusRunStartedEventData].
+  const WebhookSessionStatusRunStartedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookSessionStatusRunStartedEventData] from JSON.
+  factory WebhookSessionStatusRunStartedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookSessionStatusRunStartedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookSessionStatusRunStartedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookSessionStatusRunStartedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookSessionStatusRunStartedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookSessionStatusRunStartedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a session run status changed to terminated.
+@immutable
+class WebhookSessionStatusTerminatedEventData extends WebhookEventData {
+  /// The event-data type, always 'session.status_terminated'.
+  String get type => 'session.status_terminated';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookSessionStatusTerminatedEventData].
+  const WebhookSessionStatusTerminatedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookSessionStatusTerminatedEventData] from JSON.
+  factory WebhookSessionStatusTerminatedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookSessionStatusTerminatedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookSessionStatusTerminatedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookSessionStatusTerminatedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookSessionStatusTerminatedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookSessionStatusTerminatedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a session thread was created.
+@immutable
+class WebhookSessionThreadCreatedEventData extends WebhookEventData {
+  /// The event-data type, always 'session.thread_created'.
+  String get type => 'session.thread_created';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookSessionThreadCreatedEventData].
+  const WebhookSessionThreadCreatedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookSessionThreadCreatedEventData] from JSON.
+  factory WebhookSessionThreadCreatedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookSessionThreadCreatedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookSessionThreadCreatedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookSessionThreadCreatedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookSessionThreadCreatedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookSessionThreadCreatedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a session thread went idle.
+@immutable
+class WebhookSessionThreadIdledEventData extends WebhookEventData {
+  /// The event-data type, always 'session.thread_idled'.
+  String get type => 'session.thread_idled';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookSessionThreadIdledEventData].
+  const WebhookSessionThreadIdledEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookSessionThreadIdledEventData] from JSON.
+  factory WebhookSessionThreadIdledEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookSessionThreadIdledEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookSessionThreadIdledEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookSessionThreadIdledEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookSessionThreadIdledEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookSessionThreadIdledEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a session thread was terminated.
+@immutable
+class WebhookSessionThreadTerminatedEventData extends WebhookEventData {
+  /// The event-data type, always 'session.thread_terminated'.
+  String get type => 'session.thread_terminated';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookSessionThreadTerminatedEventData].
+  const WebhookSessionThreadTerminatedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookSessionThreadTerminatedEventData] from JSON.
+  factory WebhookSessionThreadTerminatedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookSessionThreadTerminatedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookSessionThreadTerminatedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookSessionThreadTerminatedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookSessionThreadTerminatedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookSessionThreadTerminatedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a vault was created.
+@immutable
+class WebhookVaultCreatedEventData extends WebhookEventData {
+  /// The event-data type, always 'vault.created'.
+  String get type => 'vault.created';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookVaultCreatedEventData].
+  const WebhookVaultCreatedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookVaultCreatedEventData] from JSON.
+  factory WebhookVaultCreatedEventData.fromJson(Map<String, dynamic> json) {
+    return WebhookVaultCreatedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookVaultCreatedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookVaultCreatedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookVaultCreatedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookVaultCreatedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a vault was archived.
+@immutable
+class WebhookVaultArchivedEventData extends WebhookEventData {
+  /// The event-data type, always 'vault.archived'.
+  String get type => 'vault.archived';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookVaultArchivedEventData].
+  const WebhookVaultArchivedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookVaultArchivedEventData] from JSON.
+  factory WebhookVaultArchivedEventData.fromJson(Map<String, dynamic> json) {
+    return WebhookVaultArchivedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookVaultArchivedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookVaultArchivedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookVaultArchivedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookVaultArchivedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a vault was deleted.
+@immutable
+class WebhookVaultDeletedEventData extends WebhookEventData {
+  /// The event-data type, always 'vault.deleted'.
+  String get type => 'vault.deleted';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookVaultDeletedEventData].
+  const WebhookVaultDeletedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookVaultDeletedEventData] from JSON.
+  factory WebhookVaultDeletedEventData.fromJson(Map<String, dynamic> json) {
+    return WebhookVaultDeletedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookVaultDeletedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookVaultDeletedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookVaultDeletedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookVaultDeletedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a vault credential was created.
+@immutable
+class WebhookVaultCredentialCreatedEventData extends WebhookEventData {
+  /// The event-data type, always 'vault_credential.created'.
+  String get type => 'vault_credential.created';
+
+  /// ID of the credential this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// ID of the vault the credential belongs to.
+  final String vaultId;
+
+  /// Creates a [WebhookVaultCredentialCreatedEventData].
+  const WebhookVaultCredentialCreatedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+    required this.vaultId,
+  });
+
+  /// Creates a [WebhookVaultCredentialCreatedEventData] from JSON.
+  factory WebhookVaultCredentialCreatedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookVaultCredentialCreatedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+      vaultId: json['vault_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+    'vault_id': vaultId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookVaultCredentialCreatedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+    String? vaultId,
+  }) {
+    return WebhookVaultCredentialCreatedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+      vaultId: vaultId ?? this.vaultId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookVaultCredentialCreatedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId &&
+          vaultId == other.vaultId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId, vaultId);
+
+  @override
+  String toString() =>
+      'WebhookVaultCredentialCreatedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId, vaultId: $vaultId)';
+}
+
+/// Webhook event data signalling a vault credential was archived.
+@immutable
+class WebhookVaultCredentialArchivedEventData extends WebhookEventData {
+  /// The event-data type, always 'vault_credential.archived'.
+  String get type => 'vault_credential.archived';
+
+  /// ID of the credential this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// ID of the vault the credential belongs to.
+  final String vaultId;
+
+  /// Creates a [WebhookVaultCredentialArchivedEventData].
+  const WebhookVaultCredentialArchivedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+    required this.vaultId,
+  });
+
+  /// Creates a [WebhookVaultCredentialArchivedEventData] from JSON.
+  factory WebhookVaultCredentialArchivedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookVaultCredentialArchivedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+      vaultId: json['vault_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+    'vault_id': vaultId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookVaultCredentialArchivedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+    String? vaultId,
+  }) {
+    return WebhookVaultCredentialArchivedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+      vaultId: vaultId ?? this.vaultId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookVaultCredentialArchivedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId &&
+          vaultId == other.vaultId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId, vaultId);
+
+  @override
+  String toString() =>
+      'WebhookVaultCredentialArchivedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId, vaultId: $vaultId)';
+}
+
+/// Webhook event data signalling a vault credential was deleted.
+@immutable
+class WebhookVaultCredentialDeletedEventData extends WebhookEventData {
+  /// The event-data type, always 'vault_credential.deleted'.
+  String get type => 'vault_credential.deleted';
+
+  /// ID of the credential this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// ID of the vault the credential belongs to.
+  final String vaultId;
+
+  /// Creates a [WebhookVaultCredentialDeletedEventData].
+  const WebhookVaultCredentialDeletedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+    required this.vaultId,
+  });
+
+  /// Creates a [WebhookVaultCredentialDeletedEventData] from JSON.
+  factory WebhookVaultCredentialDeletedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookVaultCredentialDeletedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+      vaultId: json['vault_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+    'vault_id': vaultId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookVaultCredentialDeletedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+    String? vaultId,
+  }) {
+    return WebhookVaultCredentialDeletedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+      vaultId: vaultId ?? this.vaultId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookVaultCredentialDeletedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId &&
+          vaultId == other.vaultId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId, vaultId);
+
+  @override
+  String toString() =>
+      'WebhookVaultCredentialDeletedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId, vaultId: $vaultId)';
+}
+
+/// Webhook event data signalling a vault credential refresh failed.
+@immutable
+class WebhookVaultCredentialRefreshFailedEventData extends WebhookEventData {
+  /// The event-data type, always 'vault_credential.refresh_failed'.
+  String get type => 'vault_credential.refresh_failed';
+
+  /// ID of the credential this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// ID of the vault the credential belongs to.
+  final String vaultId;
+
+  /// Creates a [WebhookVaultCredentialRefreshFailedEventData].
+  const WebhookVaultCredentialRefreshFailedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+    required this.vaultId,
+  });
+
+  /// Creates a [WebhookVaultCredentialRefreshFailedEventData] from JSON.
+  factory WebhookVaultCredentialRefreshFailedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookVaultCredentialRefreshFailedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+      vaultId: json['vault_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+    'vault_id': vaultId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookVaultCredentialRefreshFailedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+    String? vaultId,
+  }) {
+    return WebhookVaultCredentialRefreshFailedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+      vaultId: vaultId ?? this.vaultId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookVaultCredentialRefreshFailedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId &&
+          vaultId == other.vaultId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId, vaultId);
+
+  @override
+  String toString() =>
+      'WebhookVaultCredentialRefreshFailedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId, vaultId: $vaultId)';
+}
+
+/// Unrecognized webhook event-data type — preserves raw JSON for forward
+/// compatibility.
+@immutable
+class UnknownWebhookEventData extends WebhookEventData {
+  /// The raw JSON.
+  final Map<String, dynamic> rawJson;
+
+  /// Creates an [UnknownWebhookEventData].
+  const UnknownWebhookEventData({required this.rawJson});
+
+  @override
+  Map<String, dynamic> toJson() => rawJson;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnknownWebhookEventData &&
+          runtimeType == other.runtimeType &&
+          mapsDeepEqual(rawJson, other.rawJson);
+
+  @override
+  int get hashCode => mapDeepHashCode(rawJson);
+
+  @override
+  String toString() => 'UnknownWebhookEventData(rawJson: $rawJson)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/resources/vault_credentials_resource.dart
+++ b/packages/anthropic_sdk_dart/lib/src/resources/vault_credentials_resource.dart
@@ -5,6 +5,7 @@ import 'package:http/http.dart' as http;
 import '../models/managed_agents/credentials/create_credential_params.dart';
 import '../models/managed_agents/credentials/credential.dart';
 import '../models/managed_agents/credentials/credential_list_response.dart';
+import '../models/managed_agents/credentials/credential_validation.dart';
 import '../models/managed_agents/credentials/update_credential_params.dart';
 import 'base_resource.dart';
 
@@ -207,6 +208,40 @@ class VaultCredentialsResource extends ResourceBase {
     );
 
     return Credential.fromJson(
+      jsonDecode(response.body) as Map<String, dynamic>,
+    );
+  }
+
+  /// Validates a credential by probing its MCP server (Beta).
+  ///
+  /// Attempts an MCP-OAuth handshake (and a token refresh if applicable) and
+  /// returns the typed [CredentialValidation] result. Sensitive values in any
+  /// captured HTTP responses are scrubbed.
+  ///
+  /// Parameters:
+  /// - [credentialId]: The ID of the credential to validate.
+  /// - [abortTrigger]: Allows canceling the request.
+  Future<CredentialValidation> validateCredential(
+    String credentialId, {
+    Future<void>? abortTrigger,
+  }) async {
+    ensureNotClosed?.call();
+    final url = requestBuilder.buildUrl(
+      '/v1/vaults/$vaultId/credentials/$credentialId/mcp_oauth_validate',
+    );
+    final headers = requestBuilder.buildHeaders(
+      additionalHeaders: {'anthropic-beta': _betaHeader},
+    );
+    final httpRequest = http.Request('POST', url)
+      ..headers.addAll(headers)
+      ..body = jsonEncode(<String, dynamic>{});
+
+    final response = await interceptorChain.execute(
+      httpRequest,
+      abortTrigger: abortTrigger,
+    );
+
+    return CredentialValidation.fromJson(
       jsonDecode(response.body) as Map<String, dynamic>,
     );
   }

--- a/packages/anthropic_sdk_dart/llms.txt
+++ b/packages/anthropic_sdk_dart/llms.txt
@@ -20,7 +20,7 @@
 - [models_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/models_example.dart) (~471 tokens): Model listing.
 - [files_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/files_example.dart) (~842 tokens): File management (beta).
 - [skills_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/skills_example.dart) (~1k tokens): Skills management (beta).
-- [managed_agents_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/managed_agents_example.dart) (~1.2k tokens): Managed agents: agents, sessions, vaults, multiagent rosters, outcomes (beta).
+- [managed_agents_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/managed_agents_example.dart) (~1.5k tokens): Managed agents: agents, sessions, vaults, multiagent rosters, outcomes, webhooks, credential validation (beta).
 - [memory_stores_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/memory_stores_example.dart) (~903 tokens): Managed agents memory stores, memories, and versions (beta).
 - [error_handling_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/error_handling_example.dart) (~632 tokens): Exception handling patterns.
 - [web_search_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/web_search_example.dart) (~793 tokens): Web search tool.
@@ -36,4 +36,4 @@
 
 - [Package directory](https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/anthropic_sdk_dart): Source tree, pubspec, and package-local files.
 
-**Total: ~36k tokens**
+**Total: ~36.4k tokens**

--- a/packages/anthropic_sdk_dart/test/integration/managed_agents_integration_test.dart
+++ b/packages/anthropic_sdk_dart/test/integration/managed_agents_integration_test.dart
@@ -366,5 +366,56 @@ void main() {
         }
       },
     );
+
+    test(
+      'validate a vault credential',
+      timeout: const Timeout(Duration(minutes: 3)),
+      () async {
+        if (apiKey == null) {
+          markTestSkipped('API key not available');
+          return;
+        }
+
+        // 1. Create a vault + credential to validate.
+        final vault = await client!.vaults.create(
+          const CreateVaultParams(
+            displayName: 'Validate Test Vault - Dart SDK',
+          ),
+        );
+
+        try {
+          // The mcp_oauth_validate endpoint validates MCP-OAuth credentials, so
+          // create one (a static bearer credential is rejected with a 400).
+          final credential = await client!.vaults
+              .credentials(vault.id)
+              .create(
+                const CreateCredentialParams(
+                  auth: McpOauthCreateParams(
+                    accessToken: 'test-access-token',
+                    mcpServerUrl: 'https://mcp.example.com',
+                  ),
+                  displayName: 'Validate Test Credential',
+                ),
+              );
+
+          // 2. Validate it. A placeholder token/server legitimately yields an
+          // invalid/unknown status with a probe error — we only assert the
+          // call succeeds and returns a parseable, well-formed result.
+          final validation = await client!.vaults
+              .credentials(vault.id)
+              .validateCredential(credential.id);
+
+          expect(validation.credentialId, equals(credential.id));
+          expect(validation.vaultId, equals(vault.id));
+          expect(
+            CredentialValidationStatus.values,
+            contains(validation.status),
+          );
+        } finally {
+          // Cleanup: delete the vault (cascades to its credentials).
+          await client!.vaults.delete(vault.id);
+        }
+      },
+    );
   });
 }

--- a/packages/anthropic_sdk_dart/test/unit/models/credential_validation_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/credential_validation_test.dart
@@ -1,0 +1,175 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  const httpResponseJson = {
+    'status_code': 401,
+    'content_type': 'application/json',
+    'body': '{"error":"invalid_token"}',
+    'body_truncated': false,
+  };
+
+  group('RefreshHttpResponse', () {
+    test('round-trips', () {
+      final r = RefreshHttpResponse.fromJson(httpResponseJson);
+      expect(r.statusCode, 401);
+      expect(r.contentType, 'application/json');
+      expect(r.bodyTruncated, isFalse);
+      expect(r.toJson(), httpResponseJson);
+    });
+  });
+
+  group('RefreshObject', () {
+    test('round-trips with httpResponse set', () {
+      final json = {'status': 'failed', 'http_response': httpResponseJson};
+      final r = RefreshObject.fromJson(json);
+      expect(r.status, CredentialRefreshStatus.failed);
+      expect(r.httpResponse, isNotNull);
+      expect(r.toJson(), json);
+    });
+
+    test('emits http_response key as null when unset', () {
+      const r = RefreshObject(status: CredentialRefreshStatus.succeeded);
+      expect(r.httpResponse, isNull);
+      expect(r.toJson().containsKey('http_response'), isTrue);
+      expect(r.toJson()['http_response'], isNull);
+    });
+
+    test('copyWith clears httpResponse with explicit null', () {
+      final r = RefreshObject.fromJson(const {
+        'status': 'failed',
+        'http_response': httpResponseJson,
+      });
+      expect(r.copyWith(httpResponse: null).httpResponse, isNull);
+      // Omitting preserves it.
+      expect(
+        r.copyWith(status: CredentialRefreshStatus.succeeded).httpResponse,
+        isNotNull,
+      );
+    });
+  });
+
+  group('McpProbe', () {
+    test('round-trips with httpResponse set', () {
+      final json = {'method': 'initialize', 'http_response': httpResponseJson};
+      final p = McpProbe.fromJson(json);
+      expect(p.method, 'initialize');
+      expect(p.httpResponse, isNotNull);
+      expect(p.toJson(), json);
+    });
+
+    test('emits http_response key as null when unset', () {
+      const p = McpProbe(method: 'tools/list');
+      expect(p.toJson().containsKey('http_response'), isTrue);
+      expect(p.toJson()['http_response'], isNull);
+    });
+  });
+
+  group('CredentialValidationStatus', () {
+    test('round-trips known values', () {
+      for (final s in CredentialValidationStatus.values) {
+        expect(CredentialValidationStatus.fromJson(s.value), s);
+      }
+    });
+
+    test('unknown value falls back to unknown', () {
+      expect(
+        CredentialValidationStatus.fromJson('something_new'),
+        CredentialValidationStatus.unknown,
+      );
+    });
+  });
+
+  group('CredentialRefreshStatus', () {
+    test('round-trips known values', () {
+      for (final s in CredentialRefreshStatus.values) {
+        expect(CredentialRefreshStatus.fromJson(s.value), s);
+      }
+    });
+
+    test('maps snake_case spec values', () {
+      expect(
+        CredentialRefreshStatus.fromJson('connect_error'),
+        CredentialRefreshStatus.connectError,
+      );
+      expect(
+        CredentialRefreshStatus.fromJson('no_refresh_token'),
+        CredentialRefreshStatus.noRefreshToken,
+      );
+    });
+
+    test('unknown value falls back to unknown', () {
+      expect(
+        CredentialRefreshStatus.fromJson('something_new'),
+        CredentialRefreshStatus.unknown,
+      );
+    });
+  });
+
+  group('CredentialValidation', () {
+    Map<String, dynamic> json({Object? mcpProbe, Object? refresh}) {
+      return {
+        'type': 'vault_credential_validation',
+        'credential_id': 'vcrd_011CZkZEMt8gZan2iYOQfSkw',
+        'vault_id': 'vlt_011CZkZDLs7fYzm1hXNPeRjv',
+        'status': 'valid',
+        'validated_at': '2026-03-15T10:02:31.000Z',
+        'has_refresh_token': true,
+        'mcp_probe': mcpProbe,
+        'refresh': refresh,
+      };
+    }
+
+    test('round-trips with mcpProbe and refresh set', () {
+      final j = json(
+        mcpProbe: {'method': 'initialize', 'http_response': null},
+        refresh: {'status': 'succeeded', 'http_response': null},
+      );
+      final v = CredentialValidation.fromJson(j);
+      expect(v.credentialId, 'vcrd_011CZkZEMt8gZan2iYOQfSkw');
+      expect(v.vaultId, 'vlt_011CZkZDLs7fYzm1hXNPeRjv');
+      expect(v.status, CredentialValidationStatus.valid);
+      expect(v.hasRefreshToken, isTrue);
+      expect(v.mcpProbe, isA<McpProbe>());
+      expect(v.refresh, isA<RefreshObject>());
+      expect(v.toJson(), j);
+    });
+
+    test('round-trips with mcpProbe and refresh null', () {
+      final j = json();
+      final v = CredentialValidation.fromJson(j);
+      expect(v.mcpProbe, isNull);
+      expect(v.refresh, isNull);
+      expect(v.toJson(), j);
+    });
+
+    test('emits mcp_probe and refresh keys as null when unset', () {
+      final v = CredentialValidation(
+        credentialId: 'vcrd_1',
+        vaultId: 'vlt_1',
+        status: CredentialValidationStatus.invalid,
+        validatedAt: DateTime.utc(2026, 3, 15),
+        hasRefreshToken: false,
+      );
+      final out = v.toJson();
+      expect(out.containsKey('mcp_probe'), isTrue);
+      expect(out['mcp_probe'], isNull);
+      expect(out.containsKey('refresh'), isTrue);
+      expect(out['refresh'], isNull);
+    });
+
+    test('copyWith clears nullable fields with explicit null', () {
+      final v = CredentialValidation.fromJson(
+        json(
+          mcpProbe: {'method': 'initialize', 'http_response': null},
+          refresh: {'status': 'succeeded', 'http_response': null},
+        ),
+      );
+      final cleared = v.copyWith(mcpProbe: null, refresh: null);
+      expect(cleared.mcpProbe, isNull);
+      expect(cleared.refresh, isNull);
+      // Omitting preserves them.
+      expect(v.copyWith(vaultId: 'vlt_x').mcpProbe, isNotNull);
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/webhook_event_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/webhook_event_test.dart
@@ -1,0 +1,181 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  // (discriminator type, has vault_id, matcher) for every spec variant.
+  final variants = <(String, bool, Matcher)>[
+    ('session.archived', false, isA<WebhookSessionArchivedEventData>()),
+    ('session.created', false, isA<WebhookSessionCreatedEventData>()),
+    ('session.deleted', false, isA<WebhookSessionDeletedEventData>()),
+    ('session.idled', false, isA<WebhookSessionIdledEventData>()),
+    (
+      'session.outcome_evaluation_ended',
+      false,
+      isA<WebhookSessionOutcomeEvaluationEndedEventData>(),
+    ),
+    ('session.pending', false, isA<WebhookSessionPendingEventData>()),
+    (
+      'session.requires_action',
+      false,
+      isA<WebhookSessionRequiresActionEventData>(),
+    ),
+    ('session.running', false, isA<WebhookSessionRunningEventData>()),
+    ('session.status_idled', false, isA<WebhookSessionStatusIdledEventData>()),
+    (
+      'session.status_rescheduled',
+      false,
+      isA<WebhookSessionStatusRescheduledEventData>(),
+    ),
+    (
+      'session.status_run_started',
+      false,
+      isA<WebhookSessionStatusRunStartedEventData>(),
+    ),
+    (
+      'session.status_terminated',
+      false,
+      isA<WebhookSessionStatusTerminatedEventData>(),
+    ),
+    (
+      'session.thread_created',
+      false,
+      isA<WebhookSessionThreadCreatedEventData>(),
+    ),
+    ('session.thread_idled', false, isA<WebhookSessionThreadIdledEventData>()),
+    (
+      'session.thread_terminated',
+      false,
+      isA<WebhookSessionThreadTerminatedEventData>(),
+    ),
+    ('vault.created', false, isA<WebhookVaultCreatedEventData>()),
+    ('vault.archived', false, isA<WebhookVaultArchivedEventData>()),
+    ('vault.deleted', false, isA<WebhookVaultDeletedEventData>()),
+    (
+      'vault_credential.created',
+      true,
+      isA<WebhookVaultCredentialCreatedEventData>(),
+    ),
+    (
+      'vault_credential.archived',
+      true,
+      isA<WebhookVaultCredentialArchivedEventData>(),
+    ),
+    (
+      'vault_credential.deleted',
+      true,
+      isA<WebhookVaultCredentialDeletedEventData>(),
+    ),
+    (
+      'vault_credential.refresh_failed',
+      true,
+      isA<WebhookVaultCredentialRefreshFailedEventData>(),
+    ),
+  ];
+
+  Map<String, dynamic> dataJson(String type, {required bool withVault}) {
+    return {
+      'type': type,
+      'id': 'res_123',
+      'organization_id': 'org_123',
+      'workspace_id': 'wrkspc_123',
+      if (withVault) 'vault_id': 'vlt_123',
+    };
+  }
+
+  group('WebhookEventData dispatch', () {
+    test('covers all 22 spec variants', () {
+      expect(variants, hasLength(22));
+    });
+
+    for (final (type, withVault, matcher) in variants) {
+      test('$type dispatches and round-trips', () {
+        final json = dataJson(type, withVault: withVault);
+        final data = WebhookEventData.fromJson(json);
+        expect(data, matcher);
+        expect(data.toJson(), json);
+      });
+    }
+
+    test('unknown type falls back to UnknownWebhookEventData', () {
+      final json = {'type': 'mystery.event', 'foo': 'bar'};
+      final data = WebhookEventData.fromJson(json);
+      expect(data, isA<UnknownWebhookEventData>());
+      expect(data.toJson(), json);
+    });
+
+    test('vault-credential variants carry vaultId', () {
+      final data =
+          WebhookEventData.fromJson(
+                dataJson('vault_credential.refresh_failed', withVault: true),
+              )
+              as WebhookVaultCredentialRefreshFailedEventData;
+      expect(data.vaultId, 'vlt_123');
+      expect(data.id, 'res_123');
+    });
+  });
+
+  group('WebhookEvent wrapper', () {
+    final json = {
+      'type': 'event',
+      'id': 'evt_011CZkZRSw2kEfs6ncTVljxP',
+      'created_at': '2026-04-01T00:00:00.000Z',
+      'data': {
+        'type': 'session.created',
+        'id': 'sesn_123',
+        'organization_id': 'org_123',
+        'workspace_id': 'wrkspc_123',
+      },
+    };
+
+    test('parses the typed payload and round-trips', () {
+      final event = WebhookEvent.fromJson(json);
+      expect(event.type, 'event');
+      expect(event.id, 'evt_011CZkZRSw2kEfs6ncTVljxP');
+      expect(event.data, isA<WebhookSessionCreatedEventData>());
+      expect(event.toJson(), json);
+    });
+
+    test('copyWith replaces fields', () {
+      final event = WebhookEvent.fromJson(json);
+      final swapped = event.copyWith(
+        data: const WebhookSessionDeletedEventData(
+          id: 'sesn_123',
+          organizationId: 'org_123',
+          workspaceId: 'wrkspc_123',
+        ),
+      );
+      expect(swapped.data, isA<WebhookSessionDeletedEventData>());
+      expect(swapped.id, event.id);
+    });
+  });
+
+  group('equality', () {
+    test('value equality holds for identical variants', () {
+      const a = WebhookSessionCreatedEventData(
+        id: 'sesn_1',
+        organizationId: 'org_1',
+        workspaceId: 'wrkspc_1',
+      );
+      const b = WebhookSessionCreatedEventData(
+        id: 'sesn_1',
+        organizationId: 'org_1',
+        workspaceId: 'wrkspc_1',
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('UnknownWebhookEventData uses deep equality', () {
+      final a = WebhookEventData.fromJson({
+        'type': 'x',
+        'nested': {'k': 1},
+      });
+      final b = WebhookEventData.fromJson({
+        'type': 'x',
+        'nested': {'k': 1},
+      });
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
@@ -105,6 +105,31 @@ class ManagedAgentsFixtures {
     };
   }
 
+  static Map<String, dynamic> credentialValidation({
+    String credentialId = 'cred_test123',
+    String vaultId = 'vault_test123',
+    String status = 'valid',
+  }) {
+    return {
+      'type': 'vault_credential_validation',
+      'credential_id': credentialId,
+      'vault_id': vaultId,
+      'status': status,
+      'validated_at': '2026-04-01T00:00:00Z',
+      'has_refresh_token': true,
+      'mcp_probe': {
+        'method': 'initialize',
+        'http_response': {
+          'status_code': 200,
+          'content_type': 'application/json',
+          'body': '{}',
+          'body_truncated': false,
+        },
+      },
+      'refresh': null,
+    };
+  }
+
   static Map<String, dynamic> sessionEvent({
     String type = 'user.message',
     String id = 'event_test123',
@@ -978,6 +1003,38 @@ void main() {
       );
       expect(request.method, 'POST');
     });
+
+    test(
+      'validateCredential sends correct request and parses response',
+      () async {
+        mockHttpClient.queueJsonResponse(
+          ManagedAgentsFixtures.credentialValidation(),
+        );
+
+        final validation = await client.vaults
+            .credentials('vault_test123')
+            .validateCredential('cred_test123');
+
+        // Parses the typed result.
+        expect(validation.credentialId, 'cred_test123');
+        expect(validation.vaultId, 'vault_test123');
+        expect(validation.status, CredentialValidationStatus.valid);
+        expect(validation.mcpProbe, isA<McpProbe>());
+
+        // The unit test is the real gate for this endpoint (verify is blind to
+        // it): assert path, method, beta header, and empty body.
+        final request = mockHttpClient.lastRequest!;
+        expect(
+          request.url.path,
+          '/v1/vaults/vault_test123/credentials/cred_test123/mcp_oauth_validate',
+        );
+        expect(request.method, 'POST');
+        expect(request.headers['anthropic-beta'], 'managed-agents-2026-04-01');
+        final body =
+            jsonDecode((request as dynamic).body) as Map<String, dynamic>;
+        expect(body, isEmpty);
+      },
+    );
   });
 
   group('UnknownManagedAgentError', () {


### PR DESCRIPTION
## Summary

- Adds typed **inbound webhook event** parsing: `WebhookEvent.fromJson(...)` decodes a webhook payload into a wrapper (`type`/`id`/`createdAt`/`data`) whose `data` is a sealed `WebhookEventData` union you can `switch` over exhaustively. 22 typed variants cover session (×12), thread (×3), vault (×3), and vault-credential (×4) lifecycle events, with an `UnknownWebhookEventData` fallback for forward compatibility.
- Adds **MCP-OAuth credential validation**: `client.vaults.credentials(vaultId).validateCredential(credentialId)` probes a credential's MCP server and returns a typed `CredentialValidation` (with `McpProbe`, `RefreshObject`, `RefreshHttpResponse`, and the `CredentialValidationStatus` / `CredentialRefreshStatus` enums).
- 30 new schemas + 1 new endpoint. Purely additive, non-breaking. This is the **final PR (4 of 4)** of the Anthropic spec-refresh series (PR #223, #224, #230 already merged).

## Details

**Webhooks are parsing-only by design.** Signature/HMAC verification is intentionally *not* included — the signing scheme is not part of the OpenAPI spec, so hand-coding it would be a security footgun. The SDK gives you faithful, typed parsing; verify signatures with your framework of choice before calling `WebhookEvent.fromJson`.

```dart
final event = WebhookEvent.fromJson(jsonDecode(requestBody) as Map<String, dynamic>);
switch (event.data) {
  case WebhookSessionCreatedEventData(:final id):
    handleSessionCreated(id);
  case WebhookVaultCredentialRefreshFailedEventData(:final id, :final vaultId):
    alertCredentialRefreshFailed(vaultId, id);
  default:
    log('Unhandled webhook: ${event.data.runtimeType}');
}
```

```dart
final validation =
    await client.vaults.credentials(vaultId).validateCredential(credentialId);
print(validation.status.value); // valid | invalid | unknown
```

**Modeling decisions:**
- Required-but-nullable refs (`mcp_probe`, `refresh`, and the nested `http_response`) are **always emitted** (the key is present with a `null` value), matching the existing `Credential.archived_at` pattern, and are suppressed in the toolkit manifest via `excluded_properties`.
- `WebhookEventData` is modeled as a sealed parent + variants + `Unknown*` fallback, per the codebase convention (`SessionEvent`, `Rubric`, `CredentialAuth`).
- `CredentialRefreshStatus` adds an `unknown` fallback value for forward compatibility (the `AgentSpeed` precedent); `CredentialValidationStatus` already has `unknown` in the spec.
- The `mcp_oauth_validate` endpoint uses the bare path + `anthropic-beta` header (matching the other vault-credential methods) and an empty-body POST.

## Test Plan

- [x] Unit tests pass for `anthropic_sdk_dart` (856 pass)
- [x] New tests added for new functionality (all 22 webhook variants: dispatch + round-trip + `Unknown` fallback; all credential-validation models + enums)
- [x] Sealed class/enum changes include variant, round-trip, and error/unknown-fallback tests
- [x] `fromJson`/`toJson` round-trip serialization verified (incl. explicit assertions that required-but-nullable keys are emitted as `null`)
- [x] `==`/`hashCode` contract verified (same fields in both)
- [x] Resource test asserts `validateCredential` path / method / `anthropic-beta` header / empty body / parse (the real gate — `verify` does not cover this endpoint)
- [x] Happy-flow integration test (validate an MCP-OAuth credential) — verified live & passing
- [x] `dart analyze --fatal-infos` clean; toolkit `verify` baselines unchanged (docs 12 / readme 1 / implementation 9, all pre-existing)