### PR TITLE
chore: fix use_null_aware_elements lint flagged by Dart 3.12

### DIFF
--- a/packages/anthropic_sdk_dart/lib/src/models/tools/input_schema.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/tools/input_schema.dart
@@ -68,7 +68,7 @@ class InputSchema {
   /// [extra] is spread first; known keys are written after, so typed fields
   /// always take precedence on key collision.
   Map<String, dynamic> toJson() => {
-    if (extra != null) ...extra!,
+    ...?extra,
     'type': type,
     if (properties != null) 'properties': properties,
     if (required != null) 'required': required,

--- a/packages/chromadb/lib/src/client/request_builder.dart
+++ b/packages/chromadb/lib/src/client/request_builder.dart
@@ -43,7 +43,7 @@ class RequestBuilder {
     // Merge query parameters (request params override defaults)
     final mergedParams = <String, String>{
       ...defaultQueryParameters,
-      if (queryParameters != null) ...queryParameters,
+      ...?queryParameters,
     };
 
     // Handle path properly - avoid double slashes
@@ -66,9 +66,6 @@ class RequestBuilder {
   ///
   /// Request headers override default headers (last-write-wins).
   Map<String, String> buildHeaders(Map<String, String>? requestHeaders) {
-    return <String, String>{
-      ...defaultHeaders,
-      if (requestHeaders != null) ...requestHeaders,
-    };
+    return <String, String>{...defaultHeaders, ...?requestHeaders};
   }
 }

--- a/packages/googleai_dart/lib/src/models/interactions/agent_config.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/agent_config.dart
@@ -46,10 +46,7 @@ class DynamicAgentConfig extends AgentConfig {
   }
 
   @override
-  Map<String, dynamic> toJson() => {
-    'type': type,
-    if (additionalProperties != null) ...additionalProperties!,
-  };
+  Map<String, dynamic> toJson() => {'type': type, ...?additionalProperties};
 
   /// Creates a copy with replaced values.
   DynamicAgentConfig copyWith({

--- a/packages/mistralai_dart/lib/src/models/audio/speech_request.dart
+++ b/packages/mistralai_dart/lib/src/models/audio/speech_request.dart
@@ -74,7 +74,7 @@ class SpeechRequest {
   /// [extra] is spread first; non-null typed fields are written after, so they
   /// take precedence on key collision.
   Map<String, dynamic> toJson() => {
-    if (extra != null) ...extra!,
+    ...?extra,
     'input': input,
     if (model != null) 'model': model,
     if (voiceId != null) 'voice_id': voiceId,

--- a/packages/mistralai_dart/lib/src/models/observability/conversation_payload.dart
+++ b/packages/mistralai_dart/lib/src/models/observability/conversation_payload.dart
@@ -40,7 +40,7 @@ class ConversationPayload {
   /// Converts to JSON.
   Map<String, dynamic> toJson() => {
     'messages': messages.map(Map<String, dynamic>.from).toList(),
-    if (extra != null) ...extra!,
+    ...?extra,
   };
 
   @override

--- a/packages/openai_dart/lib/src/client/request_builder.dart
+++ b/packages/openai_dart/lib/src/client/request_builder.dart
@@ -54,7 +54,7 @@ class RequestBuilder {
     // Merge query params: base URL params + request params (request wins on conflict)
     final mergedQueryParams = <String, String>{
       ...baseUri.queryParameters,
-      if (queryParams != null) ...queryParams,
+      ...?queryParams,
     };
 
     return baseUri.replace(
@@ -98,7 +98,7 @@ class RequestBuilder {
       if (queryParameters != null)
         for (final entry in queryParameters.entries) entry.key: [entry.value],
       // Add repeated params (these override single-value params with same key)
-      if (queryParametersAll != null) ...queryParametersAll,
+      ...?queryParametersAll,
     };
 
     // Build the URI with queryParametersAll.


### PR DESCRIPTION
## Summary
- Fix the `use_null_aware_elements` lint that fails CI on Dart 3.12 (`dart analyze --fatal-infos`). Local SDKs older than 3.12 do not surface this lint, so it slipped onto `main`.
- Replace every `if (x != null) ...x!` collection element with the null-aware spread `...?x` across 5 packages. The change is behavior-identical — `...?x` spreads when `x` is non-null and contributes nothing when null.

## Details

Affected locations:
- `anthropic_sdk_dart` — `models/tools/input_schema.dart` (`toJson`)
- `googleai_dart` — `models/interactions/agent_config.dart` (`toJson`)
- `mistralai_dart` — `models/audio/speech_request.dart` and `models/observability/conversation_payload.dart` (`toJson`)
- `chromadb` — `client/request_builder.dart` (query params + headers merge)
- `openai_dart` — `client/request_builder.dart` (query params merge, two sites)

Typed as `chore` so it does not trigger version bumps for the affected packages.

## Test Plan
- [x] `dart format --output=none --set-exit-if-changed .` — no changes
- [x] `dart analyze --fatal-infos .` — no issues (note: lint requires Dart 3.12 to surface; syntax verified valid on 3.11.5)
- [x] Unit tests pass for all affected packages (anthropic_sdk_dart, googleai_dart, mistralai_dart, chromadb, openai_dart)