### PR TITLE
feat(anthropic_sdk_dart)!: support search_result_location citations and add Unknown fallback

### DIFF
--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
@@ -511,7 +511,8 @@
           "CitationCharLocation": "char_location",
           "CitationPageLocation": "page_location",
           "CitationContentBlockLocation": "content_block_location",
-          "CitationWebSearchResultLocation": "web_search_result_location"
+          "CitationWebSearchResultLocation": "web_search_result_location",
+          "CitationSearchResultLocation": "search_result_location"
         }
       },
       "note": null
@@ -559,6 +560,14 @@
       "excluded_properties": [
         "url"
       ]
+    },
+    "CitationSearchResultLocation": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "SearchResultLocationCitation",
+      "file": "lib/src/models/content/content_block.dart",
+      "schema": "BetaResponseSearchResultLocationCitation",
+      "parent": "Citation"
     },
     "WebSearchResult": {
       "spec": "main",

--- a/packages/anthropic_sdk_dart/lib/src/models/content/content_block.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/content_block.dart
@@ -991,12 +991,24 @@ class WebSearchResultError extends WebSearchResult {
 }
 
 /// Citation for text content.
+///
+/// Variants:
+/// - [CharLocationCitation] — `char_location` (plain text sources).
+/// - [PageLocationCitation] — `page_location` (paginated documents).
+/// - [ContentBlockLocationCitation] — `content_block_location`.
+/// - [WebSearchResultLocationCitation] — `web_search_result_location`.
+/// - [SearchResultLocationCitation] — `search_result_location` (search-result
+///   content blocks).
+/// - [UnknownCitation] — unrecognized citation type, for forward compatibility.
 sealed class Citation {
   const Citation();
 
   /// Creates a [Citation] from JSON.
+  ///
+  /// Dispatches on the `type` discriminator; unrecognized values fall back to
+  /// [UnknownCitation].
   factory Citation.fromJson(Map<String, dynamic> json) {
-    final type = json['type'] as String;
+    final type = json['type'] as String?;
     return switch (type) {
       'char_location' => CharLocationCitation.fromJson(json),
       'page_location' => PageLocationCitation.fromJson(json),
@@ -1004,7 +1016,8 @@ sealed class Citation {
       'web_search_result_location' => WebSearchResultLocationCitation.fromJson(
         json,
       ),
-      _ => throw FormatException('Unknown Citation type: $type'),
+      'search_result_location' => SearchResultLocationCitation.fromJson(json),
+      _ => UnknownCitation(rawJson: json),
     };
   }
 
@@ -1369,6 +1382,136 @@ class WebSearchResultLocationCitation extends Citation {
       'WebSearchResultLocationCitation(citedText: [${citedText.length} chars], '
       'encryptedIndex: [${encryptedIndex.length} chars], '
       'title: $title, url: $url)';
+}
+
+/// Citation referencing a range of blocks within a `search_result` content
+/// block (returned when the model cites search-result sources, e.g. RAG).
+@immutable
+class SearchResultLocationCitation extends Citation {
+  /// The cited text (the concatenated contents of the cited block range).
+  final String citedText;
+
+  /// 0-based index of the cited search result among all `search_result`
+  /// content blocks in the request.
+  final int searchResultIndex;
+
+  /// Source identifier of the cited search result.
+  final String source;
+
+  /// Title of the cited search result, if any.
+  final String? title;
+
+  /// 0-based index of the first cited block in the source's content array.
+  final int startBlockIndex;
+
+  /// Exclusive 0-based end index of the cited block range.
+  final int endBlockIndex;
+
+  /// Creates a [SearchResultLocationCitation].
+  const SearchResultLocationCitation({
+    required this.citedText,
+    required this.searchResultIndex,
+    required this.source,
+    this.title,
+    required this.startBlockIndex,
+    required this.endBlockIndex,
+  });
+
+  /// Creates a [SearchResultLocationCitation] from JSON.
+  factory SearchResultLocationCitation.fromJson(Map<String, dynamic> json) {
+    return SearchResultLocationCitation(
+      citedText: json['cited_text'] as String,
+      searchResultIndex: json['search_result_index'] as int,
+      source: json['source'] as String,
+      title: json['title'] as String?,
+      startBlockIndex: json['start_block_index'] as int,
+      endBlockIndex: json['end_block_index'] as int,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'search_result_location',
+    'cited_text': citedText,
+    'search_result_index': searchResultIndex,
+    'source': source,
+    if (title != null) 'title': title,
+    'start_block_index': startBlockIndex,
+    'end_block_index': endBlockIndex,
+  };
+
+  /// Creates a copy with replaced values.
+  SearchResultLocationCitation copyWith({
+    String? citedText,
+    int? searchResultIndex,
+    String? source,
+    Object? title = unsetCopyWithValue,
+    int? startBlockIndex,
+    int? endBlockIndex,
+  }) {
+    return SearchResultLocationCitation(
+      citedText: citedText ?? this.citedText,
+      searchResultIndex: searchResultIndex ?? this.searchResultIndex,
+      source: source ?? this.source,
+      title: title == unsetCopyWithValue ? this.title : title as String?,
+      startBlockIndex: startBlockIndex ?? this.startBlockIndex,
+      endBlockIndex: endBlockIndex ?? this.endBlockIndex,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SearchResultLocationCitation &&
+          runtimeType == other.runtimeType &&
+          citedText == other.citedText &&
+          searchResultIndex == other.searchResultIndex &&
+          source == other.source &&
+          title == other.title &&
+          startBlockIndex == other.startBlockIndex &&
+          endBlockIndex == other.endBlockIndex;
+
+  @override
+  int get hashCode => Object.hash(
+    citedText,
+    searchResultIndex,
+    source,
+    title,
+    startBlockIndex,
+    endBlockIndex,
+  );
+
+  @override
+  String toString() =>
+      'SearchResultLocationCitation(citedText: [${citedText.length} chars], '
+      'searchResultIndex: $searchResultIndex, source: $source, title: $title, '
+      'startBlockIndex: $startBlockIndex, endBlockIndex: $endBlockIndex)';
+}
+
+/// Unrecognized citation type — preserves raw JSON for forward compatibility.
+@immutable
+class UnknownCitation extends Citation {
+  /// The raw JSON.
+  final Map<String, dynamic> rawJson;
+
+  /// Creates an [UnknownCitation].
+  const UnknownCitation({required this.rawJson});
+
+  @override
+  Map<String, dynamic> toJson() => rawJson;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnknownCitation &&
+          runtimeType == other.runtimeType &&
+          mapsDeepEqual(rawJson, other.rawJson);
+
+  @override
+  int get hashCode => mapDeepHashCode(rawJson);
+
+  @override
+  String toString() => 'UnknownCitation(rawJson: $rawJson)';
 }
 
 // ============================================================================

--- a/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
@@ -1282,6 +1282,26 @@ void main() {
       expect(c.copyWith(source: 'y').title, 'T');
     });
 
+    test('search_result_location toString includes fields (cited text '
+        'redacted)', () {
+      const c = SearchResultLocationCitation(
+        citedText: 'hello world',
+        searchResultIndex: 2,
+        source: 'kb://doc-42',
+        title: 'T',
+        startBlockIndex: 1,
+        endBlockIndex: 3,
+      );
+      final s = c.toString();
+      expect(s, contains('SearchResultLocationCitation'));
+      expect(s, contains('citedText: [11 chars]'));
+      expect(s, contains('searchResultIndex: 2'));
+      expect(s, contains('source: kb://doc-42'));
+      expect(s, contains('title: T'));
+      expect(s, contains('startBlockIndex: 1'));
+      expect(s, contains('endBlockIndex: 3'));
+    });
+
     test('unknown type falls back to UnknownCitation (never throws)', () {
       final json = {'type': 'future_location', 'foo': 'bar'};
       final c = Citation.fromJson(json);

--- a/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
@@ -1183,4 +1183,130 @@ void main() {
       });
     });
   });
+
+  group('Citation', () {
+    final byType = <String, Map<String, dynamic>>{
+      'char_location': {
+        'type': 'char_location',
+        'cited_text': 'a',
+        'document_index': 0,
+        'start_char_index': 0,
+        'end_char_index': 1,
+      },
+      'page_location': {
+        'type': 'page_location',
+        'cited_text': 'a',
+        'document_index': 0,
+        'start_page_number': 1,
+        'end_page_number': 2,
+      },
+      'content_block_location': {
+        'type': 'content_block_location',
+        'cited_text': 'a',
+        'document_index': 0,
+        'start_block_index': 0,
+        'end_block_index': 1,
+      },
+      'web_search_result_location': {
+        'type': 'web_search_result_location',
+        'cited_text': 'a',
+        'encrypted_index': 'enc',
+      },
+      'search_result_location': {
+        'type': 'search_result_location',
+        'cited_text': 'a',
+        'search_result_index': 0,
+        'source': 'src',
+        'start_block_index': 0,
+        'end_block_index': 1,
+      },
+    };
+
+    final expectedType = <String, Matcher>{
+      'char_location': isA<CharLocationCitation>(),
+      'page_location': isA<PageLocationCitation>(),
+      'content_block_location': isA<ContentBlockLocationCitation>(),
+      'web_search_result_location': isA<WebSearchResultLocationCitation>(),
+      'search_result_location': isA<SearchResultLocationCitation>(),
+    };
+
+    byType.forEach((type, json) {
+      test('$type dispatches and round-trips', () {
+        final c = Citation.fromJson(json);
+        expect(c, expectedType[type]);
+        expect(c.toJson(), json);
+      });
+    });
+
+    test('search_result_location parses all fields incl. title', () {
+      final json = {
+        'type': 'search_result_location',
+        'cited_text': 'the cited span',
+        'search_result_index': 2,
+        'source': 'kb://doc-42',
+        'title': 'Result title',
+        'start_block_index': 1,
+        'end_block_index': 3,
+      };
+      final c = Citation.fromJson(json) as SearchResultLocationCitation;
+      expect(c.citedText, 'the cited span');
+      expect(c.searchResultIndex, 2);
+      expect(c.source, 'kb://doc-42');
+      expect(c.title, 'Result title');
+      expect(c.startBlockIndex, 1);
+      expect(c.endBlockIndex, 3);
+      expect(c.toJson(), json);
+    });
+
+    test('search_result_location omits title when null', () {
+      const c = SearchResultLocationCitation(
+        citedText: 'x',
+        searchResultIndex: 0,
+        source: 's',
+        startBlockIndex: 0,
+        endBlockIndex: 1,
+      );
+      expect(c.toJson().containsKey('title'), isFalse);
+    });
+
+    test('copyWith clears title with explicit null and preserves on omit', () {
+      const c = SearchResultLocationCitation(
+        citedText: 'x',
+        searchResultIndex: 0,
+        source: 's',
+        title: 'T',
+        startBlockIndex: 0,
+        endBlockIndex: 1,
+      );
+      expect(c.copyWith(title: null).title, isNull);
+      expect(c.copyWith(source: 'y').title, 'T');
+    });
+
+    test('unknown type falls back to UnknownCitation (never throws)', () {
+      final json = {'type': 'future_location', 'foo': 'bar'};
+      final c = Citation.fromJson(json);
+      expect(c, isA<UnknownCitation>());
+      expect(c.toJson(), json);
+    });
+
+    test('missing type falls back to UnknownCitation', () {
+      final json = {'foo': 'bar'};
+      final c = Citation.fromJson(json);
+      expect(c, isA<UnknownCitation>());
+      expect(c.toJson(), json);
+    });
+
+    test('UnknownCitation uses deep equality', () {
+      final a = Citation.fromJson({
+        'type': 'x',
+        'n': {'k': 1},
+      });
+      final b = Citation.fromJson({
+        'type': 'x',
+        'n': {'k': 1},
+      });
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
 }

--- a/packages/anthropic_sdk_dart/test/unit/models/message_stream_accumulator_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/message_stream_accumulator_test.dart
@@ -172,6 +172,23 @@ Map<String, dynamic> _webSearchCitationJson({
   'url': ?url,
 };
 
+Map<String, dynamic> _searchResultCitationJson({
+  String citedText = 'sr cited',
+  int searchResultIndex = 0,
+  String source = 'kb://doc',
+  String? title,
+  int startBlockIndex = 0,
+  int endBlockIndex = 1,
+}) => {
+  'type': 'search_result_location',
+  'cited_text': citedText,
+  'search_result_index': searchResultIndex,
+  'source': source,
+  'title': ?title,
+  'start_block_index': startBlockIndex,
+  'end_block_index': endBlockIndex,
+};
+
 // ---------------------------------------------------------------------------
 // Helper to feed a sequence of JSON events into an accumulator.
 // ---------------------------------------------------------------------------
@@ -598,6 +615,28 @@ void main() {
         expect(citations, hasLength(2));
         expect(citations[0], isA<CharLocationCitation>());
         expect(citations[1], isA<WebSearchResultLocationCitation>());
+      });
+
+      test('search_result_location citation accumulates onto text block', () {
+        final acc = _accumulate([
+          _messageStartJson(),
+          _contentBlockStartJson(0, _textBlockJson()),
+          _contentBlockDeltaJson(0, _textDeltaJson('Grounded answer')),
+          _contentBlockDeltaJson(
+            0,
+            _citationsDeltaJson(
+              _searchResultCitationJson(source: 'kb://doc-42'),
+            ),
+          ),
+          _contentBlockStopJson(0),
+          _messageDeltaJson(stopReason: 'end_turn'),
+          _messageStopJson,
+        ]);
+
+        final citations = acc.textBlocks[0].citations!;
+        expect(citations, hasLength(1));
+        final citation = citations.single as SearchResultLocationCitation;
+        expect(citation.source, 'kb://doc-42');
       });
     });
 


### PR DESCRIPTION
## Summary

- **Adds the missing `search_result_location` citation type.** A user reported citations "not working" — the `Citation` sealed family had 4 of the spec's 5 response citation types but was missing `search_result_location`, which the model returns when it cites **search-result content blocks** (RAG / agentic search).
- **Fixes a crash on unrecognized citation types.** `Citation.fromJson` threw `FormatException` on any unknown `type` (no `Unknown*` fallback, unlike every other sealed family in the SDK). A `search_result_location` citation therefore **crashed deserialization of the whole message** — in both the non-streaming and streaming (`CitationsDelta`) paths.

## Details

`Citation` was the only sealed union in the SDK without a forward-compatible fallback. This PR brings it in line with `ContentBlock`, `Rubric`, `WebhookEventData`, etc.:

- New `SearchResultLocationCitation` — fields verified 1:1 against the spec (`BetaResponseSearchResultLocationCitation`) and the official Python SDK (`CitationsSearchResultLocation`): `cited_text`, `search_result_index`, `source`, `title` (nullable), `start_block_index`, `end_block_index`.
- New `UnknownCitation` (preserves raw JSON) + null-safe discriminator read; `_ =>` now yields `UnknownCitation` instead of throwing, so unknown/future citation types degrade gracefully and round-trip.
- The streaming accumulator needed no change — it's generic over `Citation`, so the new variant flows through `CitationsDelta` automatically (covered by a new test).

**Out of scope (deliberate):** request-side per-citation location types (for supplying your own cited `search_result` blocks) — a separate, larger feature, not part of this report.

## Breaking Changes

`Citation` is a `sealed`, exported type. Adding the `SearchResultLocationCitation` and `UnknownCitation` variants is a **source-breaking change**: any downstream `switch` over a `Citation` value that was exhaustive over the previous four variants (no `default`/wildcard branch) will now fail to compile until the new variants are handled. This warrants a **major** version bump (2.2.0 → 3.0.0).

Note this is also what makes `Citation` forward-compatible from now on: previously `Citation.fromJson` *threw* `FormatException` on any unrecognized `type`, so exhaustive matching was already unsafe at runtime. With the `UnknownCitation` fallback, consumers can add a single catch-all branch and future citation types will no longer break them.

**Migration** — handle the new variants (and adopt `UnknownCitation` as the forward-compatible catch-all):

```dart
// Before (exhaustive over 4 variants — stops compiling on upgrade)
final label = switch (citation) {
  CharLocationCitation() => 'char',
  PageLocationCitation() => 'page',
  ContentBlockLocationCitation() => 'block',
  WebSearchResultLocationCitation() => 'web',
};

// After — handle search_result_location, and use UnknownCitation (or a
// wildcard) so subsequent additions are non-breaking
final label = switch (citation) {
  CharLocationCitation() => 'char',
  PageLocationCitation() => 'page',
  ContentBlockLocationCitation() => 'block',
  WebSearchResultLocationCitation() => 'web',
  SearchResultLocationCitation() => 'search_result',
  UnknownCitation() => 'unknown',
};
```

Pure-deserialization consumers (no exhaustive `switch` over `Citation`) need no changes and gain the crash fix.

## Test Plan

- [x] Unit tests pass (`+12` new; 868 total)
- [x] New `Citation` tests: dispatch + round-trip for all **5** variants, `search_result_location` with `title` present/absent, `copyWith` title-clear, `toString`
- [x] Regression guards: unknown type **and** missing/null type → `UnknownCitation`, never throws; `UnknownCitation` deep equality
- [x] Streaming: `search_result_location` `citations_delta` accumulates onto the text block
- [x] `dart analyze --fatal-infos` clean; toolkit `verify --checks implementation` unchanged at the pre-existing 9-error baseline (new variant tracked, no new errors)
