### PR TITLE
feat(anthropic_sdk_dart)!: request-side search_result blocks & per-citation locations

### DIFF
--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
@@ -312,6 +312,7 @@
           "TextBlockParam": "text",
           "ImageBlockParam": "image",
           "DocumentBlockParam": "document",
+          "SearchResultBlockParam": "search_result",
           "ToolUseBlockParam": "tool_use",
           "ToolResultBlockParam": "tool_result",
           "ServerToolUseBlockParam": "server_tool_use",
@@ -339,10 +340,7 @@
       "dart_class": "TextInputBlock",
       "file": "lib/src/models/content/input_content_block.dart",
       "schema": "RequestTextBlock",
-      "parent": "InputContentBlock",
-      "excluded_properties": [
-        "citations"
-      ]
+      "parent": "InputContentBlock"
     },
     "ImageBlockParam": {
       "spec": "main",
@@ -358,11 +356,15 @@
       "dart_class": "DocumentInputBlock",
       "file": "lib/src/models/content/input_content_block.dart",
       "schema": "RequestDocumentBlock",
-      "parent": "InputContentBlock",
-      "excluded_properties": [
-        "citations",
-        "context"
-      ]
+      "parent": "InputContentBlock"
+    },
+    "SearchResultBlockParam": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "SearchResultInputBlock",
+      "file": "lib/src/models/content/input_content_block.dart",
+      "schema": "RequestSearchResultBlock",
+      "parent": "InputContentBlock"
     },
     "ToolUseBlockParam": {
       "spec": "main",
@@ -568,6 +570,64 @@
       "file": "lib/src/models/content/content_block.dart",
       "schema": "BetaResponseSearchResultLocationCitation",
       "parent": "Citation"
+    },
+    "InputCitation": {
+      "spec": "main",
+      "kind": "sealed_parent",
+      "dart_class": "InputCitation",
+      "file": "lib/src/models/content/input_content_block.dart",
+      "schema": null,
+      "discriminator": {
+        "field": "type",
+        "mapping": {
+          "InputCitationCharLocation": "char_location",
+          "InputCitationPageLocation": "page_location",
+          "InputCitationContentBlockLocation": "content_block_location",
+          "InputCitationWebSearchResultLocation": "web_search_result_location",
+          "InputCitationSearchResultLocation": "search_result_location"
+        }
+      },
+      "note": null
+    },
+    "InputCitationCharLocation": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "CharLocationInputCitation",
+      "file": "lib/src/models/content/input_content_block.dart",
+      "schema": "RequestCharLocationCitation",
+      "parent": "InputCitation"
+    },
+    "InputCitationPageLocation": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "PageLocationInputCitation",
+      "file": "lib/src/models/content/input_content_block.dart",
+      "schema": "RequestPageLocationCitation",
+      "parent": "InputCitation"
+    },
+    "InputCitationContentBlockLocation": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "ContentBlockLocationInputCitation",
+      "file": "lib/src/models/content/input_content_block.dart",
+      "schema": "RequestContentBlockLocationCitation",
+      "parent": "InputCitation"
+    },
+    "InputCitationWebSearchResultLocation": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebSearchResultLocationInputCitation",
+      "file": "lib/src/models/content/input_content_block.dart",
+      "schema": "RequestWebSearchResultLocationCitation",
+      "parent": "InputCitation"
+    },
+    "InputCitationSearchResultLocation": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "SearchResultLocationInputCitation",
+      "file": "lib/src/models/content/input_content_block.dart",
+      "schema": "RequestSearchResultLocationCitation",
+      "parent": "InputCitation"
     },
     "WebSearchResult": {
       "spec": "main",

--- a/packages/anthropic_sdk_dart/README.md
+++ b/packages/anthropic_sdk_dart/README.md
@@ -39,7 +39,7 @@ Dart client for the **[Anthropic API](https://docs.anthropic.com/en/api)** to bu
 
 - Custom tool calling with strict schemas and tool choice controls
 - Computer use, web search, code execution, advisor, and MCP tool integration
-- Vision and document inputs with citations
+- Vision and document inputs with citations, plus your own cited `search_result` blocks (RAG)
 
 ### Operational APIs
 
@@ -667,6 +667,7 @@ See the [example/](example/) directory for complete examples:
 | [`thinking_example.dart`](example/thinking_example.dart) | Extended thinking |
 | [`vision_example.dart`](example/vision_example.dart) | Image and document inputs |
 | [`document_example.dart`](example/document_example.dart) | Document inputs with citations |
+| [`search_result_example.dart`](example/search_result_example.dart) | Supplying your own cited `search_result` blocks (RAG) |
 | [`token_counting_example.dart`](example/token_counting_example.dart) | Token counting |
 | [`message_batches_example.dart`](example/message_batches_example.dart) | Batch processing |
 | [`files_example.dart`](example/files_example.dart) | File management (beta) |

--- a/packages/anthropic_sdk_dart/example/search_result_example.dart
+++ b/packages/anthropic_sdk_dart/example/search_result_example.dart
@@ -1,0 +1,90 @@
+// ignore_for_file: avoid_print
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+
+/// Search result content blocks example (RAG / agentic search citations).
+///
+/// This example demonstrates how to supply your own cited `search_result`
+/// content blocks so Claude can ground its answer in them and return
+/// `search_result_location` citations pointing back at the exact blocks it used.
+///
+/// Use this when you run your own retrieval/RAG system and want Claude to cite
+/// the passages you provide (rather than the built-in web search tool).
+void main() async {
+  final client = AnthropicClient(
+    config: const AnthropicConfig(
+      authProvider: ApiKeyProvider(String.fromEnvironment('ANTHROPIC_API_KEY')),
+    ),
+  );
+
+  try {
+    // Build a search_result block from passages your retrieval system returned.
+    // Each passage is a citable TextInputBlock; set `citations.enabled` so the
+    // model is allowed to cite this result.
+    final searchResult = InputContentBlock.searchResult(
+      source: 'kb://astronomy/solar-system',
+      title: 'Solar System Facts',
+      citations: const RequestCitationsConfig(enabled: true),
+      content: const [
+        TextInputBlock('Earth is the third planet from the Sun.'),
+        TextInputBlock(
+          'Earth completes one orbit of the Sun every 365.25 days.',
+        ),
+        TextInputBlock("The Moon is Earth's only natural satellite."),
+      ],
+    );
+
+    print('=== Request: search_result content block ===');
+    print(searchResult.toJson());
+
+    final response = await client.messages.create(
+      MessageCreateRequest(
+        model: 'claude-sonnet-4-6',
+        maxTokens: 1024,
+        messages: [
+          InputMessage.userBlocks([
+            searchResult,
+            InputContentBlock.text('How long is one Earth year?'),
+          ]),
+        ],
+      ),
+    );
+
+    // Read the answer and any citations Claude attached to its text.
+    print('\n=== Response ===');
+    for (final block in response.content) {
+      if (block is TextBlock) {
+        print(block.text);
+        for (final citation in block.citations ?? const <Citation>[]) {
+          if (citation is SearchResultLocationCitation) {
+            print(
+              '  ↳ cited "${citation.citedText}" from '
+              '${citation.source} (blocks '
+              '${citation.startBlockIndex}..${citation.endBlockIndex})',
+            );
+          }
+        }
+      }
+    }
+
+    // You can also pre-attach per-citation locations to text you send — for
+    // example, when replaying an earlier turn. These use the request-side
+    // citation types (the `InputCitation` family):
+    print('\n=== Supplying your own per-citation locations ===');
+    const citedText = TextInputBlock(
+      'Earth completes one orbit of the Sun every 365.25 days.',
+      citations: [
+        SearchResultLocationInputCitation(
+          citedText: 'Earth completes one orbit of the Sun every 365.25 days.',
+          searchResultIndex: 0,
+          source: 'kb://astronomy/solar-system',
+          title: 'Solar System Facts',
+          startBlockIndex: 1,
+          endBlockIndex: 2,
+        ),
+      ],
+    );
+    print(citedText.toJson());
+  } finally {
+    client.close();
+  }
+}

--- a/packages/anthropic_sdk_dart/lib/anthropic_sdk_dart.dart
+++ b/packages/anthropic_sdk_dart/lib/anthropic_sdk_dart.dart
@@ -79,6 +79,7 @@ export 'src/models/beta_timestamp.dart';
 export 'src/models/completions/completion.dart';
 
 // Models - Content
+export 'src/models/content/citations_config.dart';
 export 'src/models/content/content_block.dart';
 export 'src/models/content/input_content_block.dart';
 

--- a/packages/anthropic_sdk_dart/lib/src/models/content/citations_config.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/citations_config.dart
@@ -1,0 +1,35 @@
+import 'package:meta/meta.dart';
+
+/// Citations configuration for a content block or tool output.
+///
+/// Toggles whether the model may cite the associated source (e.g. a
+/// `search_result` block, a `document` block, or web fetch tool output).
+@immutable
+class RequestCitationsConfig {
+  /// Whether citations are enabled for the associated source.
+  final bool enabled;
+
+  /// Creates a [RequestCitationsConfig].
+  const RequestCitationsConfig({this.enabled = true});
+
+  /// Creates a [RequestCitationsConfig] from JSON.
+  factory RequestCitationsConfig.fromJson(Map<String, dynamic> json) {
+    return RequestCitationsConfig(enabled: json['enabled'] as bool? ?? true);
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {'enabled': enabled};
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RequestCitationsConfig &&
+          runtimeType == other.runtimeType &&
+          enabled == other.enabled;
+
+  @override
+  int get hashCode => enabled.hashCode;
+
+  @override
+  String toString() => 'RequestCitationsConfig(enabled: $enabled)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/content/input_content_block.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/input_content_block.dart
@@ -6,6 +6,7 @@ import '../metadata/cache_control.dart';
 import '../sources/document_source.dart';
 import '../sources/image_source.dart';
 import '../tools/tool_caller.dart';
+import 'citations_config.dart';
 import 'content_block.dart';
 
 /// Content block for input messages.
@@ -30,8 +31,24 @@ sealed class InputContentBlock {
   factory InputContentBlock.document(
     DocumentSource source, {
     String? title,
+    String? context,
+    RequestCitationsConfig? citations,
     CacheControlEphemeral? cacheControl,
   }) = DocumentInputBlock;
+
+  /// Creates a search result content block.
+  ///
+  /// Supply your own cited search results (e.g. from a custom retrieval/RAG
+  /// system) so the model can reference them and return `search_result_location`
+  /// citations. Set [citations] to `RequestCitationsConfig(enabled: true)` to
+  /// allow the model to cite this result.
+  factory InputContentBlock.searchResult({
+    required List<TextInputBlock> content,
+    required String source,
+    required String title,
+    RequestCitationsConfig? citations,
+    CacheControlEphemeral? cacheControl,
+  }) = SearchResultInputBlock;
 
   /// Creates a tool use block (for assistant messages).
   factory InputContentBlock.toolUse({
@@ -131,6 +148,7 @@ sealed class InputContentBlock {
       'text' => TextInputBlock.fromJson(json),
       'image' => ImageInputBlock.fromJson(json),
       'document' => DocumentInputBlock.fromJson(json),
+      'search_result' => SearchResultInputBlock.fromJson(json),
       'tool_use' => ToolUseInputBlock.fromJson(json),
       'tool_result' => ToolResultInputBlock.fromJson(json),
       'server_tool_use' => ServerToolUseInputBlock.fromJson(json),
@@ -165,16 +183,26 @@ class TextInputBlock extends InputContentBlock {
   /// The text content.
   final String text;
 
+  /// Citations attached to this text.
+  ///
+  /// Tells the model where spans of [text] were sourced from (e.g. when this
+  /// block is part of a [SearchResultInputBlock]'s content), so it can cite
+  /// them back in its response.
+  final List<InputCitation>? citations;
+
   /// Cache control for this block.
   final CacheControlEphemeral? cacheControl;
 
   /// Creates a [TextInputBlock].
-  const TextInputBlock(this.text, {this.cacheControl});
+  const TextInputBlock(this.text, {this.citations, this.cacheControl});
 
   /// Creates a [TextInputBlock] from JSON.
   factory TextInputBlock.fromJson(Map<String, dynamic> json) {
     return TextInputBlock(
       json['text'] as String,
+      citations: (json['citations'] as List?)
+          ?.map((e) => InputCitation.fromJson(e as Map<String, dynamic>))
+          .toList(),
       cacheControl: json['cache_control'] != null
           ? CacheControlEphemeral.fromJson(
               json['cache_control'] as Map<String, dynamic>,
@@ -187,16 +215,22 @@ class TextInputBlock extends InputContentBlock {
   Map<String, dynamic> toJson() => {
     'type': 'text',
     'text': text,
+    if (citations != null)
+      'citations': citations!.map((e) => e.toJson()).toList(),
     if (cacheControl != null) 'cache_control': cacheControl!.toJson(),
   };
 
   /// Creates a copy with replaced values.
   TextInputBlock copyWith({
     String? text,
+    Object? citations = unsetCopyWithValue,
     Object? cacheControl = unsetCopyWithValue,
   }) {
     return TextInputBlock(
       text ?? this.text,
+      citations: citations == unsetCopyWithValue
+          ? this.citations
+          : citations as List<InputCitation>?,
       cacheControl: cacheControl == unsetCopyWithValue
           ? this.cacheControl
           : cacheControl as CacheControlEphemeral?,
@@ -209,14 +243,16 @@ class TextInputBlock extends InputContentBlock {
       other is TextInputBlock &&
           runtimeType == other.runtimeType &&
           text == other.text &&
+          listsEqual(citations, other.citations) &&
           cacheControl == other.cacheControl;
 
   @override
-  int get hashCode => Object.hash(text, cacheControl);
+  int get hashCode => Object.hash(text, listHash(citations), cacheControl);
 
   @override
   String toString() =>
-      'TextInputBlock(text: [${text.length} chars], cacheControl: $cacheControl)';
+      'TextInputBlock(text: [${text.length} chars], citations: $citations, '
+      'cacheControl: $cacheControl)';
 }
 
 /// Image content block for input.
@@ -288,17 +324,39 @@ class DocumentInputBlock extends InputContentBlock {
   /// Optional title for the document.
   final String? title;
 
+  /// Optional context about the document, passed to the model but not used for
+  /// citations.
+  final String? context;
+
+  /// Citations configuration for this document.
+  ///
+  /// Set to `RequestCitationsConfig(enabled: true)` to let the model cite this
+  /// document in its response.
+  final RequestCitationsConfig? citations;
+
   /// Cache control for this block.
   final CacheControlEphemeral? cacheControl;
 
   /// Creates a [DocumentInputBlock].
-  const DocumentInputBlock(this.source, {this.title, this.cacheControl});
+  const DocumentInputBlock(
+    this.source, {
+    this.title,
+    this.context,
+    this.citations,
+    this.cacheControl,
+  });
 
   /// Creates a [DocumentInputBlock] from JSON.
   factory DocumentInputBlock.fromJson(Map<String, dynamic> json) {
     return DocumentInputBlock(
       DocumentSource.fromJson(json['source'] as Map<String, dynamic>),
       title: json['title'] as String?,
+      context: json['context'] as String?,
+      citations: json['citations'] != null
+          ? RequestCitationsConfig.fromJson(
+              json['citations'] as Map<String, dynamic>,
+            )
+          : null,
       cacheControl: json['cache_control'] != null
           ? CacheControlEphemeral.fromJson(
               json['cache_control'] as Map<String, dynamic>,
@@ -312,6 +370,8 @@ class DocumentInputBlock extends InputContentBlock {
     'type': 'document',
     'source': source.toJson(),
     if (title != null) 'title': title,
+    if (context != null) 'context': context,
+    if (citations != null) 'citations': citations!.toJson(),
     if (cacheControl != null) 'cache_control': cacheControl!.toJson(),
   };
 
@@ -319,11 +379,19 @@ class DocumentInputBlock extends InputContentBlock {
   DocumentInputBlock copyWith({
     DocumentSource? source,
     Object? title = unsetCopyWithValue,
+    Object? context = unsetCopyWithValue,
+    Object? citations = unsetCopyWithValue,
     Object? cacheControl = unsetCopyWithValue,
   }) {
     return DocumentInputBlock(
       source ?? this.source,
       title: title == unsetCopyWithValue ? this.title : title as String?,
+      context: context == unsetCopyWithValue
+          ? this.context
+          : context as String?,
+      citations: citations == unsetCopyWithValue
+          ? this.citations
+          : citations as RequestCitationsConfig?,
       cacheControl: cacheControl == unsetCopyWithValue
           ? this.cacheControl
           : cacheControl as CacheControlEphemeral?,
@@ -337,15 +405,126 @@ class DocumentInputBlock extends InputContentBlock {
           runtimeType == other.runtimeType &&
           source == other.source &&
           title == other.title &&
+          context == other.context &&
+          citations == other.citations &&
           cacheControl == other.cacheControl;
 
   @override
-  int get hashCode => Object.hash(source, title, cacheControl);
+  int get hashCode =>
+      Object.hash(source, title, context, citations, cacheControl);
 
   @override
   String toString() =>
       'DocumentInputBlock(source: $source, title: $title, '
-      'cacheControl: $cacheControl)';
+      'context: $context, citations: $citations, cacheControl: $cacheControl)';
+}
+
+/// Search result content block for input.
+///
+/// Lets you supply your own cited search results (e.g. from a custom
+/// retrieval/RAG system) so the model can reference them and return
+/// `search_result_location` citations. The [content] is the searchable text,
+/// split into citable [TextInputBlock]s.
+@immutable
+class SearchResultInputBlock extends InputContentBlock {
+  /// The searchable content of this result, as citable text blocks.
+  final List<TextInputBlock> content;
+
+  /// Source identifier for this result (e.g. a URL or document id).
+  final String source;
+
+  /// Display title for this result.
+  final String title;
+
+  /// Citations configuration for this result.
+  ///
+  /// Set to `RequestCitationsConfig(enabled: true)` to let the model cite this
+  /// result in its response.
+  final RequestCitationsConfig? citations;
+
+  /// Cache control for this block.
+  final CacheControlEphemeral? cacheControl;
+
+  /// Creates a [SearchResultInputBlock].
+  const SearchResultInputBlock({
+    required this.content,
+    required this.source,
+    required this.title,
+    this.citations,
+    this.cacheControl,
+  });
+
+  /// Creates a [SearchResultInputBlock] from JSON.
+  factory SearchResultInputBlock.fromJson(Map<String, dynamic> json) {
+    return SearchResultInputBlock(
+      content: (json['content'] as List)
+          .map((e) => TextInputBlock.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      source: json['source'] as String,
+      title: json['title'] as String,
+      citations: json['citations'] != null
+          ? RequestCitationsConfig.fromJson(
+              json['citations'] as Map<String, dynamic>,
+            )
+          : null,
+      cacheControl: json['cache_control'] != null
+          ? CacheControlEphemeral.fromJson(
+              json['cache_control'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'search_result',
+    'content': content.map((e) => e.toJson()).toList(),
+    'source': source,
+    'title': title,
+    if (citations != null) 'citations': citations!.toJson(),
+    if (cacheControl != null) 'cache_control': cacheControl!.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  SearchResultInputBlock copyWith({
+    List<TextInputBlock>? content,
+    String? source,
+    String? title,
+    Object? citations = unsetCopyWithValue,
+    Object? cacheControl = unsetCopyWithValue,
+  }) {
+    return SearchResultInputBlock(
+      content: content ?? this.content,
+      source: source ?? this.source,
+      title: title ?? this.title,
+      citations: citations == unsetCopyWithValue
+          ? this.citations
+          : citations as RequestCitationsConfig?,
+      cacheControl: cacheControl == unsetCopyWithValue
+          ? this.cacheControl
+          : cacheControl as CacheControlEphemeral?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SearchResultInputBlock &&
+          runtimeType == other.runtimeType &&
+          listsEqual(content, other.content) &&
+          source == other.source &&
+          title == other.title &&
+          citations == other.citations &&
+          cacheControl == other.cacheControl;
+
+  @override
+  int get hashCode =>
+      Object.hash(listHash(content), source, title, citations, cacheControl);
+
+  @override
+  String toString() =>
+      'SearchResultInputBlock(content: $content, source: $source, '
+      'title: $title, citations: $citations, cacheControl: $cacheControl)';
 }
 
 /// Tool use block for assistant messages in input.
@@ -1701,4 +1880,553 @@ class UnknownInputContentBlock extends InputContentBlock {
 
   @override
   String toString() => 'UnknownInputContentBlock(raw: ${raw.length} entries)';
+}
+
+// ============================================================================
+// Request Citations (per-citation location types)
+// ============================================================================
+
+/// A citation supplied on a request [TextInputBlock] (e.g. inside a
+/// [SearchResultInputBlock]'s content) that tells the model where a span of
+/// text was sourced from, so the model can cite it back in its response.
+///
+/// This is the request-side counterpart to the response-side `Citation` family.
+/// Note the serialization difference: the spec marks the nullable
+/// `title` / `document_title` keys as **required**, so they are always emitted
+/// (as `null` when absent), unlike their response-side equivalents.
+///
+/// Dispatches on the `type` discriminator; unrecognized values fall back to
+/// [UnknownInputCitation].
+///
+/// Subtypes:
+/// - [CharLocationInputCitation] (`char_location`)
+/// - [PageLocationInputCitation] (`page_location`)
+/// - [ContentBlockLocationInputCitation] (`content_block_location`)
+/// - [WebSearchResultLocationInputCitation] (`web_search_result_location`)
+/// - [SearchResultLocationInputCitation] (`search_result_location`)
+/// - [UnknownInputCitation] (forward-compatible fallback)
+sealed class InputCitation {
+  const InputCitation();
+
+  /// Creates an [InputCitation] from JSON.
+  ///
+  /// Dispatches on the `type` discriminator; unrecognized values fall back to
+  /// [UnknownInputCitation].
+  factory InputCitation.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    return switch (type) {
+      'char_location' => CharLocationInputCitation.fromJson(json),
+      'page_location' => PageLocationInputCitation.fromJson(json),
+      'content_block_location' => ContentBlockLocationInputCitation.fromJson(
+        json,
+      ),
+      'web_search_result_location' =>
+        WebSearchResultLocationInputCitation.fromJson(json),
+      'search_result_location' => SearchResultLocationInputCitation.fromJson(
+        json,
+      ),
+      _ => UnknownInputCitation(rawJson: json),
+    };
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson();
+}
+
+/// Request citation with character location (for plain text document sources).
+@immutable
+class CharLocationInputCitation extends InputCitation {
+  /// The cited text.
+  final String citedText;
+
+  /// The document index.
+  final int documentIndex;
+
+  /// The document title (may be `null`; the key is always sent).
+  final String? documentTitle;
+
+  /// Start character offset.
+  final int startCharIndex;
+
+  /// End character offset.
+  final int endCharIndex;
+
+  /// Creates a [CharLocationInputCitation].
+  const CharLocationInputCitation({
+    required this.citedText,
+    required this.documentIndex,
+    required this.documentTitle,
+    required this.startCharIndex,
+    required this.endCharIndex,
+  });
+
+  /// Creates a [CharLocationInputCitation] from JSON.
+  factory CharLocationInputCitation.fromJson(Map<String, dynamic> json) {
+    return CharLocationInputCitation(
+      citedText: json['cited_text'] as String,
+      documentIndex: json['document_index'] as int,
+      documentTitle: json['document_title'] as String?,
+      startCharIndex: json['start_char_index'] as int,
+      endCharIndex: json['end_char_index'] as int,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'char_location',
+    'cited_text': citedText,
+    'document_index': documentIndex,
+    'document_title': documentTitle,
+    'start_char_index': startCharIndex,
+    'end_char_index': endCharIndex,
+  };
+
+  /// Creates a copy with replaced values.
+  CharLocationInputCitation copyWith({
+    String? citedText,
+    int? documentIndex,
+    Object? documentTitle = unsetCopyWithValue,
+    int? startCharIndex,
+    int? endCharIndex,
+  }) {
+    return CharLocationInputCitation(
+      citedText: citedText ?? this.citedText,
+      documentIndex: documentIndex ?? this.documentIndex,
+      documentTitle: documentTitle == unsetCopyWithValue
+          ? this.documentTitle
+          : documentTitle as String?,
+      startCharIndex: startCharIndex ?? this.startCharIndex,
+      endCharIndex: endCharIndex ?? this.endCharIndex,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CharLocationInputCitation &&
+          runtimeType == other.runtimeType &&
+          citedText == other.citedText &&
+          documentIndex == other.documentIndex &&
+          documentTitle == other.documentTitle &&
+          startCharIndex == other.startCharIndex &&
+          endCharIndex == other.endCharIndex;
+
+  @override
+  int get hashCode => Object.hash(
+    citedText,
+    documentIndex,
+    documentTitle,
+    startCharIndex,
+    endCharIndex,
+  );
+
+  @override
+  String toString() =>
+      'CharLocationInputCitation(citedText: [${citedText.length} chars], '
+      'documentIndex: $documentIndex, documentTitle: $documentTitle, '
+      'startCharIndex: $startCharIndex, endCharIndex: $endCharIndex)';
+}
+
+/// Request citation with page location (for PDF document sources).
+@immutable
+class PageLocationInputCitation extends InputCitation {
+  /// The cited text.
+  final String citedText;
+
+  /// The document index.
+  final int documentIndex;
+
+  /// The document title (may be `null`; the key is always sent).
+  final String? documentTitle;
+
+  /// Start page number.
+  final int startPageNumber;
+
+  /// End page number.
+  final int endPageNumber;
+
+  /// Creates a [PageLocationInputCitation].
+  const PageLocationInputCitation({
+    required this.citedText,
+    required this.documentIndex,
+    required this.documentTitle,
+    required this.startPageNumber,
+    required this.endPageNumber,
+  });
+
+  /// Creates a [PageLocationInputCitation] from JSON.
+  factory PageLocationInputCitation.fromJson(Map<String, dynamic> json) {
+    return PageLocationInputCitation(
+      citedText: json['cited_text'] as String,
+      documentIndex: json['document_index'] as int,
+      documentTitle: json['document_title'] as String?,
+      startPageNumber: json['start_page_number'] as int,
+      endPageNumber: json['end_page_number'] as int,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'page_location',
+    'cited_text': citedText,
+    'document_index': documentIndex,
+    'document_title': documentTitle,
+    'start_page_number': startPageNumber,
+    'end_page_number': endPageNumber,
+  };
+
+  /// Creates a copy with replaced values.
+  PageLocationInputCitation copyWith({
+    String? citedText,
+    int? documentIndex,
+    Object? documentTitle = unsetCopyWithValue,
+    int? startPageNumber,
+    int? endPageNumber,
+  }) {
+    return PageLocationInputCitation(
+      citedText: citedText ?? this.citedText,
+      documentIndex: documentIndex ?? this.documentIndex,
+      documentTitle: documentTitle == unsetCopyWithValue
+          ? this.documentTitle
+          : documentTitle as String?,
+      startPageNumber: startPageNumber ?? this.startPageNumber,
+      endPageNumber: endPageNumber ?? this.endPageNumber,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PageLocationInputCitation &&
+          runtimeType == other.runtimeType &&
+          citedText == other.citedText &&
+          documentIndex == other.documentIndex &&
+          documentTitle == other.documentTitle &&
+          startPageNumber == other.startPageNumber &&
+          endPageNumber == other.endPageNumber;
+
+  @override
+  int get hashCode => Object.hash(
+    citedText,
+    documentIndex,
+    documentTitle,
+    startPageNumber,
+    endPageNumber,
+  );
+
+  @override
+  String toString() =>
+      'PageLocationInputCitation(citedText: [${citedText.length} chars], '
+      'documentIndex: $documentIndex, documentTitle: $documentTitle, '
+      'startPageNumber: $startPageNumber, endPageNumber: $endPageNumber)';
+}
+
+/// Request citation with content block location (block-indexed sources).
+@immutable
+class ContentBlockLocationInputCitation extends InputCitation {
+  /// The cited text.
+  final String citedText;
+
+  /// The document index.
+  final int documentIndex;
+
+  /// The document title (may be `null`; the key is always sent).
+  final String? documentTitle;
+
+  /// Start content block index.
+  final int startBlockIndex;
+
+  /// End content block index.
+  final int endBlockIndex;
+
+  /// Creates a [ContentBlockLocationInputCitation].
+  const ContentBlockLocationInputCitation({
+    required this.citedText,
+    required this.documentIndex,
+    required this.documentTitle,
+    required this.startBlockIndex,
+    required this.endBlockIndex,
+  });
+
+  /// Creates a [ContentBlockLocationInputCitation] from JSON.
+  factory ContentBlockLocationInputCitation.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return ContentBlockLocationInputCitation(
+      citedText: json['cited_text'] as String,
+      documentIndex: json['document_index'] as int,
+      documentTitle: json['document_title'] as String?,
+      startBlockIndex: json['start_block_index'] as int,
+      endBlockIndex: json['end_block_index'] as int,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'content_block_location',
+    'cited_text': citedText,
+    'document_index': documentIndex,
+    'document_title': documentTitle,
+    'start_block_index': startBlockIndex,
+    'end_block_index': endBlockIndex,
+  };
+
+  /// Creates a copy with replaced values.
+  ContentBlockLocationInputCitation copyWith({
+    String? citedText,
+    int? documentIndex,
+    Object? documentTitle = unsetCopyWithValue,
+    int? startBlockIndex,
+    int? endBlockIndex,
+  }) {
+    return ContentBlockLocationInputCitation(
+      citedText: citedText ?? this.citedText,
+      documentIndex: documentIndex ?? this.documentIndex,
+      documentTitle: documentTitle == unsetCopyWithValue
+          ? this.documentTitle
+          : documentTitle as String?,
+      startBlockIndex: startBlockIndex ?? this.startBlockIndex,
+      endBlockIndex: endBlockIndex ?? this.endBlockIndex,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ContentBlockLocationInputCitation &&
+          runtimeType == other.runtimeType &&
+          citedText == other.citedText &&
+          documentIndex == other.documentIndex &&
+          documentTitle == other.documentTitle &&
+          startBlockIndex == other.startBlockIndex &&
+          endBlockIndex == other.endBlockIndex;
+
+  @override
+  int get hashCode => Object.hash(
+    citedText,
+    documentIndex,
+    documentTitle,
+    startBlockIndex,
+    endBlockIndex,
+  );
+
+  @override
+  String toString() =>
+      'ContentBlockLocationInputCitation(citedText: [${citedText.length} chars], '
+      'documentIndex: $documentIndex, documentTitle: $documentTitle, '
+      'startBlockIndex: $startBlockIndex, endBlockIndex: $endBlockIndex)';
+}
+
+/// Request citation referencing a web search result.
+@immutable
+class WebSearchResultLocationInputCitation extends InputCitation {
+  /// The cited text.
+  final String citedText;
+
+  /// Encrypted index for the citation.
+  final String encryptedIndex;
+
+  /// Title of the source (may be `null`; the key is always sent).
+  final String? title;
+
+  /// URL of the source.
+  final String url;
+
+  /// Creates a [WebSearchResultLocationInputCitation].
+  const WebSearchResultLocationInputCitation({
+    required this.citedText,
+    required this.encryptedIndex,
+    required this.title,
+    required this.url,
+  });
+
+  /// Creates a [WebSearchResultLocationInputCitation] from JSON.
+  factory WebSearchResultLocationInputCitation.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebSearchResultLocationInputCitation(
+      citedText: json['cited_text'] as String,
+      encryptedIndex: json['encrypted_index'] as String,
+      title: json['title'] as String?,
+      url: json['url'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'web_search_result_location',
+    'cited_text': citedText,
+    'encrypted_index': encryptedIndex,
+    'title': title,
+    'url': url,
+  };
+
+  /// Creates a copy with replaced values.
+  WebSearchResultLocationInputCitation copyWith({
+    String? citedText,
+    String? encryptedIndex,
+    Object? title = unsetCopyWithValue,
+    String? url,
+  }) {
+    return WebSearchResultLocationInputCitation(
+      citedText: citedText ?? this.citedText,
+      encryptedIndex: encryptedIndex ?? this.encryptedIndex,
+      title: title == unsetCopyWithValue ? this.title : title as String?,
+      url: url ?? this.url,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebSearchResultLocationInputCitation &&
+          runtimeType == other.runtimeType &&
+          citedText == other.citedText &&
+          encryptedIndex == other.encryptedIndex &&
+          title == other.title &&
+          url == other.url;
+
+  @override
+  int get hashCode => Object.hash(citedText, encryptedIndex, title, url);
+
+  @override
+  String toString() =>
+      'WebSearchResultLocationInputCitation('
+      'citedText: [${citedText.length} chars], '
+      'encryptedIndex: [${encryptedIndex.length} chars], '
+      'title: $title, url: $url)';
+}
+
+/// Request citation referencing a range of blocks within a `search_result`
+/// content block (for supplying your own cited search results, e.g. RAG).
+@immutable
+class SearchResultLocationInputCitation extends InputCitation {
+  /// The cited text (the concatenated contents of the cited block range).
+  final String citedText;
+
+  /// 0-based index of the cited search result among all `search_result`
+  /// content blocks in the request.
+  final int searchResultIndex;
+
+  /// Source identifier of the cited search result.
+  final String source;
+
+  /// Title of the cited search result (may be `null`; the key is always sent).
+  final String? title;
+
+  /// 0-based index of the first cited block in the source's content array.
+  final int startBlockIndex;
+
+  /// Exclusive 0-based end index of the cited block range.
+  final int endBlockIndex;
+
+  /// Creates a [SearchResultLocationInputCitation].
+  const SearchResultLocationInputCitation({
+    required this.citedText,
+    required this.searchResultIndex,
+    required this.source,
+    required this.title,
+    required this.startBlockIndex,
+    required this.endBlockIndex,
+  });
+
+  /// Creates a [SearchResultLocationInputCitation] from JSON.
+  factory SearchResultLocationInputCitation.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return SearchResultLocationInputCitation(
+      citedText: json['cited_text'] as String,
+      searchResultIndex: json['search_result_index'] as int,
+      source: json['source'] as String,
+      title: json['title'] as String?,
+      startBlockIndex: json['start_block_index'] as int,
+      endBlockIndex: json['end_block_index'] as int,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'search_result_location',
+    'cited_text': citedText,
+    'search_result_index': searchResultIndex,
+    'source': source,
+    'title': title,
+    'start_block_index': startBlockIndex,
+    'end_block_index': endBlockIndex,
+  };
+
+  /// Creates a copy with replaced values.
+  SearchResultLocationInputCitation copyWith({
+    String? citedText,
+    int? searchResultIndex,
+    String? source,
+    Object? title = unsetCopyWithValue,
+    int? startBlockIndex,
+    int? endBlockIndex,
+  }) {
+    return SearchResultLocationInputCitation(
+      citedText: citedText ?? this.citedText,
+      searchResultIndex: searchResultIndex ?? this.searchResultIndex,
+      source: source ?? this.source,
+      title: title == unsetCopyWithValue ? this.title : title as String?,
+      startBlockIndex: startBlockIndex ?? this.startBlockIndex,
+      endBlockIndex: endBlockIndex ?? this.endBlockIndex,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SearchResultLocationInputCitation &&
+          runtimeType == other.runtimeType &&
+          citedText == other.citedText &&
+          searchResultIndex == other.searchResultIndex &&
+          source == other.source &&
+          title == other.title &&
+          startBlockIndex == other.startBlockIndex &&
+          endBlockIndex == other.endBlockIndex;
+
+  @override
+  int get hashCode => Object.hash(
+    citedText,
+    searchResultIndex,
+    source,
+    title,
+    startBlockIndex,
+    endBlockIndex,
+  );
+
+  @override
+  String toString() =>
+      'SearchResultLocationInputCitation('
+      'citedText: [${citedText.length} chars], '
+      'searchResultIndex: $searchResultIndex, source: $source, title: $title, '
+      'startBlockIndex: $startBlockIndex, endBlockIndex: $endBlockIndex)';
+}
+
+/// Unrecognized request citation type — preserves raw JSON for forward
+/// compatibility.
+@immutable
+class UnknownInputCitation extends InputCitation {
+  /// The raw JSON.
+  final Map<String, dynamic> rawJson;
+
+  /// Creates an [UnknownInputCitation].
+  const UnknownInputCitation({required this.rawJson});
+
+  @override
+  Map<String, dynamic> toJson() => rawJson;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnknownInputCitation &&
+          runtimeType == other.runtimeType &&
+          mapsDeepEqual(rawJson, other.rawJson);
+
+  @override
+  int get hashCode => mapDeepHashCode(rawJson);
+
+  @override
+  String toString() => 'UnknownInputCitation(rawJson: $rawJson)';
 }

--- a/packages/anthropic_sdk_dart/lib/src/models/tools/built_in_tools.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/tools/built_in_tools.dart
@@ -5,6 +5,11 @@ import '../common/equality_helpers.dart';
 import '../content/citations_config.dart';
 import '../metadata/cache_control.dart';
 
+// RequestCitationsConfig now lives in content/citations_config.dart but is part
+// of this library's API surface (e.g. WebFetchTool.citations), so re-export it
+// to preserve the import surface for consumers of this sublibrary.
+export '../content/citations_config.dart';
+
 // Include beta tools as part of this library to allow them to extend BuiltInTool
 part '../beta/tools/advisor_tool.dart';
 part '../beta/tools/computer_use_tool.dart';

--- a/packages/anthropic_sdk_dart/lib/src/models/tools/built_in_tools.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/tools/built_in_tools.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../common/copy_with_sentinel.dart';
 import '../common/equality_helpers.dart';
+import '../content/citations_config.dart';
 import '../metadata/cache_control.dart';
 
 // Include beta tools as part of this library to allow them to extend BuiltInTool
@@ -905,37 +906,6 @@ class WebSearchTool extends BuiltInTool {
       'maxUses: $maxUses, userLocation: $userLocation, '
       'allowedCallers: $allowedCallers, deferLoading: $deferLoading, '
       'strict: $strict)';
-}
-
-/// Citations configuration for web fetch tool output.
-@immutable
-class RequestCitationsConfig {
-  /// Whether citations are enabled for fetched documents.
-  final bool enabled;
-
-  /// Creates a [RequestCitationsConfig].
-  const RequestCitationsConfig({this.enabled = true});
-
-  /// Creates a [RequestCitationsConfig] from JSON.
-  factory RequestCitationsConfig.fromJson(Map<String, dynamic> json) {
-    return RequestCitationsConfig(enabled: json['enabled'] as bool? ?? true);
-  }
-
-  /// Converts to JSON.
-  Map<String, dynamic> toJson() => {'enabled': enabled};
-
-  @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      other is RequestCitationsConfig &&
-          runtimeType == other.runtimeType &&
-          enabled == other.enabled;
-
-  @override
-  int get hashCode => enabled.hashCode;
-
-  @override
-  String toString() => 'RequestCitationsConfig(enabled: $enabled)';
 }
 
 /// Web fetch built-in tool.

--- a/packages/anthropic_sdk_dart/llms.txt
+++ b/packages/anthropic_sdk_dart/llms.txt
@@ -20,13 +20,14 @@
 - [models_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/models_example.dart) (~471 tokens): Model listing.
 - [files_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/files_example.dart) (~842 tokens): File management (beta).
 - [skills_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/skills_example.dart) (~1k tokens): Skills management (beta).
-- [managed_agents_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/managed_agents_example.dart) (~1.5k tokens): Managed agents: agents, sessions, vaults, multiagent rosters, outcomes, webhooks, credential validation (beta).
+- [managed_agents_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/managed_agents_example.dart) (~1.6k tokens): Managed agents: agents, sessions, vaults, multiagent rosters, outcomes, webhooks, credential validation (beta).
 - [memory_stores_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/memory_stores_example.dart) (~903 tokens): Managed agents memory stores, memories, and versions (beta).
 - [error_handling_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/error_handling_example.dart) (~632 tokens): Exception handling patterns.
 - [web_search_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/web_search_example.dart) (~793 tokens): Web search tool.
 - [advisor_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/advisor_example.dart) (~967 tokens): Advisor tool (beta).
 - [computer_use_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/computer_use_example.dart) (~866 tokens): Computer use tool.
 - [document_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/document_example.dart) (~937 tokens): Document inputs with citations.
+- [search_result_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/search_result_example.dart) (~707 tokens): Supplying your own cited `search_result` blocks (RAG).
 - [mcp_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/mcp_example.dart) (~904 tokens): MCP tool integration.
 - [session_threads_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/session_threads_example.dart) (~816 tokens): Session threads: list, retrieve, stream events, archive (beta).
 - [user_profiles_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/user_profiles_example.dart) (~649 tokens): User profiles and enrollment URLs (beta).
@@ -36,4 +37,4 @@
 
 - [Package directory](https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/anthropic_sdk_dart): Source tree, pubspec, and package-local files.
 
-**Total: ~36.4k tokens**
+**Total: ~37.2k tokens**

--- a/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
@@ -469,6 +469,175 @@ void main() {
 
         expect(json['cache_control'], {'type': 'ephemeral'});
       });
+
+      test('round-trips citations', () {
+        const block = TextInputBlock(
+          'cited text',
+          citations: [
+            SearchResultLocationInputCitation(
+              citedText: 'cited text',
+              searchResultIndex: 0,
+              source: 'kb://doc-1',
+              title: 'Doc 1',
+              startBlockIndex: 0,
+              endBlockIndex: 1,
+            ),
+          ],
+        );
+        final json = block.toJson();
+        expect(json['citations'], hasLength(1));
+        expect(TextInputBlock.fromJson(json), equals(block));
+      });
+
+      test('omits citations when absent; copyWith sets and clears them', () {
+        const block = TextInputBlock('no citations');
+        expect(block.toJson().containsKey('citations'), isFalse);
+
+        final withCitations = block.copyWith(
+          citations: const [
+            CharLocationInputCitation(
+              citedText: 'a',
+              documentIndex: 0,
+              documentTitle: null,
+              startCharIndex: 0,
+              endCharIndex: 1,
+            ),
+          ],
+        );
+        expect(withCitations.citations, hasLength(1));
+        expect(withCitations.copyWith(citations: null).citations, isNull);
+      });
+
+      test('toString includes citations', () {
+        const block = TextInputBlock('hi', citations: []);
+        expect(block.toString(), contains('citations: []'));
+      });
+    });
+
+    group('SearchResultInputBlock', () {
+      Map<String, dynamic> sampleJson() => {
+        'type': 'search_result',
+        'content': [
+          {
+            'type': 'text',
+            'text': 'Earth orbits the Sun.',
+            'citations': [
+              {
+                'type': 'search_result_location',
+                'cited_text': 'Earth orbits the Sun.',
+                'search_result_index': 0,
+                'source': 'kb://astro',
+                'title': 'Astronomy',
+                'start_block_index': 0,
+                'end_block_index': 1,
+              },
+            ],
+          },
+          {'type': 'text', 'text': 'It takes 365 days.'},
+        ],
+        'source': 'kb://astro',
+        'title': 'Astronomy',
+        'citations': {'enabled': true},
+      };
+
+      test('factory creates a search result block', () {
+        final block = InputContentBlock.searchResult(
+          content: const [TextInputBlock('Earth orbits the Sun.')],
+          source: 'kb://astro',
+          title: 'Astronomy',
+          citations: const RequestCitationsConfig(enabled: true),
+        );
+        expect(block, isA<SearchResultInputBlock>());
+        final b = block as SearchResultInputBlock;
+        expect(b.content, hasLength(1));
+        expect(b.source, 'kb://astro');
+        expect(b.title, 'Astronomy');
+        expect(b.citations, const RequestCitationsConfig(enabled: true));
+      });
+
+      test('dispatches via InputContentBlock.fromJson and round-trips', () {
+        final json = sampleJson();
+        final block = InputContentBlock.fromJson(json);
+        expect(block, isA<SearchResultInputBlock>());
+        expect(block.toJson(), json);
+      });
+
+      test('omits citations/cacheControl when absent', () {
+        const block = SearchResultInputBlock(
+          content: [TextInputBlock('x')],
+          source: 's',
+          title: 't',
+        );
+        final json = block.toJson();
+        expect(json.containsKey('citations'), isFalse);
+        expect(json.containsKey('cache_control'), isFalse);
+      });
+
+      test('copyWith updates fields and clears nullables', () {
+        const block = SearchResultInputBlock(
+          content: [TextInputBlock('x')],
+          source: 's',
+          title: 't',
+          citations: RequestCitationsConfig(enabled: true),
+        );
+        expect(block.copyWith(title: 'new').title, 'new');
+        expect(block.copyWith(source: 'z').citations, isNotNull);
+        expect(block.copyWith(citations: null).citations, isNull);
+      });
+
+      test('toString includes fields', () {
+        const block = SearchResultInputBlock(
+          content: [TextInputBlock('x')],
+          source: 'kb://astro',
+          title: 'Astronomy',
+        );
+        final s = block.toString();
+        expect(s, contains('SearchResultInputBlock'));
+        expect(s, contains('source: kb://astro'));
+        expect(s, contains('title: Astronomy'));
+      });
+    });
+
+    group('DocumentInputBlock citations/context', () {
+      test('round-trips citations and context', () {
+        final block = DocumentInputBlock(
+          DocumentSource.url('https://example.com/doc.pdf'),
+          title: 'Doc',
+          context: 'Quarterly report',
+          citations: const RequestCitationsConfig(enabled: true),
+        );
+        final json = block.toJson();
+        expect(json['context'], 'Quarterly report');
+        expect(json['citations'], {'enabled': true});
+        expect(DocumentInputBlock.fromJson(json), equals(block));
+      });
+
+      test('omits citations/context when absent; copyWith clears them', () {
+        final block = DocumentInputBlock(
+          DocumentSource.url('https://example.com/doc.pdf'),
+        );
+        final json = block.toJson();
+        expect(json.containsKey('context'), isFalse);
+        expect(json.containsKey('citations'), isFalse);
+
+        final withBoth = block.copyWith(
+          context: 'ctx',
+          citations: const RequestCitationsConfig(),
+        );
+        expect(withBoth.copyWith(context: null).context, isNull);
+        expect(withBoth.copyWith(citations: null).citations, isNull);
+      });
+
+      test('toString includes context and citations', () {
+        final block = DocumentInputBlock(
+          DocumentSource.url('https://example.com/doc.pdf'),
+          context: 'ctx',
+          citations: const RequestCitationsConfig(),
+        );
+        final s = block.toString();
+        expect(s, contains('context: ctx'));
+        expect(s, contains('citations:'));
+      });
     });
 
     group('ImageInputBlock', () {
@@ -1322,6 +1491,190 @@ void main() {
         'n': {'k': 1},
       });
       final b = Citation.fromJson({
+        'type': 'x',
+        'n': {'k': 1},
+      });
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+
+  group('InputCitation', () {
+    // Request citations always emit the required-but-nullable title /
+    // document_title keys, so the sample JSON includes them (as null).
+    final byType = <String, Map<String, dynamic>>{
+      'char_location': {
+        'type': 'char_location',
+        'cited_text': 'a',
+        'document_index': 0,
+        'document_title': null,
+        'start_char_index': 0,
+        'end_char_index': 1,
+      },
+      'page_location': {
+        'type': 'page_location',
+        'cited_text': 'a',
+        'document_index': 0,
+        'document_title': null,
+        'start_page_number': 1,
+        'end_page_number': 2,
+      },
+      'content_block_location': {
+        'type': 'content_block_location',
+        'cited_text': 'a',
+        'document_index': 0,
+        'document_title': null,
+        'start_block_index': 0,
+        'end_block_index': 1,
+      },
+      'web_search_result_location': {
+        'type': 'web_search_result_location',
+        'cited_text': 'a',
+        'encrypted_index': 'enc',
+        'title': null,
+        'url': 'https://example.com',
+      },
+      'search_result_location': {
+        'type': 'search_result_location',
+        'cited_text': 'a',
+        'search_result_index': 0,
+        'source': 'src',
+        'title': null,
+        'start_block_index': 0,
+        'end_block_index': 1,
+      },
+    };
+
+    final expectedType = <String, Matcher>{
+      'char_location': isA<CharLocationInputCitation>(),
+      'page_location': isA<PageLocationInputCitation>(),
+      'content_block_location': isA<ContentBlockLocationInputCitation>(),
+      'web_search_result_location': isA<WebSearchResultLocationInputCitation>(),
+      'search_result_location': isA<SearchResultLocationInputCitation>(),
+    };
+
+    byType.forEach((type, json) {
+      test('$type dispatches and round-trips', () {
+        final c = InputCitation.fromJson(json);
+        expect(c, expectedType[type]);
+        expect(c.toJson(), json);
+      });
+    });
+
+    test('search_result_location parses all fields incl. title', () {
+      final json = {
+        'type': 'search_result_location',
+        'cited_text': 'the cited span',
+        'search_result_index': 2,
+        'source': 'kb://doc-42',
+        'title': 'Result title',
+        'start_block_index': 1,
+        'end_block_index': 3,
+      };
+      final c =
+          InputCitation.fromJson(json) as SearchResultLocationInputCitation;
+      expect(c.citedText, 'the cited span');
+      expect(c.searchResultIndex, 2);
+      expect(c.source, 'kb://doc-42');
+      expect(c.title, 'Result title');
+      expect(c.startBlockIndex, 1);
+      expect(c.endBlockIndex, 3);
+      expect(c.toJson(), json);
+    });
+
+    test('always emits required-nullable title key (even when null)', () {
+      const c = SearchResultLocationInputCitation(
+        citedText: 'x',
+        searchResultIndex: 0,
+        source: 's',
+        title: null,
+        startBlockIndex: 0,
+        endBlockIndex: 1,
+      );
+      final json = c.toJson();
+      expect(json.containsKey('title'), isTrue);
+      expect(json['title'], isNull);
+    });
+
+    test('always emits required-nullable document_title key (even when '
+        'null)', () {
+      const c = CharLocationInputCitation(
+        citedText: 'a',
+        documentIndex: 0,
+        documentTitle: null,
+        startCharIndex: 0,
+        endCharIndex: 1,
+      );
+      final json = c.toJson();
+      expect(json.containsKey('document_title'), isTrue);
+      expect(json['document_title'], isNull);
+    });
+
+    test('copyWith clears title with explicit null and preserves on omit', () {
+      const c = SearchResultLocationInputCitation(
+        citedText: 'x',
+        searchResultIndex: 0,
+        source: 's',
+        title: 'T',
+        startBlockIndex: 0,
+        endBlockIndex: 1,
+      );
+      expect(c.copyWith(title: null).title, isNull);
+      expect(c.copyWith(source: 'y').title, 'T');
+    });
+
+    test('web_search_result_location round-trips and redacts in toString', () {
+      const c = WebSearchResultLocationInputCitation(
+        citedText: 'hello world',
+        encryptedIndex: 'secret-index',
+        title: 'T',
+        url: 'https://example.com',
+      );
+      final s = c.toString();
+      expect(s, contains('WebSearchResultLocationInputCitation'));
+      expect(s, contains('citedText: [11 chars]'));
+      expect(s, contains('encryptedIndex: [12 chars]'));
+      expect(s, contains('url: https://example.com'));
+    });
+
+    test('search_result_location toString includes fields (cited text '
+        'redacted)', () {
+      const c = SearchResultLocationInputCitation(
+        citedText: 'hello world',
+        searchResultIndex: 2,
+        source: 'kb://doc-42',
+        title: 'T',
+        startBlockIndex: 1,
+        endBlockIndex: 3,
+      );
+      final s = c.toString();
+      expect(s, contains('SearchResultLocationInputCitation'));
+      expect(s, contains('citedText: [11 chars]'));
+      expect(s, contains('searchResultIndex: 2'));
+      expect(s, contains('source: kb://doc-42'));
+      expect(s, contains('title: T'));
+    });
+
+    test('unknown type falls back to UnknownInputCitation (never throws)', () {
+      final json = {'type': 'future_location', 'foo': 'bar'};
+      final c = InputCitation.fromJson(json);
+      expect(c, isA<UnknownInputCitation>());
+      expect(c.toJson(), json);
+    });
+
+    test('missing type falls back to UnknownInputCitation', () {
+      final json = {'foo': 'bar'};
+      final c = InputCitation.fromJson(json);
+      expect(c, isA<UnknownInputCitation>());
+      expect(c.toJson(), json);
+    });
+
+    test('UnknownInputCitation uses deep equality', () {
+      final a = InputCitation.fromJson({
+        'type': 'x',
+        'n': {'k': 1},
+      });
+      final b = InputCitation.fromJson({
         'type': 'x',
         'n': {'k': 1},
       });


### PR DESCRIPTION
## Summary

- **Adds the request-side half of search-result citations.** [PR #233](https://github.com/davidmigloz/ai_clients_dart/pull/233) added the response-side `SearchResultLocationCitation` (citations the model *returns*) but deliberately deferred the request side. You can now **supply your own cited `search_result` content blocks** (e.g. from a custom retrieval/RAG system) so Claude can ground its answer in them and return `search_result_location` citations pointing back at the exact blocks it used.
- **Closes the related document-citations gap** by wiring `citations` (+ `context`) onto `DocumentInputBlock`, so the README's "document inputs with citations" claim is now fully backed.

## Details

New request-side surface in `lib/src/models/content/input_content_block.dart`:

- **`SearchResultInputBlock`** (`type: search_result`) — a new variant of the sealed `InputContentBlock` union, with `content: List<TextInputBlock>`, `source`, `title`, optional `citations: RequestCitationsConfig`, and `cacheControl`. Exposed via the redirecting `const` factory `InputContentBlock.searchResult(...)` and wired into `InputContentBlock.fromJson`.
- **`InputCitation` sealed family** — the request-side per-citation location types: `CharLocationInputCitation`, `PageLocationInputCitation`, `ContentBlockLocationInputCitation`, `WebSearchResultLocationInputCitation`, `SearchResultLocationInputCitation`, plus an `UnknownInputCitation` forward-compatible fallback. This mirrors the response-side `Citation` family.
- **`TextInputBlock.citations`** (`List<InputCitation>?`) and **`DocumentInputBlock.citations` (`RequestCitationsConfig?`) + `context` (`String?`)** added.
- **`RequestCitationsConfig`** extracted from `built_in_tools.dart` into its own `content/citations_config.dart` (now shared by search_result, document, and the web fetch tool); re-exported from the barrel.

```dart
final searchResult = InputContentBlock.searchResult(
  source: 'kb://astronomy/solar-system',
  title: 'Solar System Facts',
  citations: const RequestCitationsConfig(enabled: true),
  content: const [
    TextInputBlock('Earth is the third planet from the Sun.'),
    TextInputBlock('Earth completes one orbit of the Sun every 365.25 days.'),
  ],
);

final response = await client.messages.create(MessageCreateRequest(
  model: 'claude-sonnet-4-6',
  maxTokens: 1024,
  messages: [
    InputMessage.userBlocks([
      searchResult,
      InputContentBlock.text('How long is one Earth year?'),
    ]),
  ],
));

for (final block in response.content) {
  if (block is TextBlock) {
    for (final c in block.citations ?? const <Citation>[]) {
      if (c is SearchResultLocationCitation) {
        print('cited "${c.citedText}" from ${c.source}');
      }
    }
  }
}
```

**Design notes**
- **Separate request family** (not reuse of the response `Citation` types): mirrors the SDK's existing request/response split (`TextBlock`/`TextInputBlock`) and the official Anthropic Python SDK, which models request citations as distinct `*Param` types (`CitationCharLocationParam`, …). Verified field-for-field against the OpenAPI spec (`Request*Citation`, `RequestSearchResultBlock`).
- **Serialization difference:** the spec marks the nullable `title`/`document_title` keys as **required**, so request citations always emit those keys (as `null` when absent) — unlike their response-side equivalents which omit them.
- **No separate `Beta*` classes:** the SDK only creates `Beta*` Dart types for Beta-exclusive features; citations/search_result exist identically in the stable spec, so a single unified family is modeled (consistent with how `InputContentBlock` already unifies stable + Beta-only blocks).
- Toolkit `verify --checks all` adds no new errors (implementation stays at the pre-existing 9-error baseline; docs failures are pre-existing managed-agents/sessions items). Two new `consistency` **warnings** are expected and spec-faithful: `citations` legitimately has two shapes (a `List<InputCitation>` on text blocks vs the `RequestCitationsConfig` toggle on document/search-result blocks), and `title` is required on search results but optional on documents — matching the official SDK.

## Breaking Changes

`SearchResultInputBlock` is a new variant of the **sealed** `InputContentBlock` union. Any exhaustive `switch` over an `InputContentBlock` without a `default`/wildcard branch will stop compiling until a case is added.

```dart
// Add a branch for the new variant (or a wildcard for forward-compatibility):
final label = switch (block) {
  TextInputBlock() => 'text',
  DocumentInputBlock() => 'document',
  SearchResultInputBlock() => 'search_result', // new
  // ...
  _ => 'other',
};
```

Adding the new optional fields (`TextInputBlock.citations`, `DocumentInputBlock.citations`/`context`) and the new `InputCitation` type is additive. Relocating `RequestCitationsConfig` is source-compatible (still exported from the package barrel).

## References

- [PR #233 — response-side `search_result_location` citations](https://github.com/davidmigloz/ai_clients_dart/pull/233)
- [Anthropic — Search results & citations](https://docs.anthropic.com/en/docs/build-with-claude/search-results)

## Test Plan

- [x] Unit tests pass (`dart test test/unit/`): 894 pass, 4 env-skipped
- [x] New `InputCitation` tests: dispatch + round-trip for all 5 variants; required-nullable `title`/`document_title` keys always emitted; copyWith null-clear; `toString` redaction; unknown/missing type → `UnknownInputCitation` (never throws) with deep equality
- [x] New `SearchResultInputBlock` tests: factory, `InputContentBlock.fromJson` dispatch, nested `TextInputBlock` citations round-trip, copyWith, optional-omit, `toString`
- [x] New `TextInputBlock.citations` and `DocumentInputBlock.citations`/`context` tests (all 4 field contracts)
- [x] `==`/`hashCode` contract verified (deep helpers on `UnknownInputCitation.rawJson`, `listsEqual`/`listHash` for citation lists)
- [x] `dart analyze --fatal-infos` clean; `dart format` clean
- [x] Toolkit `verify --checks all` — no new errors vs baseline; example indexed in `llms.txt`