### PR TITLE
feat(anthropic_sdk_dart)!: cache diagnostics, session & skill updates

### DIFF
--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
@@ -79,6 +79,312 @@
     ]
   },
   "types": {
+    "DiagnosticsParam": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "DiagnosticsParam",
+      "file": "lib/src/models/messages/diagnostics_param.dart",
+      "schema": "BetaDiagnosticsParam"
+    },
+    "Diagnostics": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "Diagnostics",
+      "file": "lib/src/models/messages/diagnostics.dart",
+      "schema": "BetaDiagnostics"
+    },
+    "CacheMissReason": {
+      "spec": "main",
+      "kind": "sealed_parent",
+      "dart_class": "CacheMissReason",
+      "file": "lib/src/models/messages/cache_miss_reason.dart",
+      "schema": null,
+      "discriminator": {
+        "field": "type",
+        "mapping": {
+          "CacheMissModelChanged": "model_changed",
+          "CacheMissSystemChanged": "system_changed",
+          "CacheMissToolsChanged": "tools_changed",
+          "CacheMissMessagesChanged": "messages_changed",
+          "CacheMissPreviousMessageNotFound": "previous_message_not_found",
+          "CacheMissUnavailable": "unavailable"
+        }
+      }
+    },
+    "CacheMissModelChanged": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "CacheMissModelChanged",
+      "file": "lib/src/models/messages/cache_miss_reason.dart",
+      "schema": "BetaCacheMissModelChanged",
+      "parent": "CacheMissReason"
+    },
+    "CacheMissSystemChanged": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "CacheMissSystemChanged",
+      "file": "lib/src/models/messages/cache_miss_reason.dart",
+      "schema": "BetaCacheMissSystemChanged",
+      "parent": "CacheMissReason"
+    },
+    "CacheMissToolsChanged": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "CacheMissToolsChanged",
+      "file": "lib/src/models/messages/cache_miss_reason.dart",
+      "schema": "BetaCacheMissToolsChanged",
+      "parent": "CacheMissReason"
+    },
+    "CacheMissMessagesChanged": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "CacheMissMessagesChanged",
+      "file": "lib/src/models/messages/cache_miss_reason.dart",
+      "schema": "BetaCacheMissMessagesChanged",
+      "parent": "CacheMissReason"
+    },
+    "CacheMissPreviousMessageNotFound": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "CacheMissPreviousMessageNotFound",
+      "file": "lib/src/models/messages/cache_miss_reason.dart",
+      "schema": "BetaCacheMissPreviousMessageNotFound",
+      "parent": "CacheMissReason"
+    },
+    "CacheMissUnavailable": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "CacheMissUnavailable",
+      "file": "lib/src/models/messages/cache_miss_reason.dart",
+      "schema": "BetaCacheMissUnavailable",
+      "parent": "CacheMissReason"
+    },
+    "UnknownCacheMissReason": {
+      "spec": "main",
+      "kind": "extension",
+      "dart_class": "UnknownCacheMissReason",
+      "file": "lib/src/models/messages/cache_miss_reason.dart",
+      "schema": null,
+      "parent": "CacheMissReason",
+      "note": "Forward-compatible fallback for unrecognized cache_miss_reason types; preserves raw JSON."
+    },
+    "SessionAgentUpdate": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "SessionAgentUpdate",
+      "file": "lib/src/models/managed_agents/sessions/session_agent_update.dart",
+      "schema": "BetaManagedAgentsSessionAgentUpdate"
+    },
+    "SessionUpdatedEvent": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "SessionUpdatedEvent",
+      "file": "lib/src/models/managed_agents/events/session_event.dart",
+      "schema": "BetaManagedAgentsSessionUpdatedEvent",
+      "parent": "SessionEvent"
+    },
+    "UserToolResultEvent": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "UserToolResultEvent",
+      "file": "lib/src/models/managed_agents/events/session_event.dart",
+      "schema": "BetaManagedAgentsUserToolResultEvent",
+      "parent": "SessionEvent"
+    },
+    "UserToolResultEventParams": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "UserToolResultEventParams",
+      "file": "lib/src/models/managed_agents/events/send_event_params.dart",
+      "schema": "BetaManagedAgentsUserToolResultEventParams",
+      "parent": "EventParams"
+    },
+    "BetaMessage": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "Message",
+      "file": "lib/src/models/messages/message.dart",
+      "schema": "BetaMessage",
+      "tags": ["acknowledged"],
+      "note": "Beta variant of Message; unified Message class covers both surfaces (diagnostics field added)."
+    },
+    "BetaThinkingContentBlockDelta": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "ThinkingDelta",
+      "file": "lib/src/models/streaming/content_block_delta.dart",
+      "schema": "BetaThinkingContentBlockDelta",
+      "tags": ["acknowledged"],
+      "note": "Beta variant of ThinkingContentBlockDelta; unified ThinkingDelta covers both surfaces (estimated_tokens field added)."
+    },
+    "BetaManagedAgentsSearchResultBlock": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaManagedAgentsSearchResultBlock",
+      "tags": ["acknowledged"],
+      "note": "Managed-agents content block / API wrapper - used as Map<String, dynamic>."
+    },
+    "BetaManagedAgentsSearchResultCitations": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaManagedAgentsSearchResultCitations",
+      "tags": ["acknowledged"],
+      "note": "Managed-agents content block / API wrapper - used as Map<String, dynamic>."
+    },
+    "BetaManagedAgentsSearchResultContent": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaManagedAgentsSearchResultContent",
+      "tags": ["acknowledged"],
+      "note": "Managed-agents content block / API wrapper - used as Map<String, dynamic>."
+    },
+    "BetaManagedAgentsAgentToolset20260401_BashInput": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaManagedAgentsAgentToolset20260401_BashInput",
+      "tags": ["acknowledged"],
+      "note": "Toolset tool input schema - passed through as Map<String, dynamic>."
+    },
+    "BetaManagedAgentsAgentToolset20260401_EditInput": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaManagedAgentsAgentToolset20260401_EditInput",
+      "tags": ["acknowledged"],
+      "note": "Toolset tool input schema - passed through as Map<String, dynamic>."
+    },
+    "BetaManagedAgentsAgentToolset20260401_GlobInput": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaManagedAgentsAgentToolset20260401_GlobInput",
+      "tags": ["acknowledged"],
+      "note": "Toolset tool input schema - passed through as Map<String, dynamic>."
+    },
+    "BetaManagedAgentsAgentToolset20260401_GrepInput": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaManagedAgentsAgentToolset20260401_GrepInput",
+      "tags": ["acknowledged"],
+      "note": "Toolset tool input schema - passed through as Map<String, dynamic>."
+    },
+    "BetaManagedAgentsAgentToolset20260401_ReadInput": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaManagedAgentsAgentToolset20260401_ReadInput",
+      "tags": ["acknowledged"],
+      "note": "Toolset tool input schema - passed through as Map<String, dynamic>."
+    },
+    "BetaManagedAgentsAgentToolset20260401_WriteInput": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaManagedAgentsAgentToolset20260401_WriteInput",
+      "tags": ["acknowledged"],
+      "note": "Toolset tool input schema - passed through as Map<String, dynamic>."
+    },
+    "BetaEnvironment": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaEnvironment",
+      "tags": ["acknowledged"],
+      "note": "environments resource excluded - see coverage.excluded_resources."
+    },
+    "BetaPublicEnvironmentCreateRequest": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaPublicEnvironmentCreateRequest",
+      "tags": ["acknowledged"],
+      "note": "environments resource excluded - see coverage.excluded_resources."
+    },
+    "BetaPublicEnvironmentUpdateRequest": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaPublicEnvironmentUpdateRequest",
+      "tags": ["acknowledged"],
+      "note": "environments resource excluded - see coverage.excluded_resources."
+    },
+    "BetaSelfHostedConfig": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaSelfHostedConfig",
+      "tags": ["acknowledged"],
+      "note": "environments resource excluded - see coverage.excluded_resources."
+    },
+    "BetaSelfHostedConfigParams": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaSelfHostedConfigParams",
+      "tags": ["acknowledged"],
+      "note": "environments resource excluded - see coverage.excluded_resources."
+    },
+    "BetaSelfHostedWork": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaSelfHostedWork",
+      "tags": ["acknowledged"],
+      "note": "environments resource excluded - see coverage.excluded_resources."
+    },
+    "BetaSelfHostedWorkHeartbeatResponse": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaSelfHostedWorkHeartbeatResponse",
+      "tags": ["acknowledged"],
+      "note": "environments resource excluded - see coverage.excluded_resources."
+    },
+    "BetaSelfHostedWorkListResponse": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaSelfHostedWorkListResponse",
+      "tags": ["acknowledged"],
+      "note": "environments resource excluded - see coverage.excluded_resources."
+    },
+    "BetaSelfHostedWorkQueueStats": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaSelfHostedWorkQueueStats",
+      "tags": ["acknowledged"],
+      "note": "environments resource excluded - see coverage.excluded_resources."
+    },
+    "BetaSelfHostedWorkStopRequest": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaSelfHostedWorkStopRequest",
+      "tags": ["acknowledged"],
+      "note": "environments resource excluded - see coverage.excluded_resources."
+    },
+    "BetaSelfHostedWorkUpdateRequest": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaSelfHostedWorkUpdateRequest",
+      "tags": ["acknowledged"],
+      "note": "environments resource excluded - see coverage.excluded_resources."
+    },
+    "BetaSessionWorkData": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaSessionWorkData",
+      "tags": ["acknowledged"],
+      "note": "environments resource excluded - see coverage.excluded_resources."
+    },
     "Message": {
       "spec": "main",
       "kind": "object",

--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/specs.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/specs.json
@@ -21,9 +21,9 @@
           }
         },
         "schema_aliases": {
+          "BetaManagedAgentsListSessionThreadEvents": "BetaManagedAgentsListSessionEvents",
           "BetaManagedAgentsSessionThreadAgent": "BetaManagedAgentsSessionAgent",
-          "BetaManagedAgentsSessionThreadStatus": "BetaManagedAgentsSessionStatus",
-          "BetaManagedAgentsListSessionThreadEvents": "BetaManagedAgentsListSessionEvents"
+          "BetaManagedAgentsSessionThreadStatus": "BetaManagedAgentsSessionStatus"
         }
       },
       "auth_env_vars": [],
@@ -31,9 +31,9 @@
       "fetch_mode": "remote",
       "local_file": "openapi.yaml",
       "name": "Anthropic API",
-      "pinned_hash": "0df2c793ea4c3ad955e8e488be39d7041a0a95e2fe144dd69ae4d9fb72835190",
+      "pinned_hash": "945e3a57b7a6fa5974baf70845ebafdb25f185625f6e2fab98dc034e44d14a5a",
       "requires_auth": false,
-      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-0df2c793ea4c3ad955e8e488be39d7041a0a95e2fe144dd69ae4d9fb72835190.yml"
+      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-945e3a57b7a6fa5974baf70845ebafdb25f185625f6e2fab98dc034e44d14a5a.yml"
     }
   },
   "specs_dir": "packages/anthropic_sdk_dart/specs"

--- a/packages/anthropic_sdk_dart/README.md
+++ b/packages/anthropic_sdk_dart/README.md
@@ -34,6 +34,7 @@ Dart client for the **[Anthropic API](https://docs.anthropic.com/en/api)** to bu
 - Messages with typed inputs, system prompts, and multi-turn history
 - SSE streaming with cancelation and token counting
 - Extended thinking and adaptive thinking controls
+- Prompt-cache diagnostics: report why the cache prefix diverged between turns (beta)
 
 ### Tools and multimodal
 
@@ -665,6 +666,7 @@ See the [example/](example/) directory for complete examples:
 | [`advisor_example.dart`](example/advisor_example.dart) | Advisor tool (beta) |
 | [`computer_use_example.dart`](example/computer_use_example.dart) | Computer use tool |
 | [`thinking_example.dart`](example/thinking_example.dart) | Extended thinking |
+| [`diagnostics_example.dart`](example/diagnostics_example.dart) | Prompt-cache diagnostics: why the cache prefix diverged (beta) |
 | [`vision_example.dart`](example/vision_example.dart) | Image and document inputs |
 | [`document_example.dart`](example/document_example.dart) | Document inputs with citations |
 | [`search_result_example.dart`](example/search_result_example.dart) | Supplying your own cited `search_result` blocks (RAG) |

--- a/packages/anthropic_sdk_dart/example/diagnostics_example.dart
+++ b/packages/anthropic_sdk_dart/example/diagnostics_example.dart
@@ -1,0 +1,69 @@
+// ignore_for_file: avoid_print
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+
+/// Prompt-cache diagnostics example (Beta).
+///
+/// Cache diagnostics let you find out *why* the prompt cache prefix could not
+/// be fully reused between two consecutive requests. Pass the previous
+/// response's `id` via [DiagnosticsParam.previousMessageId] and the API reports
+/// a [Diagnostics.cacheMissReason] on the response explaining where the prompt
+/// diverged.
+///
+/// Requires the `cache-diagnosis-2026-04-07` beta header — pass it via the
+/// `betas` parameter of `messages.create`.
+Future<void> main() async {
+  final client = AnthropicClient(
+    config: const AnthropicConfig(
+      authProvider: ApiKeyProvider(String.fromEnvironment('ANTHROPIC_API_KEY')),
+    ),
+  );
+
+  try {
+    // First turn — opt in to diagnostics without a prior message to compare
+    // against by passing `previousMessageId: null`.
+    final first = await client.messages.create(
+      MessageCreateRequest(
+        model: 'claude-sonnet-4-6',
+        maxTokens: 1024,
+        diagnostics: const DiagnosticsParam(),
+        messages: [InputMessage.user('Summarize the rules of chess.')],
+      ),
+      betas: ['cache-diagnosis-2026-04-07'],
+    );
+    print('First message id: ${first.id}');
+
+    // Second turn — reference the previous response id. The response's
+    // `diagnostics.cacheMissReason` explains any prompt-cache divergence.
+    final second = await client.messages.create(
+      MessageCreateRequest(
+        model: 'claude-sonnet-4-6',
+        maxTokens: 1024,
+        diagnostics: DiagnosticsParam(previousMessageId: first.id),
+        messages: [InputMessage.user('Now explain en passant.')],
+      ),
+      betas: ['cache-diagnosis-2026-04-07'],
+    );
+
+    final reason = second.diagnostics?.cacheMissReason;
+    print('Cache miss reason: ${_describe(reason)}');
+  } finally {
+    client.close();
+  }
+}
+
+/// Renders a human-readable explanation for a [CacheMissReason].
+String _describe(CacheMissReason? reason) => switch (reason) {
+  null => 'diagnosis pending or no divergence detected',
+  CacheMissModelChanged(:final cacheMissedInputTokens) =>
+    'the model changed ($cacheMissedInputTokens tokens not cached)',
+  CacheMissSystemChanged(:final cacheMissedInputTokens) =>
+    'the system prompt changed ($cacheMissedInputTokens tokens not cached)',
+  CacheMissToolsChanged(:final cacheMissedInputTokens) =>
+    'the tools changed ($cacheMissedInputTokens tokens not cached)',
+  CacheMissMessagesChanged(:final cacheMissedInputTokens) =>
+    'the messages changed ($cacheMissedInputTokens tokens not cached)',
+  CacheMissPreviousMessageNotFound() =>
+    'the previous message could not be found',
+  CacheMissUnavailable() => 'diagnostics are unavailable for this request',
+  UnknownCacheMissReason() => 'an unrecognized reason (forward-compatible)',
+};

--- a/packages/anthropic_sdk_dart/example/skills_example.dart
+++ b/packages/anthropic_sdk_dart/example/skills_example.dart
@@ -82,7 +82,16 @@ void main() async {
         print('  - ${v.version}: ${v.description}');
       }
 
-      // Example 6: Delete version
+      // Example 6: Download a version's content (zip archive)
+      print('\n=== Download Version Content ===');
+      final contentBytes = await client.skills.downloadVersion(
+        skillId: skill.id,
+        version: version.version,
+      );
+      print('Downloaded ${contentBytes.length} bytes');
+      await File('downloaded_skill.zip').writeAsBytes(contentBytes);
+
+      // Example 7: Delete version
       print('\n=== Delete Version ===');
       await client.skills.deleteVersion(
         skillId: skill.id,
@@ -90,7 +99,7 @@ void main() async {
       );
       print('Version deleted');
 
-      // Example 7: Delete skill
+      // Example 8: Delete skill
       print('\n=== Delete Skill ===');
       await client.skills.deleteSkill(skillId: skill.id);
       print('Skill deleted');

--- a/packages/anthropic_sdk_dart/lib/anthropic_sdk_dart.dart
+++ b/packages/anthropic_sdk_dart/lib/anthropic_sdk_dart.dart
@@ -133,6 +133,7 @@ export 'src/models/managed_agents/resources/session_resource.dart';
 export 'src/models/managed_agents/resources/session_resource_params.dart';
 export 'src/models/managed_agents/sessions/create_session_params.dart';
 export 'src/models/managed_agents/sessions/session.dart';
+export 'src/models/managed_agents/sessions/session_agent_update.dart';
 export 'src/models/managed_agents/sessions/session_list_response.dart';
 export 'src/models/managed_agents/sessions/session_thread.dart';
 export 'src/models/managed_agents/sessions/session_thread_list_response.dart';
@@ -144,6 +145,9 @@ export 'src/models/managed_agents/vaults/vault_list_response.dart';
 export 'src/models/managed_agents/webhooks/webhook_event.dart';
 
 // Models - Messages
+export 'src/models/messages/cache_miss_reason.dart';
+export 'src/models/messages/diagnostics.dart';
+export 'src/models/messages/diagnostics_param.dart';
 export 'src/models/messages/input_message.dart';
 export 'src/models/messages/message.dart';
 export 'src/models/messages/message_create_request.dart';

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/events/send_event_params.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/events/send_event_params.dart
@@ -54,6 +54,7 @@ class SendSessionEventsParams {
 /// - [UserInterruptEventParams] — send an interrupt.
 /// - [UserToolConfirmationEventParams] — confirm or deny a tool execution.
 /// - [UserCustomToolResultEventParams] — provide custom tool result.
+/// - [UserToolResultEventParams] — provide a generic tool result.
 /// - [UserDefineOutcomeEventParams] — define an outcome the agent works toward.
 /// - [UnknownEventParams] — unrecognized event type.
 sealed class EventParams {
@@ -71,6 +72,7 @@ sealed class EventParams {
       'user.custom_tool_result' => UserCustomToolResultEventParams.fromJson(
         json,
       ),
+      'user.tool_result' => UserToolResultEventParams.fromJson(json),
       'user.define_outcome' => UserDefineOutcomeEventParams.fromJson(json),
       _ => UnknownEventParams(rawJson: json),
     };
@@ -322,6 +324,81 @@ class UserCustomToolResultEventParams extends EventParams {
   @override
   String toString() =>
       'UserCustomToolResultEventParams(customToolUseId: $customToolUseId, '
+      'content: $content, isError: $isError)';
+}
+
+/// Parameters for providing a generic tool execution result.
+@immutable
+class UserToolResultEventParams extends EventParams {
+  /// The event type, always 'user.tool_result'.
+  String get type => 'user.tool_result';
+
+  /// The id of the tool_use event this result corresponds to.
+  final String toolUseId;
+
+  /// The result content returned by the tool.
+  final List<Map<String, dynamic>>? content;
+
+  /// Whether the tool execution resulted in an error.
+  final bool? isError;
+
+  /// Creates a [UserToolResultEventParams].
+  const UserToolResultEventParams({
+    required this.toolUseId,
+    this.content,
+    this.isError,
+  });
+
+  /// Creates a [UserToolResultEventParams] from JSON.
+  factory UserToolResultEventParams.fromJson(Map<String, dynamic> json) {
+    return UserToolResultEventParams(
+      toolUseId: json['tool_use_id'] as String,
+      content: (json['content'] as List?)
+          ?.map((e) => e as Map<String, dynamic>)
+          .toList(),
+      isError: json['is_error'] as bool?,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'tool_use_id': toolUseId,
+    if (content != null) 'content': content,
+    if (isError != null) 'is_error': isError,
+  };
+
+  /// Creates a copy with replaced values.
+  UserToolResultEventParams copyWith({
+    String? toolUseId,
+    Object? content = unsetCopyWithValue,
+    Object? isError = unsetCopyWithValue,
+  }) {
+    return UserToolResultEventParams(
+      toolUseId: toolUseId ?? this.toolUseId,
+      content: content == unsetCopyWithValue
+          ? this.content
+          : content as List<Map<String, dynamic>>?,
+      isError: isError == unsetCopyWithValue ? this.isError : isError as bool?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UserToolResultEventParams &&
+          runtimeType == other.runtimeType &&
+          toolUseId == other.toolUseId &&
+          listOfMapsDeepEqual(content, other.content) &&
+          isError == other.isError;
+
+  @override
+  int get hashCode =>
+      Object.hash(toolUseId, listOfMapsHashCode(content), isError);
+
+  @override
+  String toString() =>
+      'UserToolResultEventParams(toolUseId: $toolUseId, '
       'content: $content, isError: $isError)';
 }
 

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/events/session_event.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/events/session_event.dart
@@ -5,6 +5,7 @@ import '../../common/copy_with_sentinel.dart';
 import '../../common/equality_helpers.dart';
 import '../config/agent_tool.dart' show AgentEvaluatedPermission;
 import '../outcomes/rubric.dart';
+import '../sessions/session.dart' show SessionAgent;
 import 'telemetry.dart';
 
 /// Server-sent event in a managed agents session.
@@ -24,6 +25,7 @@ import 'telemetry.dart';
 /// - [UserInterruptEvent] — user interrupt.
 /// - [UserToolConfirmationEvent] — user tool confirmation.
 /// - [UserCustomToolResultEvent] — user custom tool result.
+/// - [UserToolResultEvent] — user tool result.
 /// - [SessionStatusRunningEvent] — session is running.
 /// - [SessionStatusIdleEvent] — session is idle.
 /// - [SessionStatusRescheduledEvent] — session rescheduled.
@@ -35,6 +37,7 @@ import 'telemetry.dart';
 /// - [SessionThreadStatusTerminatedEvent] — a thread terminated.
 /// - [SessionErrorEvent] — session error.
 /// - [SessionDeletedEvent] — session deleted.
+/// - [SessionUpdatedEvent] — an UpdateSession request changed a field.
 /// - [SpanModelRequestStartEvent] — model request started.
 /// - [SpanModelRequestEndEvent] — model request completed.
 /// - [SpanOutcomeEvaluationStartEvent] — outcome evaluation cycle began.
@@ -65,6 +68,7 @@ sealed class SessionEvent {
       'user.interrupt' => UserInterruptEvent.fromJson(json),
       'user.tool_confirmation' => UserToolConfirmationEvent.fromJson(json),
       'user.custom_tool_result' => UserCustomToolResultEvent.fromJson(json),
+      'user.tool_result' => UserToolResultEvent.fromJson(json),
       'session.status_running' => SessionStatusRunningEvent.fromJson(json),
       'session.status_idle' => SessionStatusIdleEvent.fromJson(json),
       'session.status_rescheduled' => SessionStatusRescheduledEvent.fromJson(
@@ -85,6 +89,7 @@ sealed class SessionEvent {
         SessionThreadStatusTerminatedEvent.fromJson(json),
       'session.error' => SessionErrorEvent.fromJson(json),
       'session.deleted' => SessionDeletedEvent.fromJson(json),
+      'session.updated' => SessionUpdatedEvent.fromJson(json),
       'span.model_request_start' => SpanModelRequestStartEvent.fromJson(json),
       'span.model_request_end' => SpanModelRequestEndEvent.fromJson(json),
       'span.outcome_evaluation_start' =>
@@ -1242,6 +1247,122 @@ class UserCustomToolResultEvent extends SessionEvent {
       'sessionThreadId: $sessionThreadId)';
 }
 
+/// Tool result event sent by the client for a generic tool use.
+@immutable
+class UserToolResultEvent extends SessionEvent {
+  /// The event type, always 'user.tool_result'.
+  String get type => 'user.tool_result';
+
+  /// Unique identifier for this event.
+  final String id;
+
+  /// The id of the tool_use event this result corresponds to.
+  final String toolUseId;
+
+  /// The result content returned by the tool.
+  final List<Map<String, dynamic>>? content;
+
+  /// Whether the tool execution resulted in an error.
+  final bool? isError;
+
+  /// Timestamp when this result was processed.
+  final BetaTimestamp? processedAt;
+
+  /// ID of the session thread this event belongs to, if any.
+  final String? sessionThreadId;
+
+  /// Creates a [UserToolResultEvent].
+  const UserToolResultEvent({
+    required this.id,
+    required this.toolUseId,
+    this.content,
+    this.isError,
+    this.processedAt,
+    this.sessionThreadId,
+  });
+
+  /// Creates a [UserToolResultEvent] from JSON.
+  factory UserToolResultEvent.fromJson(Map<String, dynamic> json) {
+    return UserToolResultEvent(
+      id: json['id'] as String,
+      toolUseId: json['tool_use_id'] as String,
+      content: (json['content'] as List?)
+          ?.map((e) => e as Map<String, dynamic>)
+          .toList(),
+      isError: json['is_error'] as bool?,
+      processedAt: json['processed_at'] != null
+          ? DateTime.parse(json['processed_at'] as String)
+          : null,
+      sessionThreadId: json['session_thread_id'] as String?,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'tool_use_id': toolUseId,
+    if (content != null) 'content': content,
+    if (isError != null) 'is_error': isError,
+    if (processedAt != null)
+      'processed_at': processedAt!.toUtc().toIso8601String(),
+    if (sessionThreadId != null) 'session_thread_id': sessionThreadId,
+  };
+
+  /// Creates a copy with replaced values.
+  UserToolResultEvent copyWith({
+    String? id,
+    String? toolUseId,
+    Object? content = unsetCopyWithValue,
+    Object? isError = unsetCopyWithValue,
+    Object? processedAt = unsetCopyWithValue,
+    Object? sessionThreadId = unsetCopyWithValue,
+  }) {
+    return UserToolResultEvent(
+      id: id ?? this.id,
+      toolUseId: toolUseId ?? this.toolUseId,
+      content: content == unsetCopyWithValue
+          ? this.content
+          : content as List<Map<String, dynamic>>?,
+      isError: isError == unsetCopyWithValue ? this.isError : isError as bool?,
+      processedAt: processedAt == unsetCopyWithValue
+          ? this.processedAt
+          : processedAt as BetaTimestamp?,
+      sessionThreadId: sessionThreadId == unsetCopyWithValue
+          ? this.sessionThreadId
+          : sessionThreadId as String?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UserToolResultEvent &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          toolUseId == other.toolUseId &&
+          listOfMapsDeepEqual(content, other.content) &&
+          isError == other.isError &&
+          processedAt == other.processedAt &&
+          sessionThreadId == other.sessionThreadId;
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    toolUseId,
+    listOfMapsHashCode(content),
+    isError,
+    processedAt,
+    sessionThreadId,
+  );
+
+  @override
+  String toString() =>
+      'UserToolResultEvent(id: $id, toolUseId: $toolUseId, '
+      'content: $content, isError: $isError, processedAt: $processedAt, '
+      'sessionThreadId: $sessionThreadId)';
+}
+
 // ---------------------------------------------------------------------------
 // Session status events
 // ---------------------------------------------------------------------------
@@ -1767,6 +1888,101 @@ class SessionDeletedEvent extends SessionEvent {
   @override
   String toString() =>
       'SessionDeletedEvent(id: $id, processedAt: $processedAt)';
+}
+
+/// Emitted when an UpdateSession request changed at least one field.
+@immutable
+class SessionUpdatedEvent extends SessionEvent {
+  /// The event type, always 'session.updated'.
+  String get type => 'session.updated';
+
+  /// Unique identifier for this event.
+  final String id;
+
+  /// Timestamp when the update was processed.
+  final BetaTimestamp processedAt;
+
+  /// The updated agent configuration, if the agent changed.
+  final SessionAgent? agent;
+
+  /// The updated session metadata, if it changed.
+  final Map<String, String>? metadata;
+
+  /// The updated session title, if it changed.
+  final String? title;
+
+  /// Creates a [SessionUpdatedEvent].
+  const SessionUpdatedEvent({
+    required this.id,
+    required this.processedAt,
+    this.agent,
+    this.metadata,
+    this.title,
+  });
+
+  /// Creates a [SessionUpdatedEvent] from JSON.
+  factory SessionUpdatedEvent.fromJson(Map<String, dynamic> json) {
+    return SessionUpdatedEvent(
+      id: json['id'] as String,
+      processedAt: DateTime.parse(json['processed_at'] as String),
+      agent: json['agent'] != null
+          ? SessionAgent.fromJson(json['agent'] as Map<String, dynamic>)
+          : null,
+      metadata: (json['metadata'] as Map<String, dynamic>?)?.map(
+        (k, v) => MapEntry(k, v as String),
+      ),
+      title: json['title'] as String?,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'processed_at': processedAt.toUtc().toIso8601String(),
+    if (agent != null) 'agent': agent!.toJson(),
+    if (metadata != null) 'metadata': metadata,
+    if (title != null) 'title': title,
+  };
+
+  /// Creates a copy with replaced values.
+  SessionUpdatedEvent copyWith({
+    String? id,
+    BetaTimestamp? processedAt,
+    Object? agent = unsetCopyWithValue,
+    Object? metadata = unsetCopyWithValue,
+    Object? title = unsetCopyWithValue,
+  }) {
+    return SessionUpdatedEvent(
+      id: id ?? this.id,
+      processedAt: processedAt ?? this.processedAt,
+      agent: agent == unsetCopyWithValue ? this.agent : agent as SessionAgent?,
+      metadata: metadata == unsetCopyWithValue
+          ? this.metadata
+          : metadata as Map<String, String>?,
+      title: title == unsetCopyWithValue ? this.title : title as String?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SessionUpdatedEvent &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          processedAt == other.processedAt &&
+          agent == other.agent &&
+          mapsEqual(metadata, other.metadata) &&
+          title == other.title;
+
+  @override
+  int get hashCode =>
+      Object.hash(id, processedAt, agent, mapHash(metadata), title);
+
+  @override
+  String toString() =>
+      'SessionUpdatedEvent(id: $id, processedAt: $processedAt, '
+      'agent: $agent, metadata: $metadata, title: $title)';
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/session_agent_update.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/session_agent_update.dart
@@ -1,5 +1,6 @@
 import 'package:meta/meta.dart';
 
+import '../../common/copy_with_sentinel.dart';
 import '../../common/equality_helpers.dart';
 import '../config/agent_tool.dart';
 import '../config/mcp_server.dart';
@@ -51,13 +52,21 @@ class SessionAgentUpdate {
   };
 
   /// Creates a copy with replaced values.
+  ///
+  /// Uses the [unsetCopyWithValue] sentinel so callers can both preserve the
+  /// existing value (omit the argument) and explicitly set a field back to
+  /// `null` (omit/preserve semantics on the wire).
   SessionAgentUpdate copyWith({
-    List<AgentToolParams>? tools,
-    List<MCPServerParams>? mcpServers,
+    Object? tools = unsetCopyWithValue,
+    Object? mcpServers = unsetCopyWithValue,
   }) {
     return SessionAgentUpdate(
-      tools: tools ?? this.tools,
-      mcpServers: mcpServers ?? this.mcpServers,
+      tools: tools == unsetCopyWithValue
+          ? this.tools
+          : (tools as List?)?.cast<AgentToolParams>(),
+      mcpServers: mcpServers == unsetCopyWithValue
+          ? this.mcpServers
+          : (mcpServers as List?)?.cast<MCPServerParams>(),
     );
   }
 

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/session_agent_update.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/session_agent_update.dart
@@ -1,0 +1,78 @@
+import 'package:meta/meta.dart';
+
+import '../../common/equality_helpers.dart';
+import '../config/agent_tool.dart';
+import '../config/mcp_server.dart';
+
+/// Agent configuration patch applied mid-session via an UpdateSession request.
+///
+/// Full-replacement semantics apply per field:
+/// - Provide an array to replace the current value entirely.
+/// - Provide an empty array to clear the current value.
+/// - Omit a field (leave it `null`) to preserve its current value.
+@immutable
+class SessionAgentUpdate {
+  /// Tool configurations to apply to the agent.
+  ///
+  /// When provided, this array fully replaces the agent's current tools. An
+  /// empty array clears all tools. Omit to preserve the current tools.
+  final List<AgentToolParams>? tools;
+
+  /// MCP server connections to apply to the agent.
+  ///
+  /// When provided, this array fully replaces the agent's current MCP servers.
+  /// An empty array clears all MCP servers. Omit to preserve the current
+  /// servers.
+  final List<MCPServerParams>? mcpServers;
+
+  /// Creates a [SessionAgentUpdate].
+  const SessionAgentUpdate({this.tools, this.mcpServers});
+
+  /// Creates a [SessionAgentUpdate] from JSON.
+  factory SessionAgentUpdate.fromJson(Map<String, dynamic> json) {
+    return SessionAgentUpdate(
+      tools: (json['tools'] as List?)
+          ?.map((e) => AgentToolParams.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      mcpServers: (json['mcp_servers'] as List?)
+          ?.map((e) => MCPServerParams.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  /// Converts to JSON.
+  ///
+  /// Null lists are omitted (preserve semantics). Empty lists are serialized
+  /// as `[]` to clear the corresponding value on the server.
+  Map<String, dynamic> toJson() => {
+    if (tools != null) 'tools': tools!.map((e) => e.toJson()).toList(),
+    if (mcpServers != null)
+      'mcp_servers': mcpServers!.map((e) => e.toJson()).toList(),
+  };
+
+  /// Creates a copy with replaced values.
+  SessionAgentUpdate copyWith({
+    List<AgentToolParams>? tools,
+    List<MCPServerParams>? mcpServers,
+  }) {
+    return SessionAgentUpdate(
+      tools: tools ?? this.tools,
+      mcpServers: mcpServers ?? this.mcpServers,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SessionAgentUpdate &&
+          runtimeType == other.runtimeType &&
+          listsEqual(tools, other.tools) &&
+          listsEqual(mcpServers, other.mcpServers);
+
+  @override
+  int get hashCode => Object.hash(listHash(tools), listHash(mcpServers));
+
+  @override
+  String toString() =>
+      'SessionAgentUpdate(tools: $tools, mcpServers: $mcpServers)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/update_session_params.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/update_session_params.dart
@@ -28,9 +28,12 @@ class UpdateSessionParams {
   final Object? _vaultIds;
 
   /// Agent configuration patch to apply to the session.
-  SessionAgentUpdate? get agent =>
-      _agent == _notSet ? null : _agent as SessionAgentUpdate?;
-  final Object? _agent;
+  ///
+  /// Provide a [SessionAgentUpdate] to replace the agent's tools and/or MCP
+  /// servers. The API does not accept `null` for this field, so `null` here
+  /// means "not provided" and is omitted from the request. To clear tools or
+  /// MCP servers, pass empty arrays inside the [SessionAgentUpdate].
+  final SessionAgentUpdate? agent;
 
   /// Creates an [UpdateSessionParams].
   ///
@@ -40,11 +43,10 @@ class UpdateSessionParams {
     Object? title = _notSet,
     Object? metadata = _notSet,
     Object? vaultIds = _notSet,
-    Object? agent = _notSet,
+    this.agent,
   }) : _title = title,
        _metadata = metadata,
-       _vaultIds = vaultIds,
-       _agent = agent;
+       _vaultIds = vaultIds;
 
   /// Creates an [UpdateSessionParams] from JSON.
   factory UpdateSessionParams.fromJson(Map<String, dynamic> json) {
@@ -58,26 +60,23 @@ class UpdateSessionParams {
       vaultIds: json.containsKey('vault_ids')
           ? (json['vault_ids'] as List?)?.map((e) => e as String).toList()
           : _notSet,
-      agent: json.containsKey('agent')
-          ? (json['agent'] != null
-                ? SessionAgentUpdate.fromJson(
-                    json['agent'] as Map<String, dynamic>,
-                  )
-                : null)
-          : _notSet,
+      agent: json['agent'] != null
+          ? SessionAgentUpdate.fromJson(json['agent'] as Map<String, dynamic>)
+          : null,
     );
   }
 
   /// Converts to JSON.
   ///
-  /// Fields that were not set (left as default) are omitted.
-  /// Fields explicitly set to `null` are included as `null` to clear
-  /// the value on the server.
+  /// Clearable fields ([title], [metadata], [vaultIds]) that were not set are
+  /// omitted; when explicitly set to `null` they are included as `null` to
+  /// clear the value on the server. [agent] is not nullable in the API, so it
+  /// is emitted only when a value is provided.
   Map<String, dynamic> toJson() => {
     if (_title != _notSet) 'title': _title,
     if (_metadata != _notSet) 'metadata': _metadata,
     if (_vaultIds != _notSet) 'vault_ids': _vaultIds,
-    if (_agent != _notSet) 'agent': (_agent as SessionAgentUpdate?)?.toJson(),
+    if (agent != null) 'agent': agent!.toJson(),
   };
 
   /// Creates a copy with replaced values.
@@ -91,7 +90,9 @@ class UpdateSessionParams {
       title: title == unsetCopyWithValue ? _title : title,
       metadata: metadata == unsetCopyWithValue ? _metadata : metadata,
       vaultIds: vaultIds == unsetCopyWithValue ? _vaultIds : vaultIds,
-      agent: agent == unsetCopyWithValue ? _agent : agent,
+      agent: agent == unsetCopyWithValue
+          ? this.agent
+          : agent as SessionAgentUpdate?,
     );
   }
 
@@ -103,14 +104,14 @@ class UpdateSessionParams {
           _title == other._title &&
           _mapsEqualOrBothSentinel(_metadata, other._metadata) &&
           _listsEqualOrBothSentinel(_vaultIds, other._vaultIds) &&
-          _agent == other._agent;
+          agent == other.agent;
 
   @override
   int get hashCode => Object.hash(
     _title,
     _metadata == _notSet ? _notSet : mapHash(metadata),
     _vaultIds == _notSet ? _notSet : listHash(vaultIds),
-    _agent,
+    agent,
   );
 
   @override

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/update_session_params.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/update_session_params.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../../common/copy_with_sentinel.dart';
 import '../../common/equality_helpers.dart';
+import 'session_agent_update.dart';
 
 /// Private sentinel to distinguish "not provided" from explicit `null`.
 const Object _notSet = Object();
@@ -26,6 +27,11 @@ class UpdateSessionParams {
       _vaultIds == _notSet ? null : _vaultIds as List<String>?;
   final Object? _vaultIds;
 
+  /// Agent configuration patch to apply to the session.
+  SessionAgentUpdate? get agent =>
+      _agent == _notSet ? null : _agent as SessionAgentUpdate?;
+  final Object? _agent;
+
   /// Creates an [UpdateSessionParams].
   ///
   /// Omit a field to preserve its current value on the server.
@@ -34,9 +40,11 @@ class UpdateSessionParams {
     Object? title = _notSet,
     Object? metadata = _notSet,
     Object? vaultIds = _notSet,
+    Object? agent = _notSet,
   }) : _title = title,
        _metadata = metadata,
-       _vaultIds = vaultIds;
+       _vaultIds = vaultIds,
+       _agent = agent;
 
   /// Creates an [UpdateSessionParams] from JSON.
   factory UpdateSessionParams.fromJson(Map<String, dynamic> json) {
@@ -50,6 +58,13 @@ class UpdateSessionParams {
       vaultIds: json.containsKey('vault_ids')
           ? (json['vault_ids'] as List?)?.map((e) => e as String).toList()
           : _notSet,
+      agent: json.containsKey('agent')
+          ? (json['agent'] != null
+                ? SessionAgentUpdate.fromJson(
+                    json['agent'] as Map<String, dynamic>,
+                  )
+                : null)
+          : _notSet,
     );
   }
 
@@ -62,6 +77,7 @@ class UpdateSessionParams {
     if (_title != _notSet) 'title': _title,
     if (_metadata != _notSet) 'metadata': _metadata,
     if (_vaultIds != _notSet) 'vault_ids': _vaultIds,
+    if (_agent != _notSet) 'agent': (_agent as SessionAgentUpdate?)?.toJson(),
   };
 
   /// Creates a copy with replaced values.
@@ -69,11 +85,13 @@ class UpdateSessionParams {
     Object? title = unsetCopyWithValue,
     Object? metadata = unsetCopyWithValue,
     Object? vaultIds = unsetCopyWithValue,
+    Object? agent = unsetCopyWithValue,
   }) {
     return UpdateSessionParams(
       title: title == unsetCopyWithValue ? _title : title,
       metadata: metadata == unsetCopyWithValue ? _metadata : metadata,
       vaultIds: vaultIds == unsetCopyWithValue ? _vaultIds : vaultIds,
+      agent: agent == unsetCopyWithValue ? _agent : agent,
     );
   }
 
@@ -84,13 +102,15 @@ class UpdateSessionParams {
           runtimeType == other.runtimeType &&
           _title == other._title &&
           _mapsEqualOrBothSentinel(_metadata, other._metadata) &&
-          _listsEqualOrBothSentinel(_vaultIds, other._vaultIds);
+          _listsEqualOrBothSentinel(_vaultIds, other._vaultIds) &&
+          _agent == other._agent;
 
   @override
   int get hashCode => Object.hash(
     _title,
     _metadata == _notSet ? _notSet : mapHash(metadata),
     _vaultIds == _notSet ? _notSet : listHash(vaultIds),
+    _agent,
   );
 
   @override
@@ -98,7 +118,8 @@ class UpdateSessionParams {
       'UpdateSessionParams('
       'title: $title, '
       'metadata: $metadata, '
-      'vaultIds: $vaultIds)';
+      'vaultIds: $vaultIds, '
+      'agent: $agent)';
 }
 
 bool _listsEqualOrBothSentinel(Object? a, Object? b) {

--- a/packages/anthropic_sdk_dart/lib/src/models/messages/cache_miss_reason.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/messages/cache_miss_reason.dart
@@ -1,0 +1,371 @@
+import 'package:meta/meta.dart';
+
+import '../common/equality_helpers.dart';
+
+/// Reason a prompt-cache lookup missed (Beta).
+///
+/// Returned within [Diagnostics] to explain why the cached prefix could not be
+/// reused. Dispatches on the `type` discriminator.
+///
+/// Variants:
+/// - [CacheMissModelChanged] — `model_changed` (the model differs from the
+///   cached request).
+/// - [CacheMissSystemChanged] — `system_changed` (the system prompt differs).
+/// - [CacheMissToolsChanged] — `tools_changed` (the tool definitions differ).
+/// - [CacheMissMessagesChanged] — `messages_changed` (the messages differ).
+/// - [CacheMissPreviousMessageNotFound] — `previous_message_not_found` (the
+///   referenced previous message could not be located).
+/// - [CacheMissUnavailable] — `unavailable` (diagnostics are unavailable).
+/// - [UnknownCacheMissReason] — unrecognized reason type, for forward
+///   compatibility.
+sealed class CacheMissReason {
+  const CacheMissReason();
+
+  /// Creates a [CacheMissModelChanged] reason.
+  const factory CacheMissReason.modelChanged({
+    required int cacheMissedInputTokens,
+  }) = CacheMissModelChanged;
+
+  /// Creates a [CacheMissSystemChanged] reason.
+  const factory CacheMissReason.systemChanged({
+    required int cacheMissedInputTokens,
+  }) = CacheMissSystemChanged;
+
+  /// Creates a [CacheMissToolsChanged] reason.
+  const factory CacheMissReason.toolsChanged({
+    required int cacheMissedInputTokens,
+  }) = CacheMissToolsChanged;
+
+  /// Creates a [CacheMissMessagesChanged] reason.
+  const factory CacheMissReason.messagesChanged({
+    required int cacheMissedInputTokens,
+  }) = CacheMissMessagesChanged;
+
+  /// Creates a [CacheMissPreviousMessageNotFound] reason.
+  const factory CacheMissReason.previousMessageNotFound() =
+      CacheMissPreviousMessageNotFound;
+
+  /// Creates a [CacheMissUnavailable] reason.
+  const factory CacheMissReason.unavailable() = CacheMissUnavailable;
+
+  /// Creates a [CacheMissReason] from JSON.
+  ///
+  /// Dispatches on the `type` discriminator; unrecognized values fall back to
+  /// [UnknownCacheMissReason].
+  factory CacheMissReason.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    return switch (type) {
+      'model_changed' => CacheMissModelChanged.fromJson(json),
+      'system_changed' => CacheMissSystemChanged.fromJson(json),
+      'tools_changed' => CacheMissToolsChanged.fromJson(json),
+      'messages_changed' => CacheMissMessagesChanged.fromJson(json),
+      'previous_message_not_found' => CacheMissPreviousMessageNotFound.fromJson(
+        json,
+      ),
+      'unavailable' => CacheMissUnavailable.fromJson(json),
+      _ => UnknownCacheMissReason(rawJson: json),
+    };
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson();
+}
+
+/// Cache miss because the model changed.
+@immutable
+class CacheMissModelChanged extends CacheMissReason {
+  /// Number of input tokens that missed the cache.
+  final int cacheMissedInputTokens;
+
+  /// Creates a [CacheMissModelChanged].
+  const CacheMissModelChanged({required this.cacheMissedInputTokens});
+
+  /// Creates a [CacheMissModelChanged] from JSON.
+  factory CacheMissModelChanged.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'model_changed') {
+      throw FormatException(
+        'Invalid CacheMissModelChanged type: expected "model_changed", '
+        'got "$type"',
+      );
+    }
+    return CacheMissModelChanged(
+      cacheMissedInputTokens: json['cache_missed_input_tokens'] as int,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'model_changed',
+    'cache_missed_input_tokens': cacheMissedInputTokens,
+  };
+
+  /// Creates a copy with replaced values.
+  CacheMissModelChanged copyWith({int? cacheMissedInputTokens}) =>
+      CacheMissModelChanged(
+        cacheMissedInputTokens:
+            cacheMissedInputTokens ?? this.cacheMissedInputTokens,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CacheMissModelChanged &&
+          runtimeType == other.runtimeType &&
+          cacheMissedInputTokens == other.cacheMissedInputTokens;
+
+  @override
+  int get hashCode => cacheMissedInputTokens.hashCode;
+
+  @override
+  String toString() =>
+      'CacheMissModelChanged(cacheMissedInputTokens: $cacheMissedInputTokens)';
+}
+
+/// Cache miss because the system prompt changed.
+@immutable
+class CacheMissSystemChanged extends CacheMissReason {
+  /// Number of input tokens that missed the cache.
+  final int cacheMissedInputTokens;
+
+  /// Creates a [CacheMissSystemChanged].
+  const CacheMissSystemChanged({required this.cacheMissedInputTokens});
+
+  /// Creates a [CacheMissSystemChanged] from JSON.
+  factory CacheMissSystemChanged.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'system_changed') {
+      throw FormatException(
+        'Invalid CacheMissSystemChanged type: expected "system_changed", '
+        'got "$type"',
+      );
+    }
+    return CacheMissSystemChanged(
+      cacheMissedInputTokens: json['cache_missed_input_tokens'] as int,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'system_changed',
+    'cache_missed_input_tokens': cacheMissedInputTokens,
+  };
+
+  /// Creates a copy with replaced values.
+  CacheMissSystemChanged copyWith({int? cacheMissedInputTokens}) =>
+      CacheMissSystemChanged(
+        cacheMissedInputTokens:
+            cacheMissedInputTokens ?? this.cacheMissedInputTokens,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CacheMissSystemChanged &&
+          runtimeType == other.runtimeType &&
+          cacheMissedInputTokens == other.cacheMissedInputTokens;
+
+  @override
+  int get hashCode => cacheMissedInputTokens.hashCode;
+
+  @override
+  String toString() =>
+      'CacheMissSystemChanged(cacheMissedInputTokens: $cacheMissedInputTokens)';
+}
+
+/// Cache miss because the tool definitions changed.
+@immutable
+class CacheMissToolsChanged extends CacheMissReason {
+  /// Number of input tokens that missed the cache.
+  final int cacheMissedInputTokens;
+
+  /// Creates a [CacheMissToolsChanged].
+  const CacheMissToolsChanged({required this.cacheMissedInputTokens});
+
+  /// Creates a [CacheMissToolsChanged] from JSON.
+  factory CacheMissToolsChanged.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'tools_changed') {
+      throw FormatException(
+        'Invalid CacheMissToolsChanged type: expected "tools_changed", '
+        'got "$type"',
+      );
+    }
+    return CacheMissToolsChanged(
+      cacheMissedInputTokens: json['cache_missed_input_tokens'] as int,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'tools_changed',
+    'cache_missed_input_tokens': cacheMissedInputTokens,
+  };
+
+  /// Creates a copy with replaced values.
+  CacheMissToolsChanged copyWith({int? cacheMissedInputTokens}) =>
+      CacheMissToolsChanged(
+        cacheMissedInputTokens:
+            cacheMissedInputTokens ?? this.cacheMissedInputTokens,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CacheMissToolsChanged &&
+          runtimeType == other.runtimeType &&
+          cacheMissedInputTokens == other.cacheMissedInputTokens;
+
+  @override
+  int get hashCode => cacheMissedInputTokens.hashCode;
+
+  @override
+  String toString() =>
+      'CacheMissToolsChanged(cacheMissedInputTokens: $cacheMissedInputTokens)';
+}
+
+/// Cache miss because the messages changed.
+@immutable
+class CacheMissMessagesChanged extends CacheMissReason {
+  /// Number of input tokens that missed the cache.
+  final int cacheMissedInputTokens;
+
+  /// Creates a [CacheMissMessagesChanged].
+  const CacheMissMessagesChanged({required this.cacheMissedInputTokens});
+
+  /// Creates a [CacheMissMessagesChanged] from JSON.
+  factory CacheMissMessagesChanged.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'messages_changed') {
+      throw FormatException(
+        'Invalid CacheMissMessagesChanged type: expected "messages_changed", '
+        'got "$type"',
+      );
+    }
+    return CacheMissMessagesChanged(
+      cacheMissedInputTokens: json['cache_missed_input_tokens'] as int,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'messages_changed',
+    'cache_missed_input_tokens': cacheMissedInputTokens,
+  };
+
+  /// Creates a copy with replaced values.
+  CacheMissMessagesChanged copyWith({int? cacheMissedInputTokens}) =>
+      CacheMissMessagesChanged(
+        cacheMissedInputTokens:
+            cacheMissedInputTokens ?? this.cacheMissedInputTokens,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CacheMissMessagesChanged &&
+          runtimeType == other.runtimeType &&
+          cacheMissedInputTokens == other.cacheMissedInputTokens;
+
+  @override
+  int get hashCode => cacheMissedInputTokens.hashCode;
+
+  @override
+  String toString() =>
+      'CacheMissMessagesChanged('
+      'cacheMissedInputTokens: $cacheMissedInputTokens)';
+}
+
+/// Cache miss because the referenced previous message was not found.
+@immutable
+class CacheMissPreviousMessageNotFound extends CacheMissReason {
+  /// Creates a [CacheMissPreviousMessageNotFound].
+  const CacheMissPreviousMessageNotFound();
+
+  /// Creates a [CacheMissPreviousMessageNotFound] from JSON.
+  factory CacheMissPreviousMessageNotFound.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'previous_message_not_found') {
+      throw FormatException(
+        'Invalid CacheMissPreviousMessageNotFound type: expected '
+        '"previous_message_not_found", got "$type"',
+      );
+    }
+    return const CacheMissPreviousMessageNotFound();
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {'type': 'previous_message_not_found'};
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CacheMissPreviousMessageNotFound &&
+          runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() => 'CacheMissPreviousMessageNotFound()';
+}
+
+/// Cache miss because diagnostics are unavailable.
+@immutable
+class CacheMissUnavailable extends CacheMissReason {
+  /// Creates a [CacheMissUnavailable].
+  const CacheMissUnavailable();
+
+  /// Creates a [CacheMissUnavailable] from JSON.
+  factory CacheMissUnavailable.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'unavailable') {
+      throw FormatException(
+        'Invalid CacheMissUnavailable type: expected "unavailable", '
+        'got "$type"',
+      );
+    }
+    return const CacheMissUnavailable();
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {'type': 'unavailable'};
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CacheMissUnavailable && runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() => 'CacheMissUnavailable()';
+}
+
+/// Unrecognized cache miss reason — preserves raw JSON for forward
+/// compatibility.
+@immutable
+class UnknownCacheMissReason extends CacheMissReason {
+  /// The raw JSON.
+  final Map<String, dynamic> rawJson;
+
+  /// Creates an [UnknownCacheMissReason].
+  const UnknownCacheMissReason({required this.rawJson});
+
+  @override
+  Map<String, dynamic> toJson() => rawJson;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnknownCacheMissReason &&
+          runtimeType == other.runtimeType &&
+          mapsDeepEqual(rawJson, other.rawJson);
+
+  @override
+  int get hashCode => mapDeepHashCode(rawJson);
+
+  @override
+  String toString() => 'UnknownCacheMissReason(rawJson: $rawJson)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/messages/diagnostics.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/messages/diagnostics.dart
@@ -11,8 +11,10 @@ import 'cache_miss_reason.dart';
 class Diagnostics {
   /// Why the prompt-cache lookup missed, if any.
   ///
-  /// The key is always present in responses but may be `null` when there is no
-  /// cache miss to report.
+  /// The key is always present in responses but may be `null`. Per the API, a
+  /// `null` value means the diagnosis is still pending — the response was
+  /// serialized before the background prompt-cache comparison completed (it may
+  /// also indicate that no divergence was detected).
   final CacheMissReason? cacheMissReason;
 
   /// Creates a [Diagnostics].

--- a/packages/anthropic_sdk_dart/lib/src/models/messages/diagnostics.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/messages/diagnostics.dart
@@ -1,0 +1,58 @@
+import 'package:meta/meta.dart';
+
+import '../common/copy_with_sentinel.dart';
+import 'cache_miss_reason.dart';
+
+/// Response-level cache diagnostics (Beta).
+///
+/// Returned on a [Message] when prompt-cache diagnostics were requested via
+/// [DiagnosticsParam] and the `cache-diagnosis-2026-04-07` beta header.
+@immutable
+class Diagnostics {
+  /// Why the prompt-cache lookup missed, if any.
+  ///
+  /// The key is always present in responses but may be `null` when there is no
+  /// cache miss to report.
+  final CacheMissReason? cacheMissReason;
+
+  /// Creates a [Diagnostics].
+  const Diagnostics({this.cacheMissReason});
+
+  /// Creates a [Diagnostics] from JSON.
+  factory Diagnostics.fromJson(Map<String, dynamic> json) {
+    return Diagnostics(
+      cacheMissReason: json['cache_miss_reason'] != null
+          ? CacheMissReason.fromJson(
+              json['cache_miss_reason'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'cache_miss_reason': cacheMissReason?.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  Diagnostics copyWith({Object? cacheMissReason = unsetCopyWithValue}) {
+    return Diagnostics(
+      cacheMissReason: cacheMissReason == unsetCopyWithValue
+          ? this.cacheMissReason
+          : cacheMissReason as CacheMissReason?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Diagnostics &&
+          runtimeType == other.runtimeType &&
+          cacheMissReason == other.cacheMissReason;
+
+  @override
+  int get hashCode => cacheMissReason.hashCode;
+
+  @override
+  String toString() => 'Diagnostics(cacheMissReason: $cacheMissReason)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/messages/diagnostics.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/messages/diagnostics.dart
@@ -9,12 +9,13 @@ import 'cache_miss_reason.dart';
 /// [DiagnosticsParam] and the `cache-diagnosis-2026-04-07` beta header.
 @immutable
 class Diagnostics {
-  /// Why the prompt-cache lookup missed, if any.
+  /// Why the prompt-cache lookup missed.
   ///
-  /// The key is always present in responses but may be `null`. Per the API, a
-  /// `null` value means the diagnosis is still pending — the response was
-  /// serialized before the background prompt-cache comparison completed (it may
-  /// also indicate that no divergence was detected).
+  /// The key is always present, but is `null` when the diagnosis is still
+  /// pending — the response was serialized before the background prompt-cache
+  /// comparison completed. A `null` value here does NOT mean "no divergence":
+  /// when no divergence is detected the API signals it by leaving the
+  /// message-level [Message.diagnostics] itself `null`, not via this field.
   final CacheMissReason? cacheMissReason;
 
   /// Creates a [Diagnostics].

--- a/packages/anthropic_sdk_dart/lib/src/models/messages/diagnostics_param.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/messages/diagnostics_param.dart
@@ -1,0 +1,70 @@
+import 'package:meta/meta.dart';
+
+import '../common/copy_with_sentinel.dart';
+
+/// Request-level cache diagnostics parameters (Beta).
+///
+/// Opts a request into prompt-cache diagnostics, optionally anchoring the
+/// diagnosis to the immediately preceding turn so the API can report which
+/// portion of the cached prefix missed.
+///
+/// Requires the `cache-diagnosis-2026-04-07` beta header. Pass
+/// `betas: ['cache-diagnosis-2026-04-07']` to `messages.create`.
+///
+/// ```dart
+/// final response = await client.messages.create(
+///   MessageCreateRequest(
+///     model: 'claude-sonnet-4-6',
+///     maxTokens: 1024,
+///     diagnostics: DiagnosticsParam(previousMessageId: 'msg_123'),
+///     messages: [InputMessage.user('Continue the conversation.')],
+///   ),
+///   betas: ['cache-diagnosis-2026-04-07'],
+/// );
+/// ```
+@immutable
+class DiagnosticsParam {
+  /// Identifier of the previous message in the conversation.
+  ///
+  /// When set, the API anchors cache diagnostics to this prior turn. Maximum
+  /// length 256 characters.
+  final String? previousMessageId;
+
+  /// Creates a [DiagnosticsParam].
+  const DiagnosticsParam({this.previousMessageId});
+
+  /// Creates a [DiagnosticsParam] from JSON.
+  factory DiagnosticsParam.fromJson(Map<String, dynamic> json) {
+    return DiagnosticsParam(
+      previousMessageId: json['previous_message_id'] as String?,
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (previousMessageId != null) 'previous_message_id': previousMessageId,
+  };
+
+  /// Creates a copy with replaced values.
+  DiagnosticsParam copyWith({Object? previousMessageId = unsetCopyWithValue}) {
+    return DiagnosticsParam(
+      previousMessageId: previousMessageId == unsetCopyWithValue
+          ? this.previousMessageId
+          : previousMessageId as String?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DiagnosticsParam &&
+          runtimeType == other.runtimeType &&
+          previousMessageId == other.previousMessageId;
+
+  @override
+  int get hashCode => previousMessageId.hashCode;
+
+  @override
+  String toString() =>
+      'DiagnosticsParam(previousMessageId: $previousMessageId)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/messages/message.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/messages/message.dart
@@ -6,6 +6,7 @@ import '../common/equality_helpers.dart';
 import '../content/content_block.dart';
 import '../metadata/stop_reason.dart';
 import '../metadata/usage.dart';
+import 'diagnostics.dart';
 import 'message_role.dart';
 
 /// A message response from the API.
@@ -43,6 +44,10 @@ class Message {
   /// Container metadata when server-side code execution was used.
   final Container? container;
 
+  /// Cache diagnostics, when requested via the `cache-diagnosis-2026-04-07`
+  /// beta header.
+  final Diagnostics? diagnostics;
+
   /// Creates a [Message].
   const Message({
     required this.id,
@@ -55,6 +60,7 @@ class Message {
     this.stopSequence,
     required this.usage,
     this.container,
+    this.diagnostics,
   });
 
   /// Creates a [Message] from JSON.
@@ -82,6 +88,9 @@ class Message {
       container: json['container'] != null
           ? Container.fromJson(json['container'] as Map<String, dynamic>)
           : null,
+      diagnostics: json['diagnostics'] != null
+          ? Diagnostics.fromJson(json['diagnostics'] as Map<String, dynamic>)
+          : null,
     );
   }
 
@@ -97,6 +106,7 @@ class Message {
     if (stopSequence != null) 'stop_sequence': stopSequence,
     'usage': usage.toJson(),
     if (container != null) 'container': container!.toJson(),
+    if (diagnostics != null) 'diagnostics': diagnostics!.toJson(),
   };
 
   /// Creates a copy with replaced values.
@@ -111,6 +121,7 @@ class Message {
     Object? stopSequence = unsetCopyWithValue,
     Usage? usage,
     Object? container = unsetCopyWithValue,
+    Object? diagnostics = unsetCopyWithValue,
   }) {
     return Message(
       id: id ?? this.id,
@@ -131,6 +142,9 @@ class Message {
       container: container == unsetCopyWithValue
           ? this.container
           : container as Container?,
+      diagnostics: diagnostics == unsetCopyWithValue
+          ? this.diagnostics
+          : diagnostics as Diagnostics?,
     );
   }
 
@@ -148,7 +162,8 @@ class Message {
           stopDetails == other.stopDetails &&
           stopSequence == other.stopSequence &&
           usage == other.usage &&
-          container == other.container;
+          container == other.container &&
+          diagnostics == other.diagnostics;
 
   @override
   int get hashCode => Object.hash(
@@ -162,6 +177,7 @@ class Message {
     stopSequence,
     usage,
     container,
+    diagnostics,
   );
 
   @override
@@ -169,5 +185,5 @@ class Message {
       'Message(id: $id, type: $type, role: $role, '
       'content: $content, model: $model, stopReason: $stopReason, '
       'stopDetails: $stopDetails, stopSequence: $stopSequence, '
-      'usage: $usage, container: $container)';
+      'usage: $usage, container: $container, diagnostics: $diagnostics)';
 }

--- a/packages/anthropic_sdk_dart/lib/src/models/messages/message.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/messages/message.dart
@@ -44,8 +44,9 @@ class Message {
   /// Container metadata when server-side code execution was used.
   final Container? container;
 
-  /// Cache diagnostics, when requested via the `cache-diagnosis-2026-04-07`
-  /// beta header.
+  /// Cache diagnostics, present only when requested via the
+  /// `cache-diagnosis-2026-04-07` beta header. `null` when no prompt-cache
+  /// divergence was detected.
   final Diagnostics? diagnostics;
 
   /// Creates a [Message].

--- a/packages/anthropic_sdk_dart/lib/src/models/messages/message_create_request.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/messages/message_create_request.dart
@@ -9,6 +9,7 @@ import '../metadata/service_tier.dart';
 import '../metadata/speed.dart';
 import '../tools/tool_choice.dart';
 import '../tools/tool_definition.dart';
+import 'diagnostics_param.dart';
 import 'input_message.dart';
 import 'thinking_config.dart';
 
@@ -215,6 +216,13 @@ class MessageCreateRequest {
   /// Optional identifier of the end-user profile this request belongs to.
   final String? userProfileId;
 
+  /// Cache diagnostics configuration.
+  ///
+  /// Opts the request into prompt-cache diagnostics. Requires the
+  /// `cache-diagnosis-2026-04-07` beta header — pass
+  /// `betas: ['cache-diagnosis-2026-04-07']` to `messages.create`.
+  final DiagnosticsParam? diagnostics;
+
   /// Creates a [MessageCreateRequest].
   const MessageCreateRequest({
     required this.model,
@@ -237,6 +245,7 @@ class MessageCreateRequest {
     this.speed,
     this.cacheControl,
     this.userProfileId,
+    this.diagnostics,
   });
 
   /// Creates a [MessageCreateRequest] from JSON.
@@ -284,6 +293,11 @@ class MessageCreateRequest {
             )
           : null,
       userProfileId: json['user_profile_id'] as String?,
+      diagnostics: json['diagnostics'] != null
+          ? DiagnosticsParam.fromJson(
+              json['diagnostics'] as Map<String, dynamic>,
+            )
+          : null,
     );
   }
 
@@ -309,6 +323,7 @@ class MessageCreateRequest {
     if (speed != null) 'speed': speed!.toJson(),
     if (cacheControl != null) 'cache_control': cacheControl!.toJson(),
     if (userProfileId != null) 'user_profile_id': userProfileId,
+    if (diagnostics != null) 'diagnostics': diagnostics!.toJson(),
   };
 
   /// Creates a copy with replaced values.
@@ -333,6 +348,7 @@ class MessageCreateRequest {
     Object? speed = unsetCopyWithValue,
     Object? cacheControl = unsetCopyWithValue,
     Object? userProfileId = unsetCopyWithValue,
+    Object? diagnostics = unsetCopyWithValue,
   }) {
     return MessageCreateRequest(
       model: model ?? this.model,
@@ -381,6 +397,9 @@ class MessageCreateRequest {
       userProfileId: userProfileId == unsetCopyWithValue
           ? this.userProfileId
           : userProfileId as String?,
+      diagnostics: diagnostics == unsetCopyWithValue
+          ? this.diagnostics
+          : diagnostics as DiagnosticsParam?,
     );
   }
 
@@ -408,10 +427,11 @@ class MessageCreateRequest {
           container == other.container &&
           speed == other.speed &&
           cacheControl == other.cacheControl &&
-          userProfileId == other.userProfileId;
+          userProfileId == other.userProfileId &&
+          diagnostics == other.diagnostics;
 
   @override
-  int get hashCode => Object.hash(
+  int get hashCode => Object.hashAll([
     model,
     listHash(messages),
     maxTokens,
@@ -432,7 +452,8 @@ class MessageCreateRequest {
     speed,
     cacheControl,
     userProfileId,
-  );
+    diagnostics,
+  ]);
 
   @override
   String toString() =>
@@ -443,5 +464,5 @@ class MessageCreateRequest {
       'toolChoice: $toolChoice, tools: $tools, topP: $topP, topK: $topK, '
       'inferenceGeo: $inferenceGeo, outputConfig: $outputConfig, '
       'container: $container, speed: $speed, cacheControl: $cacheControl, '
-      'userProfileId: $userProfileId)';
+      'userProfileId: $userProfileId, diagnostics: $diagnostics)';
 }

--- a/packages/anthropic_sdk_dart/lib/src/models/streaming/content_block_delta.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/streaming/content_block_delta.dart
@@ -132,23 +132,43 @@ class ThinkingDelta extends ContentBlockDelta {
   /// The thinking content.
   final String thinking;
 
+  /// A coarse, lossy display hint for the number of thinking tokens so far.
+  ///
+  /// Populated only when the `thinking-token-count-2026-05-13` beta header is
+  /// set and `thinking.display` resolves to `"omitted"`. The value is a rough
+  /// estimate intended for UI display (increments are summed across frames),
+  /// NOT a billable count — `usage.output_tokens` remains authoritative.
+  final int? estimatedTokens;
+
   /// Creates a [ThinkingDelta].
-  const ThinkingDelta(this.thinking);
+  const ThinkingDelta(this.thinking, {this.estimatedTokens});
 
   /// Creates a [ThinkingDelta] from JSON.
   factory ThinkingDelta.fromJson(Map<String, dynamic> json) {
-    return ThinkingDelta(json['thinking'] as String);
+    return ThinkingDelta(
+      json['thinking'] as String,
+      estimatedTokens: json['estimated_tokens'] as int?,
+    );
   }
 
   @override
   Map<String, dynamic> toJson() => {
     'type': 'thinking_delta',
     'thinking': thinking,
+    if (estimatedTokens != null) 'estimated_tokens': estimatedTokens,
   };
 
   /// Creates a copy with replaced values.
-  ThinkingDelta copyWith({String? thinking}) {
-    return ThinkingDelta(thinking ?? this.thinking);
+  ThinkingDelta copyWith({
+    String? thinking,
+    Object? estimatedTokens = unsetCopyWithValue,
+  }) {
+    return ThinkingDelta(
+      thinking ?? this.thinking,
+      estimatedTokens: estimatedTokens == unsetCopyWithValue
+          ? this.estimatedTokens
+          : estimatedTokens as int?,
+    );
   }
 
   @override
@@ -156,13 +176,16 @@ class ThinkingDelta extends ContentBlockDelta {
       identical(this, other) ||
       other is ThinkingDelta &&
           runtimeType == other.runtimeType &&
-          thinking == other.thinking;
+          thinking == other.thinking &&
+          estimatedTokens == other.estimatedTokens;
 
   @override
-  int get hashCode => thinking.hashCode;
+  int get hashCode => Object.hash(thinking, estimatedTokens);
 
   @override
-  String toString() => 'ThinkingDelta(thinking: [${thinking.length} chars])';
+  String toString() =>
+      'ThinkingDelta(thinking: [${thinking.length} chars], '
+      'estimatedTokens: $estimatedTokens)';
 }
 
 /// Delta for compaction content updates (beta).

--- a/packages/anthropic_sdk_dart/lib/src/resources/skills_resource.dart
+++ b/packages/anthropic_sdk_dart/lib/src/resources/skills_resource.dart
@@ -333,14 +333,14 @@ class SkillsResource extends ResourceBase {
     final url = requestBuilder.buildUrl(
       '/v1/skills/$skillId/versions/$version/content',
     );
-    // The response is a binary ZIP archive, so override the default Accept
-    // header to request binary content.
+    // The response is a binary ZIP archive. Widen Accept and drop the default
+    // JSON content-type (this GET has no request body), matching the binary
+    // download convention used by FilesResource.download.
     final headers = requestBuilder.buildHeaders(
-      additionalHeaders: {
-        'anthropic-beta': _betaHeader,
-        'Accept': 'application/binary',
-      },
+      additionalHeaders: {'anthropic-beta': _betaHeader},
     );
+    headers['accept'] = '*/*';
+    headers.remove('content-type');
     final httpRequest = http.Request('GET', url)..headers.addAll(headers);
 
     final response = await interceptorChain.execute(httpRequest);

--- a/packages/anthropic_sdk_dart/lib/src/resources/skills_resource.dart
+++ b/packages/anthropic_sdk_dart/lib/src/resources/skills_resource.dart
@@ -300,6 +300,54 @@ class SkillsResource extends ResourceBase {
     );
   }
 
+  /// Downloads the content of a specific version of a skill.
+  ///
+  /// The [skillId] is the unique identifier of the skill.
+  /// The [version] is the version identifier to download.
+  ///
+  /// Returns the version's content as a ZIP archive (raw bytes).
+  ///
+  /// This is a beta feature and requires the `anthropic-beta:
+  /// skills-2025-10-02` header (sent automatically).
+  ///
+  /// Example:
+  /// ```dart
+  /// final bytes = await client.skills.downloadVersion(
+  ///   skillId: 'skill_abc123',
+  ///   version: '1759178010641129',
+  /// );
+  /// await File('skill.zip').writeAsBytes(bytes);
+  /// ```
+  Future<Uint8List> downloadVersion({
+    required String skillId,
+    required String version,
+  }) async {
+    if (skillId.isEmpty) {
+      throw ArgumentError.value(skillId, 'skillId', 'must not be empty');
+    }
+    if (version.isEmpty) {
+      throw ArgumentError.value(version, 'version', 'must not be empty');
+    }
+
+    ensureNotClosed?.call();
+    final url = requestBuilder.buildUrl(
+      '/v1/skills/$skillId/versions/$version/content',
+    );
+    // The response is a binary ZIP archive, so override the default Accept
+    // header to request binary content.
+    final headers = requestBuilder.buildHeaders(
+      additionalHeaders: {
+        'anthropic-beta': _betaHeader,
+        'Accept': 'application/binary',
+      },
+    );
+    final httpRequest = http.Request('GET', url)..headers.addAll(headers);
+
+    final response = await interceptorChain.execute(httpRequest);
+
+    return response.bodyBytes;
+  }
+
   /// Deletes a specific version of a skill.
   ///
   /// The [skillId] is the unique identifier of the skill.

--- a/packages/anthropic_sdk_dart/llms.txt
+++ b/packages/anthropic_sdk_dart/llms.txt
@@ -4,7 +4,7 @@
 
 ## Docs
 
-- [README](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/README.md) (~5k tokens): Primary package documentation with installation, configuration, and usage examples.
+- [README](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/README.md) (~5.1k tokens): Primary package documentation with installation, configuration, and usage examples.
 - [CHANGELOG](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/CHANGELOG.md) (~8k tokens): Release history and version-by-version changes.
 - [MIGRATION](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/MIGRATION.md) (~4.5k tokens): Upgrade notes and breaking-change guidance.
 
@@ -19,15 +19,16 @@
 - [message_batches_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/message_batches_example.dart) (~859 tokens): Batch processing.
 - [models_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/models_example.dart) (~471 tokens): Model listing.
 - [files_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/files_example.dart) (~842 tokens): File management (beta).
-- [skills_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/skills_example.dart) (~1k tokens): Skills management (beta).
+- [skills_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/skills_example.dart) (~1.1k tokens): Skills management (beta).
 - [managed_agents_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/managed_agents_example.dart) (~1.6k tokens): Managed agents: agents, sessions, vaults, multiagent rosters, outcomes, webhooks, credential validation (beta).
 - [memory_stores_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/memory_stores_example.dart) (~903 tokens): Managed agents memory stores, memories, and versions (beta).
 - [error_handling_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/error_handling_example.dart) (~632 tokens): Exception handling patterns.
 - [web_search_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/web_search_example.dart) (~793 tokens): Web search tool.
 - [advisor_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/advisor_example.dart) (~967 tokens): Advisor tool (beta).
 - [computer_use_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/computer_use_example.dart) (~866 tokens): Computer use tool.
+- [diagnostics_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/diagnostics_example.dart) (~660 tokens): Prompt-cache diagnostics: why the cache prefix diverged (beta).
 - [document_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/document_example.dart) (~937 tokens): Document inputs with citations.
-- [search_result_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/search_result_example.dart) (~707 tokens): Supplying your own cited `search_result` blocks (RAG).
+- [search_result_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/search_result_example.dart) (~710 tokens): Supplying your own cited `search_result` blocks (RAG).
 - [mcp_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/mcp_example.dart) (~904 tokens): MCP tool integration.
 - [session_threads_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/session_threads_example.dart) (~816 tokens): Session threads: list, retrieve, stream events, archive (beta).
 - [user_profiles_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/user_profiles_example.dart) (~649 tokens): User profiles and enrollment URLs (beta).
@@ -37,4 +38,4 @@
 
 - [Package directory](https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/anthropic_sdk_dart): Source tree, pubspec, and package-local files.
 
-**Total: ~37.2k tokens**
+**Total: ~38k tokens**

--- a/packages/anthropic_sdk_dart/specs/openapi.yaml
+++ b/packages/anthropic_sdk_dart/specs/openapi.yaml
@@ -62,7 +62,9 @@
               "output-300k-2026-03-24",
               "user-profiles-2026-03-24",
               "advisor-tool-2026-03-01",
-              "managed-agents-2026-04-01"
+              "managed-agents-2026-04-01",
+              "cache-diagnosis-2026-04-07",
+              "thinking-token-count-2026-05-13"
             ],
             "type": "string",
             "x-stainless-nominal": false
@@ -820,6 +822,120 @@
           "ephemeral_5m_input_tokens"
         ],
         "title": "CacheCreation",
+        "type": "object"
+      },
+      "BetaCacheMissMessagesChanged": {
+        "properties": {
+          "cache_missed_input_tokens": {
+            "description": "Approximate number of input tokens that would have been read from cache had the prefix matched the previous request.",
+            "title": "Cache Missed Input Tokens",
+            "type": "integer"
+          },
+          "type": {
+            "const": "messages_changed",
+            "default": "messages_changed",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "cache_missed_input_tokens",
+          "type"
+        ],
+        "title": "CacheMissMessagesChanged",
+        "type": "object"
+      },
+      "BetaCacheMissModelChanged": {
+        "properties": {
+          "cache_missed_input_tokens": {
+            "description": "Approximate number of input tokens that would have been read from cache had the prefix matched the previous request.",
+            "title": "Cache Missed Input Tokens",
+            "type": "integer"
+          },
+          "type": {
+            "const": "model_changed",
+            "default": "model_changed",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "cache_missed_input_tokens",
+          "type"
+        ],
+        "title": "CacheMissModelChanged",
+        "type": "object"
+      },
+      "BetaCacheMissPreviousMessageNotFound": {
+        "properties": {
+          "type": {
+            "const": "previous_message_not_found",
+            "default": "previous_message_not_found",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "CacheMissPreviousMessageNotFound",
+        "type": "object"
+      },
+      "BetaCacheMissSystemChanged": {
+        "properties": {
+          "cache_missed_input_tokens": {
+            "description": "Approximate number of input tokens that would have been read from cache had the prefix matched the previous request.",
+            "title": "Cache Missed Input Tokens",
+            "type": "integer"
+          },
+          "type": {
+            "const": "system_changed",
+            "default": "system_changed",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "cache_missed_input_tokens",
+          "type"
+        ],
+        "title": "CacheMissSystemChanged",
+        "type": "object"
+      },
+      "BetaCacheMissToolsChanged": {
+        "properties": {
+          "cache_missed_input_tokens": {
+            "description": "Approximate number of input tokens that would have been read from cache had the prefix matched the previous request.",
+            "title": "Cache Missed Input Tokens",
+            "type": "integer"
+          },
+          "type": {
+            "const": "tools_changed",
+            "default": "tools_changed",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "cache_missed_input_tokens",
+          "type"
+        ],
+        "title": "CacheMissToolsChanged",
+        "type": "object"
+      },
+      "BetaCacheMissUnavailable": {
+        "properties": {
+          "type": {
+            "const": "unavailable",
+            "default": "unavailable",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "CacheMissUnavailable",
         "type": "object"
       },
       "BetaCanceledResult": {
@@ -2667,6 +2783,17 @@
             ],
             "description": "Context management configuration.\n\nThis allows you to control how Claude manages context across multiple requests, such as whether to clear function results or not."
           },
+          "diagnostics": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BetaDiagnosticsParam"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Request-level diagnostics. Supply `previous_message_id` to have the response include `diagnostics.cache_miss_reason` explaining any prompt-cache divergence from that prior request."
+          },
           "inference_geo": {
             "anyOf": [
               {
@@ -3229,6 +3356,80 @@
         "title": "DeleteSkillVersionResponse",
         "type": "object"
       },
+      "BetaDiagnostics": {
+        "description": "Response envelope for request-level diagnostics. Present (possibly\nnull) whenever the caller supplied `diagnostics` on the request.",
+        "properties": {
+          "cache_miss_reason": {
+            "anyOf": [
+              {
+                "discriminator": {
+                  "mapping": {
+                    "messages_changed": "#/components/schemas/BetaCacheMissMessagesChanged",
+                    "model_changed": "#/components/schemas/BetaCacheMissModelChanged",
+                    "previous_message_not_found": "#/components/schemas/BetaCacheMissPreviousMessageNotFound",
+                    "system_changed": "#/components/schemas/BetaCacheMissSystemChanged",
+                    "tools_changed": "#/components/schemas/BetaCacheMissToolsChanged",
+                    "unavailable": "#/components/schemas/BetaCacheMissUnavailable"
+                  },
+                  "propertyName": "type"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/BetaCacheMissModelChanged"
+                  },
+                  {
+                    "$ref": "#/components/schemas/BetaCacheMissSystemChanged"
+                  },
+                  {
+                    "$ref": "#/components/schemas/BetaCacheMissToolsChanged"
+                  },
+                  {
+                    "$ref": "#/components/schemas/BetaCacheMissMessagesChanged"
+                  },
+                  {
+                    "$ref": "#/components/schemas/BetaCacheMissPreviousMessageNotFound"
+                  },
+                  {
+                    "$ref": "#/components/schemas/BetaCacheMissUnavailable"
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Explains why the prompt cache could not fully reuse the prefix from the request identified by `diagnostics.previous_message_id`. `null` means diagnosis is still pending \u2014 the response was serialized before the background comparison completed.",
+            "title": "Cache Miss Reason"
+          }
+        },
+        "required": [
+          "cache_miss_reason"
+        ],
+        "title": "Diagnostics",
+        "type": "object"
+      },
+      "BetaDiagnosticsParam": {
+        "additionalProperties": false,
+        "description": "Request-level diagnostics. Currently carries the previous response\nid for prompt-cache divergence reporting.",
+        "properties": {
+          "previous_message_id": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The `id` (`msg_...`) from this client's previous /v1/messages response. The server compares that request's prompt fingerprint against this one and returns `diagnostics.cache_miss_reason` when the prompt-cache prefix could not be reused. Pass `null` on the first turn to opt in without a prior message to compare.",
+            "title": "Previous Message Id"
+          }
+        },
+        "title": "DiagnosticsParam",
+        "type": "object"
+      },
       "BetaDirectCaller": {
         "additionalProperties": false,
         "description": "Tool invocation directly from the model.",
@@ -3403,7 +3604,8 @@
             "description": "Environment configuration (either Anthropic Cloud or self-hosted)",
             "discriminator": {
               "mapping": {
-                "cloud": "#/components/schemas/BetaCloudConfig"
+                "cloud": "#/components/schemas/BetaCloudConfig",
+                "self_hosted": "#/components/schemas/BetaSelfHostedConfig"
               },
               "propertyName": "type"
             },
@@ -3435,6 +3637,9 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/BetaCloudConfig"
+              },
+              {
+                "$ref": "#/components/schemas/BetaSelfHostedConfig"
               }
             ],
             "title": "Config"
@@ -3482,6 +3687,15 @@
               "python-data-analysis"
             ],
             "title": "Name",
+            "type": "string"
+          },
+          "scope": {
+            "description": "The visibility scope for this environment. 'organization' means visible to all accounts. 'account' means visible only to the owning account.",
+            "enum": [
+              "organization",
+              "account"
+            ],
+            "title": "Scope",
             "type": "string"
           },
           "type": {
@@ -5910,6 +6124,132 @@
         ],
         "type": "object"
       },
+      "BetaManagedAgentsAgentToolset20260401_BashInput": {
+        "additionalProperties": false,
+        "description": "Input payload for the `bash` tool of the\n`agent_toolset_20260401` toolset. All fields are optional;\na normal invocation supplies `command`, while `restart=true`\n(with no `command`) reboots the runner-side bash session.\n",
+        "properties": {
+          "command": {
+            "description": "Shell command to execute. Omit only when `restart` is true.",
+            "type": "string"
+          },
+          "restart": {
+            "description": "When true, restart the persistent bash session instead of\nrunning a command. Subsequent calls without `restart` will\nrun against the fresh session.\n",
+            "type": "boolean"
+          },
+          "timeout_ms": {
+            "description": "Per-call timeout in milliseconds. Defaults to the\nrunner-wide tool timeout when omitted or zero.\n",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "BetaManagedAgentsAgentToolset20260401_EditInput": {
+        "additionalProperties": false,
+        "description": "Input payload for the `edit` tool. Performs a string\nreplacement in the named file; by default `old_string` must\noccur exactly once.\n",
+        "properties": {
+          "file_path": {
+            "description": "Path of the file to edit.",
+            "type": "string"
+          },
+          "new_string": {
+            "description": "Replacement text.",
+            "type": "string"
+          },
+          "old_string": {
+            "description": "Substring to find and replace.",
+            "type": "string"
+          },
+          "replace_all": {
+            "description": "When true, replace every occurrence of `old_string`\ninstead of requiring a unique match.\n",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "file_path",
+          "old_string",
+          "new_string"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsAgentToolset20260401_GlobInput": {
+        "additionalProperties": false,
+        "description": "Input payload for the `glob` tool. Returns paths matching a\ndoublestar glob pattern, newest first.\n",
+        "properties": {
+          "path": {
+            "description": "Optional directory root to search under. Defaults to the\nrunner's working directory.\n",
+            "type": "string"
+          },
+          "pattern": {
+            "description": "Doublestar glob pattern (e.g. `**/*.go`). Absolute patterns\nare only permitted when the runner is configured to allow\nthem.\n",
+            "type": "string"
+          }
+        },
+        "required": [
+          "pattern"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsAgentToolset20260401_GrepInput": {
+        "additionalProperties": false,
+        "description": "Input payload for the `grep` tool. Searches file contents for\na regular expression, returning matching lines.\n",
+        "properties": {
+          "path": {
+            "description": "Optional directory root to search under. Defaults to the\nrunner's working directory.\n",
+            "type": "string"
+          },
+          "pattern": {
+            "description": "Regular expression to search for.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "pattern"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsAgentToolset20260401_ReadInput": {
+        "additionalProperties": false,
+        "description": "Input payload for the `read` tool. Reads file contents\nrelative to the runner's working directory (or absolute when\nthe runner permits).\n",
+        "properties": {
+          "file_path": {
+            "description": "Path of the file to read.",
+            "type": "string"
+          },
+          "view_range": {
+            "description": "Optional `[start_line, end_line]` 1-indexed inclusive\nrange. When omitted the entire file is returned.\n`end_line` of 0 or negative means \"to end of file\".\n",
+            "items": {
+              "type": "integer"
+            },
+            "maxItems": 2,
+            "minItems": 2,
+            "type": "array"
+          }
+        },
+        "required": [
+          "file_path"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsAgentToolset20260401_WriteInput": {
+        "additionalProperties": false,
+        "description": "Input payload for the `write` tool. Writes (overwriting) the\nentire file contents.\n",
+        "properties": {
+          "content": {
+            "description": "Full file contents to write.",
+            "type": "string"
+          },
+          "file_path": {
+            "description": "Path of the file to write.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file_path",
+          "content"
+        ],
+        "type": "object"
+      },
       "BetaManagedAgentsAgentToolsetDefaultConfig": {
         "additionalProperties": false,
         "description": "Resolved default configuration for agent tools.",
@@ -7459,7 +7799,8 @@
             "user.define_outcome": "#/components/schemas/BetaManagedAgentsUserDefineOutcomeEventParams",
             "user.interrupt": "#/components/schemas/BetaManagedAgentsUserInterruptEventParams",
             "user.message": "#/components/schemas/BetaManagedAgentsUserMessageEventParams",
-            "user.tool_confirmation": "#/components/schemas/BetaManagedAgentsUserToolConfirmationEventParams"
+            "user.tool_confirmation": "#/components/schemas/BetaManagedAgentsUserToolConfirmationEventParams",
+            "user.tool_result": "#/components/schemas/BetaManagedAgentsUserToolResultEventParams"
           },
           "propertyName": "type"
         },
@@ -7478,6 +7819,9 @@
           },
           {
             "$ref": "#/components/schemas/BetaManagedAgentsUserDefineOutcomeEventParams"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsUserToolResultEventParams"
           }
         ],
         "type": "object"
@@ -7912,7 +8256,8 @@
             "user.define_outcome": "#/components/schemas/BetaManagedAgentsUserDefineOutcomeEvent",
             "user.interrupt": "#/components/schemas/BetaManagedAgentsUserInterruptEvent",
             "user.message": "#/components/schemas/BetaManagedAgentsUserMessageEvent",
-            "user.tool_confirmation": "#/components/schemas/BetaManagedAgentsUserToolConfirmationEvent"
+            "user.tool_confirmation": "#/components/schemas/BetaManagedAgentsUserToolConfirmationEvent",
+            "user.tool_result": "#/components/schemas/BetaManagedAgentsUserToolResultEvent"
           },
           "propertyName": "type"
         },
@@ -7931,6 +8276,9 @@
           },
           {
             "$ref": "#/components/schemas/BetaManagedAgentsUserDefineOutcomeEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsUserToolResultEvent"
           }
         ],
         "type": "object"
@@ -9951,7 +10299,7 @@
             "type": "string"
           },
           "result": {
-            "description": "Current evaluation state. 'pending' before the agent begins work; 'running' while producing or revising; 'evaluating' while the grader scores; 'satisfied'/'max_iterations_reached'/'failed'/'interrupted' are terminal.",
+            "description": "Current evaluation state. `pending` before the agent begins work; `running` while producing or revising; `evaluating` while the grader scores; `satisfied`/`max_iterations_reached`/`failed`/`interrupted` are terminal.",
             "examples": [
               "satisfied"
             ],
@@ -10224,6 +10572,87 @@
             "$ref": "#/components/schemas/BetaManagedAgentsTextRubricParams"
           }
         ]
+      },
+      "BetaManagedAgentsSearchResultBlock": {
+        "additionalProperties": false,
+        "description": "A block containing a web search result.",
+        "properties": {
+          "citations": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsSearchResultCitations"
+              }
+            ],
+            "description": "Citation settings for this search result."
+          },
+          "content": {
+            "description": "Array of text content blocks from the search result.",
+            "items": {
+              "$ref": "#/components/schemas/BetaManagedAgentsSearchResultContent"
+            },
+            "type": "array"
+          },
+          "source": {
+            "description": "The URL source of the search result.",
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": {
+            "description": "The title of the search result.",
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "search_result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "source",
+          "title",
+          "content",
+          "citations"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsSearchResultCitations": {
+        "additionalProperties": false,
+        "description": "Citation settings for a search result.",
+        "properties": {
+          "enabled": {
+            "description": "Whether citations are enabled for this search result.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "enabled"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsSearchResultContent": {
+        "additionalProperties": false,
+        "description": "Text content within a search result.",
+        "properties": {
+          "text": {
+            "description": "The text content.",
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "text"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "text"
+        ],
+        "type": "object"
       },
       "BetaManagedAgentsSendSessionEvents": {
         "additionalProperties": false,
@@ -10819,6 +11248,27 @@
         ],
         "type": "object"
       },
+      "BetaManagedAgentsSessionAgentUpdate": {
+        "additionalProperties": false,
+        "description": "Mid-session agent configuration update. Only `tools` and `mcp_servers` are updatable. Full replacement: the provided array becomes the new value. To preserve existing entries, GET the session, modify the array, and POST it back.",
+        "properties": {
+          "mcp_servers": {
+            "description": "Replacement MCP server list. Full replacement: the provided array becomes the new value. Send an empty array to clear; omit to preserve.",
+            "items": {
+              "$ref": "#/components/schemas/BetaManagedAgentsMCPServerParams"
+            },
+            "type": "array"
+          },
+          "tools": {
+            "description": "Replacement tool list. Full replacement: the provided array becomes the new value. Send an empty array to clear; omit to preserve.",
+            "items": {
+              "$ref": "#/components/schemas/BetaManagedAgentsAgentToolParams"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      },
       "BetaManagedAgentsSessionDeletedEvent": {
         "additionalProperties": false,
         "description": "Emitted when a session has been deleted. Terminates any active event stream \u2014 no further events will be emitted for this session.",
@@ -10959,6 +11409,7 @@
             "session.thread_status_rescheduled": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRescheduledEvent",
             "session.thread_status_running": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRunningEvent",
             "session.thread_status_terminated": "#/components/schemas/BetaManagedAgentsSessionThreadStatusTerminatedEvent",
+            "session.updated": "#/components/schemas/BetaManagedAgentsSessionUpdatedEvent",
             "span.model_request_end": "#/components/schemas/BetaManagedAgentsSpanModelRequestEndEvent",
             "span.model_request_start": "#/components/schemas/BetaManagedAgentsSpanModelRequestStartEvent",
             "span.outcome_evaluation_end": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationEndEvent",
@@ -10968,7 +11419,8 @@
             "user.define_outcome": "#/components/schemas/BetaManagedAgentsUserDefineOutcomeEvent",
             "user.interrupt": "#/components/schemas/BetaManagedAgentsUserInterruptEvent",
             "user.message": "#/components/schemas/BetaManagedAgentsUserMessageEvent",
-            "user.tool_confirmation": "#/components/schemas/BetaManagedAgentsUserToolConfirmationEvent"
+            "user.tool_confirmation": "#/components/schemas/BetaManagedAgentsUserToolConfirmationEvent",
+            "user.tool_result": "#/components/schemas/BetaManagedAgentsUserToolResultEvent"
           },
           "propertyName": "type"
         },
@@ -11064,7 +11516,13 @@
             "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadStatusTerminatedEvent"
           },
           {
+            "$ref": "#/components/schemas/BetaManagedAgentsUserToolResultEvent"
+          },
+          {
             "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRescheduledEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionUpdatedEvent"
           }
         ],
         "type": "object"
@@ -12056,6 +12514,57 @@
         },
         "type": "object"
       },
+      "BetaManagedAgentsSessionUpdatedEvent": {
+        "additionalProperties": false,
+        "description": "Emitted when an UpdateSession request changed at least one field. Carries only the fields that changed; absent fields were not part of the update. The new configuration applies from the next turn.",
+        "properties": {
+          "agent": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsSessionAgent"
+              }
+            ],
+            "description": "The session's effective agent configuration after the update. Present only when the update changed `agent` (tools or mcp_servers); when present it is the full materialised snapshot, not a diff.",
+            "nullable": true
+          },
+          "id": {
+            "description": "Unique identifier for this event.",
+            "type": "string"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "The session's full metadata bag after the update. Present when the update set non-empty metadata; absent when metadata was unchanged or cleared to empty.",
+            "type": "object"
+          },
+          "processed_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "Timestamp when the update was applied."
+          },
+          "title": {
+            "description": "The session's new title. Present only when the update changed it.",
+            "nullable": true,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "session.updated"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "processed_at"
+        ],
+        "type": "object"
+      },
       "BetaManagedAgentsSessionUsage": {
         "additionalProperties": false,
         "description": "Cumulative token usage for a session across all turns.",
@@ -12614,6 +13123,7 @@
             "session.thread_status_rescheduled": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRescheduledEvent",
             "session.thread_status_running": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRunningEvent",
             "session.thread_status_terminated": "#/components/schemas/BetaManagedAgentsSessionThreadStatusTerminatedEvent",
+            "session.updated": "#/components/schemas/BetaManagedAgentsSessionUpdatedEvent",
             "span.model_request_end": "#/components/schemas/BetaManagedAgentsSpanModelRequestEndEvent",
             "span.model_request_start": "#/components/schemas/BetaManagedAgentsSpanModelRequestStartEvent",
             "span.outcome_evaluation_end": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationEndEvent",
@@ -12623,7 +13133,8 @@
             "user.define_outcome": "#/components/schemas/BetaManagedAgentsUserDefineOutcomeEvent",
             "user.interrupt": "#/components/schemas/BetaManagedAgentsUserInterruptEvent",
             "user.message": "#/components/schemas/BetaManagedAgentsUserMessageEvent",
-            "user.tool_confirmation": "#/components/schemas/BetaManagedAgentsUserToolConfirmationEvent"
+            "user.tool_confirmation": "#/components/schemas/BetaManagedAgentsUserToolConfirmationEvent",
+            "user.tool_result": "#/components/schemas/BetaManagedAgentsUserToolResultEvent"
           },
           "propertyName": "type"
         },
@@ -12719,7 +13230,13 @@
             "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadStatusTerminatedEvent"
           },
           {
+            "$ref": "#/components/schemas/BetaManagedAgentsUserToolResultEvent"
+          },
+          {
             "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRescheduledEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionUpdatedEvent"
           }
         ],
         "type": "object"
@@ -12749,6 +13266,7 @@
             "session.thread_status_rescheduled": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRescheduledEvent",
             "session.thread_status_running": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRunningEvent",
             "session.thread_status_terminated": "#/components/schemas/BetaManagedAgentsSessionThreadStatusTerminatedEvent",
+            "session.updated": "#/components/schemas/BetaManagedAgentsSessionUpdatedEvent",
             "span.model_request_end": "#/components/schemas/BetaManagedAgentsSpanModelRequestEndEvent",
             "span.model_request_start": "#/components/schemas/BetaManagedAgentsSpanModelRequestStartEvent",
             "span.outcome_evaluation_end": "#/components/schemas/BetaManagedAgentsSpanOutcomeEvaluationEndEvent",
@@ -12758,7 +13276,8 @@
             "user.define_outcome": "#/components/schemas/BetaManagedAgentsUserDefineOutcomeEvent",
             "user.interrupt": "#/components/schemas/BetaManagedAgentsUserInterruptEvent",
             "user.message": "#/components/schemas/BetaManagedAgentsUserMessageEvent",
-            "user.tool_confirmation": "#/components/schemas/BetaManagedAgentsUserToolConfirmationEvent"
+            "user.tool_confirmation": "#/components/schemas/BetaManagedAgentsUserToolConfirmationEvent",
+            "user.tool_result": "#/components/schemas/BetaManagedAgentsUserToolResultEvent"
           },
           "propertyName": "type"
         },
@@ -12854,7 +13373,13 @@
             "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadStatusTerminatedEvent"
           },
           {
+            "$ref": "#/components/schemas/BetaManagedAgentsUserToolResultEvent"
+          },
+          {
             "$ref": "#/components/schemas/BetaManagedAgentsSessionThreadStatusRescheduledEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSessionUpdatedEvent"
           }
         ],
         "type": "object"
@@ -13110,6 +13635,7 @@
           "mapping": {
             "document": "#/components/schemas/BetaManagedAgentsDocumentBlock",
             "image": "#/components/schemas/BetaManagedAgentsImageBlock",
+            "search_result": "#/components/schemas/BetaManagedAgentsSearchResultBlock",
             "text": "#/components/schemas/BetaManagedAgentsTextBlock"
           },
           "propertyName": "type"
@@ -13123,6 +13649,9 @@
           },
           {
             "$ref": "#/components/schemas/BetaManagedAgentsDocumentBlock"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsSearchResultBlock"
           }
         ],
         "type": "object"
@@ -13457,6 +13986,14 @@
           "title": "Order #1234 inquiry"
         },
         "properties": {
+          "agent": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsSessionAgentUpdate"
+              }
+            ],
+            "description": "Agent configuration update. Only `tools` and `mcp_servers` are updatable mid-session. Only valid for sessions created from an agent or deployment reference. The session must not be running."
+          },
           "metadata": {
             "additionalProperties": {
               "nullable": true,
@@ -14118,6 +14655,93 @@
         ],
         "type": "string"
       },
+      "BetaManagedAgentsUserToolResultEvent": {
+        "additionalProperties": false,
+        "description": "Event sent by the client providing the result of an agent-toolset tool execution. Only valid on `self_hosted` environments, where sandbox-routed tools are executed by the client rather than the server.",
+        "properties": {
+          "content": {
+            "description": "The result content returned by the tool.",
+            "items": {
+              "$ref": "#/components/schemas/BetaManagedAgentsToolResultContentBlock"
+            },
+            "type": "array"
+          },
+          "id": {
+            "description": "Unique identifier for this event.",
+            "type": "string"
+          },
+          "is_error": {
+            "description": "Whether the tool execution resulted in an error.",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "processed_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "Timestamp when this result was processed.",
+            "nullable": true
+          },
+          "session_thread_id": {
+            "description": "Routes this result to a subagent thread. Copy from the `agent.tool_use` event's `session_thread_id`.",
+            "nullable": true,
+            "type": "string"
+          },
+          "tool_use_id": {
+            "description": "The id of the `agent.tool_use` event this result corresponds to, which can be found in the last `session.status_idle` [event's](https://platform.claude.com/docs/en/api/beta/sessions/events/list#beta_managed_agents_session_requires_action.event_ids) `stop_reason.event_ids` field.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "user.tool_result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "tool_use_id"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsUserToolResultEventParams": {
+        "additionalProperties": false,
+        "description": "Parameters for providing the result of an agent-toolset tool execution. Only valid on `self_hosted` environments, where sandbox-routed tools are executed by the client rather than the server.",
+        "properties": {
+          "content": {
+            "description": "The result content returned by the tool.",
+            "items": {
+              "$ref": "#/components/schemas/BetaManagedAgentsToolResultContentBlock"
+            },
+            "type": "array"
+          },
+          "is_error": {
+            "description": "Whether the tool execution resulted in an error.",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "tool_use_id": {
+            "description": "The id of the `agent.tool_use` event this result corresponds to, which can be found in the last `session.status_idle` [event's](https://platform.claude.com/docs/en/api/beta/sessions/events/list#beta_managed_agents_session_requires_action.event_ids) `stop_reason.event_ids` field.",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "user.tool_result"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "tool_use_id"
+        ],
+        "type": "object"
+      },
       "BetaManagedAgentsVault": {
         "additionalProperties": false,
         "description": "A vault that stores credentials for use by agents during sessions.",
@@ -14561,6 +15185,18 @@
             "default": null,
             "description": "Context management response.\n\nInformation about context management strategies applied during the request."
           },
+          "diagnostics": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BetaDiagnostics"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Request-level diagnostics. Present only when `diagnostics` was supplied on the request; `null` when no prompt-cache divergence was detected."
+          },
           "id": {
             "description": "Unique object identifier.\n\nThe format and length of IDs may change over time.",
             "examples": [
@@ -14644,6 +15280,7 @@
           "stop_sequence",
           "stop_details",
           "usage",
+          "diagnostics",
           "context_management",
           "container"
         ],
@@ -15666,13 +16303,17 @@
               {
                 "discriminator": {
                   "mapping": {
-                    "cloud": "#/components/schemas/BetaCloudConfigParams"
+                    "cloud": "#/components/schemas/BetaCloudConfigParams",
+                    "self_hosted": "#/components/schemas/BetaSelfHostedConfigParams"
                   },
                   "propertyName": "type"
                 },
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/BetaCloudConfigParams"
+                  },
+                  {
+                    "$ref": "#/components/schemas/BetaSelfHostedConfigParams"
                   }
                 ]
               },
@@ -15734,6 +16375,22 @@
             "minLength": 1,
             "title": "Name",
             "type": "string"
+          },
+          "scope": {
+            "anyOf": [
+              {
+                "enum": [
+                  "organization",
+                  "account"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The visibility scope for this environment. 'organization' makes the environment visible to all accounts. 'account' restricts visibility to the owning account only. Only applicable for self-hosted environments. If not specified, defaults based on organization type.",
+            "title": "Scope"
           }
         },
         "required": [
@@ -15754,13 +16411,17 @@
               {
                 "discriminator": {
                   "mapping": {
-                    "cloud": "#/components/schemas/BetaCloudConfigParams"
+                    "cloud": "#/components/schemas/BetaCloudConfigParams",
+                    "self_hosted": "#/components/schemas/BetaSelfHostedConfigParams"
                   },
                   "propertyName": "type"
                 },
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/BetaCloudConfigParams"
+                  },
+                  {
+                    "$ref": "#/components/schemas/BetaSelfHostedConfigParams"
                   }
                 ]
               },
@@ -15815,6 +16476,22 @@
             ],
             "description": "Updated name for the environment",
             "title": "Name"
+          },
+          "scope": {
+            "anyOf": [
+              {
+                "enum": [
+                  "organization",
+                  "account"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The visibility scope for this environment. 'organization' makes the environment visible to all accounts. 'account' restricts visibility to the owning account only.",
+            "title": "Scope"
           }
         },
         "title": "PublicEnvironmentUpdateRequest",
@@ -16398,7 +17075,6 @@
           }
         },
         "required": [
-          "content",
           "type"
         ],
         "title": "RequestCompactionBlock",
@@ -20016,6 +20692,346 @@
         "title": "ResponseWebSearchToolResultError",
         "type": "object"
       },
+      "BetaSelfHostedConfig": {
+        "additionalProperties": false,
+        "description": "Configuration for self-hosted environments.",
+        "properties": {
+          "type": {
+            "const": "self_hosted",
+            "description": "Environment type",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "SelfHostedConfig",
+        "type": "object"
+      },
+      "BetaSelfHostedConfigParams": {
+        "additionalProperties": false,
+        "description": "Request params for `self_hosted` environment configuration.",
+        "properties": {
+          "type": {
+            "const": "self_hosted",
+            "description": "Environment type",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "SelfHostedConfigParams",
+        "type": "object"
+      },
+      "BetaSelfHostedWork": {
+        "description": "Work resource representing a unit of work in a self-hosted environment.\n\nWork items are queued when sessions are created or when long-dormant sessions\nreceive new messages. The environment worker polls for work to execute in a\nself-hosted sandbox.",
+        "properties": {
+          "acknowledged_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "RFC 3339 timestamp when the work item was acknowledged and assigned to a self-hosted sandbox",
+            "title": "Acknowledged At"
+          },
+          "created_at": {
+            "description": "RFC 3339 timestamp when work was created",
+            "title": "Created At",
+            "type": "string"
+          },
+          "data": {
+            "$ref": "#/components/schemas/BetaSessionWorkData",
+            "description": "The actual work to be performed"
+          },
+          "environment_id": {
+            "description": "Environment identifier this work belongs to (e.g., `env_...`)",
+            "title": "Environment Id",
+            "type": "string"
+          },
+          "id": {
+            "description": "Work identifier (e.g., 'work_...')",
+            "title": "Id",
+            "type": "string"
+          },
+          "latest_heartbeat_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "RFC 3339 timestamp of the most recent heartbeat",
+            "title": "Latest Heartbeat At"
+          },
+          "metadata": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "User-provided metadata key-value pairs associated with this work item",
+            "title": "Metadata",
+            "type": "object"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "RFC 3339 timestamp when work execution started",
+            "title": "Started At"
+          },
+          "state": {
+            "description": "Current state of the work item",
+            "enum": [
+              "queued",
+              "starting",
+              "active",
+              "stopping",
+              "stopped"
+            ],
+            "title": "State",
+            "type": "string"
+          },
+          "stop_requested_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "RFC 3339 timestamp when stop was requested",
+            "title": "Stop Requested At"
+          },
+          "stopped_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "RFC 3339 timestamp when work execution stopped",
+            "title": "Stopped At"
+          },
+          "type": {
+            "const": "work",
+            "default": "work",
+            "description": "The type of object (always 'work')",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "acknowledged_at",
+          "created_at",
+          "data",
+          "environment_id",
+          "id",
+          "latest_heartbeat_at",
+          "metadata",
+          "started_at",
+          "state",
+          "stop_requested_at",
+          "stopped_at",
+          "type"
+        ],
+        "title": "SelfHostedWork",
+        "type": "object"
+      },
+      "BetaSelfHostedWorkHeartbeatResponse": {
+        "description": "Response after recording a heartbeat for a work item.",
+        "properties": {
+          "last_heartbeat": {
+            "description": "RFC 3339 timestamp of the actual heartbeat from DB",
+            "title": "Last Heartbeat",
+            "type": "string"
+          },
+          "lease_extended": {
+            "description": "Whether the heartbeat succeeded in extending the lease",
+            "title": "Lease Extended",
+            "type": "boolean"
+          },
+          "state": {
+            "description": "Current state of the work item (active/stopping/stopped)",
+            "enum": [
+              "queued",
+              "starting",
+              "active",
+              "stopping",
+              "stopped"
+            ],
+            "title": "State",
+            "type": "string"
+          },
+          "ttl_seconds": {
+            "description": "Effective TTL applied to the lease",
+            "title": "Ttl Seconds",
+            "type": "integer"
+          },
+          "type": {
+            "const": "work_heartbeat",
+            "default": "work_heartbeat",
+            "description": "The type of response",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "last_heartbeat",
+          "lease_extended",
+          "state",
+          "ttl_seconds",
+          "type"
+        ],
+        "title": "SelfHostedWorkHeartbeatResponse",
+        "type": "object"
+      },
+      "BetaSelfHostedWorkListResponse": {
+        "description": "Response when listing work items with cursor-based pagination.",
+        "properties": {
+          "data": {
+            "description": "List of work items",
+            "items": {
+              "$ref": "#/components/schemas/BetaSelfHostedWork"
+            },
+            "title": "Data",
+            "type": "array",
+            "x-stainless-pagination-property": {
+              "purpose": "items"
+            }
+          },
+          "next_page": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Opaque cursor for fetching the next page of results",
+            "title": "Next Page",
+            "x-stainless-pagination-property": {
+              "purpose": "next_cursor_field"
+            }
+          }
+        },
+        "required": [
+          "data",
+          "next_page"
+        ],
+        "title": "SelfHostedWorkListResponse",
+        "type": "object"
+      },
+      "BetaSelfHostedWorkQueueStats": {
+        "description": "Statistics about the work queue for an environment.\n\nUses Redis Stream consumer group metrics for O(1) queries.",
+        "properties": {
+          "depth": {
+            "description": "Number of work items waiting to be picked up (lag from consumer group)",
+            "title": "Depth",
+            "type": "integer"
+          },
+          "oldest_queued_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "RFC 3339 timestamp of oldest item in the work stream (includes both queued and pending items), null if stream empty",
+            "title": "Oldest Queued At"
+          },
+          "pending": {
+            "default": 0,
+            "description": "Number of work items being processed (polled but not acknowledged)",
+            "title": "Pending",
+            "type": "integer"
+          },
+          "type": {
+            "const": "work_queue_stats",
+            "default": "work_queue_stats",
+            "description": "The type of object",
+            "title": "Type",
+            "type": "string"
+          },
+          "workers_polling": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Number of workers that have polled for work in the last 30 seconds. Requires worker_id to be sent with poll requests.",
+            "title": "Workers Polling"
+          }
+        },
+        "required": [
+          "depth",
+          "oldest_queued_at",
+          "pending",
+          "type",
+          "workers_polling"
+        ],
+        "title": "SelfHostedWorkQueueStats",
+        "type": "object"
+      },
+      "BetaSelfHostedWorkStopRequest": {
+        "description": "Request to stop a work item.",
+        "properties": {
+          "force": {
+            "default": false,
+            "description": "If true, immediately stop work without graceful shutdown",
+            "title": "Force",
+            "type": "boolean"
+          }
+        },
+        "title": "SelfHostedWorkStopRequest",
+        "type": "object"
+      },
+      "BetaSelfHostedWorkUpdateRequest": {
+        "description": "Request to update work item metadata.",
+        "properties": {
+          "metadata": {
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "description": "Metadata patch. Set a key to a string to upsert it, or to null to delete it. Omit the field to preserve existing metadata.",
+            "title": "Metadata",
+            "type": "object"
+          }
+        },
+        "required": [
+          "metadata"
+        ],
+        "title": "SelfHostedWorkUpdateRequest",
+        "type": "object"
+      },
       "BetaServerToolCaller": {
         "additionalProperties": false,
         "description": "Tool invocation generated by a server-side tool.",
@@ -20087,6 +21103,28 @@
           "web_search_requests"
         ],
         "title": "ServerToolUsage",
+        "type": "object"
+      },
+      "BetaSessionWorkData": {
+        "description": "Work data for session work items.\n\nThis resource type is used when work represents a session that needs to be executed\nin a self-hosted environment.",
+        "properties": {
+          "id": {
+            "description": "Session identifier (e.g., 'session_...')",
+            "title": "Id",
+            "type": "string"
+          },
+          "type": {
+            "const": "session",
+            "description": "Type of work data",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "type"
+        ],
+        "title": "SessionWorkData",
         "type": "object"
       },
       "BetaSignatureContentBlockDelta": {
@@ -20767,6 +21805,19 @@
       },
       "BetaThinkingContentBlockDelta": {
         "properties": {
+          "estimated_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Per-frame increment of a coarse, running estimate of the tokens this thinking block has produced so far. Present whenever the `thinking-token-count-2026-05-13` beta is set; `null` unless `thinking.display` resolves to `\"omitted\"` and a count is due this frame. Sum the increments across `thinking_delta` frames on this block for a progress indicator. Each increment is a non-negative multiple of a fixed quantum and the cadence is rate-limited, so this is a deliberately lossy display hint, not a billable count; `usage.output_tokens` remains authoritative.",
+            "title": "Estimated Tokens"
+          },
           "thinking": {
             "title": "Thinking",
             "type": "string"
@@ -20779,6 +21830,7 @@
           }
         },
         "required": [
+          "estimated_tokens",
           "thinking",
           "type"
         ],
@@ -33339,6 +34391,942 @@
         "summary": "Archive Environment"
       }
     },
+    "/v1/environments/{environment_id}/work/poll?beta=true": {
+      "get": {
+        "description": "Note: these endpoints are called automatically by the pre-built environment worker provided in the SDKs and CLI, for orchestrating sessions with self-hosted sandbox environments. They are included here as a reference; you do not need to invoke them directly.\n\nLong poll for work items in the queue.",
+        "operationId": "beta_poll_work_v1_environments__environment_id__work_poll_get",
+        "parameters": [
+          {
+            "example": "env_011CZkZ9X2dpNyB7HsEFoRfW",
+            "in": "path",
+            "name": "environment_id",
+            "required": true,
+            "schema": {
+              "title": "Environment Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "How long to wait for work to arrive before returning. Must be 1-999 in milliseconds. Defaults to non-blocking (returns immediately if no work is available).",
+            "in": "query",
+            "name": "block_ms",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "How long to wait for work to arrive before returning. Must be 1-999 in milliseconds. Defaults to non-blocking (returns immediately if no work is available).",
+              "title": "Block Ms"
+            }
+          },
+          {
+            "description": "Reclaim unacknowledged work items older than this many milliseconds. If omitted, uses the default (5000ms).",
+            "in": "query",
+            "name": "reclaim_older_than_ms",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Reclaim unacknowledged work items older than this many milliseconds. If omitted, uses the default (5000ms).",
+              "title": "Reclaim Older Than Ms"
+            }
+          },
+          {
+            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
+              "items": {
+                "type": "string"
+              },
+              "title": "Anthropic-Beta",
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "title": "Anthropic-Version",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Unique identifier for the specific worker polling, used to track aggregated environment-level work metrics in Console",
+            "in": "header",
+            "name": "Anthropic-Worker-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Unique identifier for the specific worker polling, used to track aggregated environment-level work metrics in Console",
+              "title": "Anthropic-Worker-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/BetaSelfHostedWork"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "title": "Response Poll Work V1 Environments  Environment Id  Work Poll Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+          }
+        },
+        "summary": "Poll for Work"
+      }
+    },
+    "/v1/environments/{environment_id}/work/stats?beta=true": {
+      "get": {
+        "description": "Get statistics about the work queue for an environment.",
+        "operationId": "beta_get_environment_stats_v1_environments__environment_id__work_stats_get",
+        "parameters": [
+          {
+            "example": "env_011CZkZ9X2dpNyB7HsEFoRfW",
+            "in": "path",
+            "name": "environment_id",
+            "required": true,
+            "schema": {
+              "title": "Environment Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
+              "items": {
+                "type": "string"
+              },
+              "title": "Anthropic-Beta",
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "title": "Anthropic-Version",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaSelfHostedWorkQueueStats"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+          }
+        },
+        "summary": "Get Queue Statistics"
+      }
+    },
+    "/v1/environments/{environment_id}/work/{work_id}/ack?beta=true": {
+      "post": {
+        "description": "Note: these endpoints are called automatically by the pre-built environment worker provided in the SDKs and CLI, for orchestrating sessions with self-hosted sandbox environments. They are included here as a reference; you do not need to invoke them directly.\n\nAcknowledge receipt of a work item, transitioning it from 'queued' to 'starting' and removing it from the queue.",
+        "operationId": "beta_acknowledge_work_v1_environments__environment_id__work__work_id__ack_post",
+        "parameters": [
+          {
+            "example": "env_011CZkZ9X2dpNyB7HsEFoRfW",
+            "in": "path",
+            "name": "environment_id",
+            "required": true,
+            "schema": {
+              "title": "Environment Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "work_id",
+            "required": true,
+            "schema": {
+              "title": "Work Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
+              "items": {
+                "type": "string"
+              },
+              "title": "Anthropic-Beta",
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "title": "Anthropic-Version",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaSelfHostedWork"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+          }
+        },
+        "summary": "Acknowledge Work"
+      }
+    },
+    "/v1/environments/{environment_id}/work/{work_id}/heartbeat?beta=true": {
+      "post": {
+        "description": "Note: these endpoints are called automatically by the pre-built environment worker provided in the SDKs and CLI, for orchestrating sessions with self-hosted sandbox environments. They are included here as a reference; you do not need to invoke them directly.\n\nRecord a heartbeat for a work item to maintain the lease.",
+        "operationId": "beta_record_heartbeat_v1_environments__environment_id__work__work_id__heartbeat_post",
+        "parameters": [
+          {
+            "example": "env_011CZkZ9X2dpNyB7HsEFoRfW",
+            "in": "path",
+            "name": "environment_id",
+            "required": true,
+            "schema": {
+              "title": "Environment Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "work_id",
+            "required": true,
+            "schema": {
+              "title": "Work Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Desired TTL in seconds",
+            "in": "query",
+            "name": "desired_ttl_seconds",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Desired TTL in seconds",
+              "title": "Desired Ttl Seconds"
+            }
+          },
+          {
+            "description": "Expected last_heartbeat for conditional update (optimistic concurrency). Use literal 'NO_HEARTBEAT' to claim an unclaimed lease (first heartbeat). For subsequent heartbeats, echo the server's previous last_heartbeat value exactly. Returns 412 Precondition Failed if the actual value doesn't match.",
+            "examples": {
+              "first_claim": {
+                "summary": "First heartbeat (claim unclaimed lease)",
+                "value": "NO_HEARTBEAT"
+              },
+              "subsequent": {
+                "summary": "Subsequent heartbeat (echo server's value)",
+                "value": "2026-05-14T10:30:45.123456Z"
+              }
+            },
+            "in": "query",
+            "name": "expected_last_heartbeat",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Expected last_heartbeat for conditional update (optimistic concurrency). Use literal 'NO_HEARTBEAT' to claim an unclaimed lease (first heartbeat). For subsequent heartbeats, echo the server's previous last_heartbeat value exactly. Returns 412 Precondition Failed if the actual value doesn't match.",
+              "title": "Expected Last Heartbeat"
+            }
+          },
+          {
+            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
+              "items": {
+                "type": "string"
+              },
+              "title": "Anthropic-Beta",
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "title": "Anthropic-Version",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaSelfHostedWorkHeartbeatResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+          }
+        },
+        "summary": "Record Heartbeat"
+      }
+    },
+    "/v1/environments/{environment_id}/work/{work_id}/stop?beta=true": {
+      "post": {
+        "description": "Note: these endpoints are called automatically by the pre-built environment worker provided in the SDKs and CLI, for orchestrating sessions with self-hosted sandbox environments. They are included here as a reference; you do not need to invoke them directly.\n\nStop a work item, initiating graceful or forced shutdown.",
+        "operationId": "beta_stop_work_v1_environments__environment_id__work__work_id__stop_post",
+        "parameters": [
+          {
+            "example": "env_011CZkZ9X2dpNyB7HsEFoRfW",
+            "in": "path",
+            "name": "environment_id",
+            "required": true,
+            "schema": {
+              "title": "Environment Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "work_id",
+            "required": true,
+            "schema": {
+              "title": "Work Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
+              "items": {
+                "type": "string"
+              },
+              "title": "Anthropic-Beta",
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "title": "Anthropic-Version",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaSelfHostedWorkStopRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaSelfHostedWork"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+          }
+        },
+        "summary": "Stop Work"
+      }
+    },
+    "/v1/environments/{environment_id}/work/{work_id}?beta=true": {
+      "get": {
+        "description": "Note: these endpoints are called automatically by the pre-built environment worker provided in the SDKs and CLI, for orchestrating sessions with self-hosted sandbox environments. They are included here as a reference; you do not need to invoke them directly.\n\nRetrieve detailed information about a specific work item.",
+        "operationId": "beta_get_work_v1_environments__environment_id__work__work_id__get",
+        "parameters": [
+          {
+            "example": "env_011CZkZ9X2dpNyB7HsEFoRfW",
+            "in": "path",
+            "name": "environment_id",
+            "required": true,
+            "schema": {
+              "title": "Environment Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "work_id",
+            "required": true,
+            "schema": {
+              "title": "Work Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
+              "items": {
+                "type": "string"
+              },
+              "title": "Anthropic-Beta",
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "title": "Anthropic-Version",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaSelfHostedWork"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+          }
+        },
+        "summary": "Get Work Item"
+      },
+      "post": {
+        "description": "Note: these endpoints are called automatically by the pre-built environment worker provided in the SDKs and CLI, for orchestrating sessions with self-hosted sandbox environments. They are included here as a reference; you do not need to invoke them directly.\n\nUpdate work item metadata with merge semantics.",
+        "operationId": "beta_update_work_v1_environments__environment_id__work__work_id__post",
+        "parameters": [
+          {
+            "example": "env_011CZkZ9X2dpNyB7HsEFoRfW",
+            "in": "path",
+            "name": "environment_id",
+            "required": true,
+            "schema": {
+              "title": "Environment Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "work_id",
+            "required": true,
+            "schema": {
+              "title": "Work Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
+              "items": {
+                "type": "string"
+              },
+              "title": "Anthropic-Beta",
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "title": "Anthropic-Version",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaSelfHostedWorkUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaSelfHostedWork"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+          }
+        },
+        "summary": "Update Work Item"
+      }
+    },
+    "/v1/environments/{environment_id}/work?beta=true": {
+      "get": {
+        "description": "Note: these endpoints are called automatically by the pre-built environment worker provided in the SDKs and CLI, for orchestrating sessions with self-hosted sandbox environments. They are included here as a reference; you do not need to invoke them directly.\n\nList work items in an environment.",
+        "operationId": "beta_list_work_v1_environments__environment_id__work_get",
+        "parameters": [
+          {
+            "example": "env_011CZkZ9X2dpNyB7HsEFoRfW",
+            "in": "path",
+            "name": "environment_id",
+            "required": true,
+            "schema": {
+              "title": "Environment Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of work items to return",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "Maximum number of work items to return",
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Opaque cursor from previous response for pagination",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Opaque cursor from previous response for pagination",
+              "title": "Page",
+              "x-stainless-pagination-property": {
+                "purpose": "next_cursor_param"
+              }
+            }
+          },
+          {
+            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
+              "items": {
+                "type": "string"
+              },
+              "title": "Anthropic-Beta",
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "title": "Anthropic-Version",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaSelfHostedWorkListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+          }
+        },
+        "summary": "List Work Items"
+      }
+    },
     "/v1/environments/{environment_id}?beta=true": {
       "delete": {
         "description": "Delete an environment by ID. Returns a confirmation of the deletion.",
@@ -43459,6 +45447,104 @@
           }
         },
         "summary": "Create Session"
+      }
+    },
+    "/v1/skills/{skill_id}/versions/{version}/content?beta=true": {
+      "get": {
+        "description": "Download a skill version's content as a zip archive.",
+        "operationId": "beta_download_skill_version_content_v1_skills__skill_id__versions__version__content_get",
+        "parameters": [
+          {
+            "description": "Unique identifier for the skill.\n\nThe format and length of IDs may change over time.",
+            "in": "path",
+            "name": "skill_id",
+            "required": true,
+            "schema": {
+              "description": "Unique identifier for the skill.\n\nThe format and length of IDs may change over time.",
+              "title": "Skill Id",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version identifier for the skill.\n\nEach version is identified by a Unix epoch timestamp (e.g., \"1759178010641129\").",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "description": "Version identifier for the skill.\n\nEach version is identified by a Unix epoch timestamp (e.g., \"1759178010641129\").",
+              "title": "Version",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "description": "Optional header to specify the beta version(s) you want to use.\n\nTo use multiple betas, use a comma separated list like `beta1,beta2` or specify the header multiple times for each beta.",
+              "items": {
+                "type": "string"
+              },
+              "title": "Anthropic-Beta",
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "title": "Anthropic-Version",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "description": "Your unique API key for authentication.\n\nThis key is required in the header of all API requests, to authenticate your account and access Anthropic's services. Get your API key through the [Console](https://console.anthropic.com/settings/keys). Each key is scoped to a Workspace.",
+              "title": "X-Api-Key",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "4XX": {
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+          }
+        },
+        "summary": "Download Skill Version Content"
       }
     },
     "/v1/skills/{skill_id}/versions/{version}?beta=true": {

--- a/packages/anthropic_sdk_dart/specs/spec_metadata.json
+++ b/packages/anthropic_sdk_dart/specs/spec_metadata.json
@@ -2,8 +2,8 @@
   "specs": {
     "main": {
       "current_version": "unknown",
-      "last_fetched": "2026-05-09T16:05:44.690295Z",
-      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-0df2c793ea4c3ad955e8e488be39d7041a0a95e2fe144dd69ae4d9fb72835190.yml",
+      "last_fetched": "2026-05-23T22:32:12.841626Z",
+      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-945e3a57b7a6fa5974baf70845ebafdb25f185625f6e2fab98dc034e44d14a5a.yml",
       "title": "Anthropic API",
       "version_history": [
         {

--- a/packages/anthropic_sdk_dart/test/unit/models/content_block_delta_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/content_block_delta_test.dart
@@ -1,0 +1,83 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ThinkingDelta', () {
+    test('round-trips with estimated_tokens', () {
+      final json = {
+        'type': 'thinking_delta',
+        'thinking': 'Let me think...',
+        'estimated_tokens': 42,
+      };
+
+      final delta = ContentBlockDelta.fromJson(json);
+      expect(delta, isA<ThinkingDelta>());
+      final thinkingDelta = delta as ThinkingDelta;
+      expect(thinkingDelta.thinking, 'Let me think...');
+      expect(thinkingDelta.estimatedTokens, 42);
+      expect(thinkingDelta.toJson(), json);
+    });
+
+    test('round-trips without estimated_tokens', () {
+      final json = {'type': 'thinking_delta', 'thinking': 'Let me think...'};
+
+      final delta = ContentBlockDelta.fromJson(json);
+      expect(delta, isA<ThinkingDelta>());
+      final thinkingDelta = delta as ThinkingDelta;
+      expect(thinkingDelta.thinking, 'Let me think...');
+      expect(thinkingDelta.estimatedTokens, isNull);
+      // estimated_tokens omitted from JSON when null.
+      expect(thinkingDelta.toJson(), json);
+      expect(thinkingDelta.toJson().containsKey('estimated_tokens'), isFalse);
+    });
+
+    test('partial event parses with estimatedTokens == null', () {
+      final delta = ContentBlockDelta.fromJson({
+        'type': 'thinking_delta',
+        'thinking': 'x',
+      });
+      expect(delta, isA<ThinkingDelta>());
+      expect((delta as ThinkingDelta).estimatedTokens, isNull);
+    });
+
+    test('copyWith updates estimatedTokens', () {
+      const delta = ThinkingDelta('hello', estimatedTokens: 10);
+
+      final updated = delta.copyWith(estimatedTokens: 99);
+      expect(updated.thinking, 'hello');
+      expect(updated.estimatedTokens, 99);
+    });
+
+    test('copyWith preserves estimatedTokens when not provided', () {
+      const delta = ThinkingDelta('hello', estimatedTokens: 10);
+
+      final updated = delta.copyWith(thinking: 'world');
+      expect(updated.thinking, 'world');
+      expect(updated.estimatedTokens, 10);
+    });
+
+    test('copyWith can clear estimatedTokens via sentinel', () {
+      const delta = ThinkingDelta('hello', estimatedTokens: 10);
+
+      final updated = delta.copyWith(estimatedTokens: null);
+      expect(updated.estimatedTokens, isNull);
+    });
+
+    test('toString includes estimatedTokens', () {
+      const delta = ThinkingDelta('hello', estimatedTokens: 7);
+      expect(delta.toString(), contains('estimatedTokens: 7'));
+    });
+
+    test('equality and hashCode include estimatedTokens', () {
+      const a = ThinkingDelta('hello', estimatedTokens: 5);
+      const b = ThinkingDelta('hello', estimatedTokens: 5);
+      const c = ThinkingDelta('hello', estimatedTokens: 6);
+      const d = ThinkingDelta('hello');
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+      expect(a, isNot(equals(d)));
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/diagnostics_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/diagnostics_test.dart
@@ -1,0 +1,476 @@
+import 'package:anthropic_sdk_dart/src/models/content/content_block.dart';
+import 'package:anthropic_sdk_dart/src/models/messages/cache_miss_reason.dart';
+import 'package:anthropic_sdk_dart/src/models/messages/diagnostics.dart';
+import 'package:anthropic_sdk_dart/src/models/messages/diagnostics_param.dart';
+import 'package:anthropic_sdk_dart/src/models/messages/input_message.dart';
+import 'package:anthropic_sdk_dart/src/models/messages/message.dart';
+import 'package:anthropic_sdk_dart/src/models/messages/message_create_request.dart';
+import 'package:anthropic_sdk_dart/src/models/metadata/usage.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DiagnosticsParam', () {
+    test('fromJson/toJson round-trip', () {
+      final json = {'previous_message_id': 'msg_123'};
+      final param = DiagnosticsParam.fromJson(json);
+
+      expect(param.previousMessageId, 'msg_123');
+      expect(param.toJson(), json);
+    });
+
+    test('omits previous_message_id when absent', () {
+      final param = DiagnosticsParam.fromJson(const <String, dynamic>{});
+
+      expect(param.previousMessageId, isNull);
+      expect(param.toJson(), isEmpty);
+    });
+
+    test('toJson omits key when null', () {
+      const param = DiagnosticsParam();
+
+      expect(param.toJson().containsKey('previous_message_id'), isFalse);
+    });
+
+    test('copyWith replaces value', () {
+      const original = DiagnosticsParam(previousMessageId: 'msg_1');
+      final modified = original.copyWith(previousMessageId: 'msg_2');
+
+      expect(modified.previousMessageId, 'msg_2');
+    });
+
+    test('copyWith can clear value to null', () {
+      const original = DiagnosticsParam(previousMessageId: 'msg_1');
+      final cleared = original.copyWith(previousMessageId: null);
+
+      expect(cleared.previousMessageId, isNull);
+    });
+
+    test('copyWith without args keeps original', () {
+      const original = DiagnosticsParam(previousMessageId: 'msg_1');
+      final copy = original.copyWith();
+
+      expect(copy.previousMessageId, 'msg_1');
+    });
+
+    test('equality and hashCode', () {
+      const a = DiagnosticsParam(previousMessageId: 'msg_1');
+      const b = DiagnosticsParam(previousMessageId: 'msg_1');
+      const c = DiagnosticsParam(previousMessageId: 'msg_2');
+
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(c));
+    });
+
+    test('toString includes field', () {
+      const param = DiagnosticsParam(previousMessageId: 'msg_1');
+
+      expect(param.toString(), contains('previousMessageId'));
+      expect(param.toString(), contains('msg_1'));
+    });
+  });
+
+  group('CacheMissReason', () {
+    group('token-bearing variants', () {
+      final cases = <String, CacheMissReason Function(int)>{
+        'model_changed': (t) =>
+            CacheMissModelChanged(cacheMissedInputTokens: t),
+        'system_changed': (t) =>
+            CacheMissSystemChanged(cacheMissedInputTokens: t),
+        'tools_changed': (t) =>
+            CacheMissToolsChanged(cacheMissedInputTokens: t),
+        'messages_changed': (t) =>
+            CacheMissMessagesChanged(cacheMissedInputTokens: t),
+      };
+
+      for (final entry in cases.entries) {
+        final type = entry.key;
+        final build = entry.value;
+
+        test('$type fromJson/toJson round-trip', () {
+          final json = {'type': type, 'cache_missed_input_tokens': 42};
+          final reason = CacheMissReason.fromJson(json);
+
+          expect(reason, build(42));
+          expect(reason.toJson(), json);
+        });
+
+        test('$type equality and hashCode', () {
+          final a = build(10);
+          final b = build(10);
+          final c = build(20);
+
+          expect(a, b);
+          expect(a.hashCode, b.hashCode);
+          expect(a, isNot(c));
+        });
+
+        test('$type discriminator-mismatch throws', () {
+          expect(
+            () => _fromJsonFor(build(0)).call(<String, dynamic>{
+              'type': 'wrong',
+              'cache_missed_input_tokens': 1,
+            }),
+            throwsFormatException,
+          );
+        });
+      }
+
+      test('copyWith replaces cacheMissedInputTokens on each variant', () {
+        expect(
+          const CacheMissModelChanged(
+            cacheMissedInputTokens: 1,
+          ).copyWith(cacheMissedInputTokens: 9),
+          const CacheMissModelChanged(cacheMissedInputTokens: 9),
+        );
+        expect(
+          const CacheMissSystemChanged(
+            cacheMissedInputTokens: 1,
+          ).copyWith(cacheMissedInputTokens: 9),
+          const CacheMissSystemChanged(cacheMissedInputTokens: 9),
+        );
+        expect(
+          const CacheMissToolsChanged(
+            cacheMissedInputTokens: 1,
+          ).copyWith(cacheMissedInputTokens: 9),
+          const CacheMissToolsChanged(cacheMissedInputTokens: 9),
+        );
+        expect(
+          const CacheMissMessagesChanged(
+            cacheMissedInputTokens: 1,
+          ).copyWith(cacheMissedInputTokens: 9),
+          const CacheMissMessagesChanged(cacheMissedInputTokens: 9),
+        );
+        // No-arg copyWith preserves the original value.
+        expect(
+          const CacheMissModelChanged(cacheMissedInputTokens: 5).copyWith(),
+          const CacheMissModelChanged(cacheMissedInputTokens: 5),
+        );
+      });
+
+      test('const factory constructors build the right variants', () {
+        expect(
+          const CacheMissReason.modelChanged(cacheMissedInputTokens: 1),
+          const CacheMissModelChanged(cacheMissedInputTokens: 1),
+        );
+        expect(
+          const CacheMissReason.systemChanged(cacheMissedInputTokens: 2),
+          const CacheMissSystemChanged(cacheMissedInputTokens: 2),
+        );
+        expect(
+          const CacheMissReason.toolsChanged(cacheMissedInputTokens: 3),
+          const CacheMissToolsChanged(cacheMissedInputTokens: 3),
+        );
+        expect(
+          const CacheMissReason.messagesChanged(cacheMissedInputTokens: 4),
+          const CacheMissMessagesChanged(cacheMissedInputTokens: 4),
+        );
+      });
+    });
+
+    group('type-only variants', () {
+      test('previous_message_not_found round-trips', () {
+        final json = {'type': 'previous_message_not_found'};
+        final reason = CacheMissReason.fromJson(json);
+
+        expect(reason, const CacheMissPreviousMessageNotFound());
+        expect(reason, isA<CacheMissPreviousMessageNotFound>());
+        expect(reason.toJson(), json);
+      });
+
+      test('unavailable round-trips', () {
+        final json = {'type': 'unavailable'};
+        final reason = CacheMissReason.fromJson(json);
+
+        expect(reason, const CacheMissUnavailable());
+        expect(reason, isA<CacheMissUnavailable>());
+        expect(reason.toJson(), json);
+      });
+
+      test('const factory constructors build the right variants', () {
+        expect(
+          const CacheMissReason.previousMessageNotFound(),
+          const CacheMissPreviousMessageNotFound(),
+        );
+        expect(
+          const CacheMissReason.unavailable(),
+          const CacheMissUnavailable(),
+        );
+      });
+
+      test('previous_message_not_found discriminator-mismatch throws', () {
+        expect(
+          () => CacheMissPreviousMessageNotFound.fromJson(
+            const <String, dynamic>{'type': 'unavailable'},
+          ),
+          throwsFormatException,
+        );
+      });
+
+      test('unavailable discriminator-mismatch throws', () {
+        expect(
+          () => CacheMissUnavailable.fromJson(const <String, dynamic>{
+            'type': 'previous_message_not_found',
+          }),
+          throwsFormatException,
+        );
+      });
+
+      test('equality and hashCode', () {
+        expect(
+          const CacheMissPreviousMessageNotFound(),
+          const CacheMissPreviousMessageNotFound(),
+        );
+        expect(
+          const CacheMissPreviousMessageNotFound().hashCode,
+          const CacheMissPreviousMessageNotFound().hashCode,
+        );
+        expect(
+          const CacheMissUnavailable(),
+          isNot(const CacheMissPreviousMessageNotFound()),
+        );
+      });
+    });
+
+    group('UnknownCacheMissReason', () {
+      test('unknown type falls back and preserves raw JSON', () {
+        final json = {'type': 'something_new', 'extra': 'value'};
+        final reason = CacheMissReason.fromJson(json);
+
+        expect(reason, isA<UnknownCacheMissReason>());
+        expect((reason as UnknownCacheMissReason).rawJson, json);
+        expect(reason.toJson(), json);
+      });
+
+      test('round-trips raw JSON', () {
+        final json = {
+          'type': 'future_reason',
+          'nested': {'a': 1},
+          'list': [1, 2, 3],
+        };
+        final reason = CacheMissReason.fromJson(json);
+
+        expect(reason.toJson(), json);
+      });
+
+      test('equality and hashCode based on deep map content', () {
+        const a = UnknownCacheMissReason(
+          rawJson: {
+            'type': 'x',
+            'nested': {'a': 1},
+          },
+        );
+        const b = UnknownCacheMissReason(
+          rawJson: {
+            'type': 'x',
+            'nested': {'a': 1},
+          },
+        );
+
+        expect(a, b);
+        expect(a.hashCode, b.hashCode);
+      });
+    });
+  });
+
+  group('Diagnostics', () {
+    test('round-trip with populated reason', () {
+      final json = {
+        'cache_miss_reason': {
+          'type': 'model_changed',
+          'cache_missed_input_tokens': 7,
+        },
+      };
+      final diagnostics = Diagnostics.fromJson(json);
+
+      expect(
+        diagnostics.cacheMissReason,
+        const CacheMissModelChanged(cacheMissedInputTokens: 7),
+      );
+      expect(diagnostics.toJson(), json);
+    });
+
+    test('round-trip with cache_miss_reason: null (key present)', () {
+      final json = <String, dynamic>{'cache_miss_reason': null};
+      final diagnostics = Diagnostics.fromJson(json);
+
+      expect(diagnostics.cacheMissReason, isNull);
+      final out = diagnostics.toJson();
+      expect(out.containsKey('cache_miss_reason'), isTrue);
+      expect(out['cache_miss_reason'], isNull);
+    });
+
+    test('toJson always emits cache_miss_reason key', () {
+      const diagnostics = Diagnostics();
+
+      expect(diagnostics.toJson().containsKey('cache_miss_reason'), isTrue);
+      expect(diagnostics.toJson()['cache_miss_reason'], isNull);
+    });
+
+    test('copyWith replaces reason', () {
+      const original = Diagnostics(cacheMissReason: CacheMissUnavailable());
+      final modified = original.copyWith(
+        cacheMissReason: const CacheMissModelChanged(cacheMissedInputTokens: 1),
+      );
+
+      expect(
+        modified.cacheMissReason,
+        const CacheMissModelChanged(cacheMissedInputTokens: 1),
+      );
+    });
+
+    test('copyWith can clear reason to null', () {
+      const original = Diagnostics(cacheMissReason: CacheMissUnavailable());
+      final cleared = original.copyWith(cacheMissReason: null);
+
+      expect(cleared.cacheMissReason, isNull);
+    });
+
+    test('equality and hashCode', () {
+      const a = Diagnostics(cacheMissReason: CacheMissUnavailable());
+      const b = Diagnostics(cacheMissReason: CacheMissUnavailable());
+      const c = Diagnostics();
+
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(c));
+    });
+
+    test('toString includes field', () {
+      const diagnostics = Diagnostics(cacheMissReason: CacheMissUnavailable());
+
+      expect(diagnostics.toString(), contains('cacheMissReason'));
+    });
+  });
+
+  group('Message.diagnostics', () {
+    Message buildMessage({Diagnostics? diagnostics}) => Message(
+      id: 'msg_1',
+      content: const [TextBlock(text: 'hi')],
+      model: 'claude-sonnet-4-6',
+      usage: const Usage(inputTokens: 1, outputTokens: 1),
+      diagnostics: diagnostics,
+    );
+
+    test('round-trip with diagnostics', () {
+      final message = buildMessage(
+        diagnostics: const Diagnostics(
+          cacheMissReason: CacheMissModelChanged(cacheMissedInputTokens: 3),
+        ),
+      );
+      final restored = Message.fromJson(message.toJson());
+
+      expect(restored.diagnostics, message.diagnostics);
+    });
+
+    test('omits diagnostics when null', () {
+      final message = buildMessage();
+
+      expect(message.toJson().containsKey('diagnostics'), isFalse);
+      expect(message.diagnostics, isNull);
+    });
+
+    test('copyWith replaces and clears diagnostics', () {
+      final message = buildMessage(
+        diagnostics: const Diagnostics(cacheMissReason: CacheMissUnavailable()),
+      );
+      final replaced = message.copyWith(
+        diagnostics: const Diagnostics(
+          cacheMissReason: CacheMissModelChanged(cacheMissedInputTokens: 9),
+        ),
+      );
+      final cleared = message.copyWith(diagnostics: null);
+
+      expect(
+        replaced.diagnostics,
+        const Diagnostics(
+          cacheMissReason: CacheMissModelChanged(cacheMissedInputTokens: 9),
+        ),
+      );
+      expect(cleared.diagnostics, isNull);
+    });
+
+    test('toString includes diagnostics', () {
+      final message = buildMessage(
+        diagnostics: const Diagnostics(cacheMissReason: CacheMissUnavailable()),
+      );
+
+      expect(message.toString(), contains('diagnostics'));
+    });
+  });
+
+  group('MessageCreateRequest.diagnostics', () {
+    MessageCreateRequest buildRequest({DiagnosticsParam? diagnostics}) =>
+        MessageCreateRequest(
+          model: 'claude-sonnet-4-6',
+          maxTokens: 1024,
+          messages: [InputMessage.user('hi')],
+          diagnostics: diagnostics,
+        );
+
+    test('round-trip with diagnostics', () {
+      final request = buildRequest(
+        diagnostics: const DiagnosticsParam(previousMessageId: 'msg_prev'),
+      );
+      final restored = MessageCreateRequest.fromJson(request.toJson());
+
+      expect(restored.diagnostics, request.diagnostics);
+      expect(request.toJson()['diagnostics'], {
+        'previous_message_id': 'msg_prev',
+      });
+    });
+
+    test('omits diagnostics when null', () {
+      final request = buildRequest();
+
+      expect(request.toJson().containsKey('diagnostics'), isFalse);
+      expect(request.diagnostics, isNull);
+    });
+
+    test('copyWith replaces and clears diagnostics', () {
+      final request = buildRequest(
+        diagnostics: const DiagnosticsParam(previousMessageId: 'a'),
+      );
+      final replaced = request.copyWith(
+        diagnostics: const DiagnosticsParam(previousMessageId: 'b'),
+      );
+      final cleared = request.copyWith(diagnostics: null);
+
+      expect(
+        replaced.diagnostics,
+        const DiagnosticsParam(previousMessageId: 'b'),
+      );
+      expect(cleared.diagnostics, isNull);
+    });
+
+    test('toString includes diagnostics', () {
+      final request = buildRequest(
+        diagnostics: const DiagnosticsParam(previousMessageId: 'a'),
+      );
+
+      expect(request.toString(), contains('diagnostics'));
+    });
+  });
+}
+
+/// Returns the variant-specific [fromJson] for the discriminator-mismatch
+/// test, so each token-bearing variant validates its own discriminator.
+Map<String, dynamic> Function(Map<String, dynamic>) _fromJsonFor(
+  CacheMissReason reason,
+) {
+  return switch (reason) {
+    CacheMissModelChanged() => (j) => CacheMissModelChanged.fromJson(
+      j,
+    ).toJson(),
+    CacheMissSystemChanged() => (j) => CacheMissSystemChanged.fromJson(
+      j,
+    ).toJson(),
+    CacheMissToolsChanged() => (j) => CacheMissToolsChanged.fromJson(
+      j,
+    ).toJson(),
+    CacheMissMessagesChanged() => (j) => CacheMissMessagesChanged.fromJson(
+      j,
+    ).toJson(),
+    _ => (j) => CacheMissReason.fromJson(j).toJson(),
+  };
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/managed_agents/managed_agents_events_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/managed_agents/managed_agents_events_test.dart
@@ -1,0 +1,238 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+Map<String, dynamic> _sessionAgentJson() => {
+  'id': 'agent_123',
+  'type': 'agent',
+  'version': 1,
+  'name': 'Test Agent',
+  'model': {'id': 'claude-sonnet-4-5', 'type': 'model'},
+  'mcp_servers': <Map<String, dynamic>>[],
+  'skills': <Map<String, dynamic>>[],
+  'tools': <Map<String, dynamic>>[],
+};
+
+void main() {
+  group('SessionEvent.fromJson → SessionUpdatedEvent', () {
+    test('dispatches and round-trips with all fields', () {
+      final json = <String, dynamic>{
+        'type': 'session.updated',
+        'id': 'event_001',
+        'processed_at': '2026-04-01T12:00:00Z',
+        'agent': _sessionAgentJson(),
+        'metadata': {'k': 'v'},
+        'title': 'Updated Title',
+      };
+
+      final parsed = SessionEvent.fromJson(json);
+      expect(parsed, isA<SessionUpdatedEvent>());
+      final event = parsed as SessionUpdatedEvent;
+      expect(event.id, 'event_001');
+      expect(event.processedAt, DateTime.utc(2026, 4, 1, 12));
+      expect(event.agent, isA<SessionAgent>());
+      expect(event.agent!.name, 'Test Agent');
+      expect(event.metadata, {'k': 'v'});
+      expect(event.title, 'Updated Title');
+
+      expect(event.toJson()['type'], 'session.updated');
+      expect(event.toJson()['metadata'], {'k': 'v'});
+      expect(event.toJson()['title'], 'Updated Title');
+      expect(event.toJson()['agent'], isA<Map<String, dynamic>>());
+    });
+
+    test('parses with optional fields absent', () {
+      final json = <String, dynamic>{
+        'type': 'session.updated',
+        'id': 'event_002',
+        'processed_at': '2026-04-01T12:00:00Z',
+      };
+
+      final event = SessionEvent.fromJson(json) as SessionUpdatedEvent;
+      expect(event.agent, isNull);
+      expect(event.metadata, isNull);
+      expect(event.title, isNull);
+      expect(event.toJson().containsKey('agent'), isFalse);
+      expect(event.toJson().containsKey('metadata'), isFalse);
+      expect(event.toJson().containsKey('title'), isFalse);
+    });
+
+    test('equality and hashCode', () {
+      final a = SessionEvent.fromJson({
+        'type': 'session.updated',
+        'id': 'e1',
+        'processed_at': '2026-04-01T12:00:00Z',
+        'metadata': {'k': 'v'},
+        'title': 'T',
+      });
+      final b = SessionEvent.fromJson({
+        'type': 'session.updated',
+        'id': 'e1',
+        'processed_at': '2026-04-01T12:00:00Z',
+        'metadata': {'k': 'v'},
+        'title': 'T',
+      });
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('copyWith and toString', () {
+      final event =
+          SessionEvent.fromJson({
+                'type': 'session.updated',
+                'id': 'e1',
+                'processed_at': '2026-04-01T12:00:00Z',
+              })
+              as SessionUpdatedEvent;
+
+      final copied = event.copyWith(title: 'New');
+      expect(copied.title, 'New');
+      expect(copied.id, 'e1');
+      expect(event.toString(), contains('SessionUpdatedEvent'));
+    });
+  });
+
+  group('SessionEvent.fromJson → UserToolResultEvent', () {
+    test('dispatches and round-trips with all fields', () {
+      final json = <String, dynamic>{
+        'type': 'user.tool_result',
+        'id': 'event_003',
+        'tool_use_id': 'toolu_abc',
+        'content': [
+          {'type': 'text', 'text': 'ok'},
+        ],
+        'is_error': false,
+        'processed_at': '2026-04-01T12:00:00Z',
+        'session_thread_id': 'thread_x',
+      };
+
+      final parsed = SessionEvent.fromJson(json);
+      expect(parsed, isA<UserToolResultEvent>());
+      final event = parsed as UserToolResultEvent;
+      expect(event.id, 'event_003');
+      expect(event.toolUseId, 'toolu_abc');
+      expect(event.content, hasLength(1));
+      expect(event.isError, false);
+      expect(event.processedAt, DateTime.utc(2026, 4, 1, 12));
+      expect(event.sessionThreadId, 'thread_x');
+
+      // Re-parsing the serialized form yields an equivalent event (the
+      // timestamp serializes with millisecond precision: ...T12:00:00.000Z).
+      expect(SessionEvent.fromJson(event.toJson()), event);
+      expect(event.toJson()['type'], 'user.tool_result');
+      expect(event.toJson()['content'], event.content);
+      expect(event.toJson()['is_error'], false);
+    });
+
+    test('parses with optional fields absent', () {
+      final json = <String, dynamic>{
+        'type': 'user.tool_result',
+        'id': 'event_004',
+        'tool_use_id': 'toolu_def',
+      };
+
+      final event = SessionEvent.fromJson(json) as UserToolResultEvent;
+      expect(event.content, isNull);
+      expect(event.isError, isNull);
+      expect(event.processedAt, isNull);
+      expect(event.sessionThreadId, isNull);
+      expect(event.toJson(), {
+        'type': 'user.tool_result',
+        'id': 'event_004',
+        'tool_use_id': 'toolu_def',
+      });
+    });
+
+    test('equality and hashCode', () {
+      final a = SessionEvent.fromJson({
+        'type': 'user.tool_result',
+        'id': 'e1',
+        'tool_use_id': 't1',
+        'content': [
+          {'type': 'text', 'text': 'x'},
+        ],
+        'is_error': true,
+      });
+      final b = SessionEvent.fromJson({
+        'type': 'user.tool_result',
+        'id': 'e1',
+        'tool_use_id': 't1',
+        'content': [
+          {'type': 'text', 'text': 'x'},
+        ],
+        'is_error': true,
+      });
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('copyWith and toString', () {
+      final event =
+          SessionEvent.fromJson({
+                'type': 'user.tool_result',
+                'id': 'e1',
+                'tool_use_id': 't1',
+              })
+              as UserToolResultEvent;
+
+      final copied = event.copyWith(isError: true);
+      expect(copied.isError, true);
+      expect(copied.toolUseId, 't1');
+      expect(event.toString(), contains('UserToolResultEvent'));
+    });
+  });
+
+  group('EventParams.fromJson → UserToolResultEventParams', () {
+    test('dispatches and round-trips with all fields', () {
+      final json = <String, dynamic>{
+        'type': 'user.tool_result',
+        'tool_use_id': 'toolu_abc',
+        'content': [
+          {'type': 'text', 'text': 'ok'},
+        ],
+        'is_error': false,
+      };
+
+      final parsed = EventParams.fromJson(json);
+      expect(parsed, isA<UserToolResultEventParams>());
+      final params = parsed as UserToolResultEventParams;
+      expect(params.toolUseId, 'toolu_abc');
+      expect(params.content, hasLength(1));
+      expect(params.isError, false);
+
+      expect(params.toJson(), json);
+    });
+
+    test('parses with optional fields absent', () {
+      final json = <String, dynamic>{
+        'type': 'user.tool_result',
+        'tool_use_id': 'toolu_def',
+      };
+
+      final params = EventParams.fromJson(json) as UserToolResultEventParams;
+      expect(params.content, isNull);
+      expect(params.isError, isNull);
+      expect(params.toJson(), {
+        'type': 'user.tool_result',
+        'tool_use_id': 'toolu_def',
+      });
+    });
+
+    test('equality, hashCode, copyWith and toString', () {
+      const a = UserToolResultEventParams(toolUseId: 't1', isError: true);
+      const b = UserToolResultEventParams(toolUseId: 't1', isError: true);
+      const c = UserToolResultEventParams(toolUseId: 't2');
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+
+      final copied = a.copyWith(toolUseId: 't9');
+      expect(copied.toolUseId, 't9');
+      expect(copied.isError, true);
+
+      expect(a.toString(), contains('UserToolResultEventParams'));
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/managed_agents/session_agent_update_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/managed_agents/session_agent_update_test.dart
@@ -1,0 +1,175 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SessionAgentUpdate', () {
+    test('round-trips with tools and mcp_servers', () {
+      final json = <String, dynamic>{
+        'tools': [
+          {
+            'type': 'custom',
+            'name': 'lookup',
+            'description': 'Look something up',
+            'input_schema': {'type': 'object'},
+          },
+        ],
+        'mcp_servers': [
+          {'type': 'url', 'name': 'github', 'url': 'https://mcp.example.com'},
+        ],
+      };
+
+      final parsed = SessionAgentUpdate.fromJson(json);
+      expect(parsed.tools, hasLength(1));
+      expect(parsed.tools!.first, isA<CustomToolParams>());
+      expect(parsed.mcpServers, hasLength(1));
+      expect(parsed.mcpServers!.first, isA<URLMCPServerParams>());
+
+      expect(parsed.toJson(), json);
+    });
+
+    test('empty arrays are serialized as empty lists (clear semantics)', () {
+      const update = SessionAgentUpdate(tools: [], mcpServers: []);
+
+      expect(update.toJson(), {
+        'tools': <Map<String, dynamic>>[],
+        'mcp_servers': <Map<String, dynamic>>[],
+      });
+    });
+
+    test(
+      'omitted (null) fields are omitted from JSON (preserve semantics)',
+      () {
+        const update = SessionAgentUpdate();
+
+        expect(update.toJson(), isEmpty);
+        expect(update.tools, isNull);
+        expect(update.mcpServers, isNull);
+      },
+    );
+
+    test('distinguishes empty array from omitted', () {
+      const cleared = SessionAgentUpdate(tools: []);
+      const preserved = SessionAgentUpdate();
+
+      expect(cleared.toJson().containsKey('tools'), isTrue);
+      expect(preserved.toJson().containsKey('tools'), isFalse);
+    });
+
+    test('equality and hashCode', () {
+      // Build distinct instances via fromJson so const-canonicalization does
+      // not collapse them into the same object, genuinely exercising `==`.
+      Map<String, dynamic> source() => {
+        'tools': [
+          {
+            'type': 'custom',
+            'name': 'lookup',
+            'description': 'Look up',
+            'input_schema': {'type': 'object'},
+          },
+        ],
+        'mcp_servers': [
+          {'type': 'url', 'name': 'gh', 'url': 'https://x'},
+        ],
+      };
+      final a = SessionAgentUpdate.fromJson(source());
+      final b = SessionAgentUpdate.fromJson(source());
+      const c = SessionAgentUpdate();
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('copyWith replaces only provided fields', () {
+      const update = SessionAgentUpdate(
+        mcpServers: [URLMCPServerParams(name: 'gh', url: 'https://x')],
+      );
+      final copied = update.copyWith(tools: const []);
+
+      expect(copied.tools, isEmpty);
+      expect(copied.mcpServers, equals(update.mcpServers));
+    });
+
+    test('toString includes fields', () {
+      const update = SessionAgentUpdate(tools: []);
+      expect(update.toString(), contains('SessionAgentUpdate'));
+      expect(update.toString(), contains('tools'));
+      expect(update.toString(), contains('mcpServers'));
+    });
+  });
+
+  group('UpdateSessionParams.agent', () {
+    test('round-trips agent', () {
+      final json = <String, dynamic>{
+        'agent': {
+          'tools': <Map<String, dynamic>>[],
+          'mcp_servers': [
+            {'type': 'url', 'name': 'gh', 'url': 'https://x'},
+          ],
+        },
+      };
+
+      final parsed = UpdateSessionParams.fromJson(json);
+      expect(parsed.agent, isNotNull);
+      expect(parsed.agent!.tools, isEmpty);
+      expect(parsed.agent!.mcpServers, hasLength(1));
+      expect(parsed.toJson(), json);
+    });
+
+    test('omit-to-preserve: omitted agent absent from JSON', () {
+      const params = UpdateSessionParams(title: 'New Title');
+      expect(params.toJson().containsKey('agent'), isFalse);
+      expect(params.agent, isNull);
+    });
+
+    test('explicit null agent is included as null (clear semantics)', () {
+      const params = UpdateSessionParams(agent: null);
+      expect(params.toJson().containsKey('agent'), isTrue);
+      expect(params.toJson()['agent'], isNull);
+    });
+
+    test('fromJson preserves agent when key omitted', () {
+      final parsed = UpdateSessionParams.fromJson(const {'title': 'x'});
+      expect(parsed.toJson().containsKey('agent'), isFalse);
+    });
+
+    test('copyWith replaces agent and preserves others', () {
+      const params = UpdateSessionParams(title: 'Title');
+      final copied = params.copyWith(
+        agent: const SessionAgentUpdate(tools: []),
+      );
+
+      expect(copied.title, 'Title');
+      expect(copied.agent, isNotNull);
+      expect(copied.agent!.tools, isEmpty);
+    });
+
+    test('copyWith without agent preserves existing agent', () {
+      const params = UpdateSessionParams(agent: SessionAgentUpdate(tools: []));
+      final copied = params.copyWith(title: 'New');
+
+      expect(copied.agent, isNotNull);
+      expect(copied.title, 'New');
+    });
+
+    test('equality considers agent', () {
+      // Build via fromJson so the two instances are genuinely distinct.
+      final a = UpdateSessionParams.fromJson(const {
+        'agent': {'tools': <Map<String, dynamic>>[]},
+      });
+      final b = UpdateSessionParams.fromJson(const {
+        'agent': {'tools': <Map<String, dynamic>>[]},
+      });
+      const c = UpdateSessionParams();
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('toString includes agent', () {
+      const params = UpdateSessionParams(agent: SessionAgentUpdate(tools: []));
+      expect(params.toString(), contains('agent'));
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/managed_agents/session_agent_update_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/managed_agents/session_agent_update_test.dart
@@ -90,6 +90,20 @@ void main() {
       expect(copied.mcpServers, equals(update.mcpServers));
     });
 
+    test('copyWith can clear a field back to null (omit/preserve)', () {
+      const update = SessionAgentUpdate(tools: [], mcpServers: []);
+
+      // Omitting an argument preserves the existing value...
+      final preserved = update.copyWith(tools: const []);
+      expect(preserved.mcpServers, isEmpty);
+
+      // ...while explicitly passing null clears it (omit-to-preserve on wire).
+      final cleared = update.copyWith(tools: null);
+      expect(cleared.tools, isNull);
+      expect(cleared.toJson().containsKey('tools'), isFalse);
+      expect(cleared.mcpServers, isEmpty);
+    });
+
     test('toString includes fields', () {
       const update = SessionAgentUpdate(tools: []);
       expect(update.toString(), contains('SessionAgentUpdate'));

--- a/packages/anthropic_sdk_dart/test/unit/models/managed_agents/session_agent_update_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/managed_agents/session_agent_update_test.dart
@@ -122,11 +122,14 @@ void main() {
       expect(params.agent, isNull);
     });
 
-    test('explicit null agent is included as null (clear semantics)', () {
-      const params = UpdateSessionParams(agent: null);
-      expect(params.toJson().containsKey('agent'), isTrue);
-      expect(params.toJson()['agent'], isNull);
-    });
+    test(
+      'explicit null agent is omitted (agent is not nullable in the API)',
+      () {
+        const params = UpdateSessionParams(agent: null);
+        expect(params.toJson().containsKey('agent'), isFalse);
+        expect(params.agent, isNull);
+      },
+    );
 
     test('fromJson preserves agent when key omitted', () {
       final parsed = UpdateSessionParams.fromJson(const {'title': 'x'});

--- a/packages/anthropic_sdk_dart/test/unit/resources/skills_resource_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/resources/skills_resource_test.dart
@@ -1,0 +1,82 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+import '../../mocks/mock_http_client.dart';
+
+void main() {
+  late MockHttpClient mockHttpClient;
+  late AnthropicClient client;
+
+  setUp(() {
+    mockHttpClient = MockHttpClient();
+    client = AnthropicClient(
+      config: const AnthropicConfig(
+        authProvider: ApiKeyProvider('test-api-key'),
+        retryPolicy: RetryPolicy(maxRetries: 0),
+      ),
+      httpClient: mockHttpClient,
+    );
+  });
+
+  tearDown(() {
+    client.close();
+  });
+
+  group('SkillsResource.downloadVersion', () {
+    test('sends correct request and returns raw bytes', () async {
+      // A small ASCII-safe payload so it round-trips through the harness'
+      // utf8 encoding of MockResponse.body unchanged. The expected bytes are
+      // therefore the utf8 encoding of the queued body.
+      const zipBody = 'PKfake-skill-zip-bytes';
+      final expectedBytes = Uint8List.fromList(utf8.encode(zipBody));
+
+      mockHttpClient.queueResponse(
+        const MockResponse(
+          body: zipBody,
+          headers: {'content-type': 'application/zip'},
+        ),
+      );
+
+      final bytes = await client.skills.downloadVersion(
+        skillId: 'skill_abc123',
+        version: '1759178010641129',
+      );
+
+      // Returned value equals the queued raw bytes.
+      expect(bytes, isA<Uint8List>());
+      expect(bytes, equals(expectedBytes));
+
+      final request = mockHttpClient.lastRequest! as http.Request;
+      expect(
+        request.url.path,
+        '/v1/skills/skill_abc123/versions/1759178010641129/content',
+      );
+      expect(request.method, 'GET');
+      expect(request.headers['anthropic-beta'], 'skills-2025-10-02');
+      // http lowercases header keys for lookup, so this works regardless of
+      // the casing used when the header was set.
+      expect(request.headers['Accept'], 'application/binary');
+      expect(request.headers['accept'], 'application/binary');
+      expect(request.headers['x-api-key'], 'test-api-key');
+    });
+
+    test('throws ArgumentError when skillId is empty', () {
+      expect(
+        () => client.skills.downloadVersion(skillId: '', version: 'v1'),
+        throwsArgumentError,
+      );
+    });
+
+    test('throws ArgumentError when version is empty', () {
+      expect(
+        () =>
+            client.skills.downloadVersion(skillId: 'skill_abc123', version: ''),
+        throwsArgumentError,
+      );
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/resources/skills_resource_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/resources/skills_resource_test.dart
@@ -57,10 +57,10 @@ void main() {
       );
       expect(request.method, 'GET');
       expect(request.headers['anthropic-beta'], 'skills-2025-10-02');
-      // http lowercases header keys for lookup, so this works regardless of
-      // the casing used when the header was set.
-      expect(request.headers['Accept'], 'application/binary');
-      expect(request.headers['accept'], 'application/binary');
+      // Binary download: Accept is widened and the default JSON content-type is
+      // dropped, matching FilesResource.download.
+      expect(request.headers['accept'], '*/*');
+      expect(request.headers.containsKey('content-type'), isFalse);
       expect(request.headers['x-api-key'], 'test-api-key');
     });
 


### PR DESCRIPTION
## Summary

- Syncs `anthropic_sdk_dart` to the latest Anthropic OpenAPI spec (`945e3a57…`, from `0df2c793…`).
- **Prompt-cache diagnostics** (beta): pass `DiagnosticsParam.previousMessageId` on a request and read `Message.diagnostics?.cacheMissReason` to learn *why* the prompt-cache prefix diverged from the previous turn.
- **Streaming thinking token estimates**: `ThinkingDelta.estimatedTokens` (a coarse, lossy display hint).
- **Mid-session agent updates** (managed agents, beta): replace a running session's tools / MCP servers via `UpdateSessionParams.agent`, plus two new streamed events.
- **Skill version download**: `client.skills.downloadVersion(...)` returns a version's content as zip bytes.

## Details

### Prompt-cache diagnostics
New `DiagnosticsParam` (request) and `Diagnostics` (response) models, plus a `CacheMissReason` sealed union (`CacheMissModelChanged`, `…SystemChanged`, `…ToolsChanged`, `…MessagesChanged`, `…PreviousMessageNotFound`, `…Unavailable`, and an `UnknownCacheMissReason` forward-compatible fallback). Gated behind the `cache-diagnosis-2026-04-07` beta header.

```dart
final first = await client.messages.create(
  MessageCreateRequest(
    model: 'claude-sonnet-4-6',
    maxTokens: 1024,
    diagnostics: const DiagnosticsParam(),
    messages: [InputMessage.user('Summarize the rules of chess.')],
  ),
  betas: ['cache-diagnosis-2026-04-07'],
);

final second = await client.messages.create(
  MessageCreateRequest(
    model: 'claude-sonnet-4-6',
    maxTokens: 1024,
    diagnostics: DiagnosticsParam(previousMessageId: first.id),
    messages: [InputMessage.user('Now explain en passant.')],
  ),
  betas: ['cache-diagnosis-2026-04-07'],
);
print(second.diagnostics?.cacheMissReason);
```

### Thinking token estimates
`ThinkingDelta` gains nullable `estimatedTokens`, populated only under the `thinking-token-count-2026-05-13` beta when `thinking.display` resolves to `"omitted"`. It is a deliberately lossy display hint — `usage.output_tokens` remains authoritative.

### Managed agents
- `SessionAgentUpdate` (`tools` / `mcpServers`, full-replacement semantics) wired onto `UpdateSessionParams.agent`.
- New `SessionEvent` variants `SessionUpdatedEvent` (`session.updated`) and `UserToolResultEvent` (`user.tool_result`), and new `EventParams` variant `UserToolResultEventParams` (`user.tool_result`, for client-executed sandbox tools on self-hosted environments).

### Skills
`SkillsResource.downloadVersion({skillId, version})` → `Uint8List` (GET `/v1/skills/{id}/versions/{version}/content`, `Accept: application/binary`, `skills-2025-10-02` beta).

### Scope / toolkit
- Spec promoted; `pinned_hash` updated; `manifest.json` extended with real entries for the implemented types and **acknowledged skips** for: the `environments`/self-hosted-"work" surface (deliberately excluded via `coverage.excluded_resources`), the managed-agents search-result content blocks and toolset tool-input schemas (modeled as `Map<String, dynamic>` by existing convention), and the unified `BetaMessage`/`BetaThinkingContentBlockDelta` variants.
- All in-scope schemas were validated field-by-field against the reference `anthropics/anthropic-sdk-python`.
- Toolkit `review`: 0 errors / 0 warnings / 0 missing manifest entries. `verify --checks all --scope all`: no new error-level findings vs. the pre-change baseline.

## Breaking Changes

New variants were added to existing sealed unions, so exhaustive `switch` statements over them must handle the new cases:

- `SessionEvent` → `SessionUpdatedEvent`, `UserToolResultEvent`
- `EventParams` → `UserToolResultEventParams`

```dart
// Before — exhaustive over the prior variant set
final label = switch (event) {
  UserMessageEvent() => 'message',
  // ...
};

// After — handle the new variants (or add a wildcard / Unknown* fallback)
final label = switch (event) {
  UserMessageEvent() => 'message',
  SessionUpdatedEvent() => 'updated',
  UserToolResultEvent() => 'tool_result',
  // ...
};
```

All newly added model fields (`Message.diagnostics`, `MessageCreateRequest.diagnostics`, `ThinkingDelta.estimatedTokens`, `UpdateSessionParams.agent`) are optional and nullable, so they are non-breaking on their own.

## References

- [Cache diagnostics](https://platform.claude.com/docs/en/build-with-claude/cache-diagnostics) — public beta (2026-05-13), `cache-diagnosis-2026-04-07`.
- [Self-hosted sandboxes](https://platform.claude.com/docs/en/managed-agents/self-hosted-sandboxes) — context for the `user.tool_result` event (the broader self-hosted-work API is deferred).

## Test Plan

- [x] Unit tests pass for `anthropic_sdk_dart` (`dart test test/unit/`: 986 pass, 4 pre-existing skips)
- [x] New tests added: diagnostics + cache-miss union, thinking-delta tokens, session agent update, new managed-agents events, skills download
- [x] Sealed class/enum changes include variant, round-trip, and error tests
- [x] `fromJson`/`toJson` round-trip serialization verified
- [x] `==`/`hashCode` contract verified (same fields in both)
- [x] `dart format` clean · `dart analyze --fatal-infos` clean
- [x] Toolkit `review`/`verify` pass (no new errors)
- [ ] Integration tests not run (require live API key)