### PR TITLE
fix(googleai_dart): make LiveSession.close idempotent

### DIFF
--- a/packages/googleai_dart/lib/src/live/live_session.dart
+++ b/packages/googleai_dart/lib/src/live/live_session.dart
@@ -211,10 +211,21 @@ class LiveSession {
   /// After calling this, the session can no longer send or receive messages.
   /// If session resumption is enabled, save the [resumptionToken] before
   /// closing to resume the session later.
+  ///
+  /// This is idempotent and safe to call when the connection has already been
+  /// closed (for example, when the server closed it first, or when [close] is
+  /// called more than once).
   Future<void> close([int? code, String? reason]) async {
     _isConnected = false;
     await _subscription?.cancel();
-    await _socket.close(code, reason);
+    try {
+      await _socket.close(code, reason);
+    } on WebSocketConnectionClosed {
+      // The underlying connection is already closed (the server closed it
+      // first, or close() was called more than once). Per the web_socket
+      // package contract, close() throws in that case; closing is idempotent
+      // here, so ignore it and still tear down the message controller below.
+    }
     if (!_messageController.isClosed) {
       await _messageController.close();
     }

--- a/packages/googleai_dart/lib/src/live/live_session.dart
+++ b/packages/googleai_dart/lib/src/live/live_session.dart
@@ -224,10 +224,14 @@ class LiveSession {
       // The underlying connection is already closed (the server closed it
       // first, or close() was called more than once). Per the web_socket
       // package contract, close() throws in that case; closing is idempotent
-      // here, so ignore it and still tear down the message controller below.
-    }
-    if (!_messageController.isClosed) {
-      await _messageController.close();
+      // here, so ignore it. Any other error (e.g. an invalid close code or a
+      // transport failure) propagates after the finally block runs.
+    } finally {
+      // Always tear down the message controller — even if close() throws an
+      // unexpected error — so listeners are never left hanging.
+      if (!_messageController.isClosed) {
+        await _messageController.close();
+      }
     }
   }
 }

--- a/packages/googleai_dart/test/unit/live/live_session_test.dart
+++ b/packages/googleai_dart/test/unit/live/live_session_test.dart
@@ -1,0 +1,83 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:googleai_dart/googleai_dart.dart';
+import 'package:test/test.dart';
+import 'package:web_socket/web_socket.dart';
+
+/// A fake [WebSocket] whose [close] behavior is configurable, used to exercise
+/// [LiveSession.close] without a real connection.
+class _FakeWebSocket implements WebSocket {
+  _FakeWebSocket({this.throwOnClose = false});
+
+  /// When true, [close] throws [WebSocketConnectionClosed], mimicking the
+  /// web_socket package contract for an already-closed connection.
+  final bool throwOnClose;
+
+  final StreamController<WebSocketEvent> _events =
+      StreamController<WebSocketEvent>.broadcast();
+
+  int closeCallCount = 0;
+
+  @override
+  Stream<WebSocketEvent> get events => _events.stream;
+
+  @override
+  String get protocol => '';
+
+  @override
+  void sendBytes(Uint8List b) {}
+
+  @override
+  void sendText(String s) {}
+
+  @override
+  Future<void> close([int? code, String? reason]) async {
+    closeCallCount++;
+    if (throwOnClose) {
+      throw WebSocketConnectionClosed();
+    }
+    if (!_events.isClosed) {
+      await _events.close();
+    }
+  }
+}
+
+void main() {
+  group('LiveSession.close', () {
+    test('completes normally for an open connection', () async {
+      final socket = _FakeWebSocket();
+      final session = LiveSession.fromWebSocket(socket);
+
+      await session.close();
+
+      expect(socket.closeCallCount, 1);
+      expect(session.isConnected, isFalse);
+      // The message stream is closed afterwards.
+      await expectLater(session.messages, emitsDone);
+    });
+
+    test('is idempotent when the connection is already closed '
+        '(swallows WebSocketConnectionClosed)', () async {
+      // Server closed the connection first, so the socket throws on close().
+      final socket = _FakeWebSocket(throwOnClose: true);
+      final session = LiveSession.fromWebSocket(socket);
+
+      // Must not rethrow the WebSocketConnectionClosed from the socket.
+      await expectLater(session.close(), completes);
+
+      expect(socket.closeCallCount, 1);
+      expect(session.isConnected, isFalse);
+      // The message controller is still torn down despite the socket throwing.
+      await expectLater(session.messages, emitsDone);
+    });
+
+    test('can be called more than once without throwing', () async {
+      final socket = _FakeWebSocket();
+      final session = LiveSession.fromWebSocket(socket);
+
+      await session.close();
+      await expectLater(session.close(), completes);
+    });
+  });
+}

--- a/packages/googleai_dart/test/unit/live/live_session_test.dart
+++ b/packages/googleai_dart/test/unit/live/live_session_test.dart
@@ -8,11 +8,15 @@ import 'package:web_socket/web_socket.dart';
 /// A fake [WebSocket] whose [close] behavior is configurable, used to exercise
 /// [LiveSession.close] without a real connection.
 class _FakeWebSocket implements WebSocket {
-  _FakeWebSocket({this.throwOnClose = false});
+  _FakeWebSocket({this.throwOnClose = false, this.closeError});
 
   /// When true, [close] throws [WebSocketConnectionClosed], mimicking the
   /// web_socket package contract for an already-closed connection.
   final bool throwOnClose;
+
+  /// When set, [close] throws this error (used to exercise the non-idempotent
+  /// failure path, e.g. an invalid close code or a transport error).
+  final Object? closeError;
 
   final StreamController<WebSocketEvent> _events =
       StreamController<WebSocketEvent>.broadcast();
@@ -34,6 +38,11 @@ class _FakeWebSocket implements WebSocket {
   @override
   Future<void> close([int? code, String? reason]) async {
     closeCallCount++;
+    if (closeError != null) {
+      // Intentionally throw a configurable error to exercise the failure path.
+      // ignore: only_throw_errors
+      throw closeError!;
+    }
     if (throwOnClose) {
       throw WebSocketConnectionClosed();
     }
@@ -78,6 +87,18 @@ void main() {
 
       await session.close();
       await expectLater(session.close(), completes);
+    });
+
+    test('rethrows a non-WebSocketConnectionClosed error but still closes the '
+        'message controller', () async {
+      // e.g. an invalid close code or a transport failure.
+      final socket = _FakeWebSocket(closeError: ArgumentError('bad code'));
+      final session = LiveSession.fromWebSocket(socket);
+
+      // The unexpected error propagates to the caller...
+      await expectLater(session.close(), throwsArgumentError);
+      // ...but the message controller is still torn down (no leak).
+      await expectLater(session.messages, emitsDone);
     });
   });
 }


### PR DESCRIPTION
## Summary
- `LiveSession.close()` is now **idempotent** — it no longer throws when the WebSocket connection is already closed (e.g. the server closed it first, or `close()` is called more than once).
- It also now always tears down the message-stream controller even when the socket was already closed, fixing a stream leak on that path.

## Details

`LiveSession.close()` delegated to the underlying `WebSocket.close()`. Per the
[`web_socket`](https://pub.dev/packages/web_socket) package contract, `close()`
throws `WebSocketConnectionClosed` when the connection is already closed. That
exception propagated out of `LiveSession.close()` and — worse — short-circuited
the `_messageController.close()` call that runs afterward, leaking the broadcast
stream.

Closing a connection that is already closed is a normal, expected situation
(the server commonly closes first, and cleanup code routinely calls `close()`
defensively). Idempotent close matches the convention of Dart's own
`StreamController.close`, `IOSink.close`, etc.

```dart
// Before — throws if the server already closed the connection:
await session.close(); // WebSocketConnectionClosed

// After — safe no-op when already closed; controller still torn down:
await session.close(); // completes normally
```

The fix is at the `LiveSession` layer (uniform across IO and web), so the
platform connectors keep faithfully mirroring the `web_socket` package contract
for direct callers.

## Test Plan
- [x] New unit tests (`test/unit/live/live_session_test.dart`) cover: normal close, close when the socket throws `WebSocketConnectionClosed` (asserts no rethrow + message stream still closes), and double-close.
- [x] `dart analyze --fatal-infos` clean; `dart format` clean; full unit suite passes.
- [x] Integration: `live_test.dart "manual VAD signals work"` previously **errored** with `WebSocketConnectionClosed` during its graceful-skip path; with this fix it **skips cleanly** ("Model does not support manual VAD").