### PR TITLE
feat(anthropic_sdk_dart)!: mid-conversation system + token details

### DIFF
--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
@@ -422,6 +422,47 @@
       "file": "lib/src/models/metadata/usage.dart",
       "schema": "Usage"
     },
+    "BetaUsage": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "Usage",
+      "file": "lib/src/models/metadata/usage.dart",
+      "schema": "BetaUsage",
+      "tags": ["acknowledged"],
+      "note": "Beta variant maps to same Dart class as GA Usage."
+    },
+    "OutputTokensDetails": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "OutputTokensDetails",
+      "file": "lib/src/models/metadata/usage.dart",
+      "schema": "OutputTokensDetails"
+    },
+    "BetaOutputTokensDetails": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "OutputTokensDetails",
+      "file": "lib/src/models/metadata/usage.dart",
+      "schema": "BetaOutputTokensDetails",
+      "tags": ["acknowledged"],
+      "note": "Beta variant maps to same Dart class as GA OutputTokensDetails."
+    },
+    "MessageDeltaUsage": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "MessageDeltaUsage",
+      "file": "lib/src/models/streaming/message_delta.dart",
+      "schema": "MessageDeltaUsage"
+    },
+    "BetaMessageDeltaUsage": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "MessageDeltaUsage",
+      "file": "lib/src/models/streaming/message_delta.dart",
+      "schema": "BetaMessageDeltaUsage",
+      "tags": ["acknowledged"],
+      "note": "Beta variant maps to same Dart class as GA MessageDeltaUsage."
+    },
     "CacheControlEphemeral": {
       "spec": "main",
       "kind": "object",
@@ -558,6 +599,22 @@
         "caller"
       ]
     },
+    "WebFetchToolResultErrorCode": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "WebFetchToolResultErrorCode",
+      "tags": ["acknowledged"],
+      "note": "Web fetch error content stored as raw Map<String, dynamic>; not modeled as a typed enum."
+    },
+    "BetaWebFetchToolResultErrorCode": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "schema": "BetaWebFetchToolResultErrorCode",
+      "tags": ["acknowledged"],
+      "note": "Web fetch error content stored as raw Map<String, dynamic>; not modeled as a typed enum."
+    },
     "ResponseCodeExecutionToolResultBlock": {
       "spec": "main",
       "kind": "sealed_variant",
@@ -631,7 +688,8 @@
           "RequestContainerUploadBlockParam": "container_upload",
           "RequestCompactionBlockParam": "compaction",
           "RequestToolReferenceBlockParam": "tool_reference",
-          "RequestAdvisorToolResultBlockParam": "advisor_tool_result"
+          "RequestAdvisorToolResultBlockParam": "advisor_tool_result",
+          "MidConvSystemBlockParam": "mid_conv_system"
         }
       },
       "note": null,
@@ -639,6 +697,33 @@
         "content",
         "source"
       ]
+    },
+    "BetaInputContentBlock": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "InputContentBlock",
+      "file": "lib/src/models/content/input_content_block.dart",
+      "schema": "BetaInputContentBlock",
+      "tags": ["acknowledged"],
+      "note": "Beta union maps to same Dart sealed type as GA InputContentBlock."
+    },
+    "MidConvSystemBlockParam": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "MidConversationSystemInputBlock",
+      "file": "lib/src/models/content/input_content_block.dart",
+      "schema": "RequestMidConvSystemBlock",
+      "parent": "InputContentBlock"
+    },
+    "BetaRequestMidConvSystemBlock": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "MidConversationSystemInputBlock",
+      "file": "lib/src/models/content/input_content_block.dart",
+      "schema": "BetaRequestMidConvSystemBlock",
+      "parent": "InputContentBlock",
+      "tags": ["acknowledged"],
+      "note": "Beta variant maps to same Dart class as GA RequestMidConvSystemBlock."
     },
     "TextBlockParam": {
       "spec": "main",

--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/specs.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/specs.json
@@ -31,9 +31,9 @@
       "fetch_mode": "remote",
       "local_file": "openapi.yaml",
       "name": "Anthropic API",
-      "pinned_hash": "945e3a57b7a6fa5974baf70845ebafdb25f185625f6e2fab98dc034e44d14a5a",
+      "pinned_hash": "71eed687650366ea3e1abe6cfed0d15877e6423a56ecf7193a952fd4ee0cb72b",
       "requires_auth": false,
-      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-945e3a57b7a6fa5974baf70845ebafdb25f185625f6e2fab98dc034e44d14a5a.yml"
+      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-71eed687650366ea3e1abe6cfed0d15877e6423a56ecf7193a952fd4ee0cb72b.yml"
     }
   },
   "specs_dir": "packages/anthropic_sdk_dart/specs"

--- a/packages/anthropic_sdk_dart/README.md
+++ b/packages/anthropic_sdk_dart/README.md
@@ -32,8 +32,9 @@ Dart client for the **[Anthropic API](https://docs.anthropic.com/en/api)** to bu
 ### Generation and streaming
 
 - Messages with typed inputs, system prompts, and multi-turn history
+- Mid-conversation system messages: update instructions inside the messages array, no user turn required (Opus 4.8)
 - SSE streaming with cancelation and token counting
-- Extended thinking and adaptive thinking controls
+- Extended thinking and adaptive thinking controls, with `outputTokensDetails` reasoning-token breakdown
 - Prompt-cache diagnostics: report why the cache prefix diverged between turns (beta)
 
 ### Tools and multimodal
@@ -660,6 +661,7 @@ See the [example/](example/) directory for complete examples:
 | Example | Description |
 |---------|-------------|
 | [`messages_example.dart`](example/messages_example.dart) | Basic message creation |
+| [`mid_conversation_system_example.dart`](example/mid_conversation_system_example.dart) | Mid-conversation system messages (Opus 4.8) |
 | [`streaming_example.dart`](example/streaming_example.dart) | Streaming responses |
 | [`tool_calling_example.dart`](example/tool_calling_example.dart) | Tool calling with schemas |
 | [`web_search_example.dart`](example/web_search_example.dart) | Web search tool |

--- a/packages/anthropic_sdk_dart/example/advisor_example.dart
+++ b/packages/anthropic_sdk_dart/example/advisor_example.dart
@@ -23,7 +23,7 @@ void main() async {
         model: 'claude-sonnet-4-6',
         maxTokens: 4096,
         tools: [
-          ToolDefinition.builtIn(const AdvisorTool(model: 'claude-opus-4-7')),
+          ToolDefinition.builtIn(const AdvisorTool(model: 'claude-opus-4-8')),
         ],
         messages: [
           InputMessage.user(
@@ -80,7 +80,7 @@ For long agent loops, enable advisor-side caching to reduce costs:
 final tools = [
   ToolDefinition.builtIn(
     AdvisorTool(
-      model: 'claude-opus-4-7',
+      model: 'claude-opus-4-8',
       maxUses: 3,
       caching: CacheControlEphemeral(ttl: CacheTtl.ttl5m),
     ),
@@ -117,7 +117,7 @@ final response2 = await client.messages.create(
   MessageCreateRequest(
     model: 'claude-sonnet-4-6',
     maxTokens: 4096,
-    tools: [ToolDefinition.builtIn(AdvisorTool(model: 'claude-opus-4-7'))],
+    tools: [ToolDefinition.builtIn(AdvisorTool(model: 'claude-opus-4-8'))],
     messages: messages,
   ),
   betas: ['advisor-tool-2026-03-01'],

--- a/packages/anthropic_sdk_dart/example/mid_conversation_system_example.dart
+++ b/packages/anthropic_sdk_dart/example/mid_conversation_system_example.dart
@@ -33,8 +33,8 @@ void main() async {
           // follow-up — all within the messages array.
           InputMessage.userBlocks([
             InputContentBlock.midConversationSystem(
-              content: [
-                const TextInputBlock('From now on, always answer in French.'),
+              content: const [
+                TextInputBlock('From now on, always answer in French.'),
               ],
             ),
             InputContentBlock.text('What is its population?'),

--- a/packages/anthropic_sdk_dart/example/mid_conversation_system_example.dart
+++ b/packages/anthropic_sdk_dart/example/mid_conversation_system_example.dart
@@ -1,0 +1,63 @@
+// ignore_for_file: avoid_print
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+
+/// Mid-conversation system message example.
+///
+/// This example demonstrates:
+/// - Injecting updated system instructions partway through a conversation
+///   using a `mid_conv_system` content block (via
+///   [InputContentBlock.midConversationSystem]), without a separate user turn
+///   or disrupting prompt caching.
+/// - Reading the new `outputTokensDetails` breakdown from usage.
+///
+/// Mid-conversation system messages are supported by Claude Opus 4.8.
+void main() async {
+  final client = AnthropicClient(
+    config: const AnthropicConfig(
+      authProvider: ApiKeyProvider(String.fromEnvironment('ANTHROPIC_API_KEY')),
+    ),
+  );
+
+  try {
+    final response = await client.messages.create(
+      MessageCreateRequest(
+        model: 'claude-opus-4-8',
+        maxTokens: 1024,
+        system: SystemPrompt.text(
+          'You are a helpful assistant. Answer concisely.',
+        ),
+        messages: [
+          InputMessage.user('What is the capital of France?'),
+          InputMessage.assistant('The capital of France is Paris.'),
+          // Update the system instructions mid-conversation, then ask a
+          // follow-up — all within the messages array.
+          InputMessage.userBlocks([
+            InputContentBlock.midConversationSystem(
+              content: [
+                const TextInputBlock('From now on, always answer in French.'),
+              ],
+            ),
+            InputContentBlock.text('What is its population?'),
+          ]),
+        ],
+      ),
+    );
+
+    for (final block in response.content) {
+      if (block case TextBlock(:final text)) {
+        print(text);
+      }
+    }
+
+    // Output token breakdown (e.g. reasoning tokens) is available via the new
+    // `outputTokensDetails` field on usage.
+    final details = response.usage.outputTokensDetails;
+    print('\nUsage:');
+    print('  Output tokens: ${response.usage.outputTokens}');
+    if (details != null) {
+      print('  Thinking tokens: ${details.thinkingTokens}');
+    }
+  } finally {
+    client.close();
+  }
+}

--- a/packages/anthropic_sdk_dart/example/user_profiles_example.dart
+++ b/packages/anthropic_sdk_dart/example/user_profiles_example.dart
@@ -32,7 +32,7 @@ void main() async {
     print('\n=== Send message with user_profile_id ===');
     final reply = await client.messages.create(
       MessageCreateRequest(
-        model: 'claude-opus-4-7',
+        model: 'claude-opus-4-8',
         maxTokens: 256,
         userProfileId: profile.id,
         messages: [InputMessage.user('Hello!')],

--- a/packages/anthropic_sdk_dart/lib/src/models/beta/tools/advisor_tool.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/beta/tools/advisor_tool.dart
@@ -16,7 +16,7 @@ part of '../../tools/built_in_tools.dart';
 ///     maxTokens: 4096,
 ///     tools: [
 ///       ToolDefinition.builtIn(
-///         AdvisorTool(model: 'claude-opus-4-7'),
+///         AdvisorTool(model: 'claude-opus-4-8'),
 ///       ),
 ///     ],
 ///     messages: [InputMessage.user('Plan a Go worker pool.')],
@@ -29,7 +29,7 @@ class AdvisorTool extends BuiltInTool {
   /// The tool type version.
   final String type;
 
-  /// The advisor model ID (e.g., `'claude-opus-4-7'`).
+  /// The advisor model ID (e.g., `'claude-opus-4-8'`).
   final String model;
 
   /// Maximum number of advisor calls allowed in a single request.

--- a/packages/anthropic_sdk_dart/lib/src/models/content/content_block.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/content_block.dart
@@ -1910,8 +1910,15 @@ class AdvisorResult extends AdvisorToolResultContent {
   /// The advisor's advice text.
   final String text;
 
+  /// The advisor sub-inference's stop reason.
+  ///
+  /// Same values as the top-level message `stop_reason`; `max_tokens` indicates
+  /// the advisor's output was truncated at the tool's `max_tokens` value or the
+  /// advisor model's policy cap. May be `null` when absent.
+  final String? stopReason;
+
   /// Creates an [AdvisorResult].
-  const AdvisorResult({required this.text});
+  const AdvisorResult({required this.text, this.stopReason});
 
   /// Creates an [AdvisorResult] from JSON.
   factory AdvisorResult.fromJson(Map<String, dynamic> json) {
@@ -1919,29 +1926,46 @@ class AdvisorResult extends AdvisorToolResultContent {
     if (type != 'advisor_result') {
       throw FormatException('Expected type "advisor_result", got "$type"');
     }
-    return AdvisorResult(text: json['text'] as String);
+    return AdvisorResult(
+      text: json['text'] as String,
+      stopReason: json['stop_reason'] as String?,
+    );
   }
 
   @override
-  Map<String, dynamic> toJson() => {'type': 'advisor_result', 'text': text};
+  Map<String, dynamic> toJson() => {
+    'type': 'advisor_result',
+    'text': text,
+    if (stopReason != null) 'stop_reason': stopReason,
+  };
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is AdvisorResult &&
           runtimeType == other.runtimeType &&
-          text == other.text;
+          text == other.text &&
+          stopReason == other.stopReason;
 
   @override
-  int get hashCode => text.hashCode;
+  int get hashCode => Object.hash(text, stopReason);
 
   /// Creates a copy with replaced values.
-  AdvisorResult copyWith({String? text}) {
-    return AdvisorResult(text: text ?? this.text);
+  AdvisorResult copyWith({
+    String? text,
+    Object? stopReason = unsetCopyWithValue,
+  }) {
+    return AdvisorResult(
+      text: text ?? this.text,
+      stopReason: stopReason == unsetCopyWithValue
+          ? this.stopReason
+          : stopReason as String?,
+    );
   }
 
   @override
-  String toString() => 'AdvisorResult(text: ${text.length} chars)';
+  String toString() =>
+      'AdvisorResult(text: ${text.length} chars, stopReason: $stopReason)';
 }
 
 /// Encrypted (redacted) advisor result.
@@ -1950,8 +1974,17 @@ class AdvisorRedactedResult extends AdvisorToolResultContent {
   /// The opaque encrypted content blob.
   final String encryptedContent;
 
+  /// The advisor sub-inference's stop reason.
+  ///
+  /// Same values as the top-level message `stop_reason`. May be `null` when
+  /// absent.
+  final String? stopReason;
+
   /// Creates an [AdvisorRedactedResult].
-  const AdvisorRedactedResult({required this.encryptedContent});
+  const AdvisorRedactedResult({
+    required this.encryptedContent,
+    this.stopReason,
+  });
 
   /// Creates an [AdvisorRedactedResult] from JSON.
   factory AdvisorRedactedResult.fromJson(Map<String, dynamic> json) {
@@ -1963,6 +1996,7 @@ class AdvisorRedactedResult extends AdvisorToolResultContent {
     }
     return AdvisorRedactedResult(
       encryptedContent: json['encrypted_content'] as String,
+      stopReason: json['stop_reason'] as String?,
     );
   }
 
@@ -1970,6 +2004,7 @@ class AdvisorRedactedResult extends AdvisorToolResultContent {
   Map<String, dynamic> toJson() => {
     'type': 'advisor_redacted_result',
     'encrypted_content': encryptedContent,
+    if (stopReason != null) 'stop_reason': stopReason,
   };
 
   @override
@@ -1977,22 +2012,29 @@ class AdvisorRedactedResult extends AdvisorToolResultContent {
       identical(this, other) ||
       other is AdvisorRedactedResult &&
           runtimeType == other.runtimeType &&
-          encryptedContent == other.encryptedContent;
+          encryptedContent == other.encryptedContent &&
+          stopReason == other.stopReason;
 
   @override
-  int get hashCode => encryptedContent.hashCode;
+  int get hashCode => Object.hash(encryptedContent, stopReason);
 
   /// Creates a copy with replaced values.
-  AdvisorRedactedResult copyWith({String? encryptedContent}) {
+  AdvisorRedactedResult copyWith({
+    String? encryptedContent,
+    Object? stopReason = unsetCopyWithValue,
+  }) {
     return AdvisorRedactedResult(
       encryptedContent: encryptedContent ?? this.encryptedContent,
+      stopReason: stopReason == unsetCopyWithValue
+          ? this.stopReason
+          : stopReason as String?,
     );
   }
 
   @override
   String toString() =>
       'AdvisorRedactedResult(encryptedContent: '
-      '[${encryptedContent.length} chars])';
+      '[${encryptedContent.length} chars], stopReason: $stopReason)';
 }
 
 /// Advisor tool result error.

--- a/packages/anthropic_sdk_dart/lib/src/models/content/input_content_block.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/input_content_block.dart
@@ -141,6 +141,16 @@ sealed class InputContentBlock {
     CacheControlEphemeral? cacheControl,
   }) = ToolReferenceInputBlock;
 
+  /// Creates a mid-conversation system block.
+  ///
+  /// Injects updated system instructions partway through a conversation (e.g.
+  /// with Claude Opus 4.8) without requiring a user turn or disrupting prompt
+  /// caching. The [content] holds the new system instruction as text blocks.
+  factory InputContentBlock.midConversationSystem({
+    required List<TextInputBlock> content,
+    CacheControlEphemeral? cacheControl,
+  }) = MidConversationSystemInputBlock;
+
   /// Creates an [InputContentBlock] from JSON.
   factory InputContentBlock.fromJson(Map<String, dynamic> json) {
     final type = json['type'] as String;
@@ -169,6 +179,7 @@ sealed class InputContentBlock {
       'mcp_tool_use' => MCPToolUseInputBlock.fromJson(json),
       'mcp_tool_result' => MCPToolResultInputBlock.fromJson(json),
       'advisor_tool_result' => AdvisorToolResultInputBlock.fromJson(json),
+      'mid_conv_system' => MidConversationSystemInputBlock.fromJson(json),
       _ => UnknownInputContentBlock.fromJson(json),
     };
   }
@@ -1844,6 +1855,92 @@ class MCPToolResultInputBlock extends InputContentBlock {
   String toString() =>
       'MCPToolResultInputBlock(toolUseId: $toolUseId, '
       'content: $content, isError: $isError, '
+      'cacheControl: $cacheControl)';
+}
+
+/// Mid-conversation system content block for input.
+///
+/// Injects updated system instructions partway through a conversation (e.g.
+/// with Claude Opus 4.8) without requiring a user turn or disrupting prompt
+/// caching. The [content] holds the new system instruction as text blocks.
+@immutable
+class MidConversationSystemInputBlock extends InputContentBlock {
+  /// System instruction text blocks.
+  final List<TextInputBlock> content;
+
+  /// Cache control for this block.
+  final CacheControlEphemeral? cacheControl;
+
+  /// Creates a [MidConversationSystemInputBlock].
+  const MidConversationSystemInputBlock({
+    required this.content,
+    this.cacheControl,
+  });
+
+  /// Creates a [MidConversationSystemInputBlock] from JSON.
+  factory MidConversationSystemInputBlock.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    if (type != 'mid_conv_system') {
+      throw FormatException('Expected type "mid_conv_system", got "$type"');
+    }
+    final rawContent = json['content'];
+    if (rawContent is! List) {
+      throw FormatException(
+        'mid_conv_system: "content" must be a List, '
+        'got ${rawContent.runtimeType}',
+      );
+    }
+    return MidConversationSystemInputBlock(
+      content: rawContent.map((e) {
+        if (e is! Map<String, dynamic>) {
+          throw FormatException(
+            'mid_conv_system content: expected Map, got ${e.runtimeType}',
+          );
+        }
+        return TextInputBlock.fromJson(e);
+      }).toList(),
+      cacheControl: json['cache_control'] != null
+          ? CacheControlEphemeral.fromJson(
+              json['cache_control'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'mid_conv_system',
+    'content': content.map((e) => e.toJson()).toList(),
+    if (cacheControl != null) 'cache_control': cacheControl!.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  MidConversationSystemInputBlock copyWith({
+    List<TextInputBlock>? content,
+    Object? cacheControl = unsetCopyWithValue,
+  }) {
+    return MidConversationSystemInputBlock(
+      content: content ?? this.content,
+      cacheControl: cacheControl == unsetCopyWithValue
+          ? this.cacheControl
+          : cacheControl as CacheControlEphemeral?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MidConversationSystemInputBlock &&
+          runtimeType == other.runtimeType &&
+          listsEqual(content, other.content) &&
+          cacheControl == other.cacheControl;
+
+  @override
+  int get hashCode => Object.hash(listHash(content), cacheControl);
+
+  @override
+  String toString() =>
+      'MidConversationSystemInputBlock(content: $content, '
       'cacheControl: $cacheControl)';
 }
 

--- a/packages/anthropic_sdk_dart/lib/src/models/messages/input_message.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/messages/input_message.dart
@@ -125,6 +125,23 @@ class InputMessage {
         content: MessageContent.blocks(blocks),
       );
 
+  /// Creates a system message with text content.
+  ///
+  /// Lets you place system instructions inside the messages array (e.g.
+  /// mid-conversation, with Claude Opus 4.8) instead of only the top-level
+  /// `system` prompt.
+  factory InputMessage.system(String text) => InputMessage(
+    role: MessageRole.system,
+    content: MessageContent.text(text),
+  );
+
+  /// Creates a system message with block content.
+  factory InputMessage.systemBlocks(List<InputContentBlock> blocks) =>
+      InputMessage(
+        role: MessageRole.system,
+        content: MessageContent.blocks(blocks),
+      );
+
   /// Returns the content as a list of [InputContentBlock]s.
   ///
   /// For [TextMessageContent], wraps the text in a single [TextInputBlock].

--- a/packages/anthropic_sdk_dart/lib/src/models/messages/message_role.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/messages/message_role.dart
@@ -4,7 +4,11 @@ enum MessageRole {
   user('user'),
 
   /// Assistant message.
-  assistant('assistant');
+  assistant('assistant'),
+
+  /// System message (e.g. mid-conversation system instructions supplied inside
+  /// the messages array).
+  system('system');
 
   const MessageRole(this.value);
 
@@ -15,6 +19,7 @@ enum MessageRole {
   static MessageRole fromJson(String value) => switch (value) {
     'user' => MessageRole.user,
     'assistant' => MessageRole.assistant,
+    'system' => MessageRole.system,
     _ => throw FormatException('Unknown MessageRole: $value'),
   };
 

--- a/packages/anthropic_sdk_dart/lib/src/models/metadata/usage.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/metadata/usage.dart
@@ -328,6 +328,54 @@ enum ServiceTier {
   String toJson() => name;
 }
 
+/// Breakdown of output tokens by category.
+///
+/// `outputTokens` remains the inclusive, authoritative total used for billing;
+/// this object is a read-only decomposition for observability.
+@immutable
+class OutputTokensDetails {
+  /// Number of output tokens the model generated as internal reasoning,
+  /// including the thinking-block delimiter tokens.
+  ///
+  /// Always ≤ `outputTokens`; `outputTokens - thinkingTokens` approximates the
+  /// non-reasoning output. Computed by re-tokenizing the raw reasoning text, so
+  /// it may differ from the model's exact generation count by a few tokens.
+  final int thinkingTokens;
+
+  /// Creates an [OutputTokensDetails].
+  const OutputTokensDetails({this.thinkingTokens = 0});
+
+  /// Creates an [OutputTokensDetails] from JSON.
+  factory OutputTokensDetails.fromJson(Map<String, dynamic> json) {
+    return OutputTokensDetails(
+      thinkingTokens: json['thinking_tokens'] as int? ?? 0,
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {'thinking_tokens': thinkingTokens};
+
+  /// Creates a copy with replaced values.
+  OutputTokensDetails copyWith({int? thinkingTokens}) {
+    return OutputTokensDetails(
+      thinkingTokens: thinkingTokens ?? this.thinkingTokens,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OutputTokensDetails &&
+          runtimeType == other.runtimeType &&
+          thinkingTokens == other.thinkingTokens;
+
+  @override
+  int get hashCode => thinkingTokens.hashCode;
+
+  @override
+  String toString() => 'OutputTokensDetails(thinkingTokens: $thinkingTokens)';
+}
+
 /// Token usage statistics for a request.
 @immutable
 class Usage {
@@ -336,6 +384,9 @@ class Usage {
 
   /// The number of output tokens generated.
   final int outputTokens;
+
+  /// Breakdown of output tokens by category (e.g., reasoning tokens).
+  final OutputTokensDetails? outputTokensDetails;
 
   /// Breakdown of cached tokens by TTL for creation.
   final CacheCreation? cacheCreation;
@@ -368,6 +419,7 @@ class Usage {
   const Usage({
     required this.inputTokens,
     required this.outputTokens,
+    this.outputTokensDetails,
     this.cacheCreation,
     this.cacheCreationInputTokens,
     this.cacheRead,
@@ -384,6 +436,11 @@ class Usage {
     return Usage(
       inputTokens: json['input_tokens'] as int,
       outputTokens: json['output_tokens'] as int,
+      outputTokensDetails: json['output_tokens_details'] != null
+          ? OutputTokensDetails.fromJson(
+              json['output_tokens_details'] as Map<String, dynamic>,
+            )
+          : null,
       cacheCreation: json['cache_creation'] != null
           ? CacheCreation.fromJson(
               json['cache_creation'] as Map<String, dynamic>,
@@ -416,6 +473,8 @@ class Usage {
   Map<String, dynamic> toJson() => {
     'input_tokens': inputTokens,
     'output_tokens': outputTokens,
+    if (outputTokensDetails != null)
+      'output_tokens_details': outputTokensDetails!.toJson(),
     if (cacheCreation != null) 'cache_creation': cacheCreation!.toJson(),
     if (cacheCreationInputTokens != null)
       'cache_creation_input_tokens': cacheCreationInputTokens,
@@ -434,6 +493,7 @@ class Usage {
   Usage copyWith({
     int? inputTokens,
     int? outputTokens,
+    Object? outputTokensDetails = unsetCopyWithValue,
     Object? cacheCreation = unsetCopyWithValue,
     Object? cacheCreationInputTokens = unsetCopyWithValue,
     Object? cacheRead = unsetCopyWithValue,
@@ -447,6 +507,9 @@ class Usage {
     return Usage(
       inputTokens: inputTokens ?? this.inputTokens,
       outputTokens: outputTokens ?? this.outputTokens,
+      outputTokensDetails: outputTokensDetails == unsetCopyWithValue
+          ? this.outputTokensDetails
+          : outputTokensDetails as OutputTokensDetails?,
       cacheCreation: cacheCreation == unsetCopyWithValue
           ? this.cacheCreation
           : cacheCreation as CacheCreation?,
@@ -482,6 +545,7 @@ class Usage {
           runtimeType == other.runtimeType &&
           inputTokens == other.inputTokens &&
           outputTokens == other.outputTokens &&
+          outputTokensDetails == other.outputTokensDetails &&
           cacheCreation == other.cacheCreation &&
           cacheCreationInputTokens == other.cacheCreationInputTokens &&
           cacheRead == other.cacheRead &&
@@ -496,6 +560,7 @@ class Usage {
   int get hashCode => Object.hash(
     inputTokens,
     outputTokens,
+    outputTokensDetails,
     cacheCreation,
     cacheCreationInputTokens,
     cacheRead,
@@ -510,6 +575,7 @@ class Usage {
   @override
   String toString() =>
       'Usage(inputTokens: $inputTokens, outputTokens: $outputTokens, '
+      'outputTokensDetails: $outputTokensDetails, '
       'cacheCreation: $cacheCreation, '
       'cacheCreationInputTokens: $cacheCreationInputTokens, '
       'cacheRead: $cacheRead, cacheReadInputTokens: $cacheReadInputTokens, '

--- a/packages/anthropic_sdk_dart/lib/src/models/streaming/message_delta.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/streaming/message_delta.dart
@@ -107,6 +107,9 @@ class MessageDeltaUsage {
   /// The cumulative number of output tokens generated so far.
   final int outputTokens;
 
+  /// Breakdown of output tokens by category (e.g., reasoning tokens).
+  final OutputTokensDetails? outputTokensDetails;
+
   /// The cumulative number of input tokens used.
   final int? inputTokens;
 
@@ -128,6 +131,7 @@ class MessageDeltaUsage {
   /// Creates a [MessageDeltaUsage].
   const MessageDeltaUsage({
     required this.outputTokens,
+    this.outputTokensDetails,
     this.inputTokens,
     this.cacheCreationInputTokens,
     this.cacheReadInputTokens,
@@ -140,6 +144,11 @@ class MessageDeltaUsage {
   factory MessageDeltaUsage.fromJson(Map<String, dynamic> json) {
     return MessageDeltaUsage(
       outputTokens: json['output_tokens'] as int,
+      outputTokensDetails: json['output_tokens_details'] != null
+          ? OutputTokensDetails.fromJson(
+              json['output_tokens_details'] as Map<String, dynamic>,
+            )
+          : null,
       inputTokens: json['input_tokens'] as int?,
       cacheCreationInputTokens: json['cache_creation_input_tokens'] as int?,
       cacheReadInputTokens: json['cache_read_input_tokens'] as int?,
@@ -162,6 +171,8 @@ class MessageDeltaUsage {
   /// Converts to JSON.
   Map<String, dynamic> toJson() => {
     'output_tokens': outputTokens,
+    if (outputTokensDetails != null)
+      'output_tokens_details': outputTokensDetails!.toJson(),
     if (inputTokens != null) 'input_tokens': inputTokens,
     if (cacheCreationInputTokens != null)
       'cache_creation_input_tokens': cacheCreationInputTokens,
@@ -176,6 +187,7 @@ class MessageDeltaUsage {
   /// Creates a copy with replaced values.
   MessageDeltaUsage copyWith({
     int? outputTokens,
+    Object? outputTokensDetails = unsetCopyWithValue,
     Object? inputTokens = unsetCopyWithValue,
     Object? cacheCreationInputTokens = unsetCopyWithValue,
     Object? cacheReadInputTokens = unsetCopyWithValue,
@@ -185,6 +197,9 @@ class MessageDeltaUsage {
   }) {
     return MessageDeltaUsage(
       outputTokens: outputTokens ?? this.outputTokens,
+      outputTokensDetails: outputTokensDetails == unsetCopyWithValue
+          ? this.outputTokensDetails
+          : outputTokensDetails as OutputTokensDetails?,
       inputTokens: inputTokens == unsetCopyWithValue
           ? this.inputTokens
           : inputTokens as int?,
@@ -210,6 +225,7 @@ class MessageDeltaUsage {
       other is MessageDeltaUsage &&
           runtimeType == other.runtimeType &&
           outputTokens == other.outputTokens &&
+          outputTokensDetails == other.outputTokensDetails &&
           inputTokens == other.inputTokens &&
           cacheCreationInputTokens == other.cacheCreationInputTokens &&
           cacheReadInputTokens == other.cacheReadInputTokens &&
@@ -220,6 +236,7 @@ class MessageDeltaUsage {
   @override
   int get hashCode => Object.hash(
     outputTokens,
+    outputTokensDetails,
     inputTokens,
     cacheCreationInputTokens,
     cacheReadInputTokens,
@@ -230,7 +247,8 @@ class MessageDeltaUsage {
 
   @override
   String toString() =>
-      'MessageDeltaUsage(outputTokens: $outputTokens, inputTokens: $inputTokens, '
+      'MessageDeltaUsage(outputTokens: $outputTokens, '
+      'outputTokensDetails: $outputTokensDetails, inputTokens: $inputTokens, '
       'cacheCreationInputTokens: $cacheCreationInputTokens, '
       'cacheReadInputTokens: $cacheReadInputTokens, '
       'serverToolUse: $serverToolUse, iterations: $iterations, speed: $speed)';

--- a/packages/anthropic_sdk_dart/lib/src/models/streaming/message_stream_accumulator.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/streaming/message_stream_accumulator.dart
@@ -113,6 +113,7 @@ class MessageStreamAccumulator {
       _usage = Usage(
         inputTokens: delta.inputTokens ?? 0,
         outputTokens: delta.outputTokens,
+        outputTokensDetails: delta.outputTokensDetails,
         cacheCreationInputTokens: delta.cacheCreationInputTokens,
         cacheReadInputTokens: delta.cacheReadInputTokens,
         serverToolUse: delta.serverToolUse,
@@ -124,6 +125,8 @@ class MessageStreamAccumulator {
     _usage = Usage(
       inputTokens: delta.inputTokens ?? base.inputTokens,
       outputTokens: delta.outputTokens,
+      outputTokensDetails:
+          delta.outputTokensDetails ?? base.outputTokensDetails,
       cacheCreationInputTokens:
           delta.cacheCreationInputTokens ?? base.cacheCreationInputTokens,
       cacheReadInputTokens:

--- a/packages/anthropic_sdk_dart/llms.txt
+++ b/packages/anthropic_sdk_dart/llms.txt
@@ -5,8 +5,8 @@
 ## Docs
 
 - [README](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/README.md) (~5.1k tokens): Primary package documentation with installation, configuration, and usage examples.
-- [CHANGELOG](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/CHANGELOG.md) (~8k tokens): Release history and version-by-version changes.
-- [MIGRATION](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/MIGRATION.md) (~4.5k tokens): Upgrade notes and breaking-change guidance.
+- [CHANGELOG](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/CHANGELOG.md) (~9.1k tokens): Release history and version-by-version changes.
+- [MIGRATION](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/MIGRATION.md) (~5.4k tokens): Upgrade notes and breaking-change guidance.
 
 ## Examples
 
@@ -23,6 +23,7 @@
 - [managed_agents_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/managed_agents_example.dart) (~1.6k tokens): Managed agents: agents, sessions, vaults, multiagent rosters, outcomes, webhooks, credential validation (beta).
 - [memory_stores_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/memory_stores_example.dart) (~903 tokens): Managed agents memory stores, memories, and versions (beta).
 - [error_handling_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/error_handling_example.dart) (~632 tokens): Exception handling patterns.
+- [mid_conversation_system_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/mid_conversation_system_example.dart) (~458 tokens): Mid-conversation system messages (Opus 4.8).
 - [web_search_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/web_search_example.dart) (~793 tokens): Web search tool.
 - [advisor_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/advisor_example.dart) (~967 tokens): Advisor tool (beta).
 - [computer_use_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/computer_use_example.dart) (~866 tokens): Computer use tool.
@@ -38,4 +39,4 @@
 
 - [Package directory](https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/anthropic_sdk_dart): Source tree, pubspec, and package-local files.
 
-**Total: ~38k tokens**
+**Total: ~40.5k tokens**

--- a/packages/anthropic_sdk_dart/specs/openapi.yaml
+++ b/packages/anthropic_sdk_dart/specs/openapi.yaml
@@ -4347,6 +4347,7 @@
             "image": "#/components/schemas/BetaRequestImageBlock",
             "mcp_tool_result": "#/components/schemas/BetaRequestMCPToolResultBlock",
             "mcp_tool_use": "#/components/schemas/BetaRequestMCPToolUseBlock",
+            "mid_conv_system": "#/components/schemas/BetaRequestMidConvSystemBlock",
             "redacted_thinking": "#/components/schemas/BetaRequestRedactedThinkingBlock",
             "search_result": "#/components/schemas/BetaRequestSearchResultBlock",
             "server_tool_use": "#/components/schemas/BetaRequestServerToolUseBlock",
@@ -4429,6 +4430,9 @@
           },
           {
             "$ref": "#/components/schemas/BetaRequestCompactionBlock"
+          },
+          {
+            "$ref": "#/components/schemas/BetaRequestMidConvSystemBlock"
           }
         ],
         "x-stainless-go-variant-constructor": {
@@ -4488,7 +4492,8 @@
           "role": {
             "enum": [
               "user",
-              "assistant"
+              "assistant",
+              "system"
             ],
             "title": "Role",
             "type": "string"
@@ -9882,6 +9887,11 @@
             "type": "string"
           },
           {
+            "const": "claude-opus-4-8",
+            "description": "Frontier intelligence for long-running agents and coding",
+            "x-stainless-nominal": false
+          },
+          {
             "const": "claude-opus-4-7",
             "description": "Frontier intelligence for long-running agents and coding",
             "x-stainless-nominal": false
@@ -9927,7 +9937,7 @@
             "x-stainless-nominal": false
           }
         ],
-        "description": "The model that will power your agent.\\n\\nSee [models](https://docs.anthropic.com/en/docs/models-overview) for additional details and options.",
+        "description": "The model that will power your agent.\n\nSee [models](https://docs.anthropic.com/en/docs/models-overview) for additional details and options.",
         "title": "BetaManagedAgentsModel"
       },
       "BetaManagedAgentsModelConfig": {
@@ -15659,6 +15669,18 @@
             "title": "Output Tokens",
             "type": "integer"
           },
+          "output_tokens_details": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BetaOutputTokensDetails"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Breakdown of output tokens by category.\n\n`output_tokens` remains the inclusive, authoritative total used for billing.\nThis object provides a read-only decomposition for observability \u2014 for example,\nhow many of the billed output tokens were spent on internal reasoning that may\nhave been summarized before being returned to you."
+          },
           "server_tool_use": {
             "anyOf": [
               {
@@ -15678,6 +15700,7 @@
           "input_tokens",
           "iterations",
           "output_tokens",
+          "output_tokens_details",
           "server_tool_use"
         ],
         "title": "MessageDeltaUsage",
@@ -16029,6 +16052,22 @@
           }
         },
         "title": "OutputConfig",
+        "type": "object"
+      },
+      "BetaOutputTokensDetails": {
+        "properties": {
+          "thinking_tokens": {
+            "default": 0,
+            "description": "Number of output tokens the model generated as internal reasoning, including\nthe thinking-block delimiter tokens.\n\nReflects the raw reasoning the model produced, not the (possibly shorter)\nsummarized thinking text returned in the response body. Computed by\nre-tokenizing the raw reasoning text, so it may differ from the model's exact\ngeneration count by a small number of tokens. Always \u2264 `output_tokens`;\n`output_tokens - thinking_tokens` approximates the non-reasoning output.",
+            "minimum": 0,
+            "title": "Thinking Tokens",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "thinking_tokens"
+        ],
+        "title": "OutputTokensDetails",
         "type": "object"
       },
       "BetaOverloadedError": {
@@ -16574,6 +16613,17 @@
             "title": "Encrypted Content",
             "type": "string"
           },
+          "stop_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stop Reason"
+          },
           "type": {
             "const": "advisor_redacted_result",
             "title": "Type",
@@ -16590,6 +16640,17 @@
       "BetaRequestAdvisorResultBlock": {
         "additionalProperties": false,
         "properties": {
+          "stop_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stop Reason"
+          },
           "text": {
             "title": "Text",
             "type": "string"
@@ -17636,6 +17697,63 @@
           "type"
         ],
         "title": "RequestMCPToolUseBlock",
+        "type": "object"
+      },
+      "BetaRequestMidConvSystemBlock": {
+        "additionalProperties": false,
+        "description": "System instructions that appear mid-conversation.\n\nUse this block to provide or update system-level instructions at a specific\npoint in the conversation, rather than only via the top-level `system` parameter.",
+        "properties": {
+          "cache_control": {
+            "anyOf": [
+              {
+                "discriminator": {
+                  "mapping": {
+                    "ephemeral": "#/components/schemas/BetaCacheControlEphemeral"
+                  },
+                  "propertyName": "type"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/BetaCacheControlEphemeral"
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Create a cache control breakpoint at this content block.",
+            "title": "Cache Control"
+          },
+          "content": {
+            "description": "System instruction text blocks.",
+            "items": {
+              "discriminator": {
+                "mapping": {
+                  "text": "#/components/schemas/BetaRequestTextBlock"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/BetaRequestTextBlock"
+                }
+              ]
+            },
+            "title": "Content",
+            "type": "array"
+          },
+          "type": {
+            "const": "mid_conv_system",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "content",
+          "type"
+        ],
+        "title": "RequestMidConvSystemBlock",
         "type": "object"
       },
       "BetaRequestPageLocationCitation": {
@@ -18922,6 +19040,19 @@
             "title": "Encrypted Content",
             "type": "string"
           },
+          "stop_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "The advisor sub-inference's stop reason (same values as the top-level message `stop_reason`).",
+            "title": "Stop Reason"
+          },
           "type": {
             "const": "advisor_redacted_result",
             "default": "advisor_redacted_result",
@@ -18931,6 +19062,7 @@
         },
         "required": [
           "encrypted_content",
+          "stop_reason",
           "type"
         ],
         "title": "ResponseAdvisorRedactedResultBlock",
@@ -18938,6 +19070,19 @@
       },
       "BetaResponseAdvisorResultBlock": {
         "properties": {
+          "stop_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "The advisor sub-inference's stop reason (same values as the top-level message `stop_reason`). `max_tokens` indicates the advisor's output was truncated at the tool's `max_tokens` value or the advisor model's policy cap.",
+            "title": "Stop Reason"
+          },
           "text": {
             "title": "Text",
             "type": "string"
@@ -18950,6 +19095,7 @@
           }
         },
         "required": [
+          "stop_reason",
           "text",
           "type"
         ],
@@ -22524,6 +22670,18 @@
             "title": "Output Tokens",
             "type": "integer"
           },
+          "output_tokens_details": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BetaOutputTokensDetails"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Breakdown of output tokens by category.\n\n`output_tokens` remains the inclusive, authoritative total used for billing.\nThis object provides a read-only decomposition for observability \u2014 for example,\nhow many of the billed output tokens were spent on internal reasoning that may\nhave been summarized before being returned to you."
+          },
           "server_tool_use": {
             "anyOf": [
               {
@@ -22575,6 +22733,7 @@
           "input_tokens",
           "iterations",
           "output_tokens",
+          "output_tokens_details",
           "server_tool_use",
           "service_tier",
           "speed"
@@ -22839,6 +22998,7 @@
           "invalid_tool_input",
           "url_too_long",
           "url_not_allowed",
+          "url_not_in_prior_context",
           "url_not_accessible",
           "unsupported_content_type",
           "too_many_requests",
@@ -26171,6 +26331,7 @@
             "container_upload": "#/components/schemas/RequestContainerUploadBlock",
             "document": "#/components/schemas/RequestDocumentBlock",
             "image": "#/components/schemas/RequestImageBlock",
+            "mid_conv_system": "#/components/schemas/RequestMidConvSystemBlock",
             "redacted_thinking": "#/components/schemas/RequestRedactedThinkingBlock",
             "search_result": "#/components/schemas/RequestSearchResultBlock",
             "server_tool_use": "#/components/schemas/RequestServerToolUseBlock",
@@ -26241,6 +26402,9 @@
           },
           {
             "$ref": "#/components/schemas/RequestContainerUploadBlock"
+          },
+          {
+            "$ref": "#/components/schemas/RequestMidConvSystemBlock"
           }
         ],
         "x-stainless-go-variant-constructor": {
@@ -26306,7 +26470,8 @@
           "role": {
             "enum": [
               "user",
-              "assistant"
+              "assistant",
+              "system"
             ],
             "title": "Role",
             "type": "string"
@@ -27073,6 +27238,18 @@
             "title": "Output Tokens",
             "type": "integer"
           },
+          "output_tokens_details": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputTokensDetails"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Breakdown of output tokens by category.\n\n`output_tokens` remains the inclusive, authoritative total used for billing.\nThis object provides a read-only decomposition for observability \u2014 for example,\nhow many of the billed output tokens were spent on internal reasoning that may\nhave been summarized before being returned to you."
+          },
           "server_tool_use": {
             "anyOf": [
               {
@@ -27091,6 +27268,7 @@
           "cache_read_input_tokens",
           "input_tokens",
           "output_tokens",
+          "output_tokens_details",
           "server_tool_use"
         ],
         "title": "MessageDeltaUsage",
@@ -27208,6 +27386,11 @@
             "type": "string"
           },
           {
+            "const": "claude-opus-4-8",
+            "description": "Frontier intelligence for long-running agents and coding",
+            "x-stainless-nominal": false
+          },
+          {
             "const": "claude-opus-4-7",
             "description": "Frontier intelligence for long-running agents and coding",
             "x-stainless-nominal": false
@@ -27303,7 +27486,7 @@
             "x-stainless-nominal": false
           }
         ],
-        "description": "The model that will complete your prompt.\\n\\nSee [models](https://docs.anthropic.com/en/docs/models-overview) for additional details and options.",
+        "description": "The model that will complete your prompt.\n\nSee [models](https://docs.anthropic.com/en/docs/models-overview) for additional details and options.",
         "title": "Model"
       },
       "ModelCapabilities": {
@@ -27490,6 +27673,22 @@
           }
         },
         "title": "OutputConfig",
+        "type": "object"
+      },
+      "OutputTokensDetails": {
+        "properties": {
+          "thinking_tokens": {
+            "default": 0,
+            "description": "Number of output tokens the model generated as internal reasoning, including\nthe thinking-block delimiter tokens.\n\nReflects the raw reasoning the model produced, not the (possibly shorter)\nsummarized thinking text returned in the response body. Computed by\nre-tokenizing the raw reasoning text, so it may differ from the model's exact\ngeneration count by a small number of tokens. Always \u2264 `output_tokens`;\n`output_tokens - thinking_tokens` approximates the non-reasoning output.",
+            "minimum": 0,
+            "title": "Thinking Tokens",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "thinking_tokens"
+        ],
+        "title": "OutputTokensDetails",
         "type": "object"
       },
       "OverloadedError": {
@@ -28305,6 +28504,63 @@
           "type"
         ],
         "title": "RequestImageBlock",
+        "type": "object"
+      },
+      "RequestMidConvSystemBlock": {
+        "additionalProperties": false,
+        "description": "System instructions that appear mid-conversation.\n\nUse this block to provide or update system-level instructions at a specific\npoint in the conversation, rather than only via the top-level `system` parameter.",
+        "properties": {
+          "cache_control": {
+            "anyOf": [
+              {
+                "discriminator": {
+                  "mapping": {
+                    "ephemeral": "#/components/schemas/CacheControlEphemeral"
+                  },
+                  "propertyName": "type"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CacheControlEphemeral"
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Create a cache control breakpoint at this content block.",
+            "title": "Cache Control"
+          },
+          "content": {
+            "description": "System instruction text blocks.",
+            "items": {
+              "discriminator": {
+                "mapping": {
+                  "text": "#/components/schemas/RequestTextBlock"
+                },
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/RequestTextBlock"
+                }
+              ]
+            },
+            "title": "Content",
+            "type": "array"
+          },
+          "type": {
+            "const": "mid_conv_system",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "content",
+          "type"
+        ],
+        "title": "RequestMidConvSystemBlock",
         "type": "object"
       },
       "RequestPageLocationCitation": {
@@ -32103,6 +32359,18 @@
             "title": "Output Tokens",
             "type": "integer"
           },
+          "output_tokens_details": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OutputTokensDetails"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Breakdown of output tokens by category.\n\n`output_tokens` remains the inclusive, authoritative total used for billing.\nThis object provides a read-only decomposition for observability \u2014 for example,\nhow many of the billed output tokens were spent on internal reasoning that may\nhave been summarized before being returned to you."
+          },
           "server_tool_use": {
             "anyOf": [
               {
@@ -32141,6 +32409,7 @@
           "inference_geo",
           "input_tokens",
           "output_tokens",
+          "output_tokens_details",
           "server_tool_use",
           "service_tier"
         ],
@@ -32243,6 +32512,7 @@
           "invalid_tool_input",
           "url_too_long",
           "url_not_allowed",
+          "url_not_in_prior_context",
           "url_not_accessible",
           "unsupported_content_type",
           "too_many_requests",

--- a/packages/anthropic_sdk_dart/specs/spec_metadata.json
+++ b/packages/anthropic_sdk_dart/specs/spec_metadata.json
@@ -2,8 +2,8 @@
   "specs": {
     "main": {
       "current_version": "unknown",
-      "last_fetched": "2026-05-23T22:32:12.841626Z",
-      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-945e3a57b7a6fa5974baf70845ebafdb25f185625f6e2fab98dc034e44d14a5a.yml",
+      "last_fetched": "2026-05-28T23:41:39.547394Z",
+      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-71eed687650366ea3e1abe6cfed0d15877e6423a56ecf7193a952fd4ee0cb72b.yml",
       "title": "Anthropic API",
       "version_history": [
         {

--- a/packages/anthropic_sdk_dart/test/integration/server_tools_integration_test.dart
+++ b/packages/anthropic_sdk_dart/test/integration/server_tools_integration_test.dart
@@ -121,7 +121,7 @@ void main() {
             maxTokens: 4096,
             tools: [
               ToolDefinition.builtIn(
-                const AdvisorTool(model: 'claude-opus-4-7'),
+                const AdvisorTool(model: 'claude-opus-4-8'),
               ),
             ],
             messages: [
@@ -194,7 +194,7 @@ void main() {
             maxTokens: 4096,
             tools: [
               ToolDefinition.builtIn(
-                const AdvisorTool(model: 'claude-opus-4-7'),
+                const AdvisorTool(model: 'claude-opus-4-8'),
               ),
             ],
             messages: [

--- a/packages/anthropic_sdk_dart/test/unit/models/agent_multiagent_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/agent_multiagent_test.dart
@@ -9,7 +9,7 @@ void main() {
       'version': 1,
       'name': 'Coordinator',
       'description': null,
-      'model': {'id': 'claude-opus-4-7', 'type': 'model'},
+      'model': {'id': 'claude-opus-4-8', 'type': 'model'},
       'system': null,
       'tools': <Map<String, dynamic>>[],
       'mcp_servers': <Map<String, dynamic>>[],
@@ -62,7 +62,7 @@ void main() {
         'name': 'Coordinator',
         'description': null,
         'system': null,
-        'model': {'id': 'claude-opus-4-7', 'type': 'model'},
+        'model': {'id': 'claude-opus-4-8', 'type': 'model'},
         'mcp_servers': <Map<String, dynamic>>[],
         'skills': <Map<String, dynamic>>[],
         'tools': <Map<String, dynamic>>[],
@@ -104,7 +104,7 @@ void main() {
           'type': 'agent',
           'version': 1,
           'name': 'A',
-          'model': {'id': 'claude-opus-4-7', 'type': 'model'},
+          'model': {'id': 'claude-opus-4-8', 'type': 'model'},
           'mcp_servers': <Map<String, dynamic>>[],
           'skills': <Map<String, dynamic>>[],
           'tools': <Map<String, dynamic>>[],
@@ -160,7 +160,7 @@ void main() {
     test('serializes when set and omits when null', () {
       const withMa = CreateAgentParams(
         name: 'C',
-        model: ModelParamsId(id: 'claude-opus-4-7'),
+        model: ModelParamsId(id: 'claude-opus-4-8'),
         multiagent: MultiagentCoordinatorParams(
           agents: [MultiagentSelfParams()],
         ),
@@ -174,7 +174,7 @@ void main() {
 
       const without = CreateAgentParams(
         name: 'C',
-        model: ModelParamsId(id: 'claude-opus-4-7'),
+        model: ModelParamsId(id: 'claude-opus-4-8'),
       );
       expect(without.toJson().containsKey('multiagent'), isFalse);
     });

--- a/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
@@ -670,6 +670,92 @@ void main() {
       });
     });
 
+    group('MidConversationSystemInputBlock', () {
+      Map<String, dynamic> sampleJson() => {
+        'type': 'mid_conv_system',
+        'content': [
+          {'type': 'text', 'text': 'From now on, answer in French.'},
+        ],
+        'cache_control': {'type': 'ephemeral'},
+      };
+
+      test('factory creates a mid-conversation system block', () {
+        final block = InputContentBlock.midConversationSystem(
+          content: const [TextInputBlock('Answer in French.')],
+        );
+        expect(block, isA<MidConversationSystemInputBlock>());
+        final b = block as MidConversationSystemInputBlock;
+        expect(b.content, hasLength(1));
+        expect(b.content.first.text, 'Answer in French.');
+        expect(b.cacheControl, isNull);
+      });
+
+      test('dispatches via InputContentBlock.fromJson and round-trips', () {
+        final json = sampleJson();
+        final block = InputContentBlock.fromJson(json);
+        expect(block, isA<MidConversationSystemInputBlock>());
+        expect(block.toJson(), json);
+      });
+
+      test('omits cache_control when absent', () {
+        const block = MidConversationSystemInputBlock(
+          content: [TextInputBlock('x')],
+        );
+        expect(block.toJson().containsKey('cache_control'), isFalse);
+      });
+
+      test('fromJson rejects mismatched discriminator', () {
+        final json = <String, dynamic>{'type': 'text', 'content': <dynamic>[]};
+        expect(
+          () => MidConversationSystemInputBlock.fromJson(json),
+          throwsFormatException,
+        );
+      });
+
+      test('fromJson rejects non-list content', () {
+        final json = <String, dynamic>{
+          'type': 'mid_conv_system',
+          'content': 'not-a-list',
+        };
+        expect(
+          () => MidConversationSystemInputBlock.fromJson(json),
+          throwsFormatException,
+        );
+      });
+
+      test('copyWith updates content and clears cacheControl', () {
+        const block = MidConversationSystemInputBlock(
+          content: [TextInputBlock('x')],
+          cacheControl: CacheControlEphemeral(),
+        );
+        expect(
+          block
+              .copyWith(content: const [TextInputBlock('y')])
+              .content
+              .first
+              .text,
+          'y',
+        );
+        expect(block.copyWith(cacheControl: null).cacheControl, isNull);
+      });
+
+      test('equality and toString', () {
+        const a = MidConversationSystemInputBlock(
+          content: [TextInputBlock('x')],
+        );
+        const b = MidConversationSystemInputBlock(
+          content: [TextInputBlock('x')],
+        );
+        const c = MidConversationSystemInputBlock(
+          content: [TextInputBlock('y')],
+        );
+        expect(a, equals(b));
+        expect(a.hashCode, equals(b.hashCode));
+        expect(a, isNot(equals(c)));
+        expect(a.toString(), contains('MidConversationSystemInputBlock'));
+      });
+    });
+
     group('DocumentInputBlock citations/context', () {
       test('round-trips citations and context', () {
         final block = DocumentInputBlock(
@@ -1270,6 +1356,72 @@ void main() {
       final modified = original.copyWith(toolUseId: 'id2');
       expect(modified.toolUseId, 'id2');
       expect(modified.content, isA<AdvisorResult>());
+    });
+  });
+
+  group('AdvisorResult.stopReason', () {
+    test('round-trips when present', () {
+      final json = {
+        'type': 'advisor_result',
+        'text': 'advice',
+        'stop_reason': 'max_tokens',
+      };
+      final result = AdvisorResult.fromJson(json);
+      expect(result.stopReason, 'max_tokens');
+      expect(result.toJson(), json);
+    });
+
+    test('omits stop_reason when absent', () {
+      const result = AdvisorResult(text: 'advice');
+      expect(result.toJson().containsKey('stop_reason'), isFalse);
+    });
+
+    test('copyWith updates and clears stopReason', () {
+      const result = AdvisorResult(text: 'advice', stopReason: 'end_turn');
+      expect(
+        result.copyWith(stopReason: 'max_tokens').stopReason,
+        'max_tokens',
+      );
+      expect(result.copyWith(stopReason: null).stopReason, isNull);
+    });
+
+    test('equality and toString include stopReason', () {
+      const a = AdvisorResult(text: 'advice', stopReason: 'end_turn');
+      const b = AdvisorResult(text: 'advice');
+      expect(a, isNot(equals(b)));
+      expect(a.toString(), contains('stopReason: end_turn'));
+    });
+  });
+
+  group('AdvisorRedactedResult.stopReason', () {
+    test('round-trips when present', () {
+      final json = {
+        'type': 'advisor_redacted_result',
+        'encrypted_content': 'opaque-blob',
+        'stop_reason': 'max_tokens',
+      };
+      final result = AdvisorRedactedResult.fromJson(json);
+      expect(result.stopReason, 'max_tokens');
+      expect(result.toJson(), json);
+    });
+
+    test('toString redacts encryptedContent and shows stopReason', () {
+      const result = AdvisorRedactedResult(
+        encryptedContent: 'opaque-blob',
+        stopReason: 'end_turn',
+      );
+      final s = result.toString();
+      expect(s, isNot(contains('opaque-blob')));
+      expect(s, contains('chars]'));
+      expect(s, contains('stopReason: end_turn'));
+    });
+
+    test('copyWith clears stopReason', () {
+      const result = AdvisorRedactedResult(
+        encryptedContent: 'blob',
+        stopReason: 'end_turn',
+      );
+      expect(result.copyWith(stopReason: null).stopReason, isNull);
     });
   });
 

--- a/packages/anthropic_sdk_dart/test/unit/models/message_stream_accumulator_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/message_stream_accumulator_test.dart
@@ -542,6 +542,43 @@ void main() {
         },
       );
 
+      test('threads outputTokensDetails from delta into merged usage', () {
+        final acc = _accumulate([
+          _messageStartJson(),
+          _contentBlockStartJson(0, _textBlockJson()),
+          _contentBlockDeltaJson(0, _textDeltaJson('Hi')),
+          _contentBlockStopJson(0),
+          _messageDeltaJson(
+            stopReason: 'end_turn',
+            outputTokens: 50,
+            usageExtra: {
+              'output_tokens_details': {'thinking_tokens': 30},
+            },
+          ),
+          _messageStopJson,
+        ]);
+
+        expect(acc.usage!.outputTokensDetails, isNotNull);
+        expect(acc.usage!.outputTokensDetails!.thinkingTokens, 30);
+      });
+
+      test('preserves base outputTokensDetails when delta omits it', () {
+        final acc = _accumulate([
+          _messageStartJson(
+            usageExtra: {
+              'output_tokens_details': {'thinking_tokens': 12},
+            },
+          ),
+          _contentBlockStartJson(0, _textBlockJson()),
+          _contentBlockDeltaJson(0, _textDeltaJson('Hi')),
+          _contentBlockStopJson(0),
+          _messageDeltaJson(stopReason: 'end_turn', outputTokens: 50),
+          _messageStopJson,
+        ]);
+
+        expect(acc.usage!.outputTokensDetails!.thinkingTokens, 12);
+      });
+
       test('stop reason and stop sequence', () {
         final acc = _accumulate([
           _messageStartJson(),

--- a/packages/anthropic_sdk_dart/test/unit/models/message_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/message_test.dart
@@ -160,7 +160,7 @@ void main() {
         'id': 'msg_ctx',
         'type': 'message',
         'role': 'assistant',
-        'model': 'claude-opus-4-7',
+        'model': 'claude-opus-4-8',
         'content': [
           {'type': 'text', 'text': 'Response truncated by context window.'},
         ],

--- a/packages/anthropic_sdk_dart/test/unit/models/messages/input_message_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/messages/input_message_test.dart
@@ -38,6 +38,26 @@ void main() {
         expect(message.role, MessageRole.assistant);
         expect(message.content, isA<BlocksMessageContent>());
       });
+
+      test('system() creates system message with text', () {
+        final message = InputMessage.system('Answer in French.');
+
+        expect(message.role, MessageRole.system);
+        expect(
+          (message.content as TextMessageContent).text,
+          'Answer in French.',
+        );
+        expect(message.toJson()['role'], 'system');
+      });
+
+      test('systemBlocks() creates system message with blocks', () {
+        final message = InputMessage.systemBlocks([
+          InputContentBlock.text('Answer in French.'),
+        ]);
+
+        expect(message.role, MessageRole.system);
+        expect(message.content, isA<BlocksMessageContent>());
+      });
     });
 
     group('fromJson', () {
@@ -75,6 +95,15 @@ void main() {
 
         expect(message.content, isA<BlocksMessageContent>());
         expect((message.content as BlocksMessageContent).blocks, hasLength(1));
+      });
+
+      test('parses system role (spec adds system to InputMessage.role)', () {
+        final json = {'role': 'system', 'content': 'Answer in French.'};
+
+        final message = InputMessage.fromJson(json);
+
+        expect(message.role, MessageRole.system);
+        expect(message.toJson()['role'], 'system');
       });
     });
 
@@ -197,6 +226,20 @@ void main() {
           throwsA(isA<FormatException>()),
         );
       });
+    });
+  });
+
+  group('MessageRole', () {
+    test('round-trips user, assistant, and system', () {
+      for (final role in MessageRole.values) {
+        expect(MessageRole.fromJson(role.toJson()), role);
+      }
+      expect(MessageRole.fromJson('system'), MessageRole.system);
+      expect(MessageRole.system.toJson(), 'system');
+    });
+
+    test('throws on unknown role', () {
+      expect(() => MessageRole.fromJson('tool'), throwsFormatException);
     });
   });
 }

--- a/packages/anthropic_sdk_dart/test/unit/models/models_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/models_test.dart
@@ -213,16 +213,16 @@ void main() {
     test('toJson serializes correctly', () {
       final model = ModelInfo(
         id: 'claude-opus-4-8',
-        displayName: 'Claude 3 Opus',
-        createdAt: DateTime.utc(2024, 2, 29),
+        displayName: 'Claude Opus 4.8',
+        createdAt: DateTime.utc(2026, 2, 28),
       );
 
       final json = model.toJson();
 
       expect(json['id'], 'claude-opus-4-8');
       expect(json['type'], 'model');
-      expect(json['display_name'], 'Claude 3 Opus');
-      expect(json['created_at'], '2024-02-29T00:00:00.000Z');
+      expect(json['display_name'], 'Claude Opus 4.8');
+      expect(json['created_at'], '2026-02-28T00:00:00.000Z');
       expect(json.containsKey('capabilities'), isFalse);
       expect(json.containsKey('max_input_tokens'), isFalse);
       expect(json.containsKey('max_tokens'), isFalse);
@@ -427,8 +427,8 @@ void main() {
         data: [
           ModelInfo(
             id: 'claude-opus-4-8',
-            displayName: 'Claude 3 Opus',
-            createdAt: DateTime.utc(2024, 2, 29),
+            displayName: 'Claude Opus 4.8',
+            createdAt: DateTime.utc(2026, 2, 28),
           ),
         ],
         hasMore: true,

--- a/packages/anthropic_sdk_dart/test/unit/models/models_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/models_test.dart
@@ -212,14 +212,14 @@ void main() {
 
     test('toJson serializes correctly', () {
       final model = ModelInfo(
-        id: 'claude-3-opus-20240229',
+        id: 'claude-opus-4-8',
         displayName: 'Claude 3 Opus',
         createdAt: DateTime.utc(2024, 2, 29),
       );
 
       final json = model.toJson();
 
-      expect(json['id'], 'claude-3-opus-20240229');
+      expect(json['id'], 'claude-opus-4-8');
       expect(json['type'], 'model');
       expect(json['display_name'], 'Claude 3 Opus');
       expect(json['created_at'], '2024-02-29T00:00:00.000Z');
@@ -426,14 +426,14 @@ void main() {
       final original = ModelListResponse(
         data: [
           ModelInfo(
-            id: 'claude-3-opus-20240229',
+            id: 'claude-opus-4-8',
             displayName: 'Claude 3 Opus',
             createdAt: DateTime.utc(2024, 2, 29),
           ),
         ],
         hasMore: true,
-        firstId: 'claude-3-opus-20240229',
-        lastId: 'claude-3-opus-20240229',
+        firstId: 'claude-opus-4-8',
+        lastId: 'claude-opus-4-8',
       );
 
       final json = original.toJson();

--- a/packages/anthropic_sdk_dart/test/unit/models/multiagent_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/multiagent_test.dart
@@ -139,7 +139,7 @@ void main() {
       'name': 'Worker',
       'description': null,
       'system': null,
-      'model': {'id': 'claude-opus-4-7'},
+      'model': {'id': 'claude-opus-4-8'},
       'mcp_servers': <dynamic>[],
       'skills': <dynamic>[],
       'tools': <dynamic>[],

--- a/packages/anthropic_sdk_dart/test/unit/models/token_task_budget_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/token_task_budget_test.dart
@@ -52,7 +52,7 @@ void main() {
   group('MessageCreateRequest.userProfileId', () {
     test('serializes user_profile_id when set', () {
       final request = MessageCreateRequest(
-        model: 'claude-opus-4-7',
+        model: 'claude-opus-4-8',
         messages: [InputMessage.user('hi')],
         maxTokens: 16,
         userProfileId: 'uprof_abc123',
@@ -67,7 +67,7 @@ void main() {
 
     test('omits user_profile_id when null', () {
       final request = MessageCreateRequest(
-        model: 'claude-opus-4-7',
+        model: 'claude-opus-4-8',
         messages: [InputMessage.user('hi')],
         maxTokens: 16,
       );

--- a/packages/anthropic_sdk_dart/test/unit/models/tools/advisor_tool_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/tools/advisor_tool_test.dart
@@ -4,12 +4,12 @@ import 'package:test/test.dart';
 void main() {
   group('AdvisorTool', () {
     test('toJson with minimal fields', () {
-      const tool = AdvisorTool(model: 'claude-opus-4-7');
+      const tool = AdvisorTool(model: 'claude-opus-4-8');
       final json = tool.toJson();
 
       expect(json['type'], 'advisor_20260301');
       expect(json['name'], 'advisor');
-      expect(json['model'], 'claude-opus-4-7');
+      expect(json['model'], 'claude-opus-4-8');
       expect(json.containsKey('max_uses'), isFalse);
       expect(json.containsKey('caching'), isFalse);
       expect(json.containsKey('cache_control'), isFalse);
@@ -17,7 +17,7 @@ void main() {
 
     test('toJson with all fields', () {
       const tool = AdvisorTool(
-        model: 'claude-opus-4-7',
+        model: 'claude-opus-4-8',
         maxUses: 3,
         caching: CacheControlEphemeral(ttl: CacheTtl.ttl5m),
         cacheControl: CacheControlEphemeral(ttl: CacheTtl.ttl1h),
@@ -26,7 +26,7 @@ void main() {
 
       expect(json['type'], 'advisor_20260301');
       expect(json['name'], 'advisor');
-      expect(json['model'], 'claude-opus-4-7');
+      expect(json['model'], 'claude-opus-4-8');
       expect(json['max_uses'], 3);
       expect(json['caching'], {'type': 'ephemeral', 'ttl': '5m'});
       expect(json['cache_control'], {'type': 'ephemeral', 'ttl': '1h'});
@@ -36,12 +36,12 @@ void main() {
       final json = {
         'type': 'advisor_20260301',
         'name': 'advisor',
-        'model': 'claude-opus-4-7',
+        'model': 'claude-opus-4-8',
       };
       final tool = AdvisorTool.fromJson(json);
 
       expect(tool.type, 'advisor_20260301');
-      expect(tool.model, 'claude-opus-4-7');
+      expect(tool.model, 'claude-opus-4-8');
       expect(tool.maxUses, isNull);
       expect(tool.caching, isNull);
       expect(tool.cacheControl, isNull);
@@ -49,7 +49,7 @@ void main() {
       expect(tool.toJson(), {
         'type': 'advisor_20260301',
         'name': 'advisor',
-        'model': 'claude-opus-4-7',
+        'model': 'claude-opus-4-8',
       });
     });
 
@@ -57,7 +57,7 @@ void main() {
       final json = {
         'type': 'advisor_20260301',
         'name': 'advisor',
-        'model': 'claude-opus-4-7',
+        'model': 'claude-opus-4-8',
         'max_uses': 5,
         'caching': {'type': 'ephemeral', 'ttl': '1h'},
         'cache_control': {'type': 'ephemeral', 'ttl': '5m'},
@@ -77,36 +77,36 @@ void main() {
       final json = {
         'type': 'advisor_20260301',
         'name': 'advisor',
-        'model': 'claude-opus-4-7',
+        'model': 'claude-opus-4-8',
       };
       final tool = BuiltInTool.fromJson(json);
 
       expect(tool, isA<AdvisorTool>());
-      expect((tool as AdvisorTool).model, 'claude-opus-4-7');
+      expect((tool as AdvisorTool).model, 'claude-opus-4-8');
     });
 
     test('BuiltInTool.advisor factory', () {
-      final tool = BuiltInTool.advisor(model: 'claude-opus-4-7', maxUses: 2);
+      final tool = BuiltInTool.advisor(model: 'claude-opus-4-8', maxUses: 2);
 
       expect(tool, isA<AdvisorTool>());
-      expect((tool as AdvisorTool).model, 'claude-opus-4-7');
+      expect((tool as AdvisorTool).model, 'claude-opus-4-8');
       expect(tool.maxUses, 2);
     });
 
     test('ToolDefinition.builtIn wraps AdvisorTool', () {
-      const advisorTool = AdvisorTool(model: 'claude-opus-4-7');
+      const advisorTool = AdvisorTool(model: 'claude-opus-4-8');
       final toolDef = ToolDefinition.builtIn(advisorTool);
       final json = toolDef.toJson();
 
       expect(json['type'], 'advisor_20260301');
       expect(json['name'], 'advisor');
-      expect(json['model'], 'claude-opus-4-7');
+      expect(json['model'], 'claude-opus-4-8');
     });
 
     test('equality', () {
-      const a = AdvisorTool(model: 'claude-opus-4-7');
-      const b = AdvisorTool(model: 'claude-opus-4-7');
-      const c = AdvisorTool(model: 'claude-opus-4-7', maxUses: 3);
+      const a = AdvisorTool(model: 'claude-opus-4-8');
+      const b = AdvisorTool(model: 'claude-opus-4-8');
+      const c = AdvisorTool(model: 'claude-opus-4-8', maxUses: 3);
 
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));
@@ -114,10 +114,10 @@ void main() {
     });
 
     test('copyWith', () {
-      const original = AdvisorTool(model: 'claude-opus-4-7');
+      const original = AdvisorTool(model: 'claude-opus-4-8');
 
       final withMaxUses = original.copyWith(maxUses: 5);
-      expect(withMaxUses.model, 'claude-opus-4-7');
+      expect(withMaxUses.model, 'claude-opus-4-8');
       expect(withMaxUses.maxUses, 5);
 
       final withCaching = original.copyWith(
@@ -133,23 +133,23 @@ void main() {
     });
 
     test('toString', () {
-      const tool = AdvisorTool(model: 'claude-opus-4-7');
+      const tool = AdvisorTool(model: 'claude-opus-4-8');
       expect(tool.toString(), contains('AdvisorTool'));
-      expect(tool.toString(), contains('claude-opus-4-7'));
+      expect(tool.toString(), contains('claude-opus-4-8'));
     });
 
     test('ToolDefinition.fromJson routes advisor tool correctly', () {
       final json = {
         'type': 'advisor_20260301',
         'name': 'advisor',
-        'model': 'claude-opus-4-7',
+        'model': 'claude-opus-4-8',
       };
       final toolDef = ToolDefinition.fromJson(json);
 
       expect(toolDef, isA<BuiltInToolDefinition>());
       final builtIn = (toolDef as BuiltInToolDefinition).tool;
       expect(builtIn, isA<AdvisorTool>());
-      expect((builtIn as AdvisorTool).model, 'claude-opus-4-7');
+      expect((builtIn as AdvisorTool).model, 'claude-opus-4-8');
     });
   });
 }

--- a/packages/anthropic_sdk_dart/test/unit/models/usage_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/usage_test.dart
@@ -22,7 +22,7 @@ void main() {
     test('fromJson parses advisor_message iteration with model', () {
       final json = {
         'type': 'advisor_message',
-        'model': 'claude-opus-4-7',
+        'model': 'claude-opus-4-8',
         'input_tokens': 823,
         'output_tokens': 1612,
         'cache_creation_input_tokens': 0,
@@ -31,7 +31,7 @@ void main() {
       final usage = IterationUsage.fromJson(json);
 
       expect(usage.type, 'advisor_message');
-      expect(usage.model, 'claude-opus-4-7');
+      expect(usage.model, 'claude-opus-4-8');
       expect(usage.inputTokens, 823);
       expect(usage.outputTokens, 1612);
     });
@@ -41,12 +41,12 @@ void main() {
         type: 'advisor_message',
         inputTokens: 100,
         outputTokens: 200,
-        model: 'claude-opus-4-7',
+        model: 'claude-opus-4-8',
       );
       final json = usage.toJson();
 
       expect(json['type'], 'advisor_message');
-      expect(json['model'], 'claude-opus-4-7');
+      expect(json['model'], 'claude-opus-4-8');
     });
 
     test('toJson omits model when null', () {
@@ -63,7 +63,7 @@ void main() {
     test('round-trip advisor_message iteration', () {
       final original = {
         'type': 'advisor_message',
-        'model': 'claude-opus-4-7',
+        'model': 'claude-opus-4-8',
         'input_tokens': 823,
         'output_tokens': 1612,
         'cache_creation_input_tokens': 0,
@@ -78,13 +78,13 @@ void main() {
         type: 'advisor_message',
         inputTokens: 100,
         outputTokens: 200,
-        model: 'claude-opus-4-7',
+        model: 'claude-opus-4-8',
       );
       const b = IterationUsage(
         type: 'advisor_message',
         inputTokens: 100,
         outputTokens: 200,
-        model: 'claude-opus-4-7',
+        model: 'claude-opus-4-8',
       );
       const c = IterationUsage(
         type: 'advisor_message',
@@ -103,7 +103,7 @@ void main() {
         type: 'advisor_message',
         inputTokens: 100,
         outputTokens: 200,
-        model: 'claude-opus-4-7',
+        model: 'claude-opus-4-8',
       );
 
       final changed = original.copyWith(model: 'claude-sonnet-4-6');
@@ -129,7 +129,7 @@ void main() {
           },
           {
             'type': 'advisor_message',
-            'model': 'claude-opus-4-7',
+            'model': 'claude-opus-4-8',
             'input_tokens': 823,
             'output_tokens': 1612,
             'cache_creation_input_tokens': 0,
@@ -153,11 +153,112 @@ void main() {
       expect(usage.iterations![0].model, isNull);
 
       expect(usage.iterations![1].type, 'advisor_message');
-      expect(usage.iterations![1].model, 'claude-opus-4-7');
+      expect(usage.iterations![1].model, 'claude-opus-4-8');
       expect(usage.iterations![1].inputTokens, 823);
 
       expect(usage.iterations![2].type, 'message');
       expect(usage.iterations![2].cacheReadInputTokens, 412);
+    });
+  });
+
+  group('OutputTokensDetails', () {
+    test('fromJson/toJson round-trip', () {
+      final json = {'thinking_tokens': 128};
+      final details = OutputTokensDetails.fromJson(json);
+      expect(details.thinkingTokens, 128);
+      expect(details.toJson(), json);
+    });
+
+    test('defaults thinkingTokens to 0 when absent', () {
+      final json = <String, dynamic>{};
+      final details = OutputTokensDetails.fromJson(json);
+      expect(details.thinkingTokens, 0);
+    });
+
+    test('copyWith and equality', () {
+      const a = OutputTokensDetails(thinkingTokens: 10);
+      expect(a.copyWith(thinkingTokens: 20).thinkingTokens, 20);
+      expect(a, const OutputTokensDetails(thinkingTokens: 10));
+      expect(
+        a.hashCode,
+        const OutputTokensDetails(thinkingTokens: 10).hashCode,
+      );
+      expect(a, isNot(const OutputTokensDetails(thinkingTokens: 20)));
+      expect(a.toString(), contains('thinkingTokens: 10'));
+    });
+  });
+
+  group('Usage.outputTokensDetails', () {
+    test('parses and round-trips outputTokensDetails', () {
+      final json = {
+        'input_tokens': 10,
+        'output_tokens': 200,
+        'output_tokens_details': {'thinking_tokens': 150},
+      };
+      final usage = Usage.fromJson(json);
+      expect(usage.outputTokensDetails, isNotNull);
+      expect(usage.outputTokensDetails!.thinkingTokens, 150);
+      expect(usage.toJson(), json);
+    });
+
+    test('omits output_tokens_details when null', () {
+      const usage = Usage(inputTokens: 10, outputTokens: 20);
+      expect(usage.toJson().containsKey('output_tokens_details'), isFalse);
+    });
+
+    test('copyWith updates and clears outputTokensDetails', () {
+      const usage = Usage(
+        inputTokens: 10,
+        outputTokens: 20,
+        outputTokensDetails: OutputTokensDetails(thinkingTokens: 5),
+      );
+      final updated = usage.copyWith(
+        outputTokensDetails: const OutputTokensDetails(thinkingTokens: 9),
+      );
+      expect(updated.outputTokensDetails!.thinkingTokens, 9);
+      expect(
+        usage.copyWith(outputTokensDetails: null).outputTokensDetails,
+        isNull,
+      );
+    });
+
+    test('equality and toString include outputTokensDetails', () {
+      const a = Usage(
+        inputTokens: 10,
+        outputTokens: 20,
+        outputTokensDetails: OutputTokensDetails(thinkingTokens: 5),
+      );
+      const b = Usage(inputTokens: 10, outputTokens: 20);
+      expect(a, isNot(b));
+      expect(a.toString(), contains('outputTokensDetails'));
+    });
+  });
+
+  group('MessageDeltaUsage.outputTokensDetails', () {
+    test('parses and round-trips outputTokensDetails', () {
+      final json = {
+        'output_tokens': 80,
+        'output_tokens_details': {'thinking_tokens': 40},
+      };
+      final usage = MessageDeltaUsage.fromJson(json);
+      expect(usage.outputTokensDetails!.thinkingTokens, 40);
+      expect(usage.toJson(), json);
+    });
+
+    test('omits output_tokens_details when null', () {
+      const usage = MessageDeltaUsage(outputTokens: 80);
+      expect(usage.toJson().containsKey('output_tokens_details'), isFalse);
+    });
+
+    test('copyWith clears outputTokensDetails', () {
+      const usage = MessageDeltaUsage(
+        outputTokens: 80,
+        outputTokensDetails: OutputTokensDetails(thinkingTokens: 5),
+      );
+      expect(
+        usage.copyWith(outputTokensDetails: null).outputTokensDetails,
+        isNull,
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
- Refreshes the package to the latest Anthropic OpenAPI spec (pinned hash `71eed687…`), coinciding with the **Claude Opus 4.8** release.
- Adds **mid-conversation system messages**: the new `mid_conv_system` content block lets you update system instructions inside the `messages` array without a separate user turn or disrupting prompt caching.
- Also surfaces the spec's new `system` message role: adds `MessageRole.system` and `InputMessage.system(...)` / `InputMessage.systemBlocks(...)` so `role: "system"` messages round-trip (previously `MessageRole.fromJson('system')` threw).
- Adds an `outputTokensDetails` breakdown (with `thinkingTokens`) to `Usage` and `MessageDeltaUsage` for reasoning-token observability.
- Adds a nullable `stopReason` to advisor results (`AdvisorResult`, `AdvisorRedactedResult`).
- Migrates stale Opus model references across examples, docs, and tests to `claude-opus-4-8`.

## Details

**Mid-conversation system messages (`mid_conv_system`)** — a new variant `MidConversationSystemInputBlock` on the sealed `InputContentBlock` union, plus a convenience factory:

```dart
final response = await client.messages.create(
  MessageCreateRequest(
    model: 'claude-opus-4-8',
    maxTokens: 1024,
    system: SystemPrompt.text('You are a helpful assistant.'),
    messages: [
      InputMessage.user('What is the capital of France?'),
      InputMessage.assistant('The capital of France is Paris.'),
      // Update instructions mid-conversation, then ask a follow-up.
      InputMessage.userBlocks([
        InputContentBlock.midConversationSystem(
          content: [const TextInputBlock('From now on, always answer in French.')],
        ),
        InputContentBlock.text('What is its population?'),
      ]),
    ],
  ),
);
```

The block matches the official SDK's `MidConversationSystemBlockParam` and exists only on the input/request side (there is no response-side variant). See the new [`mid_conversation_system_example.dart`](packages/anthropic_sdk_dart/example/mid_conversation_system_example.dart).

**Output token details** — `outputTokens` remains the authoritative billed total; `outputTokensDetails.thinkingTokens` is a read-only decomposition for observability:

```dart
final details = response.usage.outputTokensDetails;
if (details != null) print('Thinking tokens: ${details.thinkingTokens}');
```

**Web-fetch error code** — the spec adds `url_not_in_prior_context` to the web-fetch error enum. The SDK stores web-fetch error content as a raw `Map<String, dynamic>` (not a typed enum), so this requires no code change — only acknowledged manifest skip entries.

**Other announcements reviewed**: Opus 4.8 is otherwise a drop-in model string (no new params); refusal stop details were already modeled (`RefusalCategory`); and "Dynamic Workflows in Claude Code" adds **no** OpenAPI surface (verified: zero new schemas/endpoints in the spec diff) — it rides on existing Messages-API tool use.

Spec sync verified clean via the toolkit: `review` reports 0 changed types, 0 errors, and 0 missing manifest entries.

## Breaking Changes

- A new variant `MidConversationSystemInputBlock` was added to the **exported sealed union `InputContentBlock`**. Following the same convention as the 3.0.0 release, this is breaking only for code with exhaustive `switch` statements over `InputContentBlock` that lack a wildcard or `UnknownInputContentBlock` branch. Pure-deserialization consumers are unaffected.
- Additionally, a `system` value was added to the `MessageRole` enum. Exhaustive `switch` statements over `MessageRole` that lack a default branch must add a `system` case.

  ```dart
  // Before — exhaustive switch with no default
  switch (block) {
    case TextInputBlock(): ...
    case ImageInputBlock(): ...
    // ... all other variants
  }

  // After — add a case for the new variant (or a wildcard/Unknown branch)
  switch (block) {
    case MidConversationSystemInputBlock(): ...
    // ...
    case UnknownInputContentBlock(): ...
  }
  ```

## References

- [Claude Opus 4.8 announcement](https://www.anthropic.com/news/claude-opus-4-8) — introduces mid-conversation system messages.
- [Model migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide) — Opus 4.7 → 4.8 has no breaking API changes beyond the new mid-conversation system messages and documented refusal stop details.

## Test Plan

- [x] Unit tests pass for affected package (`dart test test/unit/`: 1011 passing)
- [x] New tests added: `OutputTokensDetails`, `Usage`/`MessageDeltaUsage` `outputTokensDetails`, `MidConversationSystemInputBlock` (dispatch, round-trip, discriminator/non-list rejection, equality), advisor `stopReason` round-trip + redaction
- [x] Sealed-variant change includes round-trip, error, and equality tests
- [x] `fromJson`/`toJson` round-trip serialization verified
- [x] `==`/`hashCode` contract verified (full-field on `Usage`/`MessageDeltaUsage`)
- [x] `dart analyze --fatal-infos` clean; `dart format` clean
- [x] Toolkit `review` reports spec in sync (0 errors, 0 missing manifest entries)
- [ ] Integration tests (not run — hit live APIs)