### PR TITLE
chore(anthropic_sdk_dart): re-pin spec and fix verify false-positives

### DIFF
--- a/.agents/shared/api-toolkit/api_toolkit/dart_inspect.py
+++ b/.agents/shared/api-toolkit/api_toolkit/dart_inspect.py
@@ -174,11 +174,12 @@ def camel_case(name: str) -> str:
     if "_" not in name:
         return name[0].lower() + name[1:] if name and name[0].isupper() else name
     parts = name.split("_")
-    # Capitalize each trailing segment's first character only. Unlike str.title(),
-    # this does NOT treat a digit as a word boundary, so a duration segment such as
-    # "1h" stays "1h" (matching Dart field names like `ephemeral1hInputTokens`)
-    # instead of becoming "1H". For all-lowercase snake segments this is identical
-    # to the previous str.title() behaviour.
+    # Capitalize each trailing segment's first character and lowercase the rest —
+    # like str.title() but WITHOUT treating digits as word boundaries, so a letter
+    # is never uppercased just because a digit precedes it: "1h" stays "1h"
+    # (matching Dart field names like `ephemeral1hInputTokens`) and "v2beta"
+    # becomes "V2beta", where str.title() would yield "1H"/"V2Beta". Behaviour is
+    # identical to str.title() only for segments with no digit-adjacent letters.
     return parts[0] + "".join(p[:1].upper() + p[1:].lower() for p in parts[1:])
 
 

--- a/.agents/shared/api-toolkit/api_toolkit/dart_inspect.py
+++ b/.agents/shared/api-toolkit/api_toolkit/dart_inspect.py
@@ -174,7 +174,12 @@ def camel_case(name: str) -> str:
     if "_" not in name:
         return name[0].lower() + name[1:] if name and name[0].isupper() else name
     parts = name.split("_")
-    return parts[0] + "".join(part.title() for part in parts[1:])
+    # Capitalize each trailing segment's first character only. Unlike str.title(),
+    # this does NOT treat a digit as a word boundary, so a duration segment such as
+    # "1h" stays "1h" (matching Dart field names like `ephemeral1hInputTokens`)
+    # instead of becoming "1H". For all-lowercase snake segments this is identical
+    # to the previous str.title() behaviour.
+    return parts[0] + "".join(p[:1].upper() + p[1:].lower() for p in parts[1:])
 
 
 def snake_case(name: str) -> str:

--- a/.agents/shared/api-toolkit/api_toolkit/operations.py
+++ b/.agents/shared/api-toolkit/api_toolkit/operations.py
@@ -901,10 +901,14 @@ def _parse_openapi_property(prop: dict[str, Any], required: set[str], name: str)
     # OpenAPI 3.1 allows type to be a list (e.g. ["integer", "null"]).
     # Presence of "null" in the list means the field's value may be null;
     # required-ness is determined solely by the schema's required list.
+    # OpenAPI 3.0 spells the same thing with a separate `nullable: true` boolean,
+    # so honor it too — otherwise required+nullable fields look required+non-nullable.
     type_list_has_null = isinstance(raw_type, list) and "null" in raw_type
     info: dict[str, Any] = {
         "required": name in required,
-        "nullable": type_list_has_null,  # value can be null (orthogonal to required)
+        # value can be null (orthogonal to required); covers both 3.1 type-unions
+        # and the 3.0 `nullable: true` flag
+        "nullable": type_list_has_null or prop.get("nullable") is True,
         "type": raw_type,
         "ref": None,
         "items": prop.get("items"),

--- a/.agents/shared/api-toolkit/tests/test_api_toolkit_commands.py
+++ b/.agents/shared/api-toolkit/tests/test_api_toolkit_commands.py
@@ -2643,6 +2643,66 @@ class ApiToolkitCommandTests(unittest.TestCase):
                 any("required in spec but nullable in Dart" in issue["message"] for issue in payload["results"]["implementation"]["issues"])
             )
 
+    def test_verify_required_openapi30_nullable_is_not_blocking(self) -> None:
+        # A required field that is ALSO `nullable: true` (OpenAPI 3.0 style) must
+        # map to a nullable Dart field — the key is always present but its value
+        # may be null. The verifier must honor the 3.0 boolean, not only the 3.1
+        # `type: [..., "null"]` union form.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            self._write_workspace(root)
+            self._write_repo_license(root)
+            package_root, config_dir = self._create_openapi_config(root)
+            (package_root / "specs" / "openapi.json").write_text(
+                json.dumps(
+                    {
+                        "openapi": "3.0.0",
+                        "info": {"title": "Sample", "version": "1"},
+                        "paths": {},
+                        "components": {
+                            "schemas": {
+                                "Example": {
+                                    "type": "object",
+                                    "properties": {"id": {"type": "string", "nullable": True}},
+                                    "required": ["id"],
+                                }
+                            }
+                        },
+                    }
+                )
+            )
+            self._write_specs_and_manifest(
+                config_dir,
+                specs_payload={
+                    "specs": {"main": {"name": "Sample", "local_file": "openapi.json", "fetch_mode": "local_file", "source_file": "specs/openapi.json"}},
+                    "specs_dir": "packages/sample_dart/specs",
+                    "output_dir": str(root / "tmp" / "sample"),
+                },
+                manifest_payload={
+                    "surface": "openapi",
+                    "type_mappings": {},
+                    "placement": {"categories": {}, "default_category": "common", "parent_model_patterns": {}},
+                    "coverage": {},
+                    "types": {
+                        "Example": {"spec": "main", "kind": "object", "dart_class": "Example", "file": "lib/src/models/common/example.dart", "schema": "Example"}
+                    },
+                },
+            )
+            self._write_model(
+                package_root / "lib" / "src" / "models" / "common" / "example.dart",
+                "Example",
+                fields=[("id", "String", True)],
+            )
+
+            _, payload = command_verify(
+                SimpleNamespace(config_dir=config_dir, spec_name=None, checks="implementation", scope="all", type_name=None, baseline=None, git_ref=None)
+            )
+
+            self.assertFalse(
+                any("required in spec but nullable in Dart" in issue["message"] for issue in payload["results"]["implementation"]["issues"]),
+                msg="OpenAPI 3.0 nullable:true on a required field must not be flagged required-but-nullable",
+            )
+
     def test_verify_missing_copywith_coverage_is_blocking(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)

--- a/.agents/shared/api-toolkit/tests/test_api_toolkit_commands.py
+++ b/.agents/shared/api-toolkit/tests/test_api_toolkit_commands.py
@@ -2694,10 +2694,15 @@ class ApiToolkitCommandTests(unittest.TestCase):
                 fields=[("id", "String", True)],
             )
 
-            _, payload = command_verify(
+            exit_code, payload = command_verify(
                 SimpleNamespace(config_dir=config_dir, spec_name=None, checks="implementation", scope="all", type_name=None, baseline=None, git_ref=None)
             )
 
+            self.assertEqual(
+                exit_code,
+                0,
+                msg="verify should pass cleanly for a correct 3.0 required+nullable field",
+            )
             self.assertFalse(
                 any("required in spec but nullable in Dart" in issue["message"] for issue in payload["results"]["implementation"]["issues"]),
                 msg="OpenAPI 3.0 nullable:true on a required field must not be flagged required-but-nullable",

--- a/.agents/shared/api-toolkit/tests/test_api_toolkit_commands.py
+++ b/.agents/shared/api-toolkit/tests/test_api_toolkit_commands.py
@@ -2688,10 +2688,36 @@ class ApiToolkitCommandTests(unittest.TestCase):
                     },
                 },
             )
-            self._write_model(
-                package_root / "lib" / "src" / "models" / "common" / "example.dart",
-                "Example",
-                fields=[("id", "String", True)],
+            # Faithful required+nullable model: `id` is `String?` AND a *required*
+            # constructor parameter, and toJson *always* emits the key (even when
+            # null) — exactly how the SDK models spec required+nullable fields. The
+            # _write_model helper would instead make `id` optional and omit it when
+            # null, which would not actually model "key always present".
+            example_path = package_root / "lib" / "src" / "models" / "common" / "example.dart"
+            example_path.parent.mkdir(parents=True, exist_ok=True)
+            example_path.write_text(
+                "class Example {\n"
+                "  final String? id;\n"
+                "\n"
+                "  const Example({required this.id});\n"
+                "\n"
+                "  factory Example.fromJson(Map<String, dynamic> json) =>\n"
+                "      Example(id: json['id'] as String?);\n"
+                "\n"
+                "  Map<String, dynamic> toJson() => {'id': id};\n"
+                "\n"
+                "  Example copyWith({String? id}) => Example(id: id ?? this.id);\n"
+                "\n"
+                "  @override\n"
+                "  bool operator ==(Object other) =>\n"
+                "      identical(this, other) || (other is Example && other.id == id);\n"
+                "\n"
+                "  @override\n"
+                "  int get hashCode => id.hashCode;\n"
+                "\n"
+                "  @override\n"
+                "  String toString() => 'Example(id: $id)';\n"
+                "}\n"
             )
 
             exit_code, payload = command_verify(

--- a/.agents/shared/api-toolkit/tests/test_dart_inspect.py
+++ b/.agents/shared/api-toolkit/tests/test_dart_inspect.py
@@ -10,6 +10,7 @@ if str(ROOT) not in os.sys.path:
     os.sys.path.insert(0, str(ROOT))
 
 from api_toolkit.dart_inspect import (
+    camel_case,
     extract_class_block,
     extract_fields,
     extract_from_json_keys,
@@ -20,6 +21,19 @@ from api_toolkit.dart_inspect import (
 
 
 class DartInspectTests(unittest.TestCase):
+    def test_camel_case_does_not_uppercase_letter_after_digit(self) -> None:
+        # A digit must not act as a word boundary: "1h"/"5m" stay lowercase so the
+        # result matches Dart fields like `ephemeral1hInputTokens`.
+        self.assertEqual(camel_case("ephemeral_1h_input_tokens"), "ephemeral1hInputTokens")
+        self.assertEqual(camel_case("ephemeral_5m_input_tokens"), "ephemeral5mInputTokens")
+        self.assertEqual(camel_case("ttl_1h"), "ttl1h")
+
+    def test_camel_case_unchanged_for_plain_snake_segments(self) -> None:
+        # Behaviour for all-lowercase snake_case segments is identical to before.
+        self.assertEqual(camel_case("cache_creation_input_tokens"), "cacheCreationInputTokens")
+        self.assertEqual(camel_case("next_page"), "nextPage")
+        self.assertEqual(camel_case("id"), "id")
+
     def test_extract_class_block_returns_matching_class_only(self) -> None:
         content = (
             "class Before {\n"

--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/documentation.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/documentation.json
@@ -17,7 +17,15 @@
   ],
   "resource_to_example": {
     "messages": "messages",
-    "models": "models"
+    "models": "models",
+    "agents": "managed_agents",
+    "sessions": "managed_agents",
+    "sessionEvents": "managed_agents",
+    "vaults": "managed_agents",
+    "vaultCredentials": "managed_agents",
+    "sessionThreadEvents": "session_threads",
+    "memories": "memory_stores",
+    "memoryVersions": "memory_stores"
   },
   "excluded_from_examples": [],
   "drift_patterns": []

--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/specs.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/specs.json
@@ -31,9 +31,9 @@
       "fetch_mode": "remote",
       "local_file": "openapi.yaml",
       "name": "Anthropic API",
-      "pinned_hash": "71eed687650366ea3e1abe6cfed0d15877e6423a56ecf7193a952fd4ee0cb72b",
+      "pinned_hash": "3044bdebca823a5e350accb2a228438e6ca5fb06cbac2cb1e0f98baa2bcc2359",
       "requires_auth": false,
-      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-71eed687650366ea3e1abe6cfed0d15877e6423a56ecf7193a952fd4ee0cb72b.yml"
+      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-3044bdebca823a5e350accb2a228438e6ca5fb06cbac2cb1e0f98baa2bcc2359.yml"
     }
   },
   "specs_dir": "packages/anthropic_sdk_dart/specs"

--- a/packages/anthropic_sdk_dart/README.md
+++ b/packages/anthropic_sdk_dart/README.md
@@ -509,7 +509,7 @@ Future<void> main() async {
 <details>
 <summary><b>Show example</b></summary>
 
-Use `client.agents`, `client.sessions`, and `client.vaults` for the Managed Agents beta API. Create an agent configuration, start sessions to interact with Claude, and use vaults to securely store credentials.
+Use `client.agents`, `client.sessions`, and `client.vaults` for the Managed Agents beta API. Create an agent configuration, start sessions to interact with Claude, list session events and session thread events as the agent works, and store vault credentials securely.
 
 ```dart
 import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';

--- a/packages/anthropic_sdk_dart/specs/spec_metadata.json
+++ b/packages/anthropic_sdk_dart/specs/spec_metadata.json
@@ -2,8 +2,8 @@
   "specs": {
     "main": {
       "current_version": "unknown",
-      "last_fetched": "2026-05-28T23:41:39.547394Z",
-      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-71eed687650366ea3e1abe6cfed0d15877e6423a56ecf7193a952fd4ee0cb72b.yml",
+      "last_fetched": "2026-06-02T11:50:53.075706Z",
+      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-3044bdebca823a5e350accb2a228438e6ca5fb06cbac2cb1e0f98baa2bcc2359.yml",
       "title": "Anthropic API",
       "version_history": [
         {


### PR DESCRIPTION
## Summary
- Refresh the pinned Anthropic OpenAPI spec hash from `71eed687` → `3044bdeb`. Stainless re-published the spec under a new hash with **byte-identical content** — `specs/openapi.yaml` is unchanged and `review` reports 0 endpoint/schema/type changes — so there are **no client code changes**, only the pin and fetch metadata are synced.
- Clear all api-toolkit `verify` errors (9 implementation + 12 docs), which were **pre-existing toolkit/config false-positives** (the spec content is unchanged, so they predate this change), via root-cause fixes — no Dart code was wrong.

## Details

### Spec re-pin (no content change)
`fetch` reported the pin as outdated, but the new spec is byte-for-byte identical to the committed one (same SHA-256, empty `diff`). Updated `pinned_hash`/`url` in `config/specs.json` and the refreshed `specs/spec_metadata.json` so future `fetch` runs report `outdated: false`.

### Toolkit verify fixes (root cause, with regression tests)
1. **Honor OpenAPI 3.0 `nullable: true`.** `_parse_openapi_property` derived field nullability **only** from OpenAPI 3.1 `type: [..., "null"]` unions and ignored the 3.0 `nullable: true` boolean the Anthropic spec uses. This falsely flagged 4 required+nullable fields as "required in spec but nullable in Dart" (`Session.title`, `ListUserProfilesResponse.next_page`, `SpanModelRequestEndEvent.is_error`, `CreateMemoryParams.content`). The Dart nullable typing is correct per the toolkit's own decision table. Safe blast radius: `nullable` is consumed only by the required/nullable check and scaffold's required detection — not by `_expected_dart_type` — so this can only *reduce* false errors across packages.
2. **camelCase digit handling.** `camel_case` used `str.title()`, so `"1h".title()` → `"1H"`; the verifier expected `ephemeral1HInputTokens` while the SDK correctly uses `ephemeral1hInputTokens` (consistent with sibling `CacheCreation`/`CacheRead`). Fixed so digits are not word boundaries. Scoped check: only 4 spec keys across **all** packages have a digit-first segment (`ephemeral_1h/5m_input_tokens`, `ttl_1h/5m`), all Anthropic cache fields using lowercase in Dart — so the change is identical to the old behavior for every other input.

### Docs registration (no missing examples)
The flagged resources are covered by *grouped* example files that simply weren't registered:
- `documentation.json` `resource_to_example`: `agents`/`sessions`/`sessionEvents`/`vaults`/`vaultCredentials` → `managed_agents`, `sessionThreadEvents` → `session_threads`, `memories`/`memoryVersions` → `memory_stores`.
- `README.md`: mention session events, session thread events, and vault credentials in the managed-agents section so the docs presence check resolves them.

### Out of scope
The remaining `verify` **warnings** are a separate pre-existing backlog unrelated to the spec (16 `ContentBlock` union-discriminator-mapping, 12 managed-agents `consistency` nullability/type mismatches, 1 README `section-order`). Left as-is.

## Test Plan
- [x] `verify --checks all --scope all` → `failing_checks: []` (21 errors → 0)
- [x] api-toolkit pytest: 3 new regression tests pass; the only failures are pre-existing and unrelated (5× `tiktoken` environmental errors, 1× a stale skip-keys snapshot that drifts across 5 packages independent of this change)
- [x] `dart analyze --fatal-infos` → no issues
- [x] `dart format --set-exit-if-changed .` → clean
- [x] `dart test test/unit/` → all pass (4 skipped only because `ANTHROPIC_API_KEY` is set locally)
- [x] No `lib/` changes → no version bump; CHANGELOG/pubspec untouched (handled by /release)