### PR TITLE
feat(openai_dart): add additional_tools item and personality preset

### DIFF
--- a/packages/openai_dart/.agents/skills/openapi-openai/config/manifest.json
+++ b/packages/openai_dart/.agents/skills/openapi-openai/config/manifest.json
@@ -242,6 +242,104 @@
     "excluded_resources": []
   },
   "types": {
+    "PersonalityEnum": {
+      "spec": "main",
+      "kind": "sealed_parent",
+      "dart_class": "Personality",
+      "file": "lib/src/models/responses/config/personality.dart",
+      "schema": "PersonalityEnum",
+      "note": "Open string enum (anyOf string | {friendly, pragmatic}) modeled as a sealed union with friendly/pragmatic variants plus a custom string variant."
+    },
+    "PersonalityEnum:FriendlyPersonality": {
+      "spec": "main",
+      "kind": "extension",
+      "dart_class": "FriendlyPersonality",
+      "file": "lib/src/models/responses/config/personality.dart",
+      "schema": null,
+      "parent": "Personality",
+      "note": "Dart-only string variant for 'friendly'."
+    },
+    "PersonalityEnum:PragmaticPersonality": {
+      "spec": "main",
+      "kind": "extension",
+      "dart_class": "PragmaticPersonality",
+      "file": "lib/src/models/responses/config/personality.dart",
+      "schema": null,
+      "parent": "Personality",
+      "note": "Dart-only string variant for 'pragmatic'."
+    },
+    "PersonalityEnum:CustomPersonality": {
+      "spec": "main",
+      "kind": "extension",
+      "dart_class": "CustomPersonality",
+      "file": "lib/src/models/responses/config/personality.dart",
+      "schema": null,
+      "parent": "Personality",
+      "note": "Dart-only open string variant for forward-compatible/custom values."
+    },
+    "TokenCountsBody": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "file": "lib/src/resources/input_tokens_resource.dart",
+      "schema": "TokenCountsBody",
+      "tags": ["acknowledged"],
+      "note": "Request body built inline in InputTokensResource.count() (no request model). personality field added."
+    },
+    "Item": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "Item",
+      "file": "lib/src/models/responses/items/item.dart",
+      "schema": null,
+      "tags": ["acknowledged"],
+      "note": "Sealed parent union of input items with untracked variants (matches ConversationItem/OutputItem). AdditionalToolsItemParam variant added."
+    },
+    "ItemField": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "file": "lib/src/models/responses/items/output_item.dart",
+      "schema": null,
+      "tags": ["acknowledged"],
+      "note": "Orphan spec union unreferenced by any endpoint; shares the OutputItem shape. AdditionalTools variant added."
+    },
+    "AdditionalTools": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "AdditionalToolsOutputItem",
+      "file": "lib/src/models/responses/items/output_item.dart",
+      "schema": "AdditionalTools",
+      "tags": ["acknowledged"],
+      "note": "Output/conversation item variant of the skip parent unions OutputItem/ItemResource/ConversationItem; also implemented as ConversationAdditionalToolsItem."
+    },
+    "AdditionalToolsItemParam": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "AdditionalToolsItemParam",
+      "file": "lib/src/models/responses/items/item.dart",
+      "schema": "AdditionalToolsItemParam",
+      "tags": ["acknowledged"],
+      "note": "Input item variant of the skip parent union Item."
+    },
+    "AuditLog": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "file": null,
+      "schema": "AuditLog",
+      "tags": ["acknowledged"],
+      "note": "Admin API audit-log schema, excluded from coverage (excluded_tags: Administration). Not implemented."
+    },
+    "AuditLogEventType": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "file": null,
+      "schema": "AuditLogEventType",
+      "tags": ["acknowledged"],
+      "note": "Admin API audit-log enum, excluded from coverage (excluded_tags: Administration). Not implemented."
+    },
     "CreateChatCompletionRequest": {
       "spec": "main",
       "kind": "skip",

--- a/packages/openai_dart/.agents/skills/openapi-openai/config/specs.json
+++ b/packages/openai_dart/.agents/skills/openapi-openai/config/specs.json
@@ -28,7 +28,7 @@
       "local_file": "openapi.json",
       "name": "OpenAI API",
       "requires_auth": false,
-      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-afacc4343d0efc074c8c5667eb83570642c8b9acaa7792ca8e075c6d18ef9f3a.yml"
+      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-a6fedde02dc6241719ebb2589062ba2892baa8dbe928a2d718643beede85e7b3.yml"
     }
   },
   "specs_dir": "packages/openai_dart/specs"

--- a/packages/openai_dart/example/input_tokens_example.dart
+++ b/packages/openai_dart/example/input_tokens_example.dart
@@ -44,6 +44,21 @@ Future<void> main() async {
     );
 
     print('Input tokens (with tools): ${countWithTools.inputTokens}\n');
+
+    // Count tokens with a model-owned style preset (personality).
+    // Known presets: Personality.friendly() / Personality.pragmatic().
+    // Use Personality.custom('...') for values not yet modeled.
+    print('=== Count Tokens with a Personality ===\n');
+
+    final countWithPersonality = await client.responses.inputTokens.count(
+      model: 'gpt-5.5',
+      input: const ResponseInput.text('Hello, how are you?'),
+      personality: const Personality.friendly(),
+    );
+
+    print(
+      'Input tokens (with personality): ${countWithPersonality.inputTokens}\n',
+    );
   } on OpenAIException catch (e) {
     print('OpenAI error: ${e.message}');
     if (e is ApiException) {

--- a/packages/openai_dart/lib/src/models/conversations/conversation_item.dart
+++ b/packages/openai_dart/lib/src/models/conversations/conversation_item.dart
@@ -58,6 +58,7 @@ sealed class ConversationItem {
       'custom_tool_call' => ConversationCustomToolCallItem.fromJson(json),
       'custom_tool_call_output' =>
         ConversationCustomToolCallOutputItem.fromJson(json),
+      'additional_tools' => ConversationAdditionalToolsItem.fromJson(json),
       _ => ConversationUnknownItem(type: type, data: json),
     };
   }
@@ -1455,6 +1456,64 @@ class ConversationCustomToolCallOutputItem extends ConversationItem {
   @override
   String toString() =>
       'ConversationCustomToolCallOutputItem(id: $id, callId: $callId, status: $status)';
+}
+
+/// An additional tools item in a conversation.
+///
+/// Surfaces the additional tool definitions that were made available at this
+/// point in the conversation.
+@immutable
+class ConversationAdditionalToolsItem extends ConversationItem {
+  /// Unique identifier.
+  final String id;
+
+  /// The role that provided the additional tools.
+  final ConversationRole role;
+
+  /// The additional tool definitions made available at this item.
+  final List<ResponseTool> tools;
+
+  /// Creates a [ConversationAdditionalToolsItem].
+  const ConversationAdditionalToolsItem({
+    required this.id,
+    required this.role,
+    required this.tools,
+  });
+
+  /// Creates a [ConversationAdditionalToolsItem] from JSON.
+  factory ConversationAdditionalToolsItem.fromJson(Map<String, dynamic> json) {
+    return ConversationAdditionalToolsItem(
+      id: json['id'] as String,
+      role: ConversationRole.fromJson(json['role'] as String),
+      tools: (json['tools'] as List)
+          .map((e) => ResponseTool.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'additional_tools',
+    'id': id,
+    'role': role.toJson(),
+    'tools': tools.map((e) => e.toJson()).toList(),
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ConversationAdditionalToolsItem &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          role == other.role &&
+          listsEqual(tools, other.tools);
+
+  @override
+  int get hashCode => Object.hash(id, role, Object.hashAll(tools));
+
+  @override
+  String toString() =>
+      'ConversationAdditionalToolsItem(id: $id, role: $role, tools: $tools)';
 }
 
 /// An unknown item type (for forward compatibility).

--- a/packages/openai_dart/lib/src/models/responses/config/config.dart
+++ b/packages/openai_dart/lib/src/models/responses/config/config.dart
@@ -9,6 +9,7 @@ export 'include.dart';
 export 'item_status.dart';
 export 'message_phase.dart';
 export 'message_role.dart';
+export 'personality.dart';
 export 'prompt_cache_retention.dart';
 export 'reasoning_config.dart';
 export 'reasoning_effort.dart';

--- a/packages/openai_dart/lib/src/models/responses/config/message_role.dart
+++ b/packages/openai_dart/lib/src/models/responses/config/message_role.dart
@@ -13,7 +13,16 @@ enum MessageRole {
   developer('developer'),
 
   /// Assistant message.
-  assistant('assistant');
+  assistant('assistant'),
+
+  /// A critic role (used in certain evaluation contexts).
+  critic('critic'),
+
+  /// A discriminator role (used in certain evaluation contexts).
+  discriminator('discriminator'),
+
+  /// Tool message.
+  tool('tool');
 
   /// The JSON value for this role.
   final String value;

--- a/packages/openai_dart/lib/src/models/responses/config/personality.dart
+++ b/packages/openai_dart/lib/src/models/responses/config/personality.dart
@@ -1,0 +1,125 @@
+import 'package:meta/meta.dart';
+
+/// A model-owned style preset to apply to a request.
+///
+/// Omit the personality to use the model's default style. Values must be at
+/// most 64 characters; the server rejects longer values.
+///
+/// Known presets are available as variants:
+/// - [FriendlyPersonality] (`Personality.friendly()`)
+/// - [PragmaticPersonality] (`Personality.pragmatic()`)
+///
+/// The set of supported presets may expand over time; use
+/// [CustomPersonality] (`Personality.custom(...)`) for any value not yet
+/// modeled as a known preset.
+///
+/// ## Example
+///
+/// ```dart
+/// final friendly = Personality.friendly();
+/// final custom = Personality.custom('concise');
+/// ```
+@immutable
+sealed class Personality {
+  /// Creates a [Personality].
+  const Personality();
+
+  /// The friendly style preset.
+  const factory Personality.friendly() = FriendlyPersonality;
+
+  /// The pragmatic style preset.
+  const factory Personality.pragmatic() = PragmaticPersonality;
+
+  /// A custom style preset with the given [value].
+  ///
+  /// Use this for presets not yet modeled as a known variant. Values must be
+  /// at most 64 characters.
+  const factory Personality.custom(String value) = CustomPersonality;
+
+  /// Creates a [Personality] from a JSON value.
+  factory Personality.fromJson(String json) => switch (json) {
+    'friendly' => const FriendlyPersonality(),
+    'pragmatic' => const PragmaticPersonality(),
+    _ => CustomPersonality(json),
+  };
+
+  /// The raw string value for this personality.
+  String get value;
+
+  /// Converts to JSON value.
+  String toJson() => value;
+}
+
+/// The friendly style preset.
+@immutable
+class FriendlyPersonality extends Personality {
+  /// Creates a [FriendlyPersonality].
+  const FriendlyPersonality();
+
+  @override
+  String get value => 'friendly';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FriendlyPersonality && runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() => 'Personality.friendly()';
+}
+
+/// The pragmatic style preset.
+@immutable
+class PragmaticPersonality extends Personality {
+  /// Creates a [PragmaticPersonality].
+  const PragmaticPersonality();
+
+  @override
+  String get value => 'pragmatic';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PragmaticPersonality && runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() => 'Personality.pragmatic()';
+}
+
+/// A custom style preset.
+///
+/// Holds an arbitrary string value for presets not modeled as a known
+/// variant. The value must be at most 64 characters; the server rejects
+/// longer values.
+@immutable
+class CustomPersonality extends Personality {
+  /// Creates a [CustomPersonality] with the given [value].
+  ///
+  /// The server rejects values longer than 64 characters; this is documented
+  /// rather than enforced client-side, matching the package convention for
+  /// length-limited string fields (e.g. `ServiceTier`, tool names).
+  const CustomPersonality(this.value);
+
+  /// The raw string value for this personality.
+  @override
+  final String value;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CustomPersonality &&
+          runtimeType == other.runtimeType &&
+          value == other.value;
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  String toString() => 'Personality.custom($value)';
+}

--- a/packages/openai_dart/lib/src/models/responses/items/item.dart
+++ b/packages/openai_dart/lib/src/models/responses/items/item.dart
@@ -24,6 +24,8 @@ import '../tools/response_tool.dart';
 /// - [ToolSearchCallItemParam] - A tool search call
 /// - [ToolSearchOutputItemParam] - Tool search results
 /// - [CompactionTriggerItem] - Triggers compaction of the current context
+/// - [AdditionalToolsItemParam] - Additional tool definitions made available
+///   mid-conversation
 sealed class Item {
   /// Creates an [Item].
   const Item();
@@ -40,6 +42,7 @@ sealed class Item {
       'tool_search_call' => ToolSearchCallItemParam.fromJson(json),
       'tool_search_output' => ToolSearchOutputItemParam.fromJson(json),
       'compaction_trigger' => CompactionTriggerItem.fromJson(json),
+      'additional_tools' => AdditionalToolsItemParam.fromJson(json),
       _ => throw FormatException('Unknown Item type: $type'),
     };
   }
@@ -699,4 +702,57 @@ class ToolSearchOutputItemParam extends Item {
   @override
   String toString() =>
       'ToolSearchOutputItemParam(id: $id, callId: $callId, execution: $execution, tools: $tools, status: $status)';
+}
+
+/// An additional tools input item.
+///
+/// Makes a list of additional tool definitions available mid-conversation.
+/// Only the `developer` role is supported.
+@immutable
+class AdditionalToolsItemParam extends Item {
+  /// Unique identifier of this additional tools item.
+  final String? id;
+
+  /// A list of additional tools made available at this item.
+  final List<ResponseTool> tools;
+
+  /// Creates an [AdditionalToolsItemParam].
+  const AdditionalToolsItemParam({this.id, required this.tools});
+
+  /// Creates an [AdditionalToolsItemParam] from JSON.
+  factory AdditionalToolsItemParam.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    if (type != 'additional_tools') {
+      throw FormatException('Expected type "additional_tools", got "$type"');
+    }
+    return AdditionalToolsItemParam(
+      id: json['id'] as String?,
+      tools: (json['tools'] as List)
+          .map((e) => ResponseTool.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'additional_tools',
+    if (id != null) 'id': id,
+    // Only the `developer` role is supported for this item.
+    'role': 'developer',
+    'tools': tools.map((e) => e.toJson()).toList(),
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AdditionalToolsItemParam &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          listsEqual(tools, other.tools);
+
+  @override
+  int get hashCode => Object.hash(id, Object.hashAll(tools));
+
+  @override
+  String toString() => 'AdditionalToolsItemParam(id: $id, tools: $tools)';
 }

--- a/packages/openai_dart/lib/src/models/responses/items/item.dart
+++ b/packages/openai_dart/lib/src/models/responses/items/item.dart
@@ -725,6 +725,14 @@ class AdditionalToolsItemParam extends Item {
     if (type != 'additional_tools') {
       throw FormatException('Expected type "additional_tools", got "$type"');
     }
+    // Only the `developer` role is supported (spec const). Reject other values
+    // when present rather than silently normalizing them on re-serialization.
+    final role = json['role'] as String?;
+    if (role != null && role != 'developer') {
+      throw FormatException(
+        'Expected "additional_tools" role "developer", got "$role"',
+      );
+    }
     return AdditionalToolsItemParam(
       id: json['id'] as String?,
       tools: (json['tools'] as List)

--- a/packages/openai_dart/lib/src/models/responses/items/output_item.dart
+++ b/packages/openai_dart/lib/src/models/responses/items/output_item.dart
@@ -37,6 +37,8 @@ import 'item.dart';
 /// - [ComputerCallOutputItem] - Computer use tool calls
 /// - [CustomToolCallItem] - Custom tool calls
 /// - [CustomToolCallOutputItem] - Custom tool call outputs
+/// - [AdditionalToolsOutputItem] - Additional tool definitions made available
+///   mid-conversation
 sealed class OutputItem {
   /// Creates an [OutputItem].
   const OutputItem();
@@ -65,6 +67,7 @@ sealed class OutputItem {
       'computer_call' => ComputerCallOutputItem.fromJson(json),
       'custom_tool_call' => CustomToolCallItem.fromJson(json),
       'custom_tool_call_output' => CustomToolCallOutputItem.fromJson(json),
+      'additional_tools' => AdditionalToolsOutputItem.fromJson(json),
       _ => throw FormatException('Unknown OutputItem type: $type'),
     };
   }
@@ -1926,4 +1929,62 @@ class CustomToolCallOutputItem extends OutputItem {
   @override
   String toString() =>
       'CustomToolCallOutputItem(id: $id, callId: $callId, output: $output, status: $status, createdBy: $createdBy)';
+}
+
+/// An additional tools output item.
+///
+/// Surfaces the additional tool definitions that were made available at this
+/// point in the conversation.
+@immutable
+class AdditionalToolsOutputItem extends OutputItem {
+  /// The unique ID of the additional tools item.
+  final String id;
+
+  /// The role that provided the additional tools.
+  final MessageRole role;
+
+  /// The additional tool definitions made available at this item.
+  final List<ResponseTool> tools;
+
+  /// Creates an [AdditionalToolsOutputItem].
+  const AdditionalToolsOutputItem({
+    required this.id,
+    required this.role,
+    required this.tools,
+  });
+
+  /// Creates an [AdditionalToolsOutputItem] from JSON.
+  factory AdditionalToolsOutputItem.fromJson(Map<String, dynamic> json) {
+    return AdditionalToolsOutputItem(
+      id: json['id'] as String,
+      role: MessageRole.fromJson(json['role'] as String),
+      tools: (json['tools'] as List)
+          .map((e) => ResponseTool.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'additional_tools',
+    'id': id,
+    'role': role.toJson(),
+    'tools': tools.map((e) => e.toJson()).toList(),
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AdditionalToolsOutputItem &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          role == other.role &&
+          listsEqual(tools, other.tools);
+
+  @override
+  int get hashCode => Object.hash(id, role, Object.hashAll(tools));
+
+  @override
+  String toString() =>
+      'AdditionalToolsOutputItem(id: $id, role: $role, tools: $tools)';
 }

--- a/packages/openai_dart/lib/src/resources/input_tokens_resource.dart
+++ b/packages/openai_dart/lib/src/resources/input_tokens_resource.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:http/http.dart' as http;
 
+import '../models/responses/config/personality.dart';
 import '../models/responses/input_token_count.dart';
 import '../models/responses/response_input.dart';
 import '../models/responses/tools/response_tool.dart';
@@ -50,6 +51,8 @@ class InputTokensResource extends ResourceBase {
   /// - [toolChoice] - Tool choice configuration.
   /// - [parallelToolCalls] - Whether parallel tool calls would be enabled.
   /// - [truncation] - Truncation strategy ('auto' or 'disabled').
+  /// - [personality] - A model-owned style preset to apply to the request.
+  ///   Omit to use the model's default style.
   /// - [abortTrigger] - Optional future that cancels the request when completed.
   ///
   /// ## Returns
@@ -91,6 +94,7 @@ class InputTokensResource extends ResourceBase {
     ResponseToolChoice? toolChoice,
     bool? parallelToolCalls,
     String? truncation,
+    Personality? personality,
     Future<void>? abortTrigger,
   }) async {
     ensureNotClosed?.call();
@@ -122,6 +126,8 @@ class InputTokensResource extends ResourceBase {
     }
 
     if (truncation != null) body['truncation'] = truncation;
+
+    if (personality != null) body['personality'] = personality.toJson();
 
     final url = requestBuilder.buildUrl('/responses/input_tokens');
     final headers = requestBuilder.buildHeaders();

--- a/packages/openai_dart/specs/openapi.json
+++ b/packages/openai_dart/specs/openapi.json
@@ -34,6 +34,88 @@
         ],
         "type": "object"
       },
+      "AdditionalTools": {
+        "properties": {
+          "id": {
+            "description": "The unique ID of the additional tools item.",
+            "type": "string"
+          },
+          "role": {
+            "$ref": "#/components/schemas/MessageRole",
+            "description": "The role that provided the additional tools."
+          },
+          "tools": {
+            "description": "The additional tool definitions made available at this item.",
+            "items": {
+              "$ref": "#/components/schemas/Tool"
+            },
+            "type": "array"
+          },
+          "type": {
+            "default": "additional_tools",
+            "description": "The type of the item. Always `additional_tools`.",
+            "enum": [
+              "additional_tools"
+            ],
+            "type": "string",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "role",
+          "tools"
+        ],
+        "type": "object"
+      },
+      "AdditionalToolsItemParam": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "description": "The unique ID of this additional tools item.",
+                "example": "at_123",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "role": {
+            "default": "developer",
+            "description": "The role that provided the additional tools. Only `developer` is supported.",
+            "enum": [
+              "developer"
+            ],
+            "type": "string",
+            "x-stainless-const": true
+          },
+          "tools": {
+            "description": "A list of additional tools made available at this item.",
+            "items": {
+              "$ref": "#/components/schemas/Tool"
+            },
+            "type": "array"
+          },
+          "type": {
+            "default": "additional_tools",
+            "description": "The item type. Always `additional_tools`.",
+            "enum": [
+              "additional_tools"
+            ],
+            "type": "string",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "type",
+          "role",
+          "tools"
+        ],
+        "type": "object"
+      },
       "AdminApiKey": {
         "description": "Represents an individual Admin API key in an org.",
         "properties": {
@@ -2380,6 +2462,106 @@
               }
             },
             "type": "object"
+          },
+          "workload_identity_provider.created": {
+            "description": "The details for events with this `type`.",
+            "properties": {
+              "data": {
+                "description": "The payload used to create the workload identity provider.",
+                "type": "object"
+              },
+              "id": {
+                "description": "The workload identity provider ID.",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "workload_identity_provider.deleted": {
+            "description": "The details for events with this `type`.",
+            "properties": {
+              "id": {
+                "description": "The workload identity provider ID.",
+                "type": "string"
+              },
+              "name": {
+                "description": "The workload identity provider name.",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "workload_identity_provider.updated": {
+            "description": "The details for events with this `type`.",
+            "properties": {
+              "changes_requested": {
+                "description": "The payload used to update the workload identity provider.",
+                "type": "object"
+              },
+              "id": {
+                "description": "The workload identity provider ID.",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "workload_identity_provider_mapping.created": {
+            "description": "The details for events with this `type`.",
+            "properties": {
+              "data": {
+                "description": "The payload used to create the workload identity provider mapping.",
+                "type": "object"
+              },
+              "id": {
+                "description": "The workload identity provider mapping ID.",
+                "type": "string"
+              },
+              "identity_provider_id": {
+                "description": "The workload identity provider ID.",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "workload_identity_provider_mapping.deleted": {
+            "description": "The details for events with this `type`.",
+            "properties": {
+              "id": {
+                "description": "The workload identity provider mapping ID.",
+                "type": "string"
+              },
+              "identity_provider_id": {
+                "description": "The workload identity provider ID.",
+                "type": "string"
+              },
+              "project_id": {
+                "description": "The project ID.",
+                "type": "string"
+              },
+              "service_account_id": {
+                "description": "The mapped service account ID.",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "workload_identity_provider_mapping.updated": {
+            "description": "The details for events with this `type`.",
+            "properties": {
+              "changes_requested": {
+                "description": "The payload used to update the workload identity provider mapping.",
+                "type": "object"
+              },
+              "id": {
+                "description": "The workload identity provider mapping ID.",
+                "type": "string"
+              },
+              "identity_provider_id": {
+                "description": "The workload identity provider ID.",
+                "type": "string"
+              }
+            },
+            "type": "object"
           }
         },
         "required": [
@@ -2515,6 +2697,12 @@
           "tunnel.created",
           "tunnel.updated",
           "tunnel.deleted",
+          "workload_identity_provider.created",
+          "workload_identity_provider.updated",
+          "workload_identity_provider.deleted",
+          "workload_identity_provider_mapping.created",
+          "workload_identity_provider_mapping.updated",
+          "workload_identity_provider_mapping.deleted",
           "role.created",
           "role.updated",
           "role.deleted",
@@ -6554,6 +6742,9 @@
           },
           {
             "$ref": "#/components/schemas/ToolSearchOutput"
+          },
+          {
+            "$ref": "#/components/schemas/AdditionalTools"
           },
           {
             "$ref": "#/components/schemas/ReasoningItem"
@@ -19025,6 +19216,9 @@
             "$ref": "#/components/schemas/ToolSearchOutputItemParam"
           },
           {
+            "$ref": "#/components/schemas/AdditionalToolsItemParam"
+          },
+          {
             "$ref": "#/components/schemas/ReasoningItem"
           },
           {
@@ -19092,6 +19286,9 @@
           },
           {
             "$ref": "#/components/schemas/ToolSearchOutput"
+          },
+          {
+            "$ref": "#/components/schemas/AdditionalTools"
           },
           {
             "$ref": "#/components/schemas/FunctionToolCallOutput"
@@ -19225,6 +19422,9 @@
           },
           {
             "$ref": "#/components/schemas/ToolSearchOutput"
+          },
+          {
+            "$ref": "#/components/schemas/AdditionalTools"
           },
           {
             "$ref": "#/components/schemas/ReasoningItem"
@@ -21854,7 +22054,7 @@
           "prompt_cache_retention": {
             "anyOf": [
               {
-                "description": "The retention policy for the prompt cache. Set to `24h` to enable extended prompt caching, which keeps cached prefixes active for longer, up to a maximum of 24 hours. [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).\n",
+                "description": "The retention policy for the prompt cache. Set to `24h` to enable extended prompt caching, which keeps cached prefixes active for longer, up to a maximum of 24 hours. [Learn more](https://platform.openai.com/docs/guides/prompt-caching#prompt-cache-retention).\nFor `gpt-5.5`, `gpt-5.5-pro`, and future models, only `24h` is supported.\n\nFor older models that support both `in_memory` and `24h`, the default depends on your organization's data retention policy:\n  - Organizations without ZDR enabled default to `24h`.\n  - Organizations with ZDR enabled default to `in_memory` when `prompt_cache_retention` is not specified.\n",
                 "enum": [
                   "in_memory",
                   "24h"
@@ -22881,6 +23081,9 @@
             "$ref": "#/components/schemas/ToolSearchOutput"
           },
           {
+            "$ref": "#/components/schemas/AdditionalTools"
+          },
+          {
             "$ref": "#/components/schemas/CompactionBody"
           },
           {
@@ -23059,6 +23262,20 @@
           },
           {
             "type": "null"
+          }
+        ]
+      },
+      "PersonalityEnum": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "enum": [
+              "friendly",
+              "pragmatic"
+            ],
+            "type": "string"
           }
         ]
       },
@@ -39647,6 +39864,10 @@
               }
             ]
           },
+          "personality": {
+            "$ref": "#/components/schemas/PersonalityEnum",
+            "description": "A model-owned style preset to apply to this request. Omit this parameter to use the model's default style. Supported values may expand over time. Values must be at most 64 characters."
+          },
           "previous_response_id": {
             "anyOf": [
               {
@@ -43829,7 +44050,8 @@
             "type": "array"
           },
           "query": {
-            "description": "[DEPRECATED] The search query.\n",
+            "deprecated": true,
+            "description": "The search query.\n",
             "type": "string"
           },
           "sources": {
@@ -43871,8 +44093,7 @@
           }
         },
         "required": [
-          "type",
-          "query"
+          "type"
         ],
         "title": "Search action",
         "type": "object"

--- a/packages/openai_dart/specs/spec_metadata.json
+++ b/packages/openai_dart/specs/spec_metadata.json
@@ -13,7 +13,7 @@
           "version": "2.3.0"
         },
         {
-          "fetched_at": "2026-06-02T11:45:18.699766Z",
+          "fetched_at": "2026-05-23T22:40:50.610721Z",
           "note": "afacc434\u2026 replaced by a6fedde\u2026 on 2026-06-02 to pick up the Responses API additional_tools item type and the personality (PersonalityEnum) style preset on the input-token-count request.",
           "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-afacc4343d0efc074c8c5667eb83570642c8b9acaa7792ca8e075c6d18ef9f3a.yml",
           "version": "2.3.0"

--- a/packages/openai_dart/specs/spec_metadata.json
+++ b/packages/openai_dart/specs/spec_metadata.json
@@ -2,14 +2,20 @@
   "specs": {
     "main": {
       "current_version": "2.3.0",
-      "last_fetched": "2026-05-23T22:40:50.610721Z",
-      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-afacc4343d0efc074c8c5667eb83570642c8b9acaa7792ca8e075c6d18ef9f3a.yml",
+      "last_fetched": "2026-06-02T11:45:18.699766Z",
+      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-a6fedde02dc6241719ebb2589062ba2892baa8dbe928a2d718643beede85e7b3.yml",
       "title": "OpenAI API",
       "version_history": [
         {
           "fetched_at": "2026-05-02T08:00:03.586206Z",
           "note": "Pre-GA Realtime spec; replaced by 371f497\u2026 on 2026-05-08 to pick up GA Realtime sessions, Realtime Translation API, gpt-realtime-2/translate/whisper models, and transcription delay.",
           "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai%2Fopenai-64c6ba619ccbf87e56b4f464230d04401fd78ad924d2606176309d19ca281af5.yml",
+          "version": "2.3.0"
+        },
+        {
+          "fetched_at": "2026-06-02T11:45:18.699766Z",
+          "note": "afacc434\u2026 replaced by a6fedde\u2026 on 2026-06-02 to pick up the Responses API additional_tools item type and the personality (PersonalityEnum) style preset on the input-token-count request.",
+          "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-afacc4343d0efc074c8c5667eb83570642c8b9acaa7792ca8e075c6d18ef9f3a.yml",
           "version": "2.3.0"
         }
       ]

--- a/packages/openai_dart/test/unit/models/conversations_test.dart
+++ b/packages/openai_dart/test/unit/models/conversations_test.dart
@@ -495,6 +495,26 @@ void main() {
       final unknown = item as ConversationUnknownItem;
       expect(unknown.type, equals('future_type'));
     });
+
+    test('round-trips additional_tools item', () {
+      final item = ConversationAdditionalToolsItem(
+        id: 'at_789',
+        role: ConversationRole.fromJson('developer'),
+        tools: [
+          ResponseTool.function(name: 'lookup', parameters: {'type': 'object'}),
+        ],
+      );
+
+      final json = item.toJson();
+      expect(json['type'], equals('additional_tools'));
+      expect(json['id'], equals('at_789'));
+      expect(json['role'], equals('developer'));
+      expect((json['tools'] as List).length, equals(1));
+
+      final restored = ConversationItem.fromJson(json);
+      expect(restored, isA<ConversationAdditionalToolsItem>());
+      expect(restored, equals(item));
+    });
   });
 
   group('ConversationContent', () {

--- a/packages/openai_dart/test/unit/models/responses_test.dart
+++ b/packages/openai_dart/test/unit/models/responses_test.dart
@@ -1080,6 +1080,47 @@ void main() {
     });
   });
 
+  group('MessageRole', () {
+    test('round-trips all spec values without falling back to unknown', () {
+      // The spec MessageRole enum has 8 values; each must parse to its own
+      // member rather than collapsing to `unknown`.
+      const values = [
+        'unknown',
+        'user',
+        'assistant',
+        'system',
+        'critic',
+        'discriminator',
+        'developer',
+        'tool',
+      ];
+      for (final value in values) {
+        final role = MessageRole.fromJson(value);
+        expect(role.value, equals(value));
+        expect(role.toJson(), equals(value));
+      }
+      // The roles previously missing from the enum now resolve explicitly.
+      expect(MessageRole.fromJson('critic'), equals(MessageRole.critic));
+      expect(
+        MessageRole.fromJson('discriminator'),
+        equals(MessageRole.discriminator),
+      );
+      expect(MessageRole.fromJson('tool'), equals(MessageRole.tool));
+    });
+
+    test('additional_tools output item round-trips a tool role', () {
+      const item = AdditionalToolsOutputItem(
+        id: 'at_tool',
+        role: MessageRole.tool,
+        tools: [],
+      );
+
+      final restored = OutputItem.fromJson(item.toJson());
+      expect(restored, equals(item));
+      expect((restored as AdditionalToolsOutputItem).role, MessageRole.tool);
+    });
+  });
+
   group('InputContent', () {
     test('creates text content', () {
       const content = InputContent.text('Hello!');

--- a/packages/openai_dart/test/unit/models/responses_test.dart
+++ b/packages/openai_dart/test/unit/models/responses_test.dart
@@ -1027,6 +1027,27 @@ void main() {
       );
     });
 
+    test('input variant fromJson rejects a non-developer role', () {
+      expect(
+        () => AdditionalToolsItemParam.fromJson(const {
+          'type': 'additional_tools',
+          'role': 'user',
+          'tools': <dynamic>[],
+        }),
+        throwsFormatException,
+      );
+    });
+
+    test('input variant fromJson accepts an explicit developer role', () {
+      final item = AdditionalToolsItemParam.fromJson(const {
+        'type': 'additional_tools',
+        'role': 'developer',
+        'tools': <dynamic>[],
+      });
+      expect(item.tools, isEmpty);
+      expect(item.toJson()['role'], equals('developer'));
+    });
+
     test('output variant round-trips via OutputItem.fromJson', () {
       final item = AdditionalToolsOutputItem(
         id: 'at_456',

--- a/packages/openai_dart/test/unit/models/responses_test.dart
+++ b/packages/openai_dart/test/unit/models/responses_test.dart
@@ -986,6 +986,100 @@ void main() {
     );
   });
 
+  group('AdditionalTools item', () {
+    test('input variant round-trips via Item.fromJson', () {
+      final item = AdditionalToolsItemParam(
+        id: 'at_123',
+        tools: [
+          ResponseTool.function(
+            name: 'get_weather',
+            parameters: {'type': 'object'},
+          ),
+        ],
+      );
+
+      final json = item.toJson();
+      expect(json['type'], equals('additional_tools'));
+      expect(json['role'], equals('developer'));
+      expect(json['id'], equals('at_123'));
+      expect((json['tools'] as List).length, equals(1));
+
+      final restored = Item.fromJson(json);
+      expect(restored, isA<AdditionalToolsItemParam>());
+      expect(restored, equals(item));
+      expect(restored.toString(), contains('AdditionalToolsItemParam'));
+    });
+
+    test('input variant omits id when null', () {
+      final item = AdditionalToolsItemParam(
+        tools: [
+          ResponseTool.function(name: 'f', parameters: {'type': 'object'}),
+        ],
+      );
+
+      expect(item.toJson().containsKey('id'), isFalse);
+    });
+
+    test('input variant fromJson rejects wrong type', () {
+      expect(
+        () => AdditionalToolsItemParam.fromJson(const {'type': 'message'}),
+        throwsFormatException,
+      );
+    });
+
+    test('output variant round-trips via OutputItem.fromJson', () {
+      final item = AdditionalToolsOutputItem(
+        id: 'at_456',
+        role: MessageRole.developer,
+        tools: [
+          ResponseTool.function(name: 'lookup', parameters: {'type': 'object'}),
+        ],
+      );
+
+      final json = item.toJson();
+      expect(json['type'], equals('additional_tools'));
+      expect(json['id'], equals('at_456'));
+      expect(json['role'], equals('developer'));
+
+      final restored = OutputItem.fromJson(json);
+      expect(restored, isA<AdditionalToolsOutputItem>());
+      expect(restored, equals(item));
+      expect(restored.toString(), contains('AdditionalToolsOutputItem'));
+    });
+  });
+
+  group('Personality', () {
+    test('known presets round-trip', () {
+      for (final personality in const [
+        FriendlyPersonality(),
+        PragmaticPersonality(),
+      ]) {
+        final restored = Personality.fromJson(personality.toJson());
+        expect(restored, equals(personality));
+      }
+
+      expect(Personality.fromJson('friendly'), isA<FriendlyPersonality>());
+      expect(Personality.fromJson('pragmatic'), isA<PragmaticPersonality>());
+      expect(const FriendlyPersonality().toJson(), equals('friendly'));
+      expect(const PragmaticPersonality().toJson(), equals('pragmatic'));
+    });
+
+    test('custom value is preserved', () {
+      final custom = Personality.fromJson('concise');
+      expect(custom, isA<CustomPersonality>());
+      expect(custom.value, equals('concise'));
+      expect(custom.toJson(), equals('concise'));
+      expect(custom, equals(const Personality.custom('concise')));
+      expect(custom, isNot(equals(const FriendlyPersonality())));
+    });
+
+    test('factory constructors build the matching variants', () {
+      expect(const Personality.friendly(), isA<FriendlyPersonality>());
+      expect(const Personality.pragmatic(), isA<PragmaticPersonality>());
+      expect(const Personality.custom('x'), isA<CustomPersonality>());
+    });
+  });
+
   group('InputContent', () {
     test('creates text content', () {
       const content = InputContent.text('Hello!');

--- a/packages/openai_dart/test/unit/resources/input_tokens_personality_test.dart
+++ b/packages/openai_dart/test/unit/resources/input_tokens_personality_test.dart
@@ -1,0 +1,63 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:openai_dart/openai_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('InputTokensResource.count personality', () {
+    OpenAIClient buildClient(MockClient mockClient) => OpenAIClient(
+      config: const OpenAIConfig(authProvider: ApiKeyProvider('sk-test-key')),
+      httpClient: mockClient,
+    );
+
+    http.Response okResponse(int tokens) => http.Response(
+      jsonEncode({'input_tokens': tokens, 'object': 'response.input_tokens'}),
+      200,
+    );
+
+    test('serializes personality into the request body', () async {
+      final requestCompleter = Completer<http.BaseRequest>();
+      final mockClient = MockClient((request) async {
+        requestCompleter.complete(request);
+        return okResponse(7);
+      });
+      final client = buildClient(mockClient);
+
+      final result = await client.responses.inputTokens.count(
+        model: 'gpt-4o',
+        input: const ResponseInput.text('Hello'),
+        personality: const Personality.friendly(),
+      );
+
+      final request = await requestCompleter.future as http.Request;
+      final body = jsonDecode(request.body) as Map<String, dynamic>;
+
+      expect(request.method, equals('POST'));
+      expect(request.url.path, endsWith('/responses/input_tokens'));
+      expect(body['personality'], equals('friendly'));
+      expect(result.inputTokens, equals(7));
+    });
+
+    test('omits personality when not provided', () async {
+      final requestCompleter = Completer<http.BaseRequest>();
+      final mockClient = MockClient((request) async {
+        requestCompleter.complete(request);
+        return okResponse(3);
+      });
+      final client = buildClient(mockClient);
+
+      await client.responses.inputTokens.count(
+        model: 'gpt-4o',
+        input: const ResponseInput.text('Hello'),
+      );
+
+      final request = await requestCompleter.future as http.Request;
+      final body = jsonDecode(request.body) as Map<String, dynamic>;
+
+      expect(body.containsKey('personality'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Bumps the pinned OpenAI spec (`afacc434…` → `a6fedde0…`) and implements the two net-new Responses features it introduces.
- Adds the Responses **`additional_tools`** item — a way to surface extra tool definitions mid-conversation — across the input, output, and conversation item unions.
- Adds the **`personality`** style preset to the input-token-count request (`responses.inputTokens.count`), modeled as a sealed `Personality` type with `friendly`/`pragmatic` presets plus a `custom(String)` variant for forward compatibility.
- Completes the **`MessageRole`** enum with the three spec values it was missing (`critic`, `discriminator`, `tool`) so they no longer silently collapse to `unknown`.

## Details

### `additional_tools` item
The spec adds an `additional_tools` item type that lets a developer inject extra tool definitions at a point in the conversation; the model echoes them back as an output/conversation item. Implemented as a new variant in each of the three item unions, mirroring the existing tools-list variants:

- **Input** — `AdditionalToolsItemParam` (`id?`, `tools`; `role` is the spec-const `developer`, emitted on serialization but not surfaced as a parameter). `fromJson` validates both the `type` discriminator and the `developer`-only `role` const, rejecting a malformed `role` rather than silently normalizing it on re-serialization.
- **Output** — `AdditionalToolsOutputItem` (`id`, `role: MessageRole`, `tools`).
- **Conversation** — `ConversationAdditionalToolsItem` (`id`, `role: ConversationRole`, `tools`).

`==`/`hashCode` use content-based list equality and include every user-visible field (the conversation variant intentionally includes `tools` in both, avoiding the partial-equality shape of its `mcp_list_tools` sibling).

### `personality` preset
`PersonalityEnum` is an open string enum (`anyOf: string | {friendly, pragmatic}`). Following the request to model it as a sealed type:

```dart
final count = await client.responses.inputTokens.count(
  model: 'gpt-5.5',
  input: const ResponseInput.text('Hello, how are you?'),
  personality: const Personality.friendly(),
  // or Personality.pragmatic(), or Personality.custom('concise')
);
```

`Personality.fromJson` maps known values to their presets and any other value to `CustomPersonality`, so new server-side presets remain representable without a client update. The 64-character server limit is documented (not asserted client-side), matching the package convention for length-limited string fields like `ServiceTier` and tool names.

In the current spec, `personality` exists **only** on the input-token-count body (`TokenCountsBody`) — not on `responses.create`. This was verified against the official `openai-python` SDK, where `personality` appears solely in `input_token_count_params.py` and is absent from `response_create_params.py`. The `Personality` type lives in the shared responses-config barrel, so it can be reused on `responses.create` unchanged if/when the spec adds it there.

### `MessageRole` completeness
The spec's `MessageRole` enum defines 8 values, but the Dart enum modeled only 5 — `critic`, `discriminator`, and `tool` silently fell back to `unknown`, including on the new `additional_tools` output item whose `role` uses `MessageRole`. This aligns `MessageRole` with the spec and with the sibling `ConversationRole` (which already had all 8). Surfaced while verifying against the official SDK; follow-up #246 tracks an api-toolkit improvement to catch this class of stale-enum gap automatically.

### Toolkit / housekeeping
- Promoted the reviewed spec into `specs/openapi.json` and recorded the transition in `spec_metadata.json` (each `version_history` entry's `fetched_at` reflects when that entry's own spec was fetched).
- Added manifest entries clearing all review errors: `PersonalityEnum` as a `sealed_parent` + variants; the new item schemas and the inline `TokenCountsBody` as acknowledged-skips (consistent with the existing item-union family); `AuditLog`/`AuditLogEventType` acknowledged-skip (Admin API, out of coverage).

## Test Plan
- [x] Unit tests pass for `openai_dart` (1297 passed, 2 env-gated skips)
- [x] New tests: all three `additional_tools` variants; input-variant `role` validation (rejects non-`developer`, accepts explicit `developer`); `Personality` presets/custom value; `MessageRole` 8-value round-trip; a MockClient resource test asserting `personality` serializes into the request body
- [x] Sealed class/enum changes include variant, round-trip, and error (wrong-type / wrong-role) tests
- [x] `fromJson`/`toJson` round-trip serialization verified
- [x] `==`/`hashCode` contract verified (same fields in both)
- [x] api-toolkit `review` (0 errors) and `verify --checks all --scope all` (no failing/warning checks) pass
- [x] `dart format` and `dart analyze --fatal-infos` clean
