### PR TITLE
chore(anthropic_sdk_dart): clear all verify warnings

### DIFF
--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
@@ -520,10 +520,26 @@
           "ResponseToolSearchToolResultBlock": "tool_search_tool_result",
           "ResponseContainerUploadBlock": "container_upload",
           "ResponseCompactionBlock": "compaction",
-          "BetaResponseAdvisorToolResultBlock": "advisor_tool_result"
+          "BetaResponseAdvisorToolResultBlock": "advisor_tool_result",
+          "ResponseTextBlock": "text",
+          "BetaResponseTextBlock": "text",
+          "BetaResponseThinkingBlock": "thinking",
+          "BetaResponseRedactedThinkingBlock": "redacted_thinking",
+          "BetaResponseToolUseBlock": "tool_use",
+          "BetaResponseServerToolUseBlock": "server_tool_use",
+          "BetaResponseWebSearchToolResultBlock": "web_search_tool_result",
+          "BetaResponseWebFetchToolResultBlock": "web_fetch_tool_result",
+          "BetaResponseCodeExecutionToolResultBlock": "code_execution_tool_result",
+          "BetaResponseBashCodeExecutionToolResultBlock": "bash_code_execution_tool_result",
+          "BetaResponseTextEditorCodeExecutionToolResultBlock": "text_editor_code_execution_tool_result",
+          "BetaResponseToolSearchToolResultBlock": "tool_search_tool_result",
+          "BetaResponseMCPToolUseBlock": "mcp_tool_use",
+          "BetaResponseMCPToolResultBlock": "mcp_tool_result",
+          "BetaResponseContainerUploadBlock": "container_upload",
+          "BetaResponseCompactionBlock": "compaction"
         }
       },
-      "note": null,
+      "note": "Unifies the stable ContentBlock and beta BetaContentBlock response unions; ContentBlock.fromJson dispatches every discriminator value from both unions to a single Dart subclass.",
       "excluded_properties": [
         "content"
       ]
@@ -695,7 +711,9 @@
       "note": null,
       "excluded_properties": [
         "content",
-        "source"
+        "source",
+        "citations",
+        "title"
       ]
     },
     "BetaInputContentBlock": {
@@ -2015,7 +2033,11 @@
       "kind": "sealed_parent",
       "dart_class": "AgentTool",
       "file": "lib/src/models/managed_agents/config/agent_tool.dart",
-      "schema": "BetaManagedAgentsAgentTool"
+      "schema": "BetaManagedAgentsAgentTool",
+      "excluded_properties": [
+        "configs",
+        "default_config"
+      ]
     },
     "AgentToolConfig": {
       "spec": "main",
@@ -2043,7 +2065,11 @@
       "kind": "sealed_parent",
       "dart_class": "AgentToolParams",
       "file": "lib/src/models/managed_agents/config/agent_tool.dart",
-      "schema": "BetaManagedAgentsAgentToolParams"
+      "schema": "BetaManagedAgentsAgentToolParams",
+      "excluded_properties": [
+        "configs",
+        "default_config"
+      ]
     },
     "AgentToolset20260401": {
       "spec": "main",
@@ -2298,7 +2324,10 @@
       "kind": "sealed_parent",
       "dart_class": "EventParams",
       "file": "lib/src/models/managed_agents/events/send_event_params.dart",
-      "schema": "BetaManagedAgentsEventParams"
+      "schema": "BetaManagedAgentsEventParams",
+      "excluded_properties": [
+        "content"
+      ]
     },
     "FileDocumentSource": {
       "spec": "main",
@@ -2755,7 +2784,10 @@
       "kind": "sealed_parent",
       "dart_class": "SessionResource",
       "file": "lib/src/models/managed_agents/resources/session_resource.dart",
-      "schema": "BetaManagedAgentsSessionResource"
+      "schema": "BetaManagedAgentsSessionResource",
+      "excluded_properties": [
+        "mount_path"
+      ]
     },
     "SessionResourceParams": {
       "spec": "main",
@@ -2886,7 +2918,13 @@
       "kind": "sealed_parent",
       "dart_class": "SessionEvent",
       "file": "lib/src/models/managed_agents/events/session_event.dart",
-      "schema": "BetaManagedAgentsStreamSessionThreadEvents"
+      "schema": "BetaManagedAgentsStreamSessionThreadEvents",
+      "excluded_properties": [
+        "content",
+        "processed_at",
+        "result",
+        "session_thread_id"
+      ]
     },
     "Struct": {
       "spec": "main",

--- a/packages/anthropic_sdk_dart/README.md
+++ b/packages/anthropic_sdk_dart/README.md
@@ -53,6 +53,14 @@ Dart client for the **[Anthropic API](https://docs.anthropic.com/en/api)** to bu
 - Memory stores for persistent agent memories with versioning and redaction (beta)
 - User profiles with relationship classification (`external`/`resold`/`internal`), trust-grant tracking, and enrollment URLs (beta)
 
+## Why choose this client?
+
+- Pure Dart with no Flutter dependency — works in mobile apps, backends, and CLIs.
+- Type-safe request and response models with minimal dependencies (`http`, `logging`, `meta`).
+- Streaming, retries, interceptors, and cancellation built into the client.
+- Follows Anthropic resource naming closely, so official docs translate directly into Dart code.
+- Strict [semver](https://semver.org/) versioning so downstream packages can depend on stable, predictable version ranges.
+
 ## Quickstart
 
 ```yaml
@@ -81,14 +89,6 @@ Future<void> main() async {
   }
 }
 ```
-
-## Why choose this client?
-
-- Pure Dart with no Flutter dependency — works in mobile apps, backends, and CLIs.
-- Type-safe request and response models with minimal dependencies (`http`, `logging`, `meta`).
-- Streaming, retries, interceptors, and cancellation built into the client.
-- Follows Anthropic resource naming closely, so official docs translate directly into Dart code.
-- Strict [semver](https://semver.org/) versioning so downstream packages can depend on stable, predictable version ranges.
 
 ## Configuration
 

--- a/packages/anthropic_sdk_dart/README.md
+++ b/packages/anthropic_sdk_dart/README.md
@@ -14,8 +14,8 @@ Dart client for the **[Anthropic API](https://docs.anthropic.com/en/api)** to bu
 <summary><b>Table of Contents</b></summary>
 
 - [Features](#features)
-- [Quickstart](#quickstart)
 - [Why choose this client?](#why-choose-this-client)
+- [Quickstart](#quickstart)
 - [Configuration](#configuration)
 - [Usage](#usage)
 - [Error Handling](#error-handling)


### PR DESCRIPTION
## Summary

- Brings api-toolkit `verify` to **fully green** for `anthropic_sdk_dart` (0 errors, **0 warnings** — down from 29), the backlog #244 left out of scope.
- **No `lib/` changes and no shared `api-toolkit/` changes** — manifest config + a README section move only. No public API change, no version bump.

## Details

The 29 warnings were all toolkit/config gaps, not SDK defects. Each was fixed at root cause:

**ContentBlock union coverage (16 warnings).** An earlier read suggested 15 of these meant the SDK "doesn't model the `BetaContentBlock` union." That was wrong: the Dart `ContentBlock` sealed class already defines a class for **every** member of both the stable `ContentBlock` and beta `BetaContentBlock` response unions (incl. `MCPToolUseBlock`, `MCPToolResultBlock`, `CompactionBlock`, `AdvisorToolResultBlock`), and `ContentBlock.fromJson` already dispatches every beta discriminator value — each `BetaResponse*Block.type` const matches the dispatch exactly. The warnings were pure **manifest under-registration**: the discriminator `mapping` never listed the beta schema names (nor the stable `ResponseTextBlock`). Fix: register all 16 in the mapping. Verified by simulating the coverage check against the spec — 0 missing members, **0 new warnings on any other union**. Mapping keys don't activate per-variant field checks, so there is zero risk of new errors.

**Consistency divergences (12 warnings).** Sibling union members legitimately disagree on a field's nullability/type (e.g. `processed_at` nullable on user-originated events but not server events; `configs`/`default_config` differ between `AgentToolset` and `MCPToolset`). These faithfully reflect the spec — the implementation required/nullable check is already green, so each variant already matches the spec. Fix: list the divergent fields in each sealed parent's `excluded_properties`, the toolkit's sanctioned "known to diverge intentionally" mechanism. Verified this is read only by the consistency sibling-comparison and is **not** inherited by variant-level checks, so it cannot mask a real per-variant error.

**README section-order (1 warning).** Moved `## Why choose this client?` above `## Quickstart` to match the toolkit's canonical H2 order. Pure section move, no content change.

### Follow-up (intentionally out of scope)

`TextBlock`, `MCPToolUseBlock`, and `MCPToolResultBlock` are now *covered* by the discriminator mapping but lack `sealed_variant` entries, so their fields aren't verified against the (beta) schemas the way the other 13 blocks are. Adding variant entries would activate type-comparison against those beta schemas (e.g. `TextBlock.citations`, a citation union) and could turn this config-only PR into a `lib/` change — so it's left as a follow-up.

## Test Plan

- [x] `verify --checks all --scope all` → 0 errors, 0 warnings (was 0 errors, 29 warnings)
- [x] `dart analyze --fatal-infos` → no issues
- [x] `dart format --set-exit-if-changed .` → clean
- [x] `dart test test/unit/` → all pass (1018 ok, 4 skipped)
- [x] No `lib/` changes → no behavior change, no version bump