### PR TITLE
chore: replace dead langchaindart.dev documentation URL

### DIFF
--- a/packages/anthropic_sdk_dart/pubspec.yaml
+++ b/packages/anthropic_sdk_dart/pubspec.yaml
@@ -4,7 +4,7 @@ version: 4.0.0
 repository: https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/anthropic_sdk_dart
 issue_tracker: https://github.com/davidmigloz/ai_clients_dart/issues?q=label:p:anthropic_sdk_dart
 homepage: https://github.com/davidmigloz/ai_clients_dart
-documentation: https://langchaindart.dev
+documentation: https://pub.dev/documentation/anthropic_sdk_dart/latest/
 
 funding:
   - https://github.com/sponsors/davidmigloz

--- a/packages/chromadb/pubspec.yaml
+++ b/packages/chromadb/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.4.0
 repository: https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/chromadb
 issue_tracker: https://github.com/davidmigloz/ai_clients_dart/issues?q=label:p:chromadb
 homepage: https://github.com/davidmigloz/ai_clients_dart
-documentation: https://langchaindart.dev
+documentation: https://pub.dev/documentation/chromadb/latest/
 
 funding:
   - https://github.com/sponsors/davidmigloz

--- a/packages/googleai_dart/pubspec.yaml
+++ b/packages/googleai_dart/pubspec.yaml
@@ -4,7 +4,7 @@ version: 7.0.0
 repository: https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/googleai_dart
 issue_tracker: https://github.com/davidmigloz/ai_clients_dart/issues?q=label:p:googleai_dart
 homepage: https://github.com/davidmigloz/ai_clients_dart
-documentation: https://langchaindart.dev
+documentation: https://pub.dev/documentation/googleai_dart/latest/
 
 funding:
   - https://github.com/sponsors/davidmigloz

--- a/packages/ollama_dart/pubspec.yaml
+++ b/packages/ollama_dart/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.2.0
 repository: https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/ollama_dart
 issue_tracker: https://github.com/davidmigloz/ai_clients_dart/issues?q=label:p:ollama_dart
 homepage: https://github.com/davidmigloz/ai_clients_dart
-documentation: https://langchaindart.dev
+documentation: https://pub.dev/documentation/ollama_dart/latest/
 
 funding:
   - https://github.com/sponsors/davidmigloz

--- a/packages/open_responses/pubspec.yaml
+++ b/packages/open_responses/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.4.1
 repository: https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/open_responses
 issue_tracker: https://github.com/davidmigloz/ai_clients_dart/issues?q=label:p:open_responses
 homepage: https://github.com/davidmigloz/ai_clients_dart
-documentation: https://langchaindart.dev
+documentation: https://pub.dev/documentation/open_responses/latest/
 
 funding:
   - https://github.com/sponsors/davidmigloz

--- a/packages/openai_dart/pubspec.yaml
+++ b/packages/openai_dart/pubspec.yaml
@@ -4,7 +4,7 @@ version: 6.1.0
 repository: https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/openai_dart
 issue_tracker: https://github.com/davidmigloz/ai_clients_dart/issues?q=label:p:openai_dart
 homepage: https://github.com/davidmigloz/ai_clients_dart
-documentation: https://langchaindart.dev
+documentation: https://pub.dev/documentation/openai_dart/latest/
 
 funding:
   - https://github.com/sponsors/davidmigloz

--- a/packages/openai_realtime_dart/pubspec.yaml
+++ b/packages/openai_realtime_dart/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.1.5
 repository: https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/openai_realtime_dart
 issue_tracker: https://github.com/davidmigloz/ai_clients_dart/issues?q=label:p:openai_realtime_dart
 homepage: https://github.com/davidmigloz/ai_clients_dart
-documentation: https://langchaindart.dev
+documentation: https://pub.dev/documentation/openai_realtime_dart/latest/
 
 funding:
   - https://github.com/sponsors/davidmigloz

--- a/packages/tavily_dart/pubspec.yaml
+++ b/packages/tavily_dart/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.2.4
 repository: https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/tavily_dart
 issue_tracker: https://github.com/davidmigloz/ai_clients_dart/issues?q=label:p:tavily_dart
 homepage: https://github.com/davidmigloz/ai_clients_dart
-documentation: https://langchaindart.dev
+documentation: https://pub.dev/documentation/tavily_dart/latest/
 
 funding:
   - https://github.com/sponsors/davidmigloz

--- a/packages/vertex_ai/pubspec.yaml
+++ b/packages/vertex_ai/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.2.4
 repository: https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/vertex_ai
 issue_tracker: https://github.com/davidmigloz/ai_clients_dart/issues?q=label:p:vertex_ai
 homepage: https://github.com/davidmigloz/ai_clients_dart
-documentation: https://langchaindart.dev
+documentation: https://pub.dev/documentation/vertex_ai/latest/
 
 funding:
   - https://github.com/sponsors/davidmigloz


### PR DESCRIPTION
## Summary
- The `langchaindart.dev` domain is no longer valid, but every package's `pubspec.yaml` still listed it as the `documentation:` URL — so pub.dev was linking visitors to a dead site.
- Repointed the `documentation:` field of all 9 packages to their pub.dev auto-generated API docs (`https://pub.dev/documentation/<package>/latest/`), which is always valid and version-tracked.

## Details

Metadata-only change. One line changed per package, e.g.:

```diff
-documentation: https://langchaindart.dev
+documentation: https://pub.dev/documentation/openai_dart/latest/
```

Affected packages: `anthropic_sdk_dart`, `chromadb`, `googleai_dart`, `ollama_dart`, `open_responses`, `openai_dart`, `openai_realtime_dart`, `tavily_dart`, `vertex_ai`.

Out of scope (left as-is): the `github.com/davidmigloz/langchain_dart` references in `README.md` and historical `CHANGELOG.md` entries point to the real predecessor GitHub repo, not the dead `langchaindart.dev` domain.

No code, changelog, or version changes — `/release` generates those.

## Test Plan
- [x] `rg "langchaindart\.dev"` returns no matches across the repo
- [x] All 9 `documentation:` fields now point to the correct `pub.dev/documentation/<package>/latest/` URL
- [x] `dart pub get` resolves cleanly (pubspecs remain valid YAML)