### PR TITLE
docs(open_responses): add quick-start example to restore pub.dev points

### DIFF
--- a/packages/open_responses/README.md
+++ b/packages/open_responses/README.md
@@ -425,6 +425,7 @@ See the [example/](example/) directory for complete examples:
 
 | Example | Description |
 |---------|-------------|
+| [`open_responses_example.dart`](example/open_responses_example.dart) | Quick start |
 | [`create_response_example.dart`](example/create_response_example.dart) | Basic response creation |
 | [`streaming_example.dart`](example/streaming_example.dart) | Streaming events |
 | [`tool_calling_example.dart`](example/tool_calling_example.dart) | Tool calling |

--- a/packages/open_responses/example/open_responses_example.dart
+++ b/packages/open_responses/example/open_responses_example.dart
@@ -1,0 +1,65 @@
+// ignore_for_file: avoid_print
+import 'dart:io';
+
+import 'package:open_responses/open_responses.dart';
+
+/// Quick-start example for the OpenResponses Dart client.
+///
+/// This example demonstrates:
+/// - Creating an [OpenResponsesClient]
+/// - Making a simple text request and reading the output
+/// - Streaming a response with the builder pattern
+///
+/// For more focused examples (tool calling, structured output, multi-turn
+/// conversations, MCP tools, reasoning, error handling, …) see the other
+/// files in this directory.
+///
+/// Set the OPENAI_API_KEY environment variable before running:
+///
+/// ```bash
+/// dart run example/open_responses_example.dart
+/// ```
+void main() async {
+  final client = OpenResponsesClient(
+    config: OpenResponsesConfig(
+      baseUrl: 'https://api.openai.com/v1',
+      authProvider: BearerTokenProvider(
+        Platform.environment['OPENAI_API_KEY'] ?? '',
+      ),
+    ),
+  );
+
+  try {
+    // 1. Simple text request.
+    print('=== Basic Request ===\n');
+    final response = await client.responses.create(
+      const CreateResponseRequest(
+        model: 'gpt-4o-mini',
+        input: ResponseTextInput('What is the capital of France?'),
+      ),
+    );
+
+    print('Output: ${response.outputText}');
+    if (response.usage != null) {
+      print(
+        'Tokens: ${response.usage!.inputTokens} in, '
+        '${response.usage!.outputTokens} out, '
+        '${response.usage!.totalTokens} total',
+      );
+    }
+
+    // 2. Streaming response with the builder pattern.
+    print('\n=== Streaming Request ===\n');
+    final runner = client.responses.stream(
+      const CreateResponseRequest(
+        model: 'gpt-4o-mini',
+        input: ResponseTextInput('Write a haiku about Dart.'),
+      ),
+    )..onTextDelta(stdout.write);
+
+    await runner.finalResponse;
+    print('\n\n[Stream completed]');
+  } finally {
+    client.close();
+  }
+}

--- a/packages/open_responses/lib/src/client/streaming_event_accumulator.dart
+++ b/packages/open_responses/lib/src/client/streaming_event_accumulator.dart
@@ -63,6 +63,9 @@ class StreamingEventAccumulatorSnapshot {
 
 /// Accumulates streaming events into progressive state snapshots.
 class StreamingEventAccumulator {
+  /// Creates a [StreamingEventAccumulator].
+  StreamingEventAccumulator();
+
   final _textBuffer = StringBuffer();
   final _reasoningBuffer = StringBuffer();
   final _reasoningSummaryBuffer = StringBuffer();


### PR DESCRIPTION
## Summary
- Adds `example/open_responses_example.dart`, a canonical quick-start example, so pub.dev's **"Package has an example"** check passes — restoring the missing **10/10 points** (Documentation section → 20/20).
- Documents `StreamingEventAccumulator`'s default constructor, clearing the lone "missing documentation" warning (1137/1137 API elements documented).

## Details

The package already ships 9 example files, yet pub.dev reported *"No example found"*. The cause is filename recognition: pub.dev's analyzer (`pana`) only detects examples at a small set of **canonical** paths — `example/example.dart`, `example/main.dart`, `example/<package>_example.dart`, `example/README.md`, etc. All existing files are named `<feature>_example.dart` (`create_response_example.dart`, `streaming_example.dart`, …), so none was recognized.

Every sibling package that passes this check has such a canonically-named entry file:
- `openai_dart` → `openai_dart_example.dart`
- `anthropic_sdk_dart` → `anthropic_sdk_dart_example.dart`
- `ollama_dart` → `ollama_dart_example.dart`
- `googleai_dart` → `example.dart`

`open_responses` was the only one missing one. This PR adds `example/open_responses_example.dart` (matching the `example/<package>_example.dart` convention) — a concise quick-start covering a basic request and a streaming request:

```dart
final client = OpenResponsesClient(
  config: OpenResponsesConfig(
    baseUrl: 'https://api.openai.com/v1',
    authProvider: BearerTokenProvider(
      Platform.environment['OPENAI_API_KEY'] ?? '',
    ),
  ),
);

final response = await client.responses.create(
  const CreateResponseRequest(
    model: 'gpt-4o-mini',
    input: ResponseTextInput('What is the capital of France?'),
  ),
);
print(response.outputText);
```

The existing feature-specific examples are kept and still linked from the README; the new file is added as a "Quick start" row rather than renaming any of them (which would break README links).

The `StreamingEventAccumulator` change adds an explicit, documented default constructor (`/// Creates a [StreamingEventAccumulator].`) following the package's established style. No behavior change.

No `pubspec`/version/`CHANGELOG` edits — those are handled by `/release`; the scorecard improvement materializes on the next publish.

## Test Plan

- [x] `dart format` — no changes needed
- [x] `dart analyze packages/open_responses` — No issues found (covers the new example)
- [x] `dart test test/unit/` — 440 passed (3 pre-existing env-related skips)
- [ ] After next publish: confirm pub.dev "Package has an example" check passes (Documentation 20/20)