### PR TITLE
feat(openai_dart): add moderation scores and deprecate sunset image models

### DIFF
--- a/packages/openai_dart/.agents/skills/openapi-openai/config/manifest.json
+++ b/packages/openai_dart/.agents/skills/openapi-openai/config/manifest.json
@@ -242,6 +242,121 @@
     "excluded_resources": []
   },
   "types": {
+    "ModerationParam": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "ModerationConfig",
+      "file": "lib/src/models/moderations/completion_moderation.dart",
+      "schema": "ModerationParam"
+    },
+    "Moderation": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "Moderation",
+      "file": "lib/src/models/moderations/completion_moderation.dart",
+      "schema": "Moderation"
+    },
+    "ModerationOutcome": {
+      "spec": "main",
+      "kind": "sealed_parent",
+      "dart_class": "ModerationOutcome",
+      "file": "lib/src/models/moderations/completion_moderation.dart",
+      "schema": null,
+      "discriminator": {
+        "field": "type",
+        "mapping": {
+          "ModerationResultBody": "moderation_result",
+          "ModerationErrorBody": "error"
+        }
+      }
+    },
+    "ModerationResultBody": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "ModerationResultBody",
+      "file": "lib/src/models/moderations/completion_moderation.dart",
+      "schema": "ModerationResultBody",
+      "parent": "ModerationOutcome"
+    },
+    "ModerationErrorBody": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "ModerationErrorBody",
+      "file": "lib/src/models/moderations/completion_moderation.dart",
+      "schema": "ModerationErrorBody",
+      "parent": "ModerationOutcome"
+    },
+    "ModerationInputType": {
+      "spec": "main",
+      "kind": "enum",
+      "dart_class": "ModerationInputType",
+      "file": "lib/src/models/moderations/completion_moderation.dart",
+      "schema": "ModerationInputType"
+    },
+    "ChatCompletionModeration": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "ChatCompletionModeration",
+      "file": "lib/src/models/chat/chat_completion_moderation.dart",
+      "schema": "ChatCompletionModeration"
+    },
+    "ChatCompletionModerationOutcome": {
+      "spec": "main",
+      "kind": "sealed_parent",
+      "dart_class": "ChatCompletionModerationOutcome",
+      "file": "lib/src/models/chat/chat_completion_moderation.dart",
+      "schema": null,
+      "discriminator": {
+        "field": "type",
+        "mapping": {
+          "ChatCompletionModerationResults": "moderation_results",
+          "ChatCompletionModerationError": "error"
+        }
+      }
+    },
+    "ChatCompletionModerationResults": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "ChatCompletionModerationResults",
+      "file": "lib/src/models/chat/chat_completion_moderation.dart",
+      "schema": "ChatCompletionModerationResults",
+      "parent": "ChatCompletionModerationOutcome"
+    },
+    "ChatCompletionModerationError": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "ChatCompletionModerationError",
+      "file": "lib/src/models/chat/chat_completion_moderation.dart",
+      "schema": "ChatCompletionModerationError",
+      "parent": "ChatCompletionModerationOutcome"
+    },
+    "CreateResponse": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "CreateResponseRequest",
+      "file": "lib/src/models/responses/create_response_request.dart",
+      "schema": "CreateResponse",
+      "tags": ["acknowledged"],
+      "note": "Spec uses allOf — verifier cannot extract top-level properties."
+    },
+    "Response": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "Response",
+      "file": "lib/src/models/responses/response.dart",
+      "schema": "Response",
+      "tags": ["acknowledged"],
+      "note": "Spec uses allOf — verifier cannot extract top-level properties."
+    },
+    "ResponsesClientEventResponseCreate": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "file": null,
+      "schema": "ResponsesClientEventResponseCreate",
+      "tags": ["acknowledged"],
+      "note": "Realtime client event embedding CreateResponse; constructed inline by the realtime resource."
+    },
     "PersonalityEnum": {
       "spec": "main",
       "kind": "sealed_parent",

--- a/packages/openai_dart/.agents/skills/openapi-openai/config/specs.json
+++ b/packages/openai_dart/.agents/skills/openapi-openai/config/specs.json
@@ -28,7 +28,7 @@
       "local_file": "openapi.json",
       "name": "OpenAI API",
       "requires_auth": false,
-      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-a6fedde02dc6241719ebb2589062ba2892baa8dbe928a2d718643beede85e7b3.yml"
+      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-0161cb2a0faadedfc17ff59c7fcad9671962dbd170f83811003c23702148cf36.yml"
     }
   },
   "specs_dir": "packages/openai_dart/specs"

--- a/packages/openai_dart/lib/src/models/chat/chat.dart
+++ b/packages/openai_dart/lib/src/models/chat/chat.dart
@@ -3,6 +3,7 @@ library;
 
 export 'chat_audio_config.dart';
 export 'chat_completion.dart';
+export 'chat_completion_moderation.dart';
 export 'chat_completion_request.dart';
 export 'chat_message.dart';
 export 'content_part.dart';

--- a/packages/openai_dart/lib/src/models/chat/chat_completion.dart
+++ b/packages/openai_dart/lib/src/models/chat/chat_completion.dart
@@ -3,6 +3,7 @@ import 'package:meta/meta.dart';
 import '../common/finish_reason.dart';
 import '../common/logprobs.dart';
 import '../common/usage.dart';
+import 'chat_completion_moderation.dart';
 import 'chat_message.dart';
 import 'reasoning_detail.dart';
 import 'tool_call.dart';
@@ -37,6 +38,7 @@ class ChatCompletion {
     this.usage,
     this.systemFingerprint,
     this.serviceTier,
+    this.moderation,
     this.provider,
   });
 
@@ -60,6 +62,11 @@ class ChatCompletion {
           : null,
       systemFingerprint: json['system_fingerprint'] as String?,
       serviceTier: json['service_tier'] as String?,
+      moderation: json['moderation'] != null
+          ? ChatCompletionModeration.fromJson(
+              json['moderation'] as Map<String, dynamic>,
+            )
+          : null,
       provider: json['provider'] as String?,
     );
   }
@@ -106,6 +113,12 @@ class ChatCompletion {
   /// The service tier used (if applicable).
   final String? serviceTier;
 
+  /// Moderation results for the request input and generated output.
+  ///
+  /// Present only when moderated completions were requested via
+  /// [ChatCompletionCreateRequest.moderation].
+  final ChatCompletionModeration? moderation;
+
   /// **OpenRouter only.** The provider that served the request.
   ///
   /// Not part of the official OpenAI API.
@@ -135,6 +148,7 @@ class ChatCompletion {
     if (usage != null) 'usage': usage!.toJson(),
     if (systemFingerprint != null) 'system_fingerprint': systemFingerprint,
     if (serviceTier != null) 'service_tier': serviceTier,
+    if (moderation != null) 'moderation': moderation!.toJson(),
     if (provider != null) 'provider': provider,
   };
 

--- a/packages/openai_dart/lib/src/models/chat/chat_completion_moderation.dart
+++ b/packages/openai_dart/lib/src/models/chat/chat_completion_moderation.dart
@@ -1,0 +1,209 @@
+import 'package:meta/meta.dart';
+
+import '../common/equality_helpers.dart';
+import '../moderations/completion_moderation.dart';
+
+/// Moderation results or errors for the request input and generated output of
+/// a Chat Completions response.
+///
+/// Present on `ChatCompletion.moderation` and `ChatStreamEvent.moderation`
+/// when moderated completions were requested via [ModerationConfig].
+@immutable
+class ChatCompletionModeration {
+  /// Creates a [ChatCompletionModeration].
+  const ChatCompletionModeration({required this.input, required this.output});
+
+  /// Creates a [ChatCompletionModeration] from JSON.
+  factory ChatCompletionModeration.fromJson(Map<String, dynamic> json) {
+    return ChatCompletionModeration(
+      input: ChatCompletionModerationOutcome.fromJson(
+        json['input'] as Map<String, dynamic>,
+      ),
+      output: ChatCompletionModerationOutcome.fromJson(
+        json['output'] as Map<String, dynamic>,
+      ),
+    );
+  }
+
+  /// Moderation for the request input.
+  final ChatCompletionModerationOutcome input;
+
+  /// Moderation for the generated output.
+  final ChatCompletionModerationOutcome output;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'input': input.toJson(),
+    'output': output.toJson(),
+  };
+
+  /// Creates a copy with the given fields replaced.
+  ChatCompletionModeration copyWith({
+    ChatCompletionModerationOutcome? input,
+    ChatCompletionModerationOutcome? output,
+  }) => ChatCompletionModeration(
+    input: input ?? this.input,
+    output: output ?? this.output,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ChatCompletionModeration &&
+          runtimeType == other.runtimeType &&
+          input == other.input &&
+          output == other.output;
+
+  @override
+  int get hashCode => Object.hash(input, output);
+
+  @override
+  String toString() =>
+      'ChatCompletionModeration(input: $input, output: $output)';
+}
+
+/// A Chat Completions moderation outcome for a single input or output.
+///
+/// Either successful [ChatCompletionModerationResults] or a
+/// [ChatCompletionModerationError], discriminated by the `type` field.
+@immutable
+sealed class ChatCompletionModerationOutcome {
+  /// Creates a [ChatCompletionModerationOutcome].
+  const ChatCompletionModerationOutcome();
+
+  /// Creates a [ChatCompletionModerationOutcome] from JSON, dispatching on
+  /// `type`.
+  factory ChatCompletionModerationOutcome.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    return switch (type) {
+      'moderation_results' => ChatCompletionModerationResults.fromJson(json),
+      'error' => ChatCompletionModerationError.fromJson(json),
+      _ => throw FormatException(
+        'Unknown chat completion moderation outcome type: $type',
+      ),
+    };
+  }
+
+  /// The discriminator type for this outcome.
+  String get type;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson();
+}
+
+/// Successful moderation results for the request input or generated output.
+@immutable
+class ChatCompletionModerationResults extends ChatCompletionModerationOutcome {
+  /// Creates a [ChatCompletionModerationResults].
+  const ChatCompletionModerationResults({
+    required this.model,
+    required this.results,
+  });
+
+  /// Creates a [ChatCompletionModerationResults] from JSON.
+  factory ChatCompletionModerationResults.fromJson(Map<String, dynamic> json) {
+    return ChatCompletionModerationResults(
+      model: json['model'] as String,
+      results: (json['results'] as List)
+          .map((e) => ModerationResultBody.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  @override
+  String get type => 'moderation_results';
+
+  /// The moderation model used to generate the results.
+  final String model;
+
+  /// A list of moderation results.
+  final List<ModerationResultBody> results;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'model': model,
+    'results': results.map((e) => e.toJson()).toList(),
+  };
+
+  /// Creates a copy with the given fields replaced.
+  ChatCompletionModerationResults copyWith({
+    String? model,
+    List<ModerationResultBody>? results,
+  }) => ChatCompletionModerationResults(
+    model: model ?? this.model,
+    results: results ?? this.results,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ChatCompletionModerationResults &&
+          runtimeType == other.runtimeType &&
+          model == other.model &&
+          listsEqual(results, other.results);
+
+  @override
+  int get hashCode => Object.hash(model, Object.hashAll(results));
+
+  @override
+  String toString() =>
+      'ChatCompletionModerationResults(model: $model, results: $results)';
+}
+
+/// An error produced while attempting moderation for a Chat Completions input
+/// or output.
+@immutable
+class ChatCompletionModerationError extends ChatCompletionModerationOutcome {
+  /// Creates a [ChatCompletionModerationError].
+  const ChatCompletionModerationError({
+    required this.code,
+    required this.message,
+  });
+
+  /// Creates a [ChatCompletionModerationError] from JSON.
+  factory ChatCompletionModerationError.fromJson(Map<String, dynamic> json) {
+    return ChatCompletionModerationError(
+      code: json['code'] as String,
+      message: json['message'] as String,
+    );
+  }
+
+  @override
+  String get type => 'error';
+
+  /// The error code.
+  final String code;
+
+  /// The error message.
+  final String message;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'code': code,
+    'message': message,
+  };
+
+  /// Creates a copy with the given fields replaced.
+  ChatCompletionModerationError copyWith({String? code, String? message}) =>
+      ChatCompletionModerationError(
+        code: code ?? this.code,
+        message: message ?? this.message,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ChatCompletionModerationError &&
+          runtimeType == other.runtimeType &&
+          code == other.code &&
+          message == other.message;
+
+  @override
+  int get hashCode => Object.hash(code, message);
+
+  @override
+  String toString() =>
+      'ChatCompletionModerationError(code: $code, message: $message)';
+}

--- a/packages/openai_dart/lib/src/models/chat/chat_completion_request.dart
+++ b/packages/openai_dart/lib/src/models/chat/chat_completion_request.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../common/copy_with_sentinel.dart';
 import '../common/response_format.dart';
+import '../moderations/completion_moderation.dart';
 import '../responses/config/prompt_cache_retention.dart';
 import '../responses/config/reasoning_effort.dart';
 import '../responses/config/verbosity.dart';
@@ -66,6 +67,7 @@ class ChatCompletionCreateRequest {
     this.modalities,
     this.audio,
     this.webSearchOptions,
+    this.moderation,
     this.promptCacheKey,
     this.promptCacheRetention,
     this.safetyIdentifier,
@@ -142,6 +144,11 @@ class ChatCompletionCreateRequest {
       webSearchOptions: json['web_search_options'] != null
           ? WebSearchOptions.fromJson(
               json['web_search_options'] as Map<String, dynamic>,
+            )
+          : null,
+      moderation: json['moderation'] != null
+          ? ModerationConfig.fromJson(
+              json['moderation'] as Map<String, dynamic>,
             )
           : null,
       promptCacheKey: json['prompt_cache_key'] as String?,
@@ -335,6 +342,14 @@ class ChatCompletionCreateRequest {
   /// [web search tool](https://platform.openai.com/docs/guides/tools-web-search?api-mode=chat).
   final WebSearchOptions? webSearchOptions;
 
+  /// Configuration for running moderation on the request input and generated
+  /// output.
+  ///
+  /// When set, the response includes `moderation` results
+  /// ([ChatCompletion.moderation]) for both the request input and the
+  /// generated output.
+  final ModerationConfig? moderation;
+
   /// Prompt cache key for optimizing cache hit rates.
   ///
   /// Used by OpenAI to cache responses for similar requests.
@@ -459,6 +474,7 @@ class ChatCompletionCreateRequest {
     if (audio != null) 'audio': audio!.toJson(),
     if (webSearchOptions != null)
       'web_search_options': webSearchOptions!.toJson(),
+    if (moderation != null) 'moderation': moderation!.toJson(),
     if (promptCacheKey != null) 'prompt_cache_key': promptCacheKey,
     if (promptCacheRetention != null)
       'prompt_cache_retention': promptCacheRetention!.toJson(),
@@ -507,6 +523,7 @@ class ChatCompletionCreateRequest {
     Object? modalities = unsetCopyWithValue,
     Object? audio = unsetCopyWithValue,
     Object? webSearchOptions = unsetCopyWithValue,
+    Object? moderation = unsetCopyWithValue,
     Object? promptCacheKey = unsetCopyWithValue,
     Object? promptCacheRetention = unsetCopyWithValue,
     Object? safetyIdentifier = unsetCopyWithValue,
@@ -592,6 +609,9 @@ class ChatCompletionCreateRequest {
       webSearchOptions: webSearchOptions == unsetCopyWithValue
           ? this.webSearchOptions
           : webSearchOptions as WebSearchOptions?,
+      moderation: moderation == unsetCopyWithValue
+          ? this.moderation
+          : moderation as ModerationConfig?,
       promptCacheKey: promptCacheKey == unsetCopyWithValue
           ? this.promptCacheKey
           : promptCacheKey as String?,

--- a/packages/openai_dart/lib/src/models/images/image_response.dart
+++ b/packages/openai_dart/lib/src/models/images/image_response.dart
@@ -385,29 +385,54 @@ class ImagesUsageOutputTokensDetails {
 
 /// Well-known OpenAI image model IDs.
 ///
-/// Mirrors the `ImageModel` literal in the official Python SDK, extended
-/// with `gpt-image-2`. The request `model` field is a free-form `String`;
-/// use these constants or pass any custom model id directly.
+/// The request `model` field is a free-form `String`; use these constants or
+/// pass any custom model id directly. `gpt-image-2` is the only image model
+/// currently recommended by OpenAI — the others have been deprecated or shut
+/// down (see the [deprecations page](https://developers.openai.com/api/docs/deprecations)).
 abstract final class ImageModels {
   /// GPT Image 2 — flagship image model with token-based pricing,
   /// flexible sizes, high-fidelity inputs, and Batch API support.
   static const String gptImage2 = 'gpt-image-2';
 
   /// GPT Image 1.5.
+  @Deprecated(
+    'Deprecated by OpenAI on 2026-06-02 and scheduled for shutdown. '
+    'Use ImageModels.gptImage2 instead.',
+  )
   static const String gptImage15 = 'gpt-image-1.5';
 
   /// GPT Image 1.
+  @Deprecated(
+    'Deprecated by OpenAI on 2026-06-02 and scheduled for shutdown. '
+    'Use ImageModels.gptImage2 instead.',
+  )
   static const String gptImage1 = 'gpt-image-1';
 
   /// GPT Image 1 mini.
+  @Deprecated(
+    'Deprecated by OpenAI on 2026-06-02 and scheduled for shutdown. '
+    'Use ImageModels.gptImage2 instead.',
+  )
   static const String gptImage1Mini = 'gpt-image-1-mini';
 
   /// ChatGPT image latest (snapshot routed to the current ChatGPT image model).
+  @Deprecated(
+    'Deprecated by OpenAI on 2026-06-02 and scheduled for shutdown. '
+    'Use ImageModels.gptImage2 instead.',
+  )
   static const String chatgptImageLatest = 'chatgpt-image-latest';
 
   /// DALL-E 3.
+  @Deprecated(
+    'Removed from the OpenAI API on 2026-05-12. '
+    'Use ImageModels.gptImage2 instead.',
+  )
   static const String dallE3 = 'dall-e-3';
 
   /// DALL-E 2.
+  @Deprecated(
+    'Removed from the OpenAI API on 2026-05-12. '
+    'Use ImageModels.gptImage2 instead.',
+  )
   static const String dallE2 = 'dall-e-2';
 }

--- a/packages/openai_dart/lib/src/models/moderations/completion_moderation.dart
+++ b/packages/openai_dart/lib/src/models/moderations/completion_moderation.dart
@@ -1,0 +1,341 @@
+import 'package:meta/meta.dart';
+
+import '../common/equality_helpers.dart';
+
+/// The input modality a moderation category score applies to.
+///
+/// Returned within [ModerationResultBody.categoryAppliedInputTypes].
+enum ModerationInputType {
+  /// Unknown modality (fallback for unrecognized values).
+  unknown('unknown'),
+
+  /// Text input.
+  text('text'),
+
+  /// Image input.
+  image('image');
+
+  const ModerationInputType(this.value);
+
+  /// The JSON value for this modality.
+  final String value;
+
+  /// Creates a [ModerationInputType] from a JSON value.
+  factory ModerationInputType.fromJson(String json) {
+    return ModerationInputType.values.firstWhere(
+      (e) => e.value == json,
+      orElse: () => ModerationInputType.unknown,
+    );
+  }
+
+  /// Converts to JSON value.
+  String toJson() => value;
+}
+
+/// Configuration for running moderation on the input and generated output of a
+/// generation request.
+///
+/// Pass this as the `moderation` field of a Chat Completions or Responses
+/// request to receive [ChatCompletionModeration]/[Moderation] results for both
+/// the request input and the generated output in the same response.
+///
+/// ## Example
+///
+/// ```dart
+/// final request = ChatCompletionCreateRequest(
+///   model: 'gpt-5.5',
+///   messages: [...],
+///   moderation: const ModerationConfig(model: 'omni-moderation-latest'),
+/// );
+/// ```
+@immutable
+class ModerationConfig {
+  /// Creates a [ModerationConfig].
+  const ModerationConfig({required this.model});
+
+  /// Creates a [ModerationConfig] from JSON.
+  factory ModerationConfig.fromJson(Map<String, dynamic> json) {
+    return ModerationConfig(model: json['model'] as String);
+  }
+
+  /// The moderation model to use, e.g. `omni-moderation-latest`.
+  final String model;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {'model': model};
+
+  /// Creates a copy with the given fields replaced.
+  ModerationConfig copyWith({String? model}) =>
+      ModerationConfig(model: model ?? this.model);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ModerationConfig &&
+          runtimeType == other.runtimeType &&
+          model == other.model;
+
+  @override
+  int get hashCode => model.hashCode;
+
+  @override
+  String toString() => 'ModerationConfig(model: $model)';
+}
+
+/// Moderation results or errors for the input and output of a Responses API
+/// response.
+///
+/// Present on `Response.moderation` when moderated completions were requested
+/// via [ModerationConfig].
+@immutable
+class Moderation {
+  /// Creates a [Moderation].
+  const Moderation({required this.input, required this.output});
+
+  /// Creates a [Moderation] from JSON.
+  factory Moderation.fromJson(Map<String, dynamic> json) {
+    return Moderation(
+      input: ModerationOutcome.fromJson(json['input'] as Map<String, dynamic>),
+      output: ModerationOutcome.fromJson(
+        json['output'] as Map<String, dynamic>,
+      ),
+    );
+  }
+
+  /// Moderation for the response input.
+  final ModerationOutcome input;
+
+  /// Moderation for the response output.
+  final ModerationOutcome output;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'input': input.toJson(),
+    'output': output.toJson(),
+  };
+
+  /// Creates a copy with the given fields replaced.
+  Moderation copyWith({ModerationOutcome? input, ModerationOutcome? output}) =>
+      Moderation(input: input ?? this.input, output: output ?? this.output);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Moderation &&
+          runtimeType == other.runtimeType &&
+          input == other.input &&
+          output == other.output;
+
+  @override
+  int get hashCode => Object.hash(input, output);
+
+  @override
+  String toString() => 'Moderation(input: $input, output: $output)';
+}
+
+/// A moderation outcome for a single input or output.
+///
+/// Either a successful [ModerationResultBody] or a [ModerationErrorBody],
+/// discriminated by the `type` field.
+@immutable
+sealed class ModerationOutcome {
+  /// Creates a [ModerationOutcome].
+  const ModerationOutcome();
+
+  /// Creates a [ModerationOutcome] from JSON, dispatching on `type`.
+  factory ModerationOutcome.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    return switch (type) {
+      'moderation_result' => ModerationResultBody.fromJson(json),
+      'error' => ModerationErrorBody.fromJson(json),
+      _ => throw FormatException('Unknown moderation outcome type: $type'),
+    };
+  }
+
+  /// The discriminator type for this outcome.
+  String get type;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson();
+}
+
+/// A successful moderation result produced for a request input or output.
+@immutable
+class ModerationResultBody extends ModerationOutcome {
+  /// Creates a [ModerationResultBody].
+  const ModerationResultBody({
+    required this.model,
+    required this.flagged,
+    required this.categories,
+    required this.categoryScores,
+    required this.categoryAppliedInputTypes,
+  });
+
+  /// Creates a [ModerationResultBody] from JSON.
+  factory ModerationResultBody.fromJson(Map<String, dynamic> json) {
+    return ModerationResultBody(
+      model: json['model'] as String,
+      flagged: json['flagged'] as bool,
+      categories: (json['categories'] as Map<String, dynamic>).map(
+        (key, value) => MapEntry(key, value as bool),
+      ),
+      categoryScores: (json['category_scores'] as Map<String, dynamic>).map(
+        (key, value) => MapEntry(key, (value as num).toDouble()),
+      ),
+      categoryAppliedInputTypes:
+          (json['category_applied_input_types'] as Map<String, dynamic>).map(
+            (key, value) => MapEntry(
+              key,
+              (value as List)
+                  .map((e) => ModerationInputType.fromJson(e as String))
+                  .toList(),
+            ),
+          ),
+    );
+  }
+
+  @override
+  String get type => 'moderation_result';
+
+  /// The moderation model that produced this result.
+  final String model;
+
+  /// Whether the content was flagged by any category.
+  final bool flagged;
+
+  /// Moderation categories mapped to whether the content is flagged.
+  final Map<String, bool> categories;
+
+  /// Moderation categories mapped to confidence scores.
+  final Map<String, double> categoryScores;
+
+  /// Which input modalities each category score applies to.
+  final Map<String, List<ModerationInputType>> categoryAppliedInputTypes;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'model': model,
+    'flagged': flagged,
+    'categories': categories,
+    'category_scores': categoryScores,
+    'category_applied_input_types': categoryAppliedInputTypes.map(
+      (key, value) => MapEntry(key, value.map((e) => e.toJson()).toList()),
+    ),
+  };
+
+  /// Creates a copy with the given fields replaced.
+  ModerationResultBody copyWith({
+    String? model,
+    bool? flagged,
+    Map<String, bool>? categories,
+    Map<String, double>? categoryScores,
+    Map<String, List<ModerationInputType>>? categoryAppliedInputTypes,
+  }) => ModerationResultBody(
+    model: model ?? this.model,
+    flagged: flagged ?? this.flagged,
+    categories: categories ?? this.categories,
+    categoryScores: categoryScores ?? this.categoryScores,
+    categoryAppliedInputTypes:
+        categoryAppliedInputTypes ?? this.categoryAppliedInputTypes,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ModerationResultBody &&
+          runtimeType == other.runtimeType &&
+          model == other.model &&
+          flagged == other.flagged &&
+          mapsEqual(categories, other.categories) &&
+          mapsEqual(categoryScores, other.categoryScores) &&
+          _appliedInputTypesEqual(
+            categoryAppliedInputTypes,
+            other.categoryAppliedInputTypes,
+          );
+
+  @override
+  int get hashCode => Object.hash(
+    model,
+    flagged,
+    mapHash(categories),
+    mapHash(categoryScores),
+    _appliedInputTypesHash(categoryAppliedInputTypes),
+  );
+
+  @override
+  String toString() =>
+      'ModerationResultBody(model: $model, flagged: $flagged, '
+      'categories: $categories, categoryScores: $categoryScores, '
+      'categoryAppliedInputTypes: $categoryAppliedInputTypes)';
+}
+
+/// An error produced while attempting moderation for a request input or output.
+@immutable
+class ModerationErrorBody extends ModerationOutcome {
+  /// Creates a [ModerationErrorBody].
+  const ModerationErrorBody({required this.code, required this.message});
+
+  /// Creates a [ModerationErrorBody] from JSON.
+  factory ModerationErrorBody.fromJson(Map<String, dynamic> json) {
+    return ModerationErrorBody(
+      code: json['code'] as String,
+      message: json['message'] as String,
+    );
+  }
+
+  @override
+  String get type => 'error';
+
+  /// The error code.
+  final String code;
+
+  /// The error message.
+  final String message;
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'code': code,
+    'message': message,
+  };
+
+  /// Creates a copy with the given fields replaced.
+  ModerationErrorBody copyWith({String? code, String? message}) =>
+      ModerationErrorBody(
+        code: code ?? this.code,
+        message: message ?? this.message,
+      );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ModerationErrorBody &&
+          runtimeType == other.runtimeType &&
+          code == other.code &&
+          message == other.message;
+
+  @override
+  int get hashCode => Object.hash(code, message);
+
+  @override
+  String toString() => 'ModerationErrorBody(code: $code, message: $message)';
+}
+
+bool _appliedInputTypesEqual(
+  Map<String, List<ModerationInputType>> a,
+  Map<String, List<ModerationInputType>> b,
+) {
+  if (a.length != b.length) return false;
+  for (final entry in a.entries) {
+    if (!b.containsKey(entry.key)) return false;
+    if (!listsEqual(entry.value, b[entry.key])) return false;
+  }
+  return true;
+}
+
+int _appliedInputTypesHash(Map<String, List<ModerationInputType>> map) {
+  return Object.hashAllUnordered(
+    map.entries.map((e) => Object.hash(e.key, Object.hashAll(e.value))),
+  );
+}

--- a/packages/openai_dart/lib/src/models/moderations/moderations.dart
+++ b/packages/openai_dart/lib/src/models/moderations/moderations.dart
@@ -1,4 +1,5 @@
 /// Content moderation models for safety checks.
 library;
 
+export 'completion_moderation.dart';
 export 'moderation.dart';

--- a/packages/openai_dart/lib/src/models/responses/config/prompt_cache_retention.dart
+++ b/packages/openai_dart/lib/src/models/responses/config/prompt_cache_retention.dart
@@ -7,6 +7,9 @@ enum PromptCacheRetention {
   inMemory('in-memory'),
 
   /// 24-hour cache retention.
+  ///
+  /// As of 2026-05-29 this is the default for organizations without Zero Data
+  /// Retention (ZDR) enabled; previously the default was [inMemory].
   h24('24h');
 
   /// The JSON value for this retention policy.

--- a/packages/openai_dart/lib/src/models/responses/create_response_request.dart
+++ b/packages/openai_dart/lib/src/models/responses/create_response_request.dart
@@ -3,6 +3,7 @@ import 'package:meta/meta.dart';
 import '../chat/chat_completion_request.dart' show StreamOptions;
 import '../common/copy_with_sentinel.dart';
 import '../common/equality_helpers.dart';
+import '../moderations/completion_moderation.dart';
 import 'config/config.dart';
 import 'items/item.dart';
 import 'response_input.dart';
@@ -129,6 +130,12 @@ class CreateResponseRequest {
   /// Safety identifier for content moderation.
   final String? safetyIdentifier;
 
+  /// Configuration for running moderation on the input and generated output.
+  ///
+  /// When set, the response includes `moderation` results
+  /// ([Response.moderation]) for both the input and the generated output.
+  final ModerationConfig? moderation;
+
   /// Prompt cache key for caching.
   final String? promptCacheKey;
 
@@ -162,6 +169,7 @@ class CreateResponseRequest {
     this.background,
     this.maxToolCalls,
     this.safetyIdentifier,
+    this.moderation,
     this.promptCacheKey,
     this.topLogprobs,
   });
@@ -227,6 +235,11 @@ class CreateResponseRequest {
       background: json['background'] as bool?,
       maxToolCalls: json['max_tool_calls'] as int?,
       safetyIdentifier: json['safety_identifier'] as String?,
+      moderation: json['moderation'] != null
+          ? ModerationConfig.fromJson(
+              json['moderation'] as Map<String, dynamic>,
+            )
+          : null,
       promptCacheKey: json['prompt_cache_key'] as String?,
       topLogprobs: json['top_logprobs'] as int?,
     );
@@ -269,6 +282,7 @@ class CreateResponseRequest {
       if (background != null) 'background': background,
       if (maxToolCalls != null) 'max_tool_calls': maxToolCalls,
       if (safetyIdentifier != null) 'safety_identifier': safetyIdentifier,
+      if (moderation != null) 'moderation': moderation!.toJson(),
       if (promptCacheKey != null) 'prompt_cache_key': promptCacheKey,
       if (topLogprobs != null) 'top_logprobs': topLogprobs,
     };
@@ -304,6 +318,7 @@ class CreateResponseRequest {
     Object? background = unsetCopyWithValue,
     Object? maxToolCalls = unsetCopyWithValue,
     Object? safetyIdentifier = unsetCopyWithValue,
+    Object? moderation = unsetCopyWithValue,
     Object? promptCacheKey = unsetCopyWithValue,
     Object? topLogprobs = unsetCopyWithValue,
   }) {
@@ -371,6 +386,9 @@ class CreateResponseRequest {
       safetyIdentifier: safetyIdentifier == unsetCopyWithValue
           ? this.safetyIdentifier
           : safetyIdentifier as String?,
+      moderation: moderation == unsetCopyWithValue
+          ? this.moderation
+          : moderation as ModerationConfig?,
       promptCacheKey: promptCacheKey == unsetCopyWithValue
           ? this.promptCacheKey
           : promptCacheKey as String?,
@@ -411,6 +429,7 @@ class CreateResponseRequest {
         background == other.background &&
         maxToolCalls == other.maxToolCalls &&
         safetyIdentifier == other.safetyIdentifier &&
+        moderation == other.moderation &&
         promptCacheKey == other.promptCacheKey &&
         topLogprobs == other.topLogprobs;
   }
@@ -442,6 +461,7 @@ class CreateResponseRequest {
     background,
     maxToolCalls,
     safetyIdentifier,
+    moderation,
     promptCacheKey,
     topLogprobs,
   ]);

--- a/packages/openai_dart/lib/src/models/responses/response.dart
+++ b/packages/openai_dart/lib/src/models/responses/response.dart
@@ -1,6 +1,7 @@
 import 'package:meta/meta.dart';
 
 import '../common/equality_helpers.dart';
+import '../moderations/completion_moderation.dart';
 import 'config/prompt_cache_retention.dart';
 import 'config/response_status.dart';
 import 'config/service_tier.dart';
@@ -75,6 +76,12 @@ class Response {
   /// The prompt cache retention policy.
   final PromptCacheRetention? promptCacheRetention;
 
+  /// Moderation results for the response input and output.
+  ///
+  /// Present only when moderated completions were requested via
+  /// [CreateResponseRequest.moderation].
+  final Moderation? moderation;
+
   /// Creates a [Response].
   const Response({
     required this.id,
@@ -97,6 +104,7 @@ class Response {
     this.parallelToolCalls,
     this.promptCacheKey,
     this.promptCacheRetention,
+    this.moderation,
   });
 
   /// Creates a [Response] from JSON.
@@ -138,6 +146,9 @@ class Response {
               json['prompt_cache_retention'] as String,
             )
           : null,
+      moderation: json['moderation'] != null
+          ? Moderation.fromJson(json['moderation'] as Map<String, dynamic>)
+          : null,
     );
   }
 
@@ -165,6 +176,7 @@ class Response {
     if (promptCacheKey != null) 'prompt_cache_key': promptCacheKey,
     if (promptCacheRetention != null)
       'prompt_cache_retention': promptCacheRetention!.toJson(),
+    if (moderation != null) 'moderation': moderation!.toJson(),
   };
 
   // ============================================================
@@ -299,7 +311,8 @@ class Response {
           background == other.background &&
           parallelToolCalls == other.parallelToolCalls &&
           promptCacheKey == other.promptCacheKey &&
-          promptCacheRetention == other.promptCacheRetention;
+          promptCacheRetention == other.promptCacheRetention &&
+          moderation == other.moderation;
 
   @override
   int get hashCode => Object.hashAll([
@@ -323,6 +336,7 @@ class Response {
     parallelToolCalls,
     promptCacheKey,
     promptCacheRetention,
+    moderation,
   ]);
 
   @override

--- a/packages/openai_dart/lib/src/models/streaming/chat_stream_event.dart
+++ b/packages/openai_dart/lib/src/models/streaming/chat_stream_event.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:meta/meta.dart';
 
 import '../chat/chat_completion.dart';
+import '../chat/chat_completion_moderation.dart';
 import '../chat/chat_message.dart';
 import '../chat/reasoning_detail.dart';
 import '../chat/tool_call.dart';
@@ -40,6 +41,7 @@ class ChatStreamEvent {
     this.usage,
     this.systemFingerprint,
     this.serviceTier,
+    this.moderation,
     this.provider,
   });
 
@@ -58,6 +60,11 @@ class ChatStreamEvent {
           : null,
       systemFingerprint: json['system_fingerprint'] as String?,
       serviceTier: json['service_tier'] as String?,
+      moderation: json['moderation'] != null
+          ? ChatCompletionModeration.fromJson(
+              json['moderation'] as Map<String, dynamic>,
+            )
+          : null,
       provider: json['provider'] as String?,
     );
   }
@@ -99,6 +106,12 @@ class ChatStreamEvent {
   /// The service tier used (if applicable).
   final String? serviceTier;
 
+  /// Moderation results for the request input and generated output.
+  ///
+  /// Present on the dedicated moderation chunk when moderated completions were
+  /// requested via [ChatCompletionCreateRequest.moderation].
+  final ChatCompletionModeration? moderation;
+
   /// **OpenRouter only.** The provider that served the request.
   ///
   /// Not part of the official OpenAI API.
@@ -124,6 +137,7 @@ class ChatStreamEvent {
     if (usage != null) 'usage': usage!.toJson(),
     if (systemFingerprint != null) 'system_fingerprint': systemFingerprint,
     if (serviceTier != null) 'service_tier': serviceTier,
+    if (moderation != null) 'moderation': moderation!.toJson(),
     if (provider != null) 'provider': provider,
   };
 
@@ -536,6 +550,7 @@ class ChatStreamAccumulator {
   String? _serviceTier;
   String? _provider;
   Usage? _usage;
+  ChatCompletionModeration? _moderation;
   final List<_AccumulatedChoice> _choices = [];
 
   _AccumulatedChoice _getOrCreateChoice(int index) {
@@ -554,6 +569,7 @@ class ChatStreamAccumulator {
     _serviceTier ??= event.serviceTier;
     _provider ??= event.provider;
     if (event.usage != null) _usage = event.usage;
+    if (event.moderation != null) _moderation = event.moderation;
 
     // Handle nullable choices for compatibility with providers like Groq
     final choices = event.choices;
@@ -711,6 +727,12 @@ class ChatStreamAccumulator {
   /// Token usage statistics.
   Usage? get usage => _usage;
 
+  /// Moderation results for the request input and generated output.
+  ///
+  /// Populated from the dedicated moderation chunk when moderated completions
+  /// were requested.
+  ChatCompletionModeration? get moderation => _moderation;
+
   /// The accumulated tool calls.
   ///
   /// For multi-choice streams, returns choice 0's tool calls.
@@ -772,6 +794,7 @@ class ChatStreamAccumulator {
       usage: _usage,
       systemFingerprint: _systemFingerprint,
       serviceTier: _serviceTier,
+      moderation: _moderation,
       provider: _provider,
     );
   }
@@ -811,6 +834,7 @@ class ChatStreamAccumulator {
     _serviceTier = null;
     _provider = null;
     _usage = null;
+    _moderation = null;
     _choices.clear();
   }
 }

--- a/packages/openai_dart/specs/openapi.json
+++ b/packages/openai_dart/specs/openapi.json
@@ -3492,6 +3492,101 @@
           }
         ]
       },
+      "ChatCompletionModeration": {
+        "description": "Moderation results or errors for the request input and generated output.",
+        "properties": {
+          "input": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ChatCompletionModerationResults"
+              },
+              {
+                "$ref": "#/components/schemas/ChatCompletionModerationError"
+              }
+            ],
+            "description": "Moderation for the request input.",
+            "discriminator": {
+              "propertyName": "type"
+            }
+          },
+          "output": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ChatCompletionModerationResults"
+              },
+              {
+                "$ref": "#/components/schemas/ChatCompletionModerationError"
+              }
+            ],
+            "description": "Moderation for the generated output.",
+            "discriminator": {
+              "propertyName": "type"
+            }
+          }
+        },
+        "required": [
+          "input",
+          "output"
+        ],
+        "type": "object"
+      },
+      "ChatCompletionModerationError": {
+        "description": "An error produced while attempting moderation.",
+        "properties": {
+          "code": {
+            "description": "The error code.",
+            "type": "string"
+          },
+          "message": {
+            "description": "The error message.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The object type, which is always `error`.",
+            "enum": [
+              "error"
+            ],
+            "type": "string",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "type",
+          "code",
+          "message"
+        ],
+        "type": "object"
+      },
+      "ChatCompletionModerationResults": {
+        "description": "Successful moderation results for the request input or generated output.",
+        "properties": {
+          "model": {
+            "description": "The moderation model used to generate the results.",
+            "type": "string"
+          },
+          "results": {
+            "description": "A list of moderation results.",
+            "items": {
+              "$ref": "#/components/schemas/ModerationResultBody"
+            },
+            "type": "array"
+          },
+          "type": {
+            "description": "The object type, which is always `moderation_results`.",
+            "enum": [
+              "moderation_results"
+            ],
+            "type": "string",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "type",
+          "model",
+          "results"
+        ],
+        "type": "object"
+      },
       "ChatCompletionNamedToolChoice": {
         "description": "Specifies a tool the model should use. Use to force the model to call a specific function.",
         "properties": {
@@ -7362,6 +7457,17 @@
                 "$ref": "#/components/schemas/ModelIdsShared",
                 "description": "Model ID used to generate the response, like `gpt-4o` or `o3`. OpenAI\noffers a wide range of models with different capabilities, performance\ncharacteristics, and price points. Refer to the [model guide](https://platform.openai.com/docs/models)\nto browse and compare available models.\n"
               },
+              "moderation": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ModerationParam",
+                    "description": "Configuration for running moderation on the request input and generated output.\n"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "n": {
                 "default": 1,
                 "description": "How many chat completion choices to generate for each input message. Note that you will be charged based on the number of generated tokens across all of the choices. Keep `n` as `1` to minimize costs.",
@@ -7531,7 +7637,7 @@
             "items": {
               "properties": {
                 "finish_reason": {
-                  "description": "The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,\n`length` if the maximum number of tokens specified in the request was reached,\n`content_filter` if content was omitted due to a flag from our content filters,\n`tool_calls` if the model called a tool, or `function_call` (deprecated) if the model called a function.\n",
+                  "description": "The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,\n`length` if the maximum number of tokens specified in the request was reached,\n`content_filter` if content was omitted due to a flag from our content filters,\n`tool_calls` if the model called a tool, or `function_call` (deprecated) if the model called a function.\nRead the [Model Spec](https://model-spec.openai.com/2025-12-18.html) for more.\n",
                   "enum": [
                     "stop",
                     "length",
@@ -7616,6 +7722,17 @@
           "model": {
             "description": "The model used for the chat completion.",
             "type": "string"
+          },
+          "moderation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ChatCompletionModeration",
+                "description": "Moderation results for the request input and generated output, if moderated\ncompletions were requested.\n"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "object": {
             "description": "The object type, which is always `chat.completion`.",
@@ -7726,6 +7843,17 @@
           "model": {
             "description": "The model to generate the completion.",
             "type": "string"
+          },
+          "moderation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ChatCompletionModeration",
+                "description": "Moderation results for the request input and generated output. Present\non the moderation chunk when moderated completions are requested.\n"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "object": {
             "description": "The object type, which is always `chat.completion.chunk`.",
@@ -10270,6 +10398,17 @@
                     "description": "An upper bound for the number of tokens that can be generated for a response, including visible output tokens and [reasoning tokens](https://platform.openai.com/docs/guides/reasoning).\n",
                     "minimum": 16,
                     "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "moderation": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ModerationParam",
+                    "description": "Configuration for running moderation on the input and output of this response.\n"
                   },
                   {
                     "type": "null"
@@ -22127,6 +22266,74 @@
         },
         "type": "object"
       },
+      "Moderation": {
+        "description": "Moderation results or errors for the response input and output.",
+        "properties": {
+          "input": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ModerationResultBody"
+              },
+              {
+                "$ref": "#/components/schemas/ModerationErrorBody"
+              }
+            ],
+            "description": "Moderation for the response input.",
+            "discriminator": {
+              "propertyName": "type"
+            }
+          },
+          "output": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ModerationResultBody"
+              },
+              {
+                "$ref": "#/components/schemas/ModerationErrorBody"
+              }
+            ],
+            "description": "Moderation for the response output.",
+            "discriminator": {
+              "propertyName": "type"
+            }
+          }
+        },
+        "required": [
+          "input",
+          "output"
+        ],
+        "title": "Moderation",
+        "type": "object"
+      },
+      "ModerationErrorBody": {
+        "description": "An error produced while attempting moderation for the response input or output.",
+        "properties": {
+          "code": {
+            "description": "The error code.",
+            "type": "string"
+          },
+          "message": {
+            "description": "The error message.",
+            "type": "string"
+          },
+          "type": {
+            "default": "error",
+            "description": "The object type, which was always `error` for moderation failures.",
+            "enum": [
+              "error"
+            ],
+            "type": "string",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "type",
+          "code",
+          "message"
+        ],
+        "title": "Moderation error",
+        "type": "object"
+      },
       "ModerationImageURLInput": {
         "description": "An object describing an image to classify.",
         "properties": {
@@ -22158,6 +22365,85 @@
           "type",
           "image_url"
         ],
+        "type": "object"
+      },
+      "ModerationInputType": {
+        "enum": [
+          "text",
+          "image"
+        ],
+        "type": "string"
+      },
+      "ModerationParam": {
+        "description": "Configuration for running moderation on the input and output of this response.",
+        "properties": {
+          "model": {
+            "description": "The moderation model to use for moderated completions, e.g. 'omni-moderation-latest'.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "model"
+        ],
+        "type": "object"
+      },
+      "ModerationResultBody": {
+        "description": "A moderation result produced for the response input or output.",
+        "properties": {
+          "categories": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "description": "A dictionary of moderation categories to booleans, True if the input is flagged under this category.",
+            "type": "object",
+            "x-oaiTypeLabel": "map"
+          },
+          "category_applied_input_types": {
+            "additionalProperties": {
+              "items": {
+                "$ref": "#/components/schemas/ModerationInputType"
+              },
+              "type": "array"
+            },
+            "description": "Which modalities of input are reflected by the score for each category.",
+            "type": "object",
+            "x-oaiTypeLabel": "map"
+          },
+          "category_scores": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "description": "A dictionary of moderation categories to scores.",
+            "type": "object",
+            "x-oaiTypeLabel": "map"
+          },
+          "flagged": {
+            "description": "A boolean indicating whether the content was flagged by any category.",
+            "type": "boolean"
+          },
+          "model": {
+            "description": "The moderation model that produced this result.",
+            "type": "string"
+          },
+          "type": {
+            "default": "moderation_result",
+            "description": "The object type, which was always `moderation_result` for successful moderation results.",
+            "enum": [
+              "moderation_result"
+            ],
+            "type": "string",
+            "x-stainless-const": true
+          }
+        },
+        "required": [
+          "type",
+          "model",
+          "flagged",
+          "categories",
+          "category_scores",
+          "category_applied_input_types"
+        ],
+        "title": "Moderation result",
         "type": "object"
       },
       "ModerationTextInput": {
@@ -33545,6 +33831,17 @@
                   {
                     "description": "An upper bound for the number of tokens that can be generated for a response, including visible output tokens and [reasoning tokens](https://platform.openai.com/docs/guides/reasoning).\n",
                     "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "moderation": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/Moderation",
+                    "description": "Moderation results for the response input and output, if moderated completions were requested.\n"
                   },
                   {
                     "type": "null"

--- a/packages/openai_dart/specs/spec_metadata.json
+++ b/packages/openai_dart/specs/spec_metadata.json
@@ -2,8 +2,8 @@
   "specs": {
     "main": {
       "current_version": "2.3.0",
-      "last_fetched": "2026-06-02T11:45:18.699766Z",
-      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-a6fedde02dc6241719ebb2589062ba2892baa8dbe928a2d718643beede85e7b3.yml",
+      "last_fetched": "2026-06-05T14:05:05.024506Z",
+      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-0161cb2a0faadedfc17ff59c7fcad9671962dbd170f83811003c23702148cf36.yml",
       "title": "OpenAI API",
       "version_history": [
         {
@@ -16,6 +16,12 @@
           "fetched_at": "2026-05-23T22:40:50.610721Z",
           "note": "afacc434\u2026 replaced by a6fedde\u2026 on 2026-06-02 to pick up the Responses API additional_tools item type and the personality (PersonalityEnum) style preset on the input-token-count request.",
           "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-afacc4343d0efc074c8c5667eb83570642c8b9acaa7792ca8e075c6d18ef9f3a.yml",
+          "version": "2.3.0"
+        },
+        {
+          "fetched_at": "2026-06-02T11:45:18.699766Z",
+          "note": "a6fedde… replaced by 0161cb2… on 2026-06-05 to pick up moderation scores on the Responses API (Moderation) and Chat Completions API (ChatCompletionModeration): the `moderation` request param (ModerationParam) plus input/output moderation results, including on chat completion stream chunks.",
+          "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-a6fedde02dc6241719ebb2589062ba2892baa8dbe928a2d718643beede85e7b3.yml",
           "version": "2.3.0"
         }
       ]

--- a/packages/openai_dart/test/unit/models/completion_moderation_test.dart
+++ b/packages/openai_dart/test/unit/models/completion_moderation_test.dart
@@ -1,0 +1,262 @@
+import 'package:openai_dart/openai_dart.dart';
+import 'package:test/test.dart';
+
+/// Builds a `moderation_result` outcome body JSON with all required fields.
+Map<String, dynamic> _resultBodyJson({bool flagged = true}) => {
+  'type': 'moderation_result',
+  'model': 'omni-moderation-latest',
+  'flagged': flagged,
+  'categories': {'hate': false, 'violence': flagged},
+  'category_scores': {'hate': 0.0001, 'violence': 0.97},
+  'category_applied_input_types': {
+    'hate': ['text'],
+    'violence': ['text', 'image'],
+  },
+};
+
+/// Builds an `error` outcome body JSON.
+Map<String, dynamic> _errorBodyJson() => {
+  'type': 'error',
+  'code': 'moderation_failed',
+  'message': 'Moderation could not be completed.',
+};
+
+void main() {
+  group('ModerationConfig', () {
+    test('round-trips through JSON', () {
+      const config = ModerationConfig(model: 'omni-moderation-latest');
+      expect(config.toJson(), {'model': 'omni-moderation-latest'});
+      expect(ModerationConfig.fromJson(config.toJson()), config);
+    });
+
+    test('equality and hashCode', () {
+      const a = ModerationConfig(model: 'omni-moderation-latest');
+      const b = ModerationConfig(model: 'omni-moderation-latest');
+      const c = ModerationConfig(model: 'text-moderation-latest');
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(c));
+    });
+  });
+
+  group('ModerationInputType', () {
+    test('maps known values', () {
+      expect(ModerationInputType.fromJson('text'), ModerationInputType.text);
+      expect(ModerationInputType.fromJson('image'), ModerationInputType.image);
+      expect(ModerationInputType.text.toJson(), 'text');
+    });
+
+    test('falls back to unknown for unrecognized values', () {
+      expect(
+        ModerationInputType.fromJson('audio'),
+        ModerationInputType.unknown,
+      );
+    });
+  });
+
+  group('ModerationOutcome', () {
+    test('parses a moderation_result body', () {
+      final outcome = ModerationOutcome.fromJson(_resultBodyJson());
+      expect(outcome, isA<ModerationResultBody>());
+      final result = outcome as ModerationResultBody;
+      expect(result.type, 'moderation_result');
+      expect(result.flagged, isTrue);
+      expect(result.categories['violence'], isTrue);
+      expect(result.categoryScores['violence'], 0.97);
+      expect(result.categoryAppliedInputTypes['violence'], [
+        ModerationInputType.text,
+        ModerationInputType.image,
+      ]);
+      expect(result.toJson(), _resultBodyJson());
+    });
+
+    test('parses an error body', () {
+      final outcome = ModerationOutcome.fromJson(_errorBodyJson());
+      expect(outcome, isA<ModerationErrorBody>());
+      final error = outcome as ModerationErrorBody;
+      expect(error.code, 'moderation_failed');
+      expect(error.toJson(), _errorBodyJson());
+    });
+
+    test('throws on unknown type', () {
+      expect(
+        () => ModerationOutcome.fromJson(const {'type': 'mystery'}),
+        throwsFormatException,
+      );
+    });
+
+    test('result body equality is content-based', () {
+      final a = ModerationOutcome.fromJson(_resultBodyJson());
+      final b = ModerationOutcome.fromJson(_resultBodyJson());
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+  });
+
+  group('Moderation (Responses)', () {
+    test('round-trips with result input and error output', () {
+      final json = {'input': _resultBodyJson(), 'output': _errorBodyJson()};
+      final moderation = Moderation.fromJson(json);
+      expect(moderation.input, isA<ModerationResultBody>());
+      expect(moderation.output, isA<ModerationErrorBody>());
+      expect(moderation.toJson(), json);
+      expect(Moderation.fromJson(moderation.toJson()), moderation);
+    });
+  });
+
+  group('ChatCompletionModeration', () {
+    test('round-trips moderation_results input', () {
+      final json = {
+        'input': {
+          'type': 'moderation_results',
+          'model': 'omni-moderation-latest',
+          'results': [_resultBodyJson()],
+        },
+        'output': _errorBodyJson(),
+      };
+      final moderation = ChatCompletionModeration.fromJson(json);
+      expect(moderation.input, isA<ChatCompletionModerationResults>());
+      final results = moderation.input as ChatCompletionModerationResults;
+      expect(results.results, hasLength(1));
+      expect(results.results.first.flagged, isTrue);
+      expect(moderation.output, isA<ChatCompletionModerationError>());
+      expect(moderation.toJson(), json);
+      expect(
+        ChatCompletionModeration.fromJson(moderation.toJson()),
+        moderation,
+      );
+    });
+  });
+
+  group('moderation on requests', () {
+    test('ChatCompletionCreateRequest serializes moderation', () {
+      const request = ChatCompletionCreateRequest(
+        model: 'gpt-5.5',
+        messages: [],
+        moderation: ModerationConfig(model: 'omni-moderation-latest'),
+      );
+      expect(request.toJson()['moderation'], {
+        'model': 'omni-moderation-latest',
+      });
+      final decoded = ChatCompletionCreateRequest.fromJson(request.toJson());
+      expect(decoded.moderation, request.moderation);
+    });
+
+    test('CreateResponseRequest serializes and copies moderation', () {
+      const request = CreateResponseRequest(
+        model: 'gpt-5.5',
+        input: ResponseInput.text('hello'),
+        moderation: ModerationConfig(model: 'omni-moderation-latest'),
+      );
+      expect(request.toJson()['moderation'], {
+        'model': 'omni-moderation-latest',
+      });
+      expect(
+        CreateResponseRequest.fromJson(request.toJson()).moderation,
+        request.moderation,
+      );
+      // copyWith preserves moderation when omitted, clears it when nulled.
+      expect(request.copyWith().moderation, request.moderation);
+      expect(request.copyWith(moderation: null).moderation, isNull);
+    });
+  });
+
+  group('moderation on responses', () {
+    test('ChatCompletion parses moderation', () {
+      final completion = ChatCompletion.fromJson({
+        'object': 'chat.completion',
+        'model': 'gpt-5.5',
+        'choices': const <Map<String, dynamic>>[],
+        'moderation': {
+          'input': {
+            'type': 'moderation_results',
+            'model': 'omni-moderation-latest',
+            'results': [_resultBodyJson()],
+          },
+          'output': {
+            'type': 'moderation_results',
+            'model': 'omni-moderation-latest',
+            'results': [_resultBodyJson(flagged: false)],
+          },
+        },
+      });
+      expect(completion.moderation, isNotNull);
+      expect(completion.toJson()['moderation'], isNotNull);
+    });
+
+    test('Response parses moderation', () {
+      final response = Response.fromJson({
+        'id': 'resp_1',
+        'object': 'response',
+        'created_at': 0,
+        'status': 'completed',
+        'output': const <Map<String, dynamic>>[],
+        'moderation': {'input': _resultBodyJson(), 'output': _errorBodyJson()},
+      });
+      expect(response.moderation, isNotNull);
+      expect(response.moderation!.input, isA<ModerationResultBody>());
+      expect(response.toJson()['moderation'], isNotNull);
+    });
+  });
+
+  group('streaming moderation', () {
+    test('ChatStreamEvent parses moderation chunk', () {
+      final event = ChatStreamEvent.fromJson({
+        'id': 'chatcmpl_1',
+        'object': 'chat.completion.chunk',
+        'choices': const <Map<String, dynamic>>[],
+        'moderation': {
+          'input': {
+            'type': 'moderation_results',
+            'model': 'omni-moderation-latest',
+            'results': [_resultBodyJson()],
+          },
+          'output': _errorBodyJson(),
+        },
+      });
+      expect(event.moderation, isNotNull);
+      expect(event.toJson()['moderation'], isNotNull);
+    });
+
+    test('accumulator captures moderation and surfaces it on completion', () {
+      final accumulator = ChatStreamAccumulator()
+        ..add(
+          ChatStreamEvent.fromJson(const {
+            'id': 'chatcmpl_1',
+            'object': 'chat.completion.chunk',
+            'choices': [
+              {
+                'index': 0,
+                'delta': {'content': 'hi'},
+              },
+            ],
+          }),
+        )
+        ..add(
+          ChatStreamEvent.fromJson({
+            'id': 'chatcmpl_1',
+            'object': 'chat.completion.chunk',
+            'choices': const <Map<String, dynamic>>[],
+            'moderation': {
+              'input': {
+                'type': 'moderation_results',
+                'model': 'omni-moderation-latest',
+                'results': [_resultBodyJson()],
+              },
+              'output': {
+                'type': 'moderation_results',
+                'model': 'omni-moderation-latest',
+                'results': [_resultBodyJson(flagged: false)],
+              },
+            },
+          }),
+        );
+
+      expect(accumulator.moderation, isNotNull);
+      expect(accumulator.toChatCompletion().moderation, isNotNull);
+
+      accumulator.reset();
+      expect(accumulator.moderation, isNull);
+    });
+  });
+}

--- a/packages/openai_dart/test/unit/models/images_test.dart
+++ b/packages/openai_dart/test/unit/models/images_test.dart
@@ -533,12 +533,17 @@ void main() {
     test('exposes well-known model ids', () {
       expect(ImageModels.gptImage2, 'gpt-image-2');
       // Deprecated constants are retained for compatibility; verify their ids.
-      // ignore_for_file: deprecated_member_use_from_same_package
+      // ignore: deprecated_member_use_from_same_package
       expect(ImageModels.gptImage15, 'gpt-image-1.5');
+      // ignore: deprecated_member_use_from_same_package
       expect(ImageModels.gptImage1, 'gpt-image-1');
+      // ignore: deprecated_member_use_from_same_package
       expect(ImageModels.gptImage1Mini, 'gpt-image-1-mini');
+      // ignore: deprecated_member_use_from_same_package
       expect(ImageModels.chatgptImageLatest, 'chatgpt-image-latest');
+      // ignore: deprecated_member_use_from_same_package
       expect(ImageModels.dallE3, 'dall-e-3');
+      // ignore: deprecated_member_use_from_same_package
       expect(ImageModels.dallE2, 'dall-e-2');
     });
   });

--- a/packages/openai_dart/test/unit/models/images_test.dart
+++ b/packages/openai_dart/test/unit/models/images_test.dart
@@ -532,6 +532,8 @@ void main() {
   group('ImageModels constants', () {
     test('exposes well-known model ids', () {
       expect(ImageModels.gptImage2, 'gpt-image-2');
+      // Deprecated constants are retained for compatibility; verify their ids.
+      // ignore_for_file: deprecated_member_use_from_same_package
       expect(ImageModels.gptImage15, 'gpt-image-1.5');
       expect(ImageModels.gptImage1, 'gpt-image-1');
       expect(ImageModels.gptImage1Mini, 'gpt-image-1-mini');


### PR DESCRIPTION
## Summary
- Add support for the new **moderation scores** feature on the Chat Completions and Responses APIs ([changelog Jun 4, 2026](https://developers.openai.com/api/docs/guides/moderation#moderate-generated-content)). Pass a `moderation` object in a request to receive moderation results for both the model input and the generated output in the same response.
- Mark the image model id constants OpenAI has deprecated or removed, keeping `ImageModels.gptImage2` as the only recommended image model.
- Refresh the canonical spec to `openai-0161cb2…` (from `a6fedde…`) and register the new schemas in the api-toolkit manifest.

## Details

### Moderation
The request side adds an optional `moderation` field (`ModerationConfig`, spec `ModerationParam`) to both `ChatCompletionCreateRequest` and `CreateResponseRequest`:

```dart
final request = ChatCompletionCreateRequest(
  model: 'gpt-5.5',
  messages: [ChatMessage.user('…')],
  moderation: const ModerationConfig(model: 'omni-moderation-latest'),
);
```

The response side surfaces results as a sealed input/output outcome (successful result **or** error):

- `ChatCompletion.moderation` / `ChatStreamEvent.moderation` → `ChatCompletionModeration` (input/output are `ChatCompletionModerationResults` | `ChatCompletionModerationError`).
- `Response.moderation` → `Moderation` (input/output are `ModerationResultBody` | `ModerationErrorBody`).
- `ModerationResultBody` carries the free-form `categories`, `categoryScores`, and `categoryAppliedInputTypes` maps (`ModerationInputType` = text/image).

For streaming, moderation arrives on a dedicated chunk; `ChatStreamAccumulator` captures it and exposes it via `accumulator.moderation` and `accumulator.toChatCompletion().moderation`.

These are new, additive, nullable fields — present only when moderated completions were requested. `Response`/`CreateResponseRequest` (full equality contracts) include `moderation`; `ChatCompletion`/`ChatStreamEvent`/`ChatCompletionCreateRequest` keep their existing partial-identity equality unchanged.

### Image model deprecations
Per the [deprecations page](https://developers.openai.com/api/docs/deprecations), all image models except `gpt-image-2` are deprecated or removed. The following `ImageModels` constants are now `@Deprecated` (retained for compatibility — non-breaking):

| Constant | Status |
| --- | --- |
| `dallE2`, `dallE3` | Removed from the API on 2026-05-12 |
| `gptImage1`, `gptImage1Mini`, `gptImage15`, `chatgptImageLatest` | Deprecated 2026-06-02, scheduled for shutdown |

### Notes
- `return_token_budget` (web search tool, changelog May 11) was **not** found in the upstream OpenAPI schema, so no field was added.
- New model snapshots `gpt-5.4` / `gpt-5.5` / `chat-latest` need no code change — chat/responses `model` is a free-form `String`.
- `prompt_cache_retention` now defaults to `24h` server-side for non-ZDR orgs; documented on `PromptCacheRetention.h24`.
- Out of scope (not modeled in this package): reusable prompts, Evals, Agent Builder, Admin APIs, Bedrock, Realtime Beta removal.

## References
- [Moderation guide — moderate generated content](https://developers.openai.com/api/docs/guides/moderation#moderate-generated-content)
- [OpenAI API deprecations](https://developers.openai.com/api/docs/deprecations)

## Test Plan
- [x] New `completion_moderation_test.dart`: request/response/stream round-trips, sealed outcome dispatch + unknown-type error, accumulator capture, `copyWith`, equality
- [x] `==`/`hashCode` contract verified for new types (same fields in both)
- [x] `fromJson`/`toJson` round-trip serialization verified
- [x] api-toolkit `verify --checks all --scope all` passes (exit 0, no failing/warning checks)
- [x] `dart format --set-exit-if-changed .`, `dart fix --apply`, `dart analyze --fatal-infos` clean
- [x] `dart test test/unit/` — 1313 pass, 2 pre-existing skips