### PR TITLE
fix(mistralai_dart): migrate deprecated model identifiers

### DIFF
--- a/packages/mistralai_dart/MIGRATION.md
+++ b/packages/mistralai_dart/MIGRATION.md
@@ -701,7 +701,7 @@ final response = await client.chat.create(
 ```dart
 final response = await client.chat.create(
   request: ChatCompletionRequest(
-    model: 'mistral-large-2411',
+    model: 'mistral-large-latest',
     messages: [ChatMessage.user('Complete this code...')],
     prediction: Prediction(
       type: 'content',

--- a/packages/mistralai_dart/README.md
+++ b/packages/mistralai_dart/README.md
@@ -574,7 +574,7 @@ Use `client.moderations` for text and chat-aware content moderation, and `client
 // Text moderation
 final result = await client.moderations.create(
   request: ModerationRequest(
-    model: 'mistral-moderation-latest',
+    model: 'mistral-moderation-2603',
     input: ['Check this content for safety'],
   ),
 );
@@ -588,7 +588,7 @@ for (final item in result.results) {
 // Chat-aware moderation
 final result = await client.moderations.createChat(
   request: ChatModerationRequest(
-    model: 'mistral-moderation-latest',
+    model: 'mistral-moderation-2603',
     input: [
       ChatMessage.user('Hello'),
       ChatMessage.assistant('Hi there!'),
@@ -600,7 +600,7 @@ final result = await client.moderations.createChat(
 ```dart
 final result = await client.classifications.create(
   request: ClassificationRequest(
-    model: 'mistral-moderation-latest',
+    model: 'mistral-moderation-2603',
     input: ['Is this spam?'],
   ),
 );

--- a/packages/mistralai_dart/lib/src/models/chat/chat_completion_request.dart
+++ b/packages/mistralai_dart/lib/src/models/chat/chat_completion_request.dart
@@ -86,7 +86,7 @@ class ChatCompletionRequest {
   /// Enables users to define anticipated output content, optimizing response
   /// times by leveraging known or predictable content.
   ///
-  /// Supported models: `mistral-large-2411`, `codestral-latest`
+  /// Supported models: `mistral-large-latest`, `codestral-latest`
   ///
   /// Note: The `n` parameter is not supported when using predictions.
   final Prediction? prediction;

--- a/packages/mistralai_dart/lib/src/models/classifications/chat_classification_request.dart
+++ b/packages/mistralai_dart/lib/src/models/classifications/chat_classification_request.dart
@@ -13,14 +13,14 @@ class ChatClassificationRequest {
 
   /// Creates a [ChatClassificationRequest].
   const ChatClassificationRequest({
-    this.model = 'mistral-moderation-latest',
+    this.model = 'mistral-moderation-2603',
     required this.input,
   });
 
   /// Creates a [ChatClassificationRequest] from JSON.
   factory ChatClassificationRequest.fromJson(Map<String, dynamic> json) =>
       ChatClassificationRequest(
-        model: json['model'] as String? ?? 'mistral-moderation-latest',
+        model: json['model'] as String? ?? 'mistral-moderation-2603',
         input:
             (json['input'] as List?)
                 ?.map((e) => ChatMessage.fromJson(e as Map<String, dynamic>))

--- a/packages/mistralai_dart/lib/src/models/classifications/classification_request.dart
+++ b/packages/mistralai_dart/lib/src/models/classifications/classification_request.dart
@@ -16,14 +16,14 @@ class ClassificationRequest {
 
   /// Creates a [ClassificationRequest].
   const ClassificationRequest({
-    this.model = 'mistral-moderation-latest',
+    this.model = 'mistral-moderation-2603',
     required this.input,
     this.metadata,
   });
 
   /// Creates a [ClassificationRequest] for a single text input.
   factory ClassificationRequest.single({
-    String model = 'mistral-moderation-latest',
+    String model = 'mistral-moderation-2603',
     required String input,
   }) {
     return ClassificationRequest(model: model, input: [input]);
@@ -42,7 +42,7 @@ class ClassificationRequest {
     }
 
     return ClassificationRequest(
-      model: json['model'] as String? ?? 'mistral-moderation-latest',
+      model: json['model'] as String? ?? 'mistral-moderation-2603',
       input: inputs,
       metadata: json['metadata'] as Map<String, dynamic>?,
     );

--- a/packages/mistralai_dart/lib/src/models/metadata/prediction.dart
+++ b/packages/mistralai_dart/lib/src/models/metadata/prediction.dart
@@ -8,7 +8,7 @@ import 'package:meta/meta.dart';
 /// This is particularly useful for scenarios like code modification tasks,
 /// where significant portions of the output are often predetermined.
 ///
-/// Supported models: `mistral-large-2411`, `codestral-latest`
+/// Supported models: `mistral-large-latest`, `codestral-latest`
 ///
 /// Note: The `n` parameter (number of completions) is not supported when
 /// using predicted outputs.

--- a/packages/mistralai_dart/lib/src/models/moderations/chat_moderation_request.dart
+++ b/packages/mistralai_dart/lib/src/models/moderations/chat_moderation_request.dart
@@ -14,14 +14,14 @@ class ChatModerationRequest {
 
   /// Creates a [ChatModerationRequest].
   const ChatModerationRequest({
-    this.model = 'mistral-moderation-latest',
+    this.model = 'mistral-moderation-2603',
     required this.input,
   });
 
   /// Creates a [ChatModerationRequest] from JSON.
   factory ChatModerationRequest.fromJson(Map<String, dynamic> json) =>
       ChatModerationRequest(
-        model: json['model'] as String? ?? 'mistral-moderation-latest',
+        model: json['model'] as String? ?? 'mistral-moderation-2603',
         input:
             (json['input'] as List?)
                 ?.map((e) => ChatMessage.fromJson(e as Map<String, dynamic>))

--- a/packages/mistralai_dart/lib/src/models/moderations/moderation_request.dart
+++ b/packages/mistralai_dart/lib/src/models/moderations/moderation_request.dart
@@ -15,13 +15,13 @@ class ModerationRequest {
 
   /// Creates a [ModerationRequest].
   const ModerationRequest({
-    this.model = 'mistral-moderation-latest',
+    this.model = 'mistral-moderation-2603',
     required this.input,
   });
 
   /// Creates a [ModerationRequest] for a single text input.
   factory ModerationRequest.single({
-    String model = 'mistral-moderation-latest',
+    String model = 'mistral-moderation-2603',
     required String input,
   }) {
     return ModerationRequest(model: model, input: [input]);
@@ -40,7 +40,7 @@ class ModerationRequest {
     }
 
     return ModerationRequest(
-      model: json['model'] as String? ?? 'mistral-moderation-latest',
+      model: json['model'] as String? ?? 'mistral-moderation-2603',
       input: inputs,
     );
   }

--- a/packages/mistralai_dart/specs/spec_metadata.json
+++ b/packages/mistralai_dart/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "1.0.0",
-      "last_fetched": "2026-05-09T16:23:18.351534Z",
+      "last_fetched": "2026-06-05T13:43:40.371909Z",
       "source_url": "https://docs.mistral.ai/openapi.yaml",
       "title": "Mistral AI API",
       "version_history": []

--- a/packages/mistralai_dart/test/integration/test_config.dart
+++ b/packages/mistralai_dart/test/integration/test_config.dart
@@ -17,7 +17,7 @@ const defaultVisionModel = 'mistral-small-latest';
 const defaultFimModel = 'codestral-latest';
 
 /// The default moderation model to use for moderation tests.
-const defaultModerationModel = 'mistral-moderation-latest';
+const defaultModerationModel = 'mistral-moderation-2603';
 
 /// The default TTS model to use for text-to-speech tests.
 const defaultTtsModel = 'voxtral-mini-tts-2603';

--- a/packages/mistralai_dart/test/unit/models/batch/create_batch_job_request_test.dart
+++ b/packages/mistralai_dart/test/unit/models/batch/create_batch_job_request_test.dart
@@ -99,7 +99,7 @@ void main() {
         final json = {
           'input_files': ['file-789'],
           'endpoint': '/v1/moderations',
-          'model': 'mistral-moderation-latest',
+          'model': 'mistral-moderation-2603',
           'metadata': {'key': 'value'},
           'timeout_hours': 48,
         };
@@ -108,7 +108,7 @@ void main() {
 
         expect(request.inputFiles, ['file-789']);
         expect(request.endpoint, '/v1/moderations');
-        expect(request.model, 'mistral-moderation-latest');
+        expect(request.model, 'mistral-moderation-2603');
         expect(request.metadata, {'key': 'value'});
         expect(request.timeoutHours, 48);
       });

--- a/packages/mistralai_dart/test/unit/models/classifications/chat_classification_request_test.dart
+++ b/packages/mistralai_dart/test/unit/models/classifications/chat_classification_request_test.dart
@@ -13,7 +13,7 @@ void main() {
         );
 
         expect(request.input, hasLength(2));
-        expect(request.model, 'mistral-moderation-latest');
+        expect(request.model, 'mistral-moderation-2603');
       });
 
       test('should create request with custom model', () {
@@ -29,7 +29,7 @@ void main() {
     group('fromJson', () {
       test('should parse request with messages', () {
         final json = <String, dynamic>{
-          'model': 'mistral-moderation-latest',
+          'model': 'mistral-moderation-2603',
           'input': [
             {'role': 'user', 'content': 'Hello'},
             {'role': 'assistant', 'content': 'Hi there!'},
@@ -38,7 +38,7 @@ void main() {
 
         final request = ChatClassificationRequest.fromJson(json);
 
-        expect(request.model, 'mistral-moderation-latest');
+        expect(request.model, 'mistral-moderation-2603');
         expect(request.input, hasLength(2));
       });
 
@@ -51,7 +51,7 @@ void main() {
 
         final request = ChatClassificationRequest.fromJson(json);
 
-        expect(request.model, 'mistral-moderation-latest');
+        expect(request.model, 'mistral-moderation-2603');
       });
 
       test('should handle empty input list', () {
@@ -66,13 +66,13 @@ void main() {
     group('toJson', () {
       test('should serialize request', () {
         final request = ChatClassificationRequest(
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           input: [ChatMessage.user('Hello'), ChatMessage.assistant('Hi!')],
         );
 
         final json = request.toJson();
 
-        expect(json['model'], 'mistral-moderation-latest');
+        expect(json['model'], 'mistral-moderation-2603');
         expect(json['input'], hasLength(2));
       });
     });

--- a/packages/mistralai_dart/test/unit/models/classifications/classification_request_test.dart
+++ b/packages/mistralai_dart/test/unit/models/classifications/classification_request_test.dart
@@ -8,7 +8,7 @@ void main() {
         final request = ClassificationRequest.single(input: 'Test content');
 
         expect(request.input, ['Test content']);
-        expect(request.model, 'mistral-moderation-latest');
+        expect(request.model, 'mistral-moderation-2603');
       });
 
       test('should create request with list input', () {
@@ -17,7 +17,7 @@ void main() {
         );
 
         expect(request.input, ['Content 1', 'Content 2', 'Content 3']);
-        expect(request.model, 'mistral-moderation-latest');
+        expect(request.model, 'mistral-moderation-2603');
       });
 
       test('should create request with custom model', () {
@@ -33,20 +33,20 @@ void main() {
     group('fromJson', () {
       test('should parse request with list input', () {
         final json = <String, dynamic>{
-          'model': 'mistral-moderation-latest',
+          'model': 'mistral-moderation-2603',
           'input': ['Content 1', 'Content 2'],
         };
 
         final request = ClassificationRequest.fromJson(json);
 
-        expect(request.model, 'mistral-moderation-latest');
+        expect(request.model, 'mistral-moderation-2603');
         expect(request.input, ['Content 1', 'Content 2']);
         expect(request.metadata, isNull);
       });
 
       test('should parse request with metadata', () {
         final json = <String, dynamic>{
-          'model': 'mistral-moderation-latest',
+          'model': 'mistral-moderation-2603',
           'input': ['Content 1'],
           'metadata': {'project': 'test'},
         };
@@ -59,7 +59,7 @@ void main() {
 
       test('should parse request with string input', () {
         final json = <String, dynamic>{
-          'model': 'mistral-moderation-latest',
+          'model': 'mistral-moderation-2603',
           'input': 'Single content',
         };
 
@@ -75,7 +75,7 @@ void main() {
 
         final request = ClassificationRequest.fromJson(json);
 
-        expect(request.model, 'mistral-moderation-latest');
+        expect(request.model, 'mistral-moderation-2603');
       });
 
       test('should handle empty input list', () {
@@ -90,13 +90,13 @@ void main() {
     group('toJson', () {
       test('should serialize request', () {
         final request = ClassificationRequest.single(
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           input: 'Test content',
         );
 
         final json = request.toJson();
 
-        expect(json['model'], 'mistral-moderation-latest');
+        expect(json['model'], 'mistral-moderation-2603');
         expect(json['input'], ['Test content']);
         expect(json.containsKey('metadata'), isFalse);
       });

--- a/packages/mistralai_dart/test/unit/models/classifications/classification_response_test.dart
+++ b/packages/mistralai_dart/test/unit/models/classifications/classification_response_test.dart
@@ -35,7 +35,7 @@ void main() {
       test('should parse complete classification response', () {
         final json = <String, dynamic>{
           'id': 'cls-123',
-          'model': 'mistral-moderation-latest',
+          'model': 'mistral-moderation-2603',
           'results': [
             {
               'categories': <String, dynamic>{'sexual': true},
@@ -51,7 +51,7 @@ void main() {
         final response = ClassificationResponse.fromJson(json);
 
         expect(response.id, 'cls-123');
-        expect(response.model, 'mistral-moderation-latest');
+        expect(response.model, 'mistral-moderation-2603');
         expect(response.results, hasLength(2));
         expect(response.results[0].flagged, isTrue);
         expect(response.results[1].flagged, isFalse);
@@ -60,7 +60,7 @@ void main() {
       test('should handle empty results', () {
         final json = <String, dynamic>{
           'id': 'cls-456',
-          'model': 'mistral-moderation-latest',
+          'model': 'mistral-moderation-2603',
           'results': <Map<String, dynamic>>[],
         };
 
@@ -84,7 +84,7 @@ void main() {
       test('should serialize classification response', () {
         const response = ClassificationResponse(
           id: 'cls-123',
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           results: [
             ClassificationResult(
               categories: {'sexual': true},
@@ -96,7 +96,7 @@ void main() {
         final json = response.toJson();
 
         expect(json['id'], 'cls-123');
-        expect(json['model'], 'mistral-moderation-latest');
+        expect(json['model'], 'mistral-moderation-2603');
         expect(json['results'], hasLength(1));
         final firstResult =
             (json['results'] as List).first as Map<String, dynamic>;
@@ -109,7 +109,7 @@ void main() {
       test('should return true if any result is flagged', () {
         const response = ClassificationResponse(
           id: 'cls-123',
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           results: [
             ClassificationResult(
               categories: {'sexual': false},
@@ -132,7 +132,7 @@ void main() {
       test('should return false if no results are flagged', () {
         const response = ClassificationResponse(
           id: 'cls-123',
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           results: [
             ClassificationResult(
               categories: {'sexual': false},
@@ -151,7 +151,7 @@ void main() {
       test('should return false if results are empty', () {
         const response = ClassificationResponse(
           id: 'cls-123',
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           results: [],
         );
 
@@ -163,7 +163,7 @@ void main() {
       test('should return first result when available', () {
         const response = ClassificationResponse(
           id: 'cls-123',
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           results: [
             ClassificationResult(
               categories: {'sexual': true},
@@ -179,7 +179,7 @@ void main() {
       test('should return null when no results', () {
         const response = ClassificationResponse(
           id: 'cls-123',
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           results: [],
         );
 
@@ -191,12 +191,12 @@ void main() {
       test('should be equal when id and model are the same', () {
         const response1 = ClassificationResponse(
           id: 'cls-123',
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           results: [],
         );
         const response2 = ClassificationResponse(
           id: 'cls-123',
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           results: [],
         );
 
@@ -224,7 +224,7 @@ void main() {
       test('should return a meaningful string representation', () {
         const response = ClassificationResponse(
           id: 'cls-123',
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           results: [
             ClassificationResult(
               categories: {'sexual': true},

--- a/packages/mistralai_dart/test/unit/models/moderations/chat_moderation_request_test.dart
+++ b/packages/mistralai_dart/test/unit/models/moderations/chat_moderation_request_test.dart
@@ -13,7 +13,7 @@ void main() {
         );
 
         expect(request.input, hasLength(2));
-        expect(request.model, 'mistral-moderation-latest');
+        expect(request.model, 'mistral-moderation-2603');
       });
 
       test('should create request with custom model', () {
@@ -29,7 +29,7 @@ void main() {
     group('fromJson', () {
       test('should parse request with messages', () {
         final json = <String, dynamic>{
-          'model': 'mistral-moderation-latest',
+          'model': 'mistral-moderation-2603',
           'input': [
             {'role': 'user', 'content': 'Hello'},
             {'role': 'assistant', 'content': 'Hi there!'},
@@ -38,7 +38,7 @@ void main() {
 
         final request = ChatModerationRequest.fromJson(json);
 
-        expect(request.model, 'mistral-moderation-latest');
+        expect(request.model, 'mistral-moderation-2603');
         expect(request.input, hasLength(2));
       });
 
@@ -51,7 +51,7 @@ void main() {
 
         final request = ChatModerationRequest.fromJson(json);
 
-        expect(request.model, 'mistral-moderation-latest');
+        expect(request.model, 'mistral-moderation-2603');
       });
 
       test('should handle empty input list', () {
@@ -66,13 +66,13 @@ void main() {
     group('toJson', () {
       test('should serialize request', () {
         final request = ChatModerationRequest(
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           input: [ChatMessage.user('Hello'), ChatMessage.assistant('Hi!')],
         );
 
         final json = request.toJson();
 
-        expect(json['model'], 'mistral-moderation-latest');
+        expect(json['model'], 'mistral-moderation-2603');
         expect(json['input'], hasLength(2));
       });
     });

--- a/packages/mistralai_dart/test/unit/models/moderations/guardrail_config_test.dart
+++ b/packages/mistralai_dart/test/unit/models/moderations/guardrail_config_test.dart
@@ -382,12 +382,12 @@ void main() {
           action: ModerationLLMAction.block,
           customCategoryThresholds: ModerationLLMV1CategoryThresholds(pii: 0.5),
           ignoreOtherCategories: true,
-          modelName: 'mistral-moderation-latest',
+          modelName: 'mistral-moderation-2603',
         );
         expect(config.action, ModerationLLMAction.block);
         expect(config.customCategoryThresholds?.pii, 0.5);
         expect(config.ignoreOtherCategories, true);
-        expect(config.modelName, 'mistral-moderation-latest');
+        expect(config.modelName, 'mistral-moderation-2603');
       });
     });
 
@@ -407,14 +407,14 @@ void main() {
           action: ModerationLLMAction.block,
           customCategoryThresholds: ModerationLLMV1CategoryThresholds(pii: 0.5),
           ignoreOtherCategories: true,
-          modelName: 'mistral-moderation-latest',
+          modelName: 'mistral-moderation-2603',
         );
         final json = config.toJson();
         expect(json['action'], 'block');
         expect(json['custom_category_thresholds'], isA<Map<String, dynamic>>());
         expect((json['custom_category_thresholds'] as Map)['pii'], 0.5);
         expect(json['ignore_other_categories'], true);
-        expect(json['model_name'], 'mistral-moderation-latest');
+        expect(json['model_name'], 'mistral-moderation-2603');
       });
 
       test('omits null fields', () {
@@ -433,13 +433,13 @@ void main() {
           'action': 'block',
           'custom_category_thresholds': {'pii': 0.5},
           'ignore_other_categories': true,
-          'model_name': 'mistral-moderation-latest',
+          'model_name': 'mistral-moderation-2603',
         };
         final config = ModerationLLMV1Config.fromJson(json);
         expect(config.action, ModerationLLMAction.block);
         expect(config.customCategoryThresholds?.pii, 0.5);
         expect(config.ignoreOtherCategories, true);
-        expect(config.modelName, 'mistral-moderation-latest');
+        expect(config.modelName, 'mistral-moderation-2603');
       });
 
       test('handles missing optional fields', () {
@@ -496,7 +496,7 @@ void main() {
             health: 0.3,
           ),
           ignoreOtherCategories: true,
-          modelName: 'mistral-moderation-latest',
+          modelName: 'mistral-moderation-2603',
         );
         final json = original.toJson();
         final restored = ModerationLLMV1Config.fromJson(json);
@@ -777,7 +777,7 @@ void main() {
               pii: 0.5,
             ),
             ignoreOtherCategories: true,
-            modelName: 'mistral-moderation-latest',
+            modelName: 'mistral-moderation-2603',
           ),
           moderationLlmV2: ModerationLLMV2Config(
             action: ModerationLLMAction.none,

--- a/packages/mistralai_dart/test/unit/models/moderations/moderation_request_test.dart
+++ b/packages/mistralai_dart/test/unit/models/moderations/moderation_request_test.dart
@@ -8,7 +8,7 @@ void main() {
         final request = ModerationRequest.single(input: 'Test content');
 
         expect(request.input, ['Test content']);
-        expect(request.model, 'mistral-moderation-latest');
+        expect(request.model, 'mistral-moderation-2603');
       });
 
       test('should create request with list input', () {
@@ -17,7 +17,7 @@ void main() {
         );
 
         expect(request.input, ['Content 1', 'Content 2', 'Content 3']);
-        expect(request.model, 'mistral-moderation-latest');
+        expect(request.model, 'mistral-moderation-2603');
       });
 
       test('should create request with custom model', () {
@@ -33,19 +33,19 @@ void main() {
     group('fromJson', () {
       test('should parse request with list input', () {
         final json = <String, dynamic>{
-          'model': 'mistral-moderation-latest',
+          'model': 'mistral-moderation-2603',
           'input': ['Content 1', 'Content 2'],
         };
 
         final request = ModerationRequest.fromJson(json);
 
-        expect(request.model, 'mistral-moderation-latest');
+        expect(request.model, 'mistral-moderation-2603');
         expect(request.input, ['Content 1', 'Content 2']);
       });
 
       test('should parse request with string input', () {
         final json = <String, dynamic>{
-          'model': 'mistral-moderation-latest',
+          'model': 'mistral-moderation-2603',
           'input': 'Single content',
         };
 
@@ -61,7 +61,7 @@ void main() {
 
         final request = ModerationRequest.fromJson(json);
 
-        expect(request.model, 'mistral-moderation-latest');
+        expect(request.model, 'mistral-moderation-2603');
       });
 
       test('should handle empty input list', () {
@@ -76,13 +76,13 @@ void main() {
     group('toJson', () {
       test('should serialize request', () {
         final request = ModerationRequest.single(
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           input: 'Test content',
         );
 
         final json = request.toJson();
 
-        expect(json['model'], 'mistral-moderation-latest');
+        expect(json['model'], 'mistral-moderation-2603');
         expect(json['input'], ['Test content']);
       });
 

--- a/packages/mistralai_dart/test/unit/models/moderations/moderation_response_test.dart
+++ b/packages/mistralai_dart/test/unit/models/moderations/moderation_response_test.dart
@@ -35,7 +35,7 @@ void main() {
       test('should parse complete moderation response', () {
         final json = <String, dynamic>{
           'id': 'mod-123',
-          'model': 'mistral-moderation-latest',
+          'model': 'mistral-moderation-2603',
           'results': [
             {
               'categories': <String, dynamic>{'sexual': true},
@@ -51,7 +51,7 @@ void main() {
         final response = ModerationResponse.fromJson(json);
 
         expect(response.id, 'mod-123');
-        expect(response.model, 'mistral-moderation-latest');
+        expect(response.model, 'mistral-moderation-2603');
         expect(response.results, hasLength(2));
         expect(response.results[0].flagged, isTrue);
         expect(response.results[1].flagged, isFalse);
@@ -60,7 +60,7 @@ void main() {
       test('should handle empty results', () {
         final json = <String, dynamic>{
           'id': 'mod-456',
-          'model': 'mistral-moderation-latest',
+          'model': 'mistral-moderation-2603',
           'results': <Map<String, dynamic>>[],
         };
 
@@ -84,7 +84,7 @@ void main() {
       test('should serialize moderation response', () {
         const response = ModerationResponse(
           id: 'mod-123',
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           results: [
             ModerationResult(
               categories: {'sexual': true},
@@ -96,7 +96,7 @@ void main() {
         final json = response.toJson();
 
         expect(json['id'], 'mod-123');
-        expect(json['model'], 'mistral-moderation-latest');
+        expect(json['model'], 'mistral-moderation-2603');
         expect(json['results'], hasLength(1));
         final firstResult =
             (json['results'] as List).first as Map<String, dynamic>;
@@ -109,7 +109,7 @@ void main() {
       test('should return true if any result is flagged', () {
         const response = ModerationResponse(
           id: 'mod-123',
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           results: [
             ModerationResult(
               categories: {'sexual': false},
@@ -132,7 +132,7 @@ void main() {
       test('should return false if no results are flagged', () {
         const response = ModerationResponse(
           id: 'mod-123',
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           results: [
             ModerationResult(
               categories: {'sexual': false},
@@ -151,7 +151,7 @@ void main() {
       test('should return false if results are empty', () {
         const response = ModerationResponse(
           id: 'mod-123',
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           results: [],
         );
 
@@ -163,7 +163,7 @@ void main() {
       test('should return first result when available', () {
         const response = ModerationResponse(
           id: 'mod-123',
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           results: [
             ModerationResult(
               categories: {'sexual': true},
@@ -179,7 +179,7 @@ void main() {
       test('should return null when no results', () {
         const response = ModerationResponse(
           id: 'mod-123',
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           results: [],
         );
 
@@ -191,12 +191,12 @@ void main() {
       test('should be equal when id and model are the same', () {
         const response1 = ModerationResponse(
           id: 'mod-123',
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           results: [],
         );
         const response2 = ModerationResponse(
           id: 'mod-123',
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           results: [],
         );
 
@@ -224,7 +224,7 @@ void main() {
       test('should return a meaningful string representation', () {
         const response = ModerationResponse(
           id: 'mod-123',
-          model: 'mistral-moderation-latest',
+          model: 'mistral-moderation-2603',
           results: [
             ModerationResult(
               categories: {'sexual': true},


### PR DESCRIPTION
## Summary
- Migrate deprecated Mistral model identifiers to current ones (verified against live Mistral docs, June 2026), keeping examples, docs, defaults, and tests on supported models.
- `mistral-moderation-latest` → `mistral-moderation-2603`: updates the default `model` value of the moderation/classification request classes (`ModerationRequest`, `ChatModerationRequest`, `ClassificationRequest`, `ChatClassificationRequest`), plus README, integration test config, and unit fixtures. **Behavior change**: requests that omit `model` now target `mistral-moderation-2603` (Mistral Moderation 2, the current model that backs guardrails).
- `mistral-large-2411` → `mistral-large-latest`: 2 lib doc comments and one `MIGRATION.md` example. Mistral Large 2.1 is deprecated; `mistral-large-latest` is a live alias (now → Mistral Large 3).
- Re-synced the spec: re-fetched `https://docs.mistral.ai/openapi.yaml` and confirmed it is **byte-identical** to the in-repo `specs/openapi.json` (117 paths / 154 operations / 449 schemas — no API changes). Only `specs/spec_metadata.json` `last_fetched` was refreshed (→ 2026-06-05).

## Details
The Mistral spec already contains everything from the recent changelog (custom guardrails, Agents, Conversations, audio diarize/context-bias, Voxtral TTS, OCR/Document Annotations, inline batching, `reasoning_effort`) and these are already implemented, so this PR makes no schema/model changes.

Scope notes:
- `mistral-large-latest` was **intentionally left as-is everywhere** (~125 refs across README, examples, doc comments, tests). It is a current, active alias resolving to Mistral Large 3 (`mistral-large-2512`) and is not deprecated — Mistral's own docs use it as the canonical chat example.
- The spec-mirrored guardrail-config defaults `ModerationLLMV1Config.model_name` (`mistral-moderation-2411`) and `ModerationLLMV2Config.model_name` (`mistral-moderation-2603`) were **not** touched — they mirror the upstream spec exactly. The migration targeted only the `mistral-moderation-latest` string.
- `specs/openapi.json` is upstream-controlled and unchanged (it still legitimately contains `mistral-large-latest`/`mistral-moderation-latest` as examples).

Verification model migration (request-class default), before/after:

```dart
// Before — default targeted a model retiring with the moderation -latest usage
const ModerationRequest({ this.model = 'mistral-moderation-latest', required this.input });

// After — pinned to the current Mistral Moderation 2 model
const ModerationRequest({ this.model = 'mistral-moderation-2603', required this.input });
```

## References
- [Mistral Moderation 2 (mistral-moderation-26-03)](https://docs.mistral.ai/models/model-cards/mistral-moderation-26-03) — current moderation model that backs custom guardrails.
- [Mistral Large 3 (mistral-large-2512)](https://docs.mistral.ai/models/mistral-large-3-25-12) — what `mistral-large-latest` currently resolves to.
- [Moderation & Guardrailing](https://docs.mistral.ai/capabilities/guardrailing) — examples use the explicit `mistral-moderation-2603`.

## Test Plan
- [x] `dart test test/unit/` passes (1495 passing, 3 pre-existing env-dependent skips)
- [x] `dart analyze --fatal-infos` — no issues
- [x] `dart format --set-exit-if-changed .` — clean
- [x] api-toolkit `verify --checks all --scope all` — `failing_checks: []` (unchanged baseline)
- [x] `fromJson`/`toJson` round-trip serialization verified (moderation/classification request + response tests)
- [x] Confirmed no deprecated `mistral-large-2411`/`mistral-moderation-latest` refs remain outside `specs/`