### PR TITLE
feat(anthropic_sdk_dart): add advisor & computer-use tool fields

### DIFF
--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
@@ -1687,12 +1687,7 @@
       "schema": "BetaComputerUseTool_20251124",
       "parent": "BuiltInTool",
       "excluded_properties": [
-        "allowed_callers",
-        "defer_loading",
-        "enable_zoom",
-        "input_examples",
-        "name",
-        "strict"
+        "name"
       ]
     },
     "McpToolset (beta)": {
@@ -1716,10 +1711,7 @@
       "schema": "BetaAdvisorTool_20260301",
       "parent": "BuiltInTool",
       "excluded_properties": [
-        "allowed_callers",
-        "defer_loading",
-        "name",
-        "strict"
+        "name"
       ]
     },
     "BetaResponseAdvisorToolResultBlock": {

--- a/packages/anthropic_sdk_dart/lib/src/models/beta/tools/advisor_tool.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/beta/tools/advisor_tool.dart
@@ -44,6 +44,15 @@ class AdvisorTool extends BuiltInTool {
   /// Cache control breakpoint for the tool definition itself.
   final CacheControlEphemeral? cacheControl;
 
+  /// Allowed caller types.
+  final List<String>? allowedCallers;
+
+  /// Whether to defer loading until requested via tool reference.
+  final bool? deferLoading;
+
+  /// Whether strict schema validation is enabled.
+  final bool? strict;
+
   /// Creates an [AdvisorTool].
   const AdvisorTool({
     String? type,
@@ -51,6 +60,9 @@ class AdvisorTool extends BuiltInTool {
     this.maxUses,
     this.caching,
     this.cacheControl,
+    this.allowedCallers,
+    this.deferLoading,
+    this.strict,
   }) : type = type ?? 'advisor_20260301';
 
   /// Creates an [AdvisorTool] from JSON.
@@ -69,6 +81,9 @@ class AdvisorTool extends BuiltInTool {
               json['cache_control'] as Map<String, dynamic>,
             )
           : null,
+      allowedCallers: (json['allowed_callers'] as List?)?.cast<String>(),
+      deferLoading: json['defer_loading'] as bool?,
+      strict: json['strict'] as bool?,
     );
   }
 
@@ -80,6 +95,9 @@ class AdvisorTool extends BuiltInTool {
     if (maxUses != null) 'max_uses': maxUses,
     if (caching != null) 'caching': caching!.toJson(),
     if (cacheControl != null) 'cache_control': cacheControl!.toJson(),
+    if (allowedCallers != null) 'allowed_callers': allowedCallers,
+    if (deferLoading != null) 'defer_loading': deferLoading,
+    if (strict != null) 'strict': strict,
   };
 
   /// Creates a copy with replaced values.
@@ -89,6 +107,9 @@ class AdvisorTool extends BuiltInTool {
     Object? maxUses = unsetCopyWithValue,
     Object? caching = unsetCopyWithValue,
     Object? cacheControl = unsetCopyWithValue,
+    Object? allowedCallers = unsetCopyWithValue,
+    Object? deferLoading = unsetCopyWithValue,
+    Object? strict = unsetCopyWithValue,
   }) {
     return AdvisorTool(
       type: type ?? this.type,
@@ -100,6 +121,13 @@ class AdvisorTool extends BuiltInTool {
       cacheControl: cacheControl == unsetCopyWithValue
           ? this.cacheControl
           : cacheControl as CacheControlEphemeral?,
+      allowedCallers: allowedCallers == unsetCopyWithValue
+          ? this.allowedCallers
+          : allowedCallers as List<String>?,
+      deferLoading: deferLoading == unsetCopyWithValue
+          ? this.deferLoading
+          : deferLoading as bool?,
+      strict: strict == unsetCopyWithValue ? this.strict : strict as bool?,
     );
   }
 
@@ -112,13 +140,27 @@ class AdvisorTool extends BuiltInTool {
           model == other.model &&
           maxUses == other.maxUses &&
           caching == other.caching &&
-          cacheControl == other.cacheControl;
+          cacheControl == other.cacheControl &&
+          listsEqual(allowedCallers, other.allowedCallers) &&
+          deferLoading == other.deferLoading &&
+          strict == other.strict;
 
   @override
-  int get hashCode => Object.hash(type, model, maxUses, caching, cacheControl);
+  int get hashCode => Object.hash(
+    type,
+    model,
+    maxUses,
+    caching,
+    cacheControl,
+    listHash(allowedCallers),
+    deferLoading,
+    strict,
+  );
 
   @override
   String toString() =>
       'AdvisorTool(type: $type, model: $model, maxUses: $maxUses, '
-      'caching: $caching, cacheControl: $cacheControl)';
+      'caching: $caching, cacheControl: $cacheControl, '
+      'allowedCallers: $allowedCallers, deferLoading: $deferLoading, '
+      'strict: $strict)';
 }

--- a/packages/anthropic_sdk_dart/lib/src/models/beta/tools/computer_use_tool.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/beta/tools/computer_use_tool.dart
@@ -21,6 +21,24 @@ class ComputerUseTool extends BuiltInTool {
   /// Cache control for this tool definition.
   final CacheControlEphemeral? cacheControl;
 
+  /// Allowed caller types.
+  final List<String>? allowedCallers;
+
+  /// Whether to defer loading until requested via tool reference.
+  final bool? deferLoading;
+
+  /// Whether strict schema validation is enabled.
+  final bool? strict;
+
+  /// Optional input examples.
+  final List<Map<String, dynamic>>? inputExamples;
+
+  /// Whether to enable a zoomed-in screenshot action.
+  ///
+  /// Only supported by the `computer_20251124` tool version; ignored during
+  /// serialization for older versions.
+  final bool? enableZoom;
+
   /// Creates a [ComputerUseTool].
   const ComputerUseTool({
     this.type = 'computer_20251124',
@@ -28,6 +46,11 @@ class ComputerUseTool extends BuiltInTool {
     required this.displayHeightPx,
     this.displayNumber,
     this.cacheControl,
+    this.allowedCallers,
+    this.deferLoading,
+    this.strict,
+    this.inputExamples,
+    this.enableZoom,
   });
 
   /// Creates a [ComputerUseTool] with version 2024-10-22.
@@ -36,6 +59,10 @@ class ComputerUseTool extends BuiltInTool {
     required int displayHeightPx,
     int? displayNumber,
     CacheControlEphemeral? cacheControl,
+    List<String>? allowedCallers,
+    bool? deferLoading,
+    bool? strict,
+    List<Map<String, dynamic>>? inputExamples,
   }) {
     return ComputerUseTool(
       type: 'computer_20241022',
@@ -43,6 +70,10 @@ class ComputerUseTool extends BuiltInTool {
       displayHeightPx: displayHeightPx,
       displayNumber: displayNumber,
       cacheControl: cacheControl,
+      allowedCallers: allowedCallers,
+      deferLoading: deferLoading,
+      strict: strict,
+      inputExamples: inputExamples,
     );
   }
 
@@ -52,6 +83,10 @@ class ComputerUseTool extends BuiltInTool {
     required int displayHeightPx,
     int? displayNumber,
     CacheControlEphemeral? cacheControl,
+    List<String>? allowedCallers,
+    bool? deferLoading,
+    bool? strict,
+    List<Map<String, dynamic>>? inputExamples,
   }) {
     return ComputerUseTool(
       type: 'computer_20250124',
@@ -59,6 +94,10 @@ class ComputerUseTool extends BuiltInTool {
       displayHeightPx: displayHeightPx,
       displayNumber: displayNumber,
       cacheControl: cacheControl,
+      allowedCallers: allowedCallers,
+      deferLoading: deferLoading,
+      strict: strict,
+      inputExamples: inputExamples,
     );
   }
 
@@ -74,6 +113,13 @@ class ComputerUseTool extends BuiltInTool {
               json['cache_control'] as Map<String, dynamic>,
             )
           : null,
+      allowedCallers: (json['allowed_callers'] as List?)?.cast<String>(),
+      deferLoading: json['defer_loading'] as bool?,
+      strict: json['strict'] as bool?,
+      inputExamples: (json['input_examples'] as List?)
+          ?.map((e) => (e as Map).cast<String, dynamic>())
+          .toList(),
+      enableZoom: json['enable_zoom'] as bool?,
     );
   }
 
@@ -85,6 +131,13 @@ class ComputerUseTool extends BuiltInTool {
     'display_height_px': displayHeightPx,
     if (displayNumber != null) 'display_number': displayNumber,
     if (cacheControl != null) 'cache_control': cacheControl!.toJson(),
+    if (allowedCallers != null) 'allowed_callers': allowedCallers,
+    if (deferLoading != null) 'defer_loading': deferLoading,
+    if (strict != null) 'strict': strict,
+    if (inputExamples != null) 'input_examples': inputExamples,
+    // enable_zoom is only valid for the 2025-11-24 tool version.
+    if (enableZoom != null && type == 'computer_20251124')
+      'enable_zoom': enableZoom,
   };
 
   /// Creates a copy with replaced values.
@@ -94,6 +147,11 @@ class ComputerUseTool extends BuiltInTool {
     int? displayHeightPx,
     Object? displayNumber = unsetCopyWithValue,
     Object? cacheControl = unsetCopyWithValue,
+    Object? allowedCallers = unsetCopyWithValue,
+    Object? deferLoading = unsetCopyWithValue,
+    Object? strict = unsetCopyWithValue,
+    Object? inputExamples = unsetCopyWithValue,
+    Object? enableZoom = unsetCopyWithValue,
   }) {
     return ComputerUseTool(
       type: type ?? this.type,
@@ -105,6 +163,19 @@ class ComputerUseTool extends BuiltInTool {
       cacheControl: cacheControl == unsetCopyWithValue
           ? this.cacheControl
           : cacheControl as CacheControlEphemeral?,
+      allowedCallers: allowedCallers == unsetCopyWithValue
+          ? this.allowedCallers
+          : allowedCallers as List<String>?,
+      deferLoading: deferLoading == unsetCopyWithValue
+          ? this.deferLoading
+          : deferLoading as bool?,
+      strict: strict == unsetCopyWithValue ? this.strict : strict as bool?,
+      inputExamples: inputExamples == unsetCopyWithValue
+          ? this.inputExamples
+          : inputExamples as List<Map<String, dynamic>>?,
+      enableZoom: enableZoom == unsetCopyWithValue
+          ? this.enableZoom
+          : enableZoom as bool?,
     );
   }
 
@@ -117,7 +188,12 @@ class ComputerUseTool extends BuiltInTool {
           displayWidthPx == other.displayWidthPx &&
           displayHeightPx == other.displayHeightPx &&
           displayNumber == other.displayNumber &&
-          cacheControl == other.cacheControl;
+          cacheControl == other.cacheControl &&
+          listsEqual(allowedCallers, other.allowedCallers) &&
+          deferLoading == other.deferLoading &&
+          strict == other.strict &&
+          listOfMapsEqual(inputExamples, other.inputExamples) &&
+          enableZoom == other.enableZoom;
 
   @override
   int get hashCode => Object.hash(
@@ -126,11 +202,18 @@ class ComputerUseTool extends BuiltInTool {
     displayHeightPx,
     displayNumber,
     cacheControl,
+    listHash(allowedCallers),
+    deferLoading,
+    strict,
+    listOfMapsHash(inputExamples),
+    enableZoom,
   );
 
   @override
   String toString() =>
       'ComputerUseTool(type: $type, displayWidthPx: $displayWidthPx, '
       'displayHeightPx: $displayHeightPx, displayNumber: $displayNumber, '
-      'cacheControl: $cacheControl)';
+      'cacheControl: $cacheControl, allowedCallers: $allowedCallers, '
+      'deferLoading: $deferLoading, strict: $strict, '
+      'inputExamples: $inputExamples, enableZoom: $enableZoom)';
 }

--- a/packages/anthropic_sdk_dart/lib/src/models/tools/built_in_tools.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/tools/built_in_tools.dart
@@ -193,6 +193,11 @@ sealed class BuiltInTool {
     required int displayHeightPx,
     int? displayNumber,
     CacheControlEphemeral? cacheControl,
+    List<String>? allowedCallers,
+    bool? deferLoading,
+    bool? strict,
+    List<Map<String, dynamic>>? inputExamples,
+    bool? enableZoom,
   }) = ComputerUseTool;
 
   /// Creates an advisor tool (Beta).
@@ -204,6 +209,9 @@ sealed class BuiltInTool {
     int? maxUses,
     CacheControlEphemeral? caching,
     CacheControlEphemeral? cacheControl,
+    List<String>? allowedCallers,
+    bool? deferLoading,
+    bool? strict,
   }) = AdvisorTool;
 
   /// Creates an MCP toolset (Beta).

--- a/packages/anthropic_sdk_dart/test/unit/models/tools/advisor_tool_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/tools/advisor_tool_test.dart
@@ -151,5 +151,83 @@ void main() {
       expect(builtIn, isA<AdvisorTool>());
       expect((builtIn as AdvisorTool).model, 'claude-opus-4-8');
     });
+
+    test('toJson includes allowed_callers, defer_loading, strict', () {
+      const tool = AdvisorTool(
+        model: 'claude-opus-4-8',
+        allowedCallers: ['direct', 'code_execution_20260120'],
+        deferLoading: true,
+        strict: true,
+      );
+      final json = tool.toJson();
+
+      expect(json['allowed_callers'], ['direct', 'code_execution_20260120']);
+      expect(json['defer_loading'], true);
+      expect(json['strict'], true);
+    });
+
+    test('fromJson round-trip with parity fields', () {
+      final json = {
+        'type': 'advisor_20260301',
+        'name': 'advisor',
+        'model': 'claude-opus-4-8',
+        'allowed_callers': ['direct'],
+        'defer_loading': false,
+        'strict': true,
+      };
+      final tool = AdvisorTool.fromJson(json);
+
+      expect(tool.allowedCallers, ['direct']);
+      expect(tool.deferLoading, false);
+      expect(tool.strict, true);
+      expect(tool.toJson(), json);
+    });
+
+    test('BuiltInTool.advisor forwards parity fields', () {
+      final tool =
+          BuiltInTool.advisor(
+                model: 'claude-opus-4-8',
+                allowedCallers: const ['direct'],
+                deferLoading: true,
+                strict: true,
+              )
+              as AdvisorTool;
+
+      expect(tool.allowedCallers, ['direct']);
+      expect(tool.deferLoading, true);
+      expect(tool.strict, true);
+    });
+
+    test('copyWith updates and clears parity fields', () {
+      const original = AdvisorTool(
+        model: 'claude-opus-4-8',
+        allowedCallers: ['direct'],
+        deferLoading: true,
+        strict: true,
+      );
+
+      final updated = original.copyWith(allowedCallers: const ['direct', 'x']);
+      expect(updated.allowedCallers, ['direct', 'x']);
+      expect(updated.deferLoading, true);
+
+      final cleared = original.copyWith(
+        allowedCallers: null,
+        deferLoading: null,
+        strict: null,
+      );
+      expect(cleared.allowedCallers, isNull);
+      expect(cleared.deferLoading, isNull);
+      expect(cleared.strict, isNull);
+    });
+
+    test('equality includes parity fields', () {
+      const a = AdvisorTool(model: 'claude-opus-4-8', strict: true);
+      const b = AdvisorTool(model: 'claude-opus-4-8', strict: true);
+      const c = AdvisorTool(model: 'claude-opus-4-8', strict: false);
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
   });
 }

--- a/packages/anthropic_sdk_dart/test/unit/models/tools/computer_use_tool_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/tools/computer_use_tool_test.dart
@@ -1,0 +1,201 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ComputerUseTool', () {
+    test('toJson with minimal fields', () {
+      const tool = ComputerUseTool(displayWidthPx: 1024, displayHeightPx: 768);
+      final json = tool.toJson();
+
+      expect(json['type'], 'computer_20251124');
+      expect(json['name'], 'computer');
+      expect(json['display_width_px'], 1024);
+      expect(json['display_height_px'], 768);
+      expect(json.containsKey('allowed_callers'), isFalse);
+      expect(json.containsKey('defer_loading'), isFalse);
+      expect(json.containsKey('strict'), isFalse);
+      expect(json.containsKey('input_examples'), isFalse);
+      expect(json.containsKey('enable_zoom'), isFalse);
+    });
+
+    test('toJson with all parity fields (computer_20251124)', () {
+      const tool = ComputerUseTool(
+        displayWidthPx: 1024,
+        displayHeightPx: 768,
+        displayNumber: 1,
+        allowedCallers: ['direct', 'code_execution_20260120'],
+        deferLoading: true,
+        strict: true,
+        inputExamples: [
+          {'action': 'screenshot'},
+        ],
+        enableZoom: true,
+      );
+      final json = tool.toJson();
+
+      expect(json['allowed_callers'], ['direct', 'code_execution_20260120']);
+      expect(json['defer_loading'], true);
+      expect(json['strict'], true);
+      expect(json['input_examples'], [
+        {'action': 'screenshot'},
+      ]);
+      expect(json['enable_zoom'], true);
+    });
+
+    test('fromJson round-trip with parity fields', () {
+      final json = {
+        'type': 'computer_20251124',
+        'name': 'computer',
+        'display_width_px': 1024,
+        'display_height_px': 768,
+        'allowed_callers': ['direct'],
+        'defer_loading': false,
+        'strict': true,
+        'input_examples': [
+          {'action': 'left_click'},
+        ],
+        'enable_zoom': true,
+      };
+      final tool = ComputerUseTool.fromJson(json);
+
+      expect(tool.allowedCallers, ['direct']);
+      expect(tool.deferLoading, false);
+      expect(tool.strict, true);
+      expect(tool.inputExamples, [
+        {'action': 'left_click'},
+      ]);
+      expect(tool.enableZoom, true);
+      expect(tool.toJson(), json);
+    });
+
+    test('BuiltInTool.fromJson dispatches to ComputerUseTool', () {
+      final json = {
+        'type': 'computer_20251124',
+        'name': 'computer',
+        'display_width_px': 1024,
+        'display_height_px': 768,
+      };
+      final tool = BuiltInTool.fromJson(json);
+
+      expect(tool, isA<ComputerUseTool>());
+      expect((tool as ComputerUseTool).displayWidthPx, 1024);
+    });
+
+    test('BuiltInTool.computerUse forwards parity fields', () {
+      final tool =
+          BuiltInTool.computerUse(
+                displayWidthPx: 1024,
+                displayHeightPx: 768,
+                allowedCallers: const ['direct'],
+                deferLoading: true,
+                strict: true,
+                inputExamples: const [
+                  {'action': 'screenshot'},
+                ],
+                enableZoom: true,
+              )
+              as ComputerUseTool;
+
+      expect(tool.allowedCallers, ['direct']);
+      expect(tool.deferLoading, true);
+      expect(tool.strict, true);
+      expect(tool.inputExamples, [
+        {'action': 'screenshot'},
+      ]);
+      expect(tool.enableZoom, true);
+    });
+
+    test('v20241022 factory forwards parity fields', () {
+      final tool = ComputerUseTool.v20241022(
+        displayWidthPx: 1024,
+        displayHeightPx: 768,
+        allowedCallers: const ['direct'],
+        deferLoading: true,
+        strict: true,
+        inputExamples: const [
+          {'action': 'screenshot'},
+        ],
+      );
+
+      expect(tool.type, 'computer_20241022');
+      expect(tool.allowedCallers, ['direct']);
+      expect(tool.deferLoading, true);
+      expect(tool.strict, true);
+      expect(tool.inputExamples, [
+        {'action': 'screenshot'},
+      ]);
+      // Forwarded fields are serialized for the older version too...
+      final json = tool.toJson();
+      expect(json['allowed_callers'], ['direct']);
+      expect(json['input_examples'], [
+        {'action': 'screenshot'},
+      ]);
+    });
+
+    test('v20250124 factory forwards parity fields', () {
+      final tool = ComputerUseTool.v20250124(
+        displayWidthPx: 1024,
+        displayHeightPx: 768,
+        allowedCallers: const ['direct'],
+        deferLoading: true,
+        strict: true,
+        inputExamples: const [
+          {'action': 'screenshot'},
+        ],
+      );
+
+      expect(tool.type, 'computer_20250124');
+      expect(tool.toJson()['strict'], true);
+    });
+
+    test('enable_zoom only serializes for computer_20251124', () {
+      // Older version objects must never emit enable_zoom, even if the field
+      // is set via copyWith / manual type override.
+      final older = ComputerUseTool.v20250124(
+        displayWidthPx: 1024,
+        displayHeightPx: 768,
+      ).copyWith(enableZoom: true);
+
+      expect(older.enableZoom, true);
+      expect(older.toJson().containsKey('enable_zoom'), isFalse);
+
+      // The latest version serializes it.
+      final latest = const ComputerUseTool(
+        displayWidthPx: 1024,
+        displayHeightPx: 768,
+      ).copyWith(enableZoom: true);
+      expect(latest.toJson()['enable_zoom'], true);
+    });
+
+    test('equality and copyWith include parity fields', () {
+      const a = ComputerUseTool(
+        displayWidthPx: 1024,
+        displayHeightPx: 768,
+        strict: true,
+      );
+      const b = ComputerUseTool(
+        displayWidthPx: 1024,
+        displayHeightPx: 768,
+        strict: true,
+      );
+      const c = ComputerUseTool(
+        displayWidthPx: 1024,
+        displayHeightPx: 768,
+        strict: false,
+      );
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+
+      final cleared = a.copyWith(strict: null);
+      expect(cleared.strict, isNull);
+    });
+
+    test('toString includes parity fields', () {
+      const tool = ComputerUseTool(displayWidthPx: 1024, displayHeightPx: 768);
+      expect(tool.toString(), contains('ComputerUseTool'));
+      expect(tool.toString(), contains('enableZoom'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Completes field-level parity for the **advisor** and **computer-use** built-in beta tools. These fields exist in the checked-in OpenAPI spec and the official `anthropic-sdk-python` param types but had been dropped from the Dart classes, so they were silently lost on parse/serialization.
- `AdvisorTool` now supports `allowedCallers`, `deferLoading`, `strict`.
- `ComputerUseTool` now supports `allowedCallers`, `deferLoading`, `strict`, `inputExamples` (all versions) and `enableZoom` (`computer_20251124` only).
- The new params are forwarded through the `BuiltInTool.advisor` and `BuiltInTool.computerUse` factories.

## Details

The api-toolkit's `review`/`verify` only diff **named schemas**, not individual fields, and the toolkit manifest had these properties listed under `excluded_properties` — so coverage stayed green while the fields were missing. This PR implements them following the existing `BashTool`/`CodeExecutionTool` pattern and **prunes them from `excluded_properties`** so `verify` actually gates them from now on.

`enableZoom` only exists on the `computer_20251124` tool version, so `toJson` emits `enable_zoom` only when `enableZoom != null && type == 'computer_20251124'` — guarding the `copyWith`/manual-`type` path, not just the factories. A test locks this in (an older-version object with `enableZoom` set does not serialize the key).

```dart
// Advisor tool with the new fields
final advisor = BuiltInTool.advisor(
  model: 'claude-opus-4-8',
  allowedCallers: const ['direct', 'code_execution_20260120'],
  deferLoading: true,
  strict: true,
);

// Computer-use tool with input examples + zoom (computer_20251124)
final computer = BuiltInTool.computerUse(
  displayWidthPx: 1024,
  displayHeightPx: 768,
  inputExamples: const [{'action': 'screenshot'}],
  enableZoom: true,
);
```

**Intentionally excluded:** the advisor-tool `max_tokens` parameter from the June 2, 2026 changelog. Cross-checking the official SDK (its `.stats.yml` points to the same spec hash this package pins), `BetaAdvisorTool20260301Param` does **not** yet contain `max_tokens` — the published spec/SDK haven't caught up to the changelog. It will be added when the spec republishes. MCP toolset `configs`/`default_config` are also out of scope (different schema).

## References
- [Anthropic API release notes](https://platform.claude.com/docs/en/release-notes/overview) — advisor tool, computer use, and Opus 4.8 updates (Jan–Jun 2026).

## Test Plan
- [x] Unit tests pass for affected package (`dart test test/unit/` — 1033 passed, 4 pre-existing env-gated skips)
- [x] New tests added: extended `advisor_tool_test.dart`; new `computer_use_tool_test.dart`
- [x] `fromJson`/`toJson` round-trip verified for all new fields
- [x] `==`/`hashCode`/`copyWith`/`toString` contract verified (same fields in all)
- [x] Factory forwarding asserted (`BuiltInTool.advisor`, `BuiltInTool.computerUse`, `ComputerUseTool.v20241022/.v20250124`)
- [x] `enableZoom` version guard verified (older-version object does not serialize `enable_zoom`)
- [x] `dart format --set-exit-if-changed .` and `dart analyze --fatal-infos .` clean
- [x] api-toolkit `verify --checks all --scope all` → `failing_checks: []`, `warning_checks: []`