### PR TITLE
feat(ollama_dart): add experimental image generation and draft_num_predict option

### DIFF
--- a/packages/ollama_dart/.agents/skills/openapi-ollama/config/manifest.json
+++ b/packages/ollama_dart/.agents/skills/openapi-ollama/config/manifest.json
@@ -106,6 +106,7 @@
         "stop",
         "num_ctx",
         "num_predict",
+        "draft_num_predict",
         "num_keep",
         "numa",
         "num_batch",
@@ -134,7 +135,10 @@
         "options",
         "think",
         "logprobs",
-        "top_logprobs"
+        "top_logprobs",
+        "width",
+        "height",
+        "steps"
       ],
       "GenerateResponse": [
         "model",
@@ -150,7 +154,10 @@
         "prompt_eval_duration",
         "eval_count",
         "eval_duration",
-        "logprobs"
+        "logprobs",
+        "image",
+        "completed",
+        "total"
       ],
       "ChatRequest": [
         "model",
@@ -241,6 +248,7 @@
       "dart_class": "GenerateRequest",
       "file": "lib/src/models/completions/generate_request.dart",
       "schema": "GenerateRequest",
+      "note": "Dart class adds experimental image-generation request fields (width, height, steps) sourced from Ollama api/types.go + docs/api.md; intentionally ahead of upstream docs/openapi.yaml, which omits them as experimental.",
       "tags": []
     },
     "GenerateResponse": {
@@ -249,6 +257,7 @@
       "dart_class": "GenerateResponse",
       "file": "lib/src/models/completions/generate_response.dart",
       "schema": "GenerateResponse",
+      "note": "Dart class adds experimental image-generation response fields (image, completed, total) sourced from Ollama api/types.go + docs/api.md; intentionally ahead of upstream docs/openapi.yaml, which omits them as experimental.",
       "tags": []
     },
     "EmbedRequest": {
@@ -306,7 +315,7 @@
       "file": "lib/src/models/metadata/model_options.dart",
       "schema": "ModelOptions",
       "tags": ["acknowledged"],
-      "note": "Spec has additionalProperties: true with only 8 fields; Dart class intentionally declares 30 typed fields covering all known Ollama options for type safety"
+      "note": "Spec has additionalProperties: true with only 8 fields; Dart class intentionally declares 31 typed fields covering all known Ollama options for type safety, including draft_num_predict (from docs/modelfile.mdx + api/types.go Runner), which is ahead of upstream docs/openapi.yaml"
     }
   }
 }

--- a/packages/ollama_dart/README.md
+++ b/packages/ollama_dart/README.md
@@ -280,6 +280,47 @@ Future<void> main() async {
 
 </details>
 
+### How do I generate images (experimental)?
+
+<details>
+<summary><b>Show example</b></summary>
+
+Image generation is **experimental** and only works with image generation models. Pass `width`/`height`/`steps` to `/api/generate`; the response carries the image as a base64 string in `image` (decode it before writing bytes). These fields may change or be removed in a future Ollama release.
+
+```dart
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:ollama_dart/ollama_dart.dart';
+
+Future<void> main() async {
+  final client = OllamaClient();
+
+  try {
+    final result = await client.completions.generate(
+      request: const GenerateRequest(
+        model: 'x/z-image-turbo',
+        prompt: 'a sunset over mountains',
+        width: 1024,
+        height: 768,
+        steps: 20,
+      ),
+    );
+
+    final image = result.image;
+    if (image != null) {
+      File('generated_image.png').writeAsBytesSync(base64Decode(image));
+    }
+  } finally {
+    client.close();
+  }
+}
+```
+
+→ [Full example](example/image_generation_example.dart)
+
+</details>
+
 ### How do I create embeddings?
 
 <details>

--- a/packages/ollama_dart/example/image_generation_example.dart
+++ b/packages/ollama_dart/example/image_generation_example.dart
@@ -1,0 +1,63 @@
+// ignore_for_file: avoid_print
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:ollama_dart/ollama_dart.dart';
+
+/// Example demonstrating experimental image generation via `/api/generate`.
+///
+/// Image generation is experimental in Ollama and only works with image
+/// generation models (e.g. `x/z-image-turbo`). The `width`, `height`, and
+/// `steps` request parameters — and the `image`/`completed`/`total` response
+/// fields — may change or be removed in a future Ollama release.
+void main() async {
+  final client = OllamaClient();
+
+  try {
+    // Non-streaming: generate a single image and save it to disk.
+    print('--- Image Generation ---');
+    final result = await client.completions.generate(
+      request: const GenerateRequest(
+        model: 'x/z-image-turbo',
+        prompt: 'a sunset over mountains',
+        width: 1024,
+        height: 768,
+        steps: 20,
+      ),
+    );
+
+    final base64Image = result.image;
+    if (base64Image != null) {
+      // The `image` field is base64-encoded; decode it before writing bytes.
+      final bytes = base64Decode(base64Image);
+      final file = File('generated_image.png')..writeAsBytesSync(bytes);
+      print('Saved ${bytes.length} bytes to ${file.path}');
+    } else {
+      print('No image returned (is this an image generation model?)');
+    }
+    print('');
+
+    // Streaming: observe diffusion progress, then capture the final image.
+    print('--- Streaming Image Generation ---');
+    await for (final chunk in client.completions.generateStream(
+      request: const GenerateRequest(
+        model: 'x/z-image-turbo',
+        prompt: 'a futuristic city at night',
+        width: 512,
+        height: 512,
+        steps: 20,
+      ),
+    )) {
+      if (chunk.completed != null && chunk.total != null) {
+        print('Progress: ${chunk.completed}/${chunk.total} steps');
+      }
+      if ((chunk.done ?? false) && chunk.image != null) {
+        final bytes = base64Decode(chunk.image!);
+        File('generated_image_stream.png').writeAsBytesSync(bytes);
+        print('Saved ${bytes.length} bytes (streamed)');
+      }
+    }
+  } finally {
+    client.close();
+  }
+}

--- a/packages/ollama_dart/lib/src/models/chat/chat_stream_event.dart
+++ b/packages/ollama_dart/lib/src/models/chat/chat_stream_event.dart
@@ -1,6 +1,7 @@
 import 'package:meta/meta.dart';
 
 import '../common/done_reason.dart';
+import '../common/equality_helpers.dart';
 import '../completions/logprob.dart';
 import 'chat_response.dart';
 
@@ -116,20 +117,53 @@ class ChatStreamEvent {
       other is ChatStreamEvent &&
           runtimeType == other.runtimeType &&
           model == other.model &&
+          remoteModel == other.remoteModel &&
+          remoteHost == other.remoteHost &&
           createdAt == other.createdAt &&
-          done == other.done;
+          message == other.message &&
+          done == other.done &&
+          doneReason == other.doneReason &&
+          totalDuration == other.totalDuration &&
+          loadDuration == other.loadDuration &&
+          promptEvalCount == other.promptEvalCount &&
+          promptEvalDuration == other.promptEvalDuration &&
+          evalCount == other.evalCount &&
+          evalDuration == other.evalDuration &&
+          listsEqual(logprobs, other.logprobs);
 
   @override
-  int get hashCode => Object.hash(model, createdAt, done);
+  int get hashCode => Object.hashAll([
+    model,
+    remoteModel,
+    remoteHost,
+    createdAt,
+    message,
+    done,
+    doneReason,
+    totalDuration,
+    loadDuration,
+    promptEvalCount,
+    promptEvalDuration,
+    evalCount,
+    evalDuration,
+    listHash(logprobs),
+  ]);
 
   @override
   String toString() =>
       'ChatStreamEvent('
       'model: $model, '
+      'remoteModel: $remoteModel, '
+      'remoteHost: $remoteHost, '
+      'createdAt: $createdAt, '
       'message: $message, '
       'done: $done, '
       'doneReason: $doneReason, '
       'totalDuration: $totalDuration, '
+      'loadDuration: $loadDuration, '
       'promptEvalCount: $promptEvalCount, '
-      'evalCount: $evalCount)';
+      'promptEvalDuration: $promptEvalDuration, '
+      'evalCount: $evalCount, '
+      'evalDuration: $evalDuration, '
+      'logprobs: $logprobs)';
 }

--- a/packages/ollama_dart/lib/src/models/completions/generate_request.dart
+++ b/packages/ollama_dart/lib/src/models/completions/generate_request.dart
@@ -66,6 +66,24 @@ class GenerateRequest {
   /// Number of most likely tokens to return at each position.
   final int? topLogprobs;
 
+  /// Width of the generated image in pixels.
+  ///
+  /// Experimental: only used by image generation models, and may change or be
+  /// removed in a future Ollama release.
+  final int? width;
+
+  /// Height of the generated image in pixels.
+  ///
+  /// Experimental: only used by image generation models, and may change or be
+  /// removed in a future Ollama release.
+  final int? height;
+
+  /// Number of diffusion steps for image generation.
+  ///
+  /// Experimental: only used by image generation models, and may change or be
+  /// removed in a future Ollama release.
+  final int? steps;
+
   /// Creates a [GenerateRequest].
   const GenerateRequest({
     required this.model,
@@ -83,6 +101,9 @@ class GenerateRequest {
     this.options,
     this.logprobs,
     this.topLogprobs,
+    this.width,
+    this.height,
+    this.steps,
   });
 
   /// Creates a [GenerateRequest] from JSON.
@@ -105,6 +126,9 @@ class GenerateRequest {
             : null,
         logprobs: json['logprobs'] as bool?,
         topLogprobs: json['top_logprobs'] as int?,
+        width: json['width'] as int?,
+        height: json['height'] as int?,
+        steps: json['steps'] as int?,
       );
 
   /// Converts to JSON.
@@ -124,6 +148,9 @@ class GenerateRequest {
     if (options != null) 'options': options!.toJson(),
     if (logprobs != null) 'logprobs': logprobs,
     if (topLogprobs != null) 'top_logprobs': topLogprobs,
+    if (width != null) 'width': width,
+    if (height != null) 'height': height,
+    if (steps != null) 'steps': steps,
   };
 
   /// Creates a copy with replaced values.
@@ -143,6 +170,9 @@ class GenerateRequest {
     Object? options = unsetCopyWithValue,
     Object? logprobs = unsetCopyWithValue,
     Object? topLogprobs = unsetCopyWithValue,
+    Object? width = unsetCopyWithValue,
+    Object? height = unsetCopyWithValue,
+    Object? steps = unsetCopyWithValue,
   }) {
     return GenerateRequest(
       model: model ?? this.model,
@@ -176,6 +206,9 @@ class GenerateRequest {
       topLogprobs: topLogprobs == unsetCopyWithValue
           ? this.topLogprobs
           : topLogprobs as int?,
+      width: width == unsetCopyWithValue ? this.width : width as int?,
+      height: height == unsetCopyWithValue ? this.height : height as int?,
+      steps: steps == unsetCopyWithValue ? this.steps : steps as int?,
     );
   }
 
@@ -198,7 +231,10 @@ class GenerateRequest {
           keepAlive == other.keepAlive &&
           options == other.options &&
           logprobs == other.logprobs &&
-          topLogprobs == other.topLogprobs;
+          topLogprobs == other.topLogprobs &&
+          width == other.width &&
+          height == other.height &&
+          steps == other.steps;
 
   @override
   int get hashCode => Object.hashAll([
@@ -217,6 +253,9 @@ class GenerateRequest {
     options,
     logprobs,
     topLogprobs,
+    width,
+    height,
+    steps,
   ]);
 
   @override
@@ -236,5 +275,8 @@ class GenerateRequest {
       'keepAlive: $keepAlive, '
       'options: $options, '
       'logprobs: $logprobs, '
-      'topLogprobs: $topLogprobs)';
+      'topLogprobs: $topLogprobs, '
+      'width: $width, '
+      'height: $height, '
+      'steps: $steps)';
 }

--- a/packages/ollama_dart/lib/src/models/completions/generate_response.dart
+++ b/packages/ollama_dart/lib/src/models/completions/generate_response.dart
@@ -66,14 +66,20 @@ class GenerateResponse {
   /// release.
   final String? image;
 
-  /// Number of completed diffusion steps during image generation.
+  /// Number of completed diffusion steps for image generation.
   ///
-  /// Experimental: only present for image generation models while streaming.
+  /// Experimental: image generation models only. Reports diffusion progress;
+  /// streamed progress events carry intermediate values, while a non-streaming
+  /// response carries the final counts. May change or be removed in a future
+  /// Ollama release.
   final int? completed;
 
   /// Total number of diffusion steps for image generation.
   ///
-  /// Experimental: only present for image generation models while streaming.
+  /// Experimental: image generation models only. Reports diffusion progress;
+  /// streamed progress events carry intermediate values, while a non-streaming
+  /// response carries the final counts. May change or be removed in a future
+  /// Ollama release.
   final int? total;
 
   /// Creates a [GenerateResponse].

--- a/packages/ollama_dart/lib/src/models/completions/generate_response.dart
+++ b/packages/ollama_dart/lib/src/models/completions/generate_response.dart
@@ -59,6 +59,23 @@ class GenerateResponse {
   /// Log probability information for generated tokens.
   final List<Logprob>? logprobs;
 
+  /// Base64-encoded generated image.
+  ///
+  /// Experimental: only present for image generation models. Decode with
+  /// `base64Decode` before use. May change or be removed in a future Ollama
+  /// release.
+  final String? image;
+
+  /// Number of completed diffusion steps during image generation.
+  ///
+  /// Experimental: only present for image generation models while streaming.
+  final int? completed;
+
+  /// Total number of diffusion steps for image generation.
+  ///
+  /// Experimental: only present for image generation models while streaming.
+  final int? total;
+
   /// Creates a [GenerateResponse].
   const GenerateResponse({
     this.model,
@@ -77,6 +94,9 @@ class GenerateResponse {
     this.evalCount,
     this.evalDuration,
     this.logprobs,
+    this.image,
+    this.completed,
+    this.total,
   });
 
   /// Creates a [GenerateResponse] from JSON.
@@ -100,6 +120,9 @@ class GenerateResponse {
         logprobs: (json['logprobs'] as List?)
             ?.map((e) => Logprob.fromJson(e as Map<String, dynamic>))
             .toList(),
+        image: json['image'] as String?,
+        completed: json['completed'] as int?,
+        total: json['total'] as int?,
       );
 
   /// Converts to JSON.
@@ -120,6 +143,9 @@ class GenerateResponse {
     if (evalCount != null) 'eval_count': evalCount,
     if (evalDuration != null) 'eval_duration': evalDuration,
     if (logprobs != null) 'logprobs': logprobs!.map((e) => e.toJson()).toList(),
+    if (image != null) 'image': image,
+    if (completed != null) 'completed': completed,
+    if (total != null) 'total': total,
   };
 
   /// Creates a copy with replaced values.
@@ -140,6 +166,9 @@ class GenerateResponse {
     Object? evalCount = unsetCopyWithValue,
     Object? evalDuration = unsetCopyWithValue,
     Object? logprobs = unsetCopyWithValue,
+    Object? image = unsetCopyWithValue,
+    Object? completed = unsetCopyWithValue,
+    Object? total = unsetCopyWithValue,
   }) {
     return GenerateResponse(
       model: model == unsetCopyWithValue ? this.model : model as String?,
@@ -186,6 +215,11 @@ class GenerateResponse {
       logprobs: logprobs == unsetCopyWithValue
           ? this.logprobs
           : logprobs as List<Logprob>?,
+      image: image == unsetCopyWithValue ? this.image : image as String?,
+      completed: completed == unsetCopyWithValue
+          ? this.completed
+          : completed as int?,
+      total: total == unsetCopyWithValue ? this.total : total as int?,
     );
   }
 
@@ -209,7 +243,10 @@ class GenerateResponse {
           promptEvalDuration == other.promptEvalDuration &&
           evalCount == other.evalCount &&
           evalDuration == other.evalDuration &&
-          listsEqual(logprobs, other.logprobs);
+          listsEqual(logprobs, other.logprobs) &&
+          image == other.image &&
+          completed == other.completed &&
+          total == other.total;
 
   @override
   int get hashCode => Object.hashAll([
@@ -229,6 +266,9 @@ class GenerateResponse {
     evalCount,
     evalDuration,
     listHash(logprobs),
+    image,
+    completed,
+    total,
   ]);
 
   @override
@@ -249,5 +289,8 @@ class GenerateResponse {
       'promptEvalDuration: $promptEvalDuration, '
       'evalCount: $evalCount, '
       'evalDuration: $evalDuration, '
-      'logprobs: $logprobs)';
+      'logprobs: $logprobs, '
+      'image: ${image == null ? null : '[${image!.length} chars]'}, '
+      'completed: $completed, '
+      'total: $total)';
 }

--- a/packages/ollama_dart/lib/src/models/completions/generate_stream_event.dart
+++ b/packages/ollama_dart/lib/src/models/completions/generate_stream_event.dart
@@ -47,6 +47,23 @@ class GenerateStreamEvent {
   /// Time spent generating tokens in nanoseconds.
   final int? evalDuration;
 
+  /// Base64-encoded generated image (final chunk for image generation models).
+  ///
+  /// Experimental: only present for image generation models. Decode with
+  /// `base64Decode` before use. May change or be removed in a future Ollama
+  /// release.
+  final String? image;
+
+  /// Number of completed diffusion steps during image generation.
+  ///
+  /// Experimental: only present for image generation models while streaming.
+  final int? completed;
+
+  /// Total number of diffusion steps for image generation.
+  ///
+  /// Experimental: only present for image generation models while streaming.
+  final int? total;
+
   /// Creates a [GenerateStreamEvent].
   const GenerateStreamEvent({
     this.model,
@@ -63,6 +80,9 @@ class GenerateStreamEvent {
     this.promptEvalDuration,
     this.evalCount,
     this.evalDuration,
+    this.image,
+    this.completed,
+    this.total,
   });
 
   /// Creates a [GenerateStreamEvent] from JSON.
@@ -82,6 +102,9 @@ class GenerateStreamEvent {
         promptEvalDuration: json['prompt_eval_duration'] as int?,
         evalCount: json['eval_count'] as int?,
         evalDuration: json['eval_duration'] as int?,
+        image: json['image'] as String?,
+        completed: json['completed'] as int?,
+        total: json['total'] as int?,
       );
 
   /// Converts to JSON.
@@ -100,6 +123,9 @@ class GenerateStreamEvent {
     if (promptEvalDuration != null) 'prompt_eval_duration': promptEvalDuration,
     if (evalCount != null) 'eval_count': evalCount,
     if (evalDuration != null) 'eval_duration': evalDuration,
+    if (image != null) 'image': image,
+    if (completed != null) 'completed': completed,
+    if (total != null) 'total': total,
   };
 
   @override
@@ -108,16 +134,62 @@ class GenerateStreamEvent {
       other is GenerateStreamEvent &&
           runtimeType == other.runtimeType &&
           model == other.model &&
+          remoteModel == other.remoteModel &&
+          remoteHost == other.remoteHost &&
+          createdAt == other.createdAt &&
           response == other.response &&
-          done == other.done;
+          thinking == other.thinking &&
+          done == other.done &&
+          doneReason == other.doneReason &&
+          totalDuration == other.totalDuration &&
+          loadDuration == other.loadDuration &&
+          promptEvalCount == other.promptEvalCount &&
+          promptEvalDuration == other.promptEvalDuration &&
+          evalCount == other.evalCount &&
+          evalDuration == other.evalDuration &&
+          image == other.image &&
+          completed == other.completed &&
+          total == other.total;
 
   @override
-  int get hashCode => Object.hash(model, response, done);
+  int get hashCode => Object.hashAll([
+    model,
+    remoteModel,
+    remoteHost,
+    createdAt,
+    response,
+    thinking,
+    done,
+    doneReason,
+    totalDuration,
+    loadDuration,
+    promptEvalCount,
+    promptEvalDuration,
+    evalCount,
+    evalDuration,
+    image,
+    completed,
+    total,
+  ]);
 
   @override
   String toString() =>
       'GenerateStreamEvent('
       'model: $model, '
+      'remoteModel: $remoteModel, '
+      'remoteHost: $remoteHost, '
+      'createdAt: $createdAt, '
       'response: $response, '
-      'done: $done)';
+      'thinking: $thinking, '
+      'done: $done, '
+      'doneReason: $doneReason, '
+      'totalDuration: $totalDuration, '
+      'loadDuration: $loadDuration, '
+      'promptEvalCount: $promptEvalCount, '
+      'promptEvalDuration: $promptEvalDuration, '
+      'evalCount: $evalCount, '
+      'evalDuration: $evalDuration, '
+      'image: ${image == null ? null : '[${image!.length} chars]'}, '
+      'completed: $completed, '
+      'total: $total)';
 }

--- a/packages/ollama_dart/lib/src/models/metadata/model_options.dart
+++ b/packages/ollama_dart/lib/src/models/metadata/model_options.dart
@@ -74,6 +74,13 @@ class ModelOptions {
   /// Maximum number of tokens to generate.
   final int? numPredict;
 
+  /// Maximum number of speculative draft tokens to predict per step when a
+  /// draft model is available.
+  ///
+  /// Separate draft models default to 4; set to 0 to disable speculative
+  /// drafting.
+  final int? draftNumPredict;
+
   /// Number of tokens to keep from the initial prompt.
   final int? numKeep;
 
@@ -144,6 +151,7 @@ class ModelOptions {
     // Context and output
     this.numCtx,
     this.numPredict,
+    this.draftNumPredict,
     this.numKeep,
     // Runtime and GPU
     this.numa,
@@ -182,6 +190,7 @@ class ModelOptions {
     // Context and output
     numCtx: json['num_ctx'] as int?,
     numPredict: json['num_predict'] as int?,
+    draftNumPredict: json['draft_num_predict'] as int?,
     numKeep: json['num_keep'] as int?,
     // Runtime and GPU
     numa: json['numa'] as bool?,
@@ -220,6 +229,7 @@ class ModelOptions {
     // Context and output
     if (numCtx != null) 'num_ctx': numCtx,
     if (numPredict != null) 'num_predict': numPredict,
+    if (draftNumPredict != null) 'draft_num_predict': draftNumPredict,
     if (numKeep != null) 'num_keep': numKeep,
     // Runtime and GPU
     if (numa != null) 'numa': numa,
@@ -258,6 +268,7 @@ class ModelOptions {
     // Context and output
     Object? numCtx = unsetCopyWithValue,
     Object? numPredict = unsetCopyWithValue,
+    Object? draftNumPredict = unsetCopyWithValue,
     Object? numKeep = unsetCopyWithValue,
     // Runtime and GPU
     Object? numa = unsetCopyWithValue,
@@ -316,6 +327,9 @@ class ModelOptions {
       numPredict: numPredict == unsetCopyWithValue
           ? this.numPredict
           : numPredict as int?,
+      draftNumPredict: draftNumPredict == unsetCopyWithValue
+          ? this.draftNumPredict
+          : draftNumPredict as int?,
       numKeep: numKeep == unsetCopyWithValue ? this.numKeep : numKeep as int?,
       // Runtime and GPU
       numa: numa == unsetCopyWithValue ? this.numa : numa as bool?,
@@ -366,6 +380,7 @@ class ModelOptions {
           stop == other.stop &&
           numCtx == other.numCtx &&
           numPredict == other.numPredict &&
+          draftNumPredict == other.draftNumPredict &&
           numKeep == other.numKeep &&
           numa == other.numa &&
           numBatch == other.numBatch &&
@@ -399,6 +414,7 @@ class ModelOptions {
     stop,
     numCtx,
     numPredict,
+    draftNumPredict,
     numKeep,
     numa,
     numBatch,
@@ -434,6 +450,7 @@ class ModelOptions {
       'stop: $stop, '
       'numCtx: $numCtx, '
       'numPredict: $numPredict, '
+      'draftNumPredict: $draftNumPredict, '
       'numKeep: $numKeep, '
       'numa: $numa, '
       'numBatch: $numBatch, '

--- a/packages/ollama_dart/llms.txt
+++ b/packages/ollama_dart/llms.txt
@@ -14,6 +14,7 @@
 - [streaming_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/ollama_dart/example/streaming_example.dart) (~366 tokens): Streaming responses.
 - [tool_calling_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/ollama_dart/example/tool_calling_example.dart) (~709 tokens): Tool calling.
 - [completions_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/ollama_dart/example/completions_example.dart) (~918 tokens): Plain text generation.
+- [image_generation_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/ollama_dart/example/image_generation_example.dart) (~450 tokens): Experimental image generation.
 - [embeddings_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/ollama_dart/example/embeddings_example.dart) (~616 tokens): Text embeddings.
 - [models_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/ollama_dart/example/models_example.dart) (~660 tokens): Model management.
 - [error_handling_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/ollama_dart/example/error_handling_example.dart) (~240 tokens): Exception handling patterns.
@@ -24,4 +25,4 @@
 
 - [Package directory](https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/ollama_dart): Source tree, pubspec, and package-local files.
 
-**Total: ~19.7k tokens**
+**Total: ~20.2k tokens**

--- a/packages/ollama_dart/specs/spec_metadata.json
+++ b/packages/ollama_dart/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "0.1.0",
-      "last_fetched": "2026-05-23T06:45:12.934679Z",
+      "last_fetched": "2026-06-05T18:16:46.435579Z",
       "source_url": "https://raw.githubusercontent.com/ollama/ollama/refs/heads/main/docs/openapi.yaml",
       "title": "Ollama API",
       "version_history": []

--- a/packages/ollama_dart/test/unit/models/chat_stream_event_test.dart
+++ b/packages/ollama_dart/test/unit/models/chat_stream_event_test.dart
@@ -1,0 +1,44 @@
+import 'package:ollama_dart/ollama_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ChatStreamEvent', () {
+    test('fromJson/toJson round-trip with message and stats', () {
+      final json = {
+        'model': 'llama3.2',
+        'created_at': '2026-01-01T00:00:00Z',
+        'message': {'role': 'assistant', 'content': 'Hi'},
+        'done': true,
+        'done_reason': 'stop',
+        'total_duration': 1000,
+        'eval_count': 5,
+      };
+
+      final event = ChatStreamEvent.fromJson(json);
+      expect(event.message?.content, 'Hi');
+      expect(event.message?.role, MessageRole.assistant);
+      expect(event.totalDuration, 1000);
+
+      final roundTrip = event.toJson();
+      expect(roundTrip['total_duration'], 1000);
+      expect(roundTrip['done_reason'], 'stop');
+    });
+
+    test('equality compares all fields, not just model/createdAt/done', () {
+      const a = ChatStreamEvent(
+        model: 'llama3.2',
+        done: true,
+        totalDuration: 1000,
+      );
+      const b = ChatStreamEvent(
+        model: 'llama3.2',
+        done: true,
+        totalDuration: 2000,
+      );
+
+      // Previously these compared equal (totalDuration was ignored).
+      expect(a, isNot(equals(b)));
+      expect(a.hashCode, isNot(equals(b.hashCode)));
+    });
+  });
+}

--- a/packages/ollama_dart/test/unit/models/generate_test.dart
+++ b/packages/ollama_dart/test/unit/models/generate_test.dart
@@ -121,6 +121,42 @@ void main() {
       final outputJson = request.toJson();
       expect(outputJson.containsKey('context'), isFalse);
     });
+
+    test(
+      'image generation params serialize, deserialize, copyWith, toString',
+      () {
+        const request = GenerateRequest(
+          model: 'x/z-image-turbo',
+          prompt: 'a sunset over mountains',
+          width: 1024,
+          height: 768,
+          steps: 20,
+        );
+
+        final json = request.toJson();
+        expect(json['width'], 1024);
+        expect(json['height'], 768);
+        expect(json['steps'], 20);
+
+        final restored = GenerateRequest.fromJson(json);
+        expect(restored.width, 1024);
+        expect(restored.height, 768);
+        expect(restored.steps, 20);
+
+        expect(restored.copyWith(width: 512).width, 512);
+        expect(restored.copyWith(steps: null).steps, isNull);
+        expect(request.toString(), contains('width: 1024'));
+      },
+    );
+
+    test('image generation params omitted when absent', () {
+      const request = GenerateRequest(model: 'llama3.2', prompt: 'Hello');
+
+      final json = request.toJson();
+      expect(json.containsKey('width'), isFalse);
+      expect(json.containsKey('height'), isFalse);
+      expect(json.containsKey('steps'), isFalse);
+    });
   });
 
   group('GenerateResponse', () {
@@ -271,6 +307,55 @@ void main() {
       expect(nextRequest.context, [100, 200, 300]);
       expect(nextRequest.toJson()['context'], [100, 200, 300]);
     });
+
+    test('image generation fields serialize and deserialize', () {
+      final json = {
+        'model': 'x/z-image-turbo',
+        'done': true,
+        'image': 'aW1hZ2VkYXRh', // base64 of "imagedata" (12 chars)
+        'completed': 20,
+        'total': 20,
+      };
+
+      final response = GenerateResponse.fromJson(json);
+      expect(response.image, 'aW1hZ2VkYXRh');
+      expect(response.completed, 20);
+      expect(response.total, 20);
+
+      final roundTrip = response.toJson();
+      expect(roundTrip['image'], 'aW1hZ2VkYXRh');
+      expect(roundTrip['completed'], 20);
+      expect(roundTrip['total'], 20);
+    });
+
+    test('image field is summarized in toString, not dumped raw', () {
+      const response = GenerateResponse(
+        model: 'x/z-image-turbo',
+        done: true,
+        image: 'aW1hZ2VkYXRh',
+      );
+
+      final str = response.toString();
+      expect(str, contains('image: [12 chars]'));
+      expect(str, isNot(contains('aW1hZ2VkYXRh')));
+    });
+
+    test('image generation fields omitted when absent; copyWith clears', () {
+      const response = GenerateResponse(
+        model: 'llama3.2',
+        response: 'Hi',
+        done: true,
+      );
+
+      final json = response.toJson();
+      expect(json.containsKey('image'), isFalse);
+      expect(json.containsKey('completed'), isFalse);
+      expect(json.containsKey('total'), isFalse);
+
+      final withImage = response.copyWith(image: 'abc', completed: 1, total: 2);
+      expect(withImage.image, 'abc');
+      expect(withImage.copyWith(image: null).image, isNull);
+    });
   });
 
   group('GenerateStreamEvent', () {
@@ -300,6 +385,46 @@ void main() {
       expect(event.doneReason, DoneReason.stop);
       expect(event.totalDuration, 5000000000);
       expect(event.evalCount, 50);
+    });
+
+    test('image generation progress and final events round-trip', () {
+      final progress = GenerateStreamEvent.fromJson(const {
+        'model': 'x/z-image-turbo',
+        'completed': 5,
+        'total': 20,
+        'done': false,
+      });
+      expect(progress.completed, 5);
+      expect(progress.total, 20);
+      expect(progress.done, false);
+
+      final finalEvent = GenerateStreamEvent.fromJson(const {
+        'model': 'x/z-image-turbo',
+        'image': 'aW1hZ2VkYXRh',
+        'done': true,
+      });
+      expect(finalEvent.image, 'aW1hZ2VkYXRh');
+      expect(finalEvent.toJson()['image'], 'aW1hZ2VkYXRh');
+      expect(finalEvent.toString(), contains('image: [12 chars]'));
+    });
+
+    test('equality compares all fields, not just model/response/done', () {
+      const a = GenerateStreamEvent(
+        model: 'llama3.2',
+        response: 'Hi',
+        done: true,
+        totalDuration: 1000,
+      );
+      const b = GenerateStreamEvent(
+        model: 'llama3.2',
+        response: 'Hi',
+        done: true,
+        totalDuration: 2000,
+      );
+
+      // Previously these compared equal (totalDuration was ignored).
+      expect(a, isNot(equals(b)));
+      expect(a.hashCode, isNot(equals(b.hashCode)));
     });
   });
 }

--- a/packages/ollama_dart/test/unit/models/model_options_test.dart
+++ b/packages/ollama_dart/test/unit/models/model_options_test.dart
@@ -1,0 +1,47 @@
+import 'package:ollama_dart/ollama_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ModelOptions', () {
+    test('serializes and deserializes core options', () {
+      const options = ModelOptions(temperature: 0.7, topK: 40, numPredict: 128);
+
+      final json = options.toJson();
+      expect(json['temperature'], 0.7);
+      expect(json['top_k'], 40);
+      expect(json['num_predict'], 128);
+
+      final restored = ModelOptions.fromJson(json);
+      expect(restored.temperature, 0.7);
+      expect(restored.topK, 40);
+      expect(restored.numPredict, 128);
+    });
+
+    test('draftNumPredict serializes, deserializes, copyWith, toString', () {
+      const options = ModelOptions(draftNumPredict: 4);
+
+      final json = options.toJson();
+      expect(json['draft_num_predict'], 4);
+
+      final restored = ModelOptions.fromJson(json);
+      expect(restored.draftNumPredict, 4);
+
+      // 0 disables speculative drafting and must still serialize.
+      final disabled = options.copyWith(draftNumPredict: 0);
+      expect(disabled.draftNumPredict, 0);
+      expect(disabled.toJson()['draft_num_predict'], 0);
+
+      // copyWith can clear the value back to null.
+      expect(options.copyWith(draftNumPredict: null).draftNumPredict, isNull);
+
+      expect(options.toString(), contains('draftNumPredict: 4'));
+    });
+
+    test('draftNumPredict omitted when absent', () {
+      const options = ModelOptions(temperature: 0.5);
+
+      expect(options.toJson().containsKey('draft_num_predict'), isFalse);
+      expect(options.draftNumPredict, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add **experimental image generation** to `/api/generate`: `GenerateRequest` gains `width`/`height`/`steps`, and `GenerateResponse` + streaming `GenerateStreamEvent` gain `image` (base64, singular), `completed`, and `total`.
- Add the **`draft_num_predict`** model option to `ModelOptions` (the only Go `Runner` option the Dart class was missing).
- Complete the previously-partial `==`/`hashCode`/`toString` contracts on `GenerateStreamEvent` and `ChatStreamEvent` (they compared only a few fields).

## Context
This is the periodic Ollama OpenAPI sync. The canonical `openapi.yaml` is **already byte-identical to upstream** (v0.1.0, unchanged since 2026-02-12) and the client fully implements it, so a strict spec refresh is a no-op. Reviewing every 2026 Ollama release surfaced the two genuine native `/api/*` gaps above, each cross-validated against upstream `api/types.go`, `docs/api.md`, `docs/modelfile.mdx`, and the `ollama-python` reference client.

Everything else from the release review was already covered (logprobs/`top_logprobs`, embeddings `dimensions`, `think` `high`/`medium`/`low`, cloud `:cloud` model tags, cached token counts) or out of scope for this native-API client (the `/v1/*` OpenAI- and Anthropic-compat layers, audio transcription; `think:"max"` is not in the spec or docs).

## Details

### Image generation (experimental)
Image generation is exposed through the standard `/api/generate` endpoint when an image model is used. Upstream deliberately keeps these fields **out of `openapi.yaml`** ("experimental, may change"), so they are implemented client-side ahead of the spec — the established pattern in this package (e.g. `template`/`context` on `GenerateRequest`, and the typed `ModelOptions` superset). The vendored `specs/openapi.json` is left untouched; the intent is recorded via `note` fields on the affected `manifest.json` entries.

`image` is base64-encoded; `toString` summarizes it as `[N chars]` to avoid log bloat. Decode before use:

```dart
final result = await client.completions.generate(
  request: const GenerateRequest(
    model: 'x/z-image-turbo',
    prompt: 'a sunset over mountains',
    width: 1024,
    height: 768,
    steps: 20,
  ),
);
final image = result.image;
if (image != null) {
  File('generated_image.png').writeAsBytesSync(base64Decode(image));
}
```

Streaming yields diffusion progress via `completed`/`total`, with the final chunk carrying `image`.

### `draft_num_predict`
Speculative-draft token budget (`Runner.DraftNumPredict`, documented in `docs/modelfile.mdx`): defaults to 4, set to 0 to disable. Added to `ModelOptions` as `draftNumPredict` (the manifest's `ModelOptions` skip note is updated accordingly).

### Stream-event equality fix
`GenerateStreamEvent` and `ChatStreamEvent` both compared only a tiny subset of fields in `==`/`hashCode`, so events differing in message/timing/logprobs compared equal. Both now compare all user-visible fields (content-based helpers for the `logprobs` list).

## Test Plan
- [x] Unit tests pass for affected package (`dart test test/unit/` — 234 pass, 2 pre-existing env-skips)
- [x] New tests added for new functionality (`width`/`height`/`steps`, `image`/`completed`/`total`, `draftNumPredict`)
- [x] `fromJson`/`toJson` round-trip serialization verified (incl. optional-omit when absent)
- [x] `copyWith` set + null-clear verified for new nullable fields
- [x] `==`/`hashCode` contract verified (stream-event equality regression tests added)
- [x] `toString` `image` summary verified (`[N chars]`, raw base64 not dumped)
- [x] api-toolkit `fetch`/`review` (no drift) + `verify --checks all --scope all` (0 errors / 0 warnings / 5 intentional infos)
- [x] `dart analyze --fatal-infos` clean; `dart format` clean; image-gen example compiles

> No `CHANGELOG`/`MIGRATION`/`pubspec` version edits — left for `/release`. `specs/spec_metadata.json` `last_fetched` was bumped by the toolkit `fetch` step.