### PR TITLE
fix(anthropic_sdk_dart): safe casts for Update*Params sentinel collections

### DIFF
--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/agents/update_agent_params.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/agents/update_agent_params.dart
@@ -40,23 +40,25 @@ class UpdateAgentParams {
   /// Tool configurations. Full replacement. Omit to preserve; send null to
   /// clear.
   List<AgentToolParams>? get tools =>
-      _tools == _notSet ? null : _tools as List<AgentToolParams>?;
+      _tools == _notSet ? null : (_tools as List?)?.cast<AgentToolParams>();
   final Object? _tools;
 
   /// MCP servers. Full replacement. Omit to preserve; send null to clear.
-  List<MCPServerParams>? get mcpServers =>
-      _mcpServers == _notSet ? null : _mcpServers as List<MCPServerParams>?;
+  List<MCPServerParams>? get mcpServers => _mcpServers == _notSet
+      ? null
+      : (_mcpServers as List?)?.cast<MCPServerParams>();
   final Object? _mcpServers;
 
   /// Skills. Full replacement. Omit to preserve; send null to clear.
   List<AgentSkillParams>? get skills =>
-      _skills == _notSet ? null : _skills as List<AgentSkillParams>?;
+      _skills == _notSet ? null : (_skills as List?)?.cast<AgentSkillParams>();
   final Object? _skills;
 
   /// Metadata patch. Set a key to a string to upsert it, or to null to
   /// delete it. Omit the field to preserve.
-  Map<String, String?>? get metadata =>
-      _metadata == _notSet ? null : _metadata as Map<String, String?>?;
+  Map<String, String?>? get metadata => _metadata == _notSet
+      ? null
+      : (_metadata as Map?)?.cast<String, String?>();
   final Object? _metadata;
 
   /// Multiagent orchestration configuration. Full replacement. Omit to
@@ -150,16 +152,19 @@ class UpdateAgentParams {
     if (_system != _notSet) 'system': _system,
     if (_model != _notSet) 'model': (_model as ModelParams?)?.toJson(),
     if (_tools != _notSet)
-      'tools': (_tools as List<AgentToolParams>?)
-          ?.map((e) => e.toJson())
+      'tools': (_tools as List?)
+          ?.cast<AgentToolParams>()
+          .map((e) => e.toJson())
           .toList(),
     if (_mcpServers != _notSet)
-      'mcp_servers': (_mcpServers as List<MCPServerParams>?)
-          ?.map((e) => e.toJson())
+      'mcp_servers': (_mcpServers as List?)
+          ?.cast<MCPServerParams>()
+          .map((e) => e.toJson())
           .toList(),
     if (_skills != _notSet)
-      'skills': (_skills as List<AgentSkillParams>?)
-          ?.map((e) => e.toJson())
+      'skills': (_skills as List?)
+          ?.cast<AgentSkillParams>()
+          .map((e) => e.toJson())
           .toList(),
     if (_metadata != _notSet) 'metadata': _metadata,
     if (_multiagent != _notSet)

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/credentials/update_credential_params.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/credentials/update_credential_params.dart
@@ -28,8 +28,9 @@ class UpdateCredentialParams {
 
   /// Metadata patch. Set a key to a string to upsert it, or to null to
   /// delete it. Omitted keys are preserved.
-  Map<String, String?>? get metadata =>
-      _metadata == _notSet ? null : _metadata as Map<String, String?>?;
+  Map<String, String?>? get metadata => _metadata == _notSet
+      ? null
+      : (_metadata as Map?)?.cast<String, String?>();
   final Object? _metadata;
 
   /// Creates an [UpdateCredentialParams].

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/memory_stores/update_memory_store_params.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/memory_stores/update_memory_store_params.dart
@@ -23,8 +23,9 @@ class UpdateMemoryStoreParams {
 
   /// Metadata patch. Set a key to a string to upsert it, or to `null` to
   /// delete it. Omit the field to preserve.
-  Map<String, String?>? get metadata =>
-      _metadata == _notSet ? null : _metadata as Map<String, String?>?;
+  Map<String, String?>? get metadata => _metadata == _notSet
+      ? null
+      : (_metadata as Map?)?.cast<String, String?>();
   final Object? _metadata;
 
   /// Creates an [UpdateMemoryStoreParams].

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/update_session_params.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/update_session_params.dart
@@ -18,13 +18,14 @@ class UpdateSessionParams {
   final Object? _title;
 
   /// Metadata patch. Set a key to a string to upsert, or to null to delete.
-  Map<String, String?>? get metadata =>
-      _metadata == _notSet ? null : _metadata as Map<String, String?>?;
+  Map<String, String?>? get metadata => _metadata == _notSet
+      ? null
+      : (_metadata as Map?)?.cast<String, String?>();
   final Object? _metadata;
 
   /// Vault IDs to attach to the session.
   List<String>? get vaultIds =>
-      _vaultIds == _notSet ? null : _vaultIds as List<String>?;
+      _vaultIds == _notSet ? null : (_vaultIds as List?)?.cast<String>();
   final Object? _vaultIds;
 
   /// Agent configuration patch to apply to the session.

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/vaults/update_vault_params.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/vaults/update_vault_params.dart
@@ -20,8 +20,9 @@ class UpdateVaultParams {
 
   /// Metadata patch. Set a key to a string to upsert it, or to null to
   /// delete it. Omitted keys are preserved.
-  Map<String, String?>? get metadata =>
-      _metadata == _notSet ? null : _metadata as Map<String, String?>?;
+  Map<String, String?>? get metadata => _metadata == _notSet
+      ? null
+      : (_metadata as Map?)?.cast<String, String?>();
   final Object? _metadata;
 
   /// Creates an [UpdateVaultParams].

--- a/packages/anthropic_sdk_dart/lib/src/models/user_profiles/update_user_profile_request.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/user_profiles/update_user_profile_request.dart
@@ -54,7 +54,7 @@ class UpdateUserProfileRequest {
   /// Set a key's value to the empty string to delete it server-side.
   /// Keys not included are preserved.
   Map<String, String>? get metadata =>
-      _metadata == _notSet ? null : _metadata as Map<String, String>?;
+      _metadata == _notSet ? null : (_metadata as Map?)?.cast<String, String>();
 
   /// Whether a metadata update was provided.
   bool get hasMetadata => _metadata != _notSet;

--- a/packages/anthropic_sdk_dart/test/unit/models/update_params_empty_literals_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/update_params_empty_literals_test.dart
@@ -1,0 +1,66 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+/// Regression for the `_notSet` tri-state sentinel pattern.
+///
+/// Clearable fields are stored as `Object?`. Passing an untyped empty literal
+/// (`[]` / `{}` — the natural "clear to empty" / full-replacement case) infers
+/// a dynamic-typed collection, which previously threw a runtime `TypeError` on
+/// the direct `as List<T>?` / `as Map<K,V>?` cast in the getters and `toJson`.
+/// The getters now use `(x as List?)?.cast<T>()` / `(x as Map?)?.cast<K,V>()`,
+/// so these must not throw and must serialize to empty collections.
+void main() {
+  group('Update*Params untyped empty literals do not throw', () {
+    test('UpdateSessionParams', () {
+      const p = UpdateSessionParams(metadata: {}, vaultIds: []);
+      expect(p.metadata, isEmpty);
+      expect(p.vaultIds, isEmpty);
+      final j = p.toJson();
+      expect(j['metadata'], isEmpty);
+      expect(j['vault_ids'], isEmpty);
+    });
+
+    test('UpdateAgentParams', () {
+      const p = UpdateAgentParams(
+        version: 1,
+        tools: [],
+        mcpServers: [],
+        skills: [],
+        metadata: {},
+      );
+      expect(p.tools, isEmpty);
+      expect(p.mcpServers, isEmpty);
+      expect(p.skills, isEmpty);
+      expect(p.metadata, isEmpty);
+      final j = p.toJson();
+      expect(j['tools'], isEmpty);
+      expect(j['mcp_servers'], isEmpty);
+      expect(j['skills'], isEmpty);
+      expect(j['metadata'], isEmpty);
+    });
+
+    test('UpdateVaultParams', () {
+      const p = UpdateVaultParams(metadata: {});
+      expect(p.metadata, isEmpty);
+      expect(p.toJson()['metadata'], isEmpty);
+    });
+
+    test('UpdateMemoryStoreParams', () {
+      const p = UpdateMemoryStoreParams(metadata: {});
+      expect(p.metadata, isEmpty);
+      expect(p.toJson()['metadata'], isEmpty);
+    });
+
+    test('UpdateCredentialParams', () {
+      const p = UpdateCredentialParams(metadata: {});
+      expect(p.metadata, isEmpty);
+      expect(p.toJson()['metadata'], isEmpty);
+    });
+
+    // Note: UpdateUserProfileRequest is also hardened with the same `.cast`
+    // fix, but its constructor asserts `metadata is Map<String, String>`, so
+    // the untyped-`{}` input is rejected at construction in debug/test mode
+    // (the `.cast` guard only matters in release, where asserts are stripped) —
+    // it can't be exercised the same way here.
+  });
+}


### PR DESCRIPTION
## Summary

Fixes a latent runtime crash in the `Update*Params` family. The `_notSet` tri-state sentinel stores clearable fields as `Object?`; the getters (and some `toJson` chains) then cast directly to the typed collection. Passing an **untyped empty literal** — e.g. `UpdateSessionParams(vaultIds: [])`, the natural "clear to empty" / full-replacement case — infers `List<dynamic>` / `Map<dynamic, dynamic>`, which throws `TypeError: List<dynamic> is not a subtype of List<String>?` on `as List<T>?` / `as Map<K, V>?`.

This extends the fix already shipped for `UpdateDeploymentParams` in #259 to the rest of the family that shares the pattern.

## Details

Replaced every direct sentinel-field collection cast with a checked view:
- `_x as List<T>?` → `(_x as List?)?.cast<T>()`
- `_x as Map<K, V>?` → `(_x as Map?)?.cast<K, V>()`

Across:
- `UpdateSessionParams` — `metadata`, `vaultIds`
- `UpdateAgentParams` — `tools`, `mcpServers`, `skills`, `metadata` (getters + `toJson`)
- `UpdateVaultParams` — `metadata`
- `UpdateMemoryStoreParams` — `metadata`
- `UpdateCredentialParams` — `metadata`
- `UpdateUserProfileRequest` — `metadata`

Behavior is unchanged for correct usage (a properly-typed list/map already cast fine; `.cast()` is a no-op view). It only stops the crash on untyped literals and on the explicit-`null` clear path.

```dart
// Before: threw at runtime
await client.sessions.update(id, UpdateSessionParams(vaultIds: []));
// After: serializes to "vault_ids": [] (clear-to-empty)
```

> `UpdateUserProfileRequest` is hardened the same way, but its constructor also `assert`s `metadata is Map<String, String>`, so the untyped input is rejected at construction in debug/test mode — the `.cast` guard there only matters in release builds (where asserts are stripped). It's therefore covered by the fix but not by the regression test.

## Test Plan

- [x] New `test/unit/models/update_params_empty_literals_test.dart` — constructs each affected type with `[]` / `{}` and asserts the getters + `toJson` don't throw and serialize to empty collections (5 cases; would throw before the fix)
- [x] `dart analyze --fatal-infos` — clean
- [x] `dart format --set-exit-if-changed .` — clean
- [x] `dart test test/unit/` — 1229 passed
- [x] `verify --checks all --scope all` — 0 errors / 0 warnings