### PR TITLE
feat(openai_dart)!: Reasoning context mode + MCP tunnel/connector

### DIFF
--- a/packages/openai_dart/.agents/skills/openapi-openai/config/manifest.json
+++ b/packages/openai_dart/.agents/skills/openapi-openai/config/manifest.json
@@ -455,6 +455,42 @@
       "tags": ["acknowledged"],
       "note": "Admin API audit-log enum, excluded from coverage (excluded_tags: Administration). Not implemented."
     },
+    "AdminApiKey": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "file": null,
+      "schema": "AdminApiKey",
+      "tags": ["acknowledged"],
+      "note": "Admin API key schema, excluded from coverage (excluded_tags: Administration). Not implemented."
+    },
+    "AdminApiKeyCreateResponse": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "file": null,
+      "schema": "AdminApiKeyCreateResponse",
+      "tags": ["acknowledged"],
+      "note": "Admin API key creation response, excluded from coverage (excluded_tags: Administration). Not implemented."
+    },
+    "Reasoning": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "ReasoningConfig",
+      "file": "lib/src/models/responses/config/reasoning_config.dart",
+      "schema": "Reasoning",
+      "tags": ["acknowledged"],
+      "note": "Implemented (not codegen-tracked) as ReasoningConfig; context added."
+    },
+    "MCPTool": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "McpTool",
+      "file": "lib/src/models/responses/tools/response_tool.dart",
+      "schema": "MCPTool",
+      "tags": ["acknowledged"],
+      "note": "Implemented (not codegen-tracked) as McpTool (a ResponseTool variant); tunnel_id + connector_id added, server_url now optional."
+    },
     "CreateChatCompletionRequest": {
       "spec": "main",
       "kind": "skip",
@@ -793,7 +829,7 @@
       "file": null,
       "schema": "ResponseProperties",
       "tags": ["acknowledged"],
-      "note": "Spec helper schema; properties inlined on CreateResponse and Response. max_output_tokens moved to inline."
+      "note": "Spec helper schema; properties inlined on CreateResponse and Response. max_output_tokens, reasoning, and truncation moved to inline."
     },
     "ToolChoice": {
       "spec": "main",

--- a/packages/openai_dart/.agents/skills/openapi-openai/config/specs.json
+++ b/packages/openai_dart/.agents/skills/openapi-openai/config/specs.json
@@ -28,7 +28,7 @@
       "local_file": "openapi.json",
       "name": "OpenAI API",
       "requires_auth": false,
-      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-0161cb2a0faadedfc17ff59c7fcad9671962dbd170f83811003c23702148cf36.yml"
+      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-b5b621065906a2579dc180db1236ee3b08a4fca9539accc2fbbf88da0ca3923f.yml"
     }
   },
   "specs_dir": "packages/openai_dart/specs"

--- a/packages/openai_dart/lib/src/models/responses/config/config.dart
+++ b/packages/openai_dart/lib/src/models/responses/config/config.dart
@@ -12,6 +12,7 @@ export 'message_role.dart';
 export 'personality.dart';
 export 'prompt_cache_retention.dart';
 export 'reasoning_config.dart';
+export 'reasoning_context.dart';
 export 'reasoning_effort.dart';
 export 'reasoning_summary.dart';
 export 'response_status.dart';

--- a/packages/openai_dart/lib/src/models/responses/config/reasoning_config.dart
+++ b/packages/openai_dart/lib/src/models/responses/config/reasoning_config.dart
@@ -1,5 +1,6 @@
 import 'package:meta/meta.dart';
 
+import 'reasoning_context.dart';
 import 'reasoning_effort.dart';
 import 'reasoning_summary.dart';
 
@@ -12,8 +13,13 @@ class ReasoningConfig {
   /// How to summarize the reasoning.
   final ReasoningSummary? summary;
 
+  /// Controls which reasoning items are rendered back to the model on later
+  /// turns. When returned on a response, this is the effective reasoning
+  /// context mode used for the response.
+  final ReasoningContext? context;
+
   /// Creates a [ReasoningConfig].
-  const ReasoningConfig({this.effort, this.summary});
+  const ReasoningConfig({this.effort, this.summary, this.context});
 
   /// Creates a [ReasoningConfig] from JSON.
   factory ReasoningConfig.fromJson(Map<String, dynamic> json) {
@@ -24,6 +30,9 @@ class ReasoningConfig {
       summary: json['summary'] != null
           ? ReasoningSummary.fromJson(json['summary'] as String)
           : null,
+      context: json['context'] != null
+          ? ReasoningContext.fromJson(json['context'] as String)
+          : null,
     );
   }
 
@@ -31,6 +40,7 @@ class ReasoningConfig {
   Map<String, dynamic> toJson() => {
     if (effort != null) 'effort': effort!.toJson(),
     if (summary != null) 'summary': summary!.toJson(),
+    if (context != null) 'context': context!.toJson(),
   };
 
   @override
@@ -39,11 +49,13 @@ class ReasoningConfig {
       other is ReasoningConfig &&
           runtimeType == other.runtimeType &&
           effort == other.effort &&
-          summary == other.summary;
+          summary == other.summary &&
+          context == other.context;
 
   @override
-  int get hashCode => Object.hash(effort, summary);
+  int get hashCode => Object.hash(effort, summary, context);
 
   @override
-  String toString() => 'ReasoningConfig(effort: $effort, summary: $summary)';
+  String toString() =>
+      'ReasoningConfig(effort: $effort, summary: $summary, context: $context)';
 }

--- a/packages/openai_dart/lib/src/models/responses/config/reasoning_context.dart
+++ b/packages/openai_dart/lib/src/models/responses/config/reasoning_context.dart
@@ -1,0 +1,33 @@
+/// Controls which reasoning items are rendered back to the model on later turns.
+///
+/// When returned on a response, this is the effective reasoning context mode
+/// used for the response.
+enum ReasoningContext {
+  /// Unknown mode (fallback for unrecognized values).
+  unknown('unknown'),
+
+  /// Let the model decide which reasoning items to render on later turns.
+  auto('auto'),
+
+  /// Render only the current turn's reasoning items.
+  currentTurn('current_turn'),
+
+  /// Render reasoning items from all turns.
+  allTurns('all_turns');
+
+  /// The JSON value for this mode.
+  final String value;
+
+  const ReasoningContext(this.value);
+
+  /// Creates a [ReasoningContext] from a JSON value.
+  factory ReasoningContext.fromJson(String json) {
+    return ReasoningContext.values.firstWhere(
+      (e) => e.value == json,
+      orElse: () => ReasoningContext.unknown,
+    );
+  }
+
+  /// Converts to JSON value.
+  String toJson() => value;
+}

--- a/packages/openai_dart/lib/src/models/responses/response.dart
+++ b/packages/openai_dart/lib/src/models/responses/response.dart
@@ -365,7 +365,9 @@ class Response {
   ]);
 
   @override
-  String toString() => 'Response(id: $id, status: $status, output: $output)';
+  String toString() =>
+      'Response(id: $id, status: $status, output: $output, '
+      'reasoning: $reasoning, truncation: $truncation)';
 }
 
 /// A list of responses with pagination.

--- a/packages/openai_dart/lib/src/models/responses/response.dart
+++ b/packages/openai_dart/lib/src/models/responses/response.dart
@@ -3,8 +3,10 @@ import 'package:meta/meta.dart';
 import '../common/equality_helpers.dart';
 import '../moderations/completion_moderation.dart';
 import 'config/prompt_cache_retention.dart';
+import 'config/reasoning_config.dart';
 import 'config/response_status.dart';
 import 'config/service_tier.dart';
+import 'config/truncation.dart';
 import 'content/output_content.dart';
 import 'incomplete_details.dart';
 import 'items/output_item.dart';
@@ -82,6 +84,15 @@ class Response {
   /// [CreateResponseRequest.moderation].
   final Moderation? moderation;
 
+  /// The reasoning configuration used for the response.
+  ///
+  /// For reasoning models, reflects the effective reasoning context mode and
+  /// summary settings applied to the response.
+  final ReasoningConfig? reasoning;
+
+  /// The truncation strategy applied to the response.
+  final Truncation? truncation;
+
   /// Creates a [Response].
   const Response({
     required this.id,
@@ -105,6 +116,8 @@ class Response {
     this.promptCacheKey,
     this.promptCacheRetention,
     this.moderation,
+    this.reasoning,
+    this.truncation,
   });
 
   /// Creates a [Response] from JSON.
@@ -149,6 +162,12 @@ class Response {
       moderation: json['moderation'] != null
           ? Moderation.fromJson(json['moderation'] as Map<String, dynamic>)
           : null,
+      reasoning: json['reasoning'] != null
+          ? ReasoningConfig.fromJson(json['reasoning'] as Map<String, dynamic>)
+          : null,
+      truncation: json['truncation'] != null
+          ? Truncation.fromJson(json['truncation'] as String)
+          : null,
     );
   }
 
@@ -177,6 +196,8 @@ class Response {
     if (promptCacheRetention != null)
       'prompt_cache_retention': promptCacheRetention!.toJson(),
     if (moderation != null) 'moderation': moderation!.toJson(),
+    if (reasoning != null) 'reasoning': reasoning!.toJson(),
+    if (truncation != null) 'truncation': truncation!.toJson(),
   };
 
   // ============================================================
@@ -312,7 +333,9 @@ class Response {
           parallelToolCalls == other.parallelToolCalls &&
           promptCacheKey == other.promptCacheKey &&
           promptCacheRetention == other.promptCacheRetention &&
-          moderation == other.moderation;
+          moderation == other.moderation &&
+          reasoning == other.reasoning &&
+          truncation == other.truncation;
 
   @override
   int get hashCode => Object.hashAll([
@@ -337,6 +360,8 @@ class Response {
     promptCacheKey,
     promptCacheRetention,
     moderation,
+    reasoning,
+    truncation,
   ]);
 
   @override

--- a/packages/openai_dart/lib/src/models/responses/tools/response_tool.dart
+++ b/packages/openai_dart/lib/src/models/responses/tools/response_tool.dart
@@ -157,19 +157,33 @@ sealed class ResponseTool {
   );
 
   /// Creates an MCP tool.
+  ///
+  /// One of [serverUrl], [connectorId], or [tunnelId] must be provided;
+  /// otherwise an [ArgumentError] is thrown.
   static McpTool mcp({
     required String serverLabel,
-    required String serverUrl,
+    String? serverUrl,
+    String? connectorId,
+    String? tunnelId,
     List<String>? allowedTools,
     String? requireApproval,
     bool? deferLoading,
-  }) => McpTool(
-    serverLabel: serverLabel,
-    serverUrl: serverUrl,
-    allowedTools: allowedTools,
-    requireApproval: requireApproval,
-    deferLoading: deferLoading,
-  );
+  }) {
+    if (serverUrl == null && connectorId == null && tunnelId == null) {
+      throw ArgumentError(
+        'McpTool requires one of serverUrl, connectorId, or tunnelId',
+      );
+    }
+    return McpTool(
+      serverLabel: serverLabel,
+      serverUrl: serverUrl,
+      connectorId: connectorId,
+      tunnelId: tunnelId,
+      allowedTools: allowedTools,
+      requireApproval: requireApproval,
+      deferLoading: deferLoading,
+    );
+  }
 
   /// Creates a hosted shell tool.
   static ShellTool shell() => const ShellTool();
@@ -823,13 +837,34 @@ class ImageGenerationTool extends ResponseTool {
 }
 
 /// Model Context Protocol (MCP) tool.
+///
+/// One of [serverUrl], [connectorId], or [tunnelId] must be provided. The
+/// default [McpTool] constructor enforces this with an `assert` (debug/test
+/// builds); use [ResponseTool.mcp] for a runtime [ArgumentError] in all build
+/// modes.
 @immutable
 class McpTool extends ResponseTool {
   /// Label for the MCP server.
   final String serverLabel;
 
   /// URL of the MCP server.
-  final String serverUrl;
+  ///
+  /// One of [serverUrl], [connectorId], or [tunnelId] must be provided.
+  final String? serverUrl;
+
+  /// Identifier for a service connector, like those available in ChatGPT
+  /// (e.g. `connector_dropbox`, `connector_gmail`, `connector_googlecalendar`,
+  /// `connector_googledrive`, `connector_microsoftteams`,
+  /// `connector_outlookcalendar`, `connector_outlookemail`,
+  /// `connector_sharepoint`).
+  ///
+  /// One of [serverUrl], [connectorId], or [tunnelId] must be provided.
+  final String? connectorId;
+
+  /// The Secure MCP Tunnel ID to use instead of a direct server URL.
+  ///
+  /// One of [serverUrl], [connectorId], or [tunnelId] must be provided.
+  final String? tunnelId;
 
   /// List of allowed tools from this server.
   final List<String>? allowedTools;
@@ -841,9 +876,31 @@ class McpTool extends ResponseTool {
   final bool? deferLoading;
 
   /// Creates an [McpTool].
+  ///
+  /// One of [serverUrl], [connectorId], or [tunnelId] must be provided.
   const McpTool({
     required this.serverLabel,
-    required this.serverUrl,
+    this.serverUrl,
+    this.connectorId,
+    this.tunnelId,
+    this.allowedTools,
+    this.requireApproval,
+    this.deferLoading,
+  }) : assert(
+         serverUrl != null || connectorId != null || tunnelId != null,
+         'McpTool requires one of serverUrl, connectorId, or tunnelId',
+       );
+
+  /// Unchecked constructor used by [fromJson].
+  ///
+  /// Deserialization is intentionally lenient — it does not enforce the
+  /// one-of constraint — so server-originated tools always parse and
+  /// round-trip without loss.
+  const McpTool._parsed({
+    required this.serverLabel,
+    this.serverUrl,
+    this.connectorId,
+    this.tunnelId,
     this.allowedTools,
     this.requireApproval,
     this.deferLoading,
@@ -851,9 +908,11 @@ class McpTool extends ResponseTool {
 
   /// Creates an [McpTool] from JSON.
   factory McpTool.fromJson(Map<String, dynamic> json) {
-    return McpTool(
+    return McpTool._parsed(
       serverLabel: json['server_label'] as String,
-      serverUrl: json['server_url'] as String,
+      serverUrl: json['server_url'] as String?,
+      connectorId: json['connector_id'] as String?,
+      tunnelId: json['tunnel_id'] as String?,
       allowedTools: (json['allowed_tools'] as List?)?.cast<String>(),
       requireApproval: json['require_approval'] as String?,
       deferLoading: json['defer_loading'] as bool?,
@@ -864,7 +923,9 @@ class McpTool extends ResponseTool {
   Map<String, dynamic> toJson() => {
     'type': 'mcp',
     'server_label': serverLabel,
-    'server_url': serverUrl,
+    if (serverUrl != null) 'server_url': serverUrl,
+    if (connectorId != null) 'connector_id': connectorId,
+    if (tunnelId != null) 'tunnel_id': tunnelId,
     if (allowedTools != null) 'allowed_tools': allowedTools,
     if (requireApproval != null) 'require_approval': requireApproval,
     if (deferLoading != null) 'defer_loading': deferLoading,
@@ -877,6 +938,8 @@ class McpTool extends ResponseTool {
           runtimeType == other.runtimeType &&
           serverLabel == other.serverLabel &&
           serverUrl == other.serverUrl &&
+          connectorId == other.connectorId &&
+          tunnelId == other.tunnelId &&
           listsEqual(allowedTools, other.allowedTools) &&
           requireApproval == other.requireApproval &&
           deferLoading == other.deferLoading;
@@ -885,6 +948,8 @@ class McpTool extends ResponseTool {
   int get hashCode => Object.hash(
     serverLabel,
     serverUrl,
+    connectorId,
+    tunnelId,
     allowedTools != null ? Object.hashAll(allowedTools!) : null,
     requireApproval,
     deferLoading,
@@ -892,7 +957,7 @@ class McpTool extends ResponseTool {
 
   @override
   String toString() =>
-      'McpTool(serverLabel: $serverLabel, serverUrl: $serverUrl, allowedTools: $allowedTools, requireApproval: $requireApproval, deferLoading: $deferLoading)';
+      'McpTool(serverLabel: $serverLabel, serverUrl: $serverUrl, connectorId: $connectorId, tunnelId: $tunnelId, allowedTools: $allowedTools, requireApproval: $requireApproval, deferLoading: $deferLoading)';
 }
 
 /// Hosted shell tool for command execution.

--- a/packages/openai_dart/lib/src/models/responses/tools/response_tool.dart
+++ b/packages/openai_dart/lib/src/models/responses/tools/response_tool.dart
@@ -891,28 +891,25 @@ class McpTool extends ResponseTool {
          'McpTool requires one of serverUrl, connectorId, or tunnelId',
        );
 
-  /// Unchecked constructor used by [fromJson].
-  ///
-  /// Deserialization is intentionally lenient — it does not enforce the
-  /// one-of constraint — so server-originated tools always parse and
-  /// round-trip without loss.
-  const McpTool._parsed({
-    required this.serverLabel,
-    this.serverUrl,
-    this.connectorId,
-    this.tunnelId,
-    this.allowedTools,
-    this.requireApproval,
-    this.deferLoading,
-  });
-
   /// Creates an [McpTool] from JSON.
+  ///
+  /// Throws a [FormatException] if none of `server_url`, `connector_id`, or
+  /// `tunnel_id` is present, since such a tool has no address and would
+  /// re-serialize as an invalid request.
   factory McpTool.fromJson(Map<String, dynamic> json) {
-    return McpTool._parsed(
+    final serverUrl = json['server_url'] as String?;
+    final connectorId = json['connector_id'] as String?;
+    final tunnelId = json['tunnel_id'] as String?;
+    if (serverUrl == null && connectorId == null && tunnelId == null) {
+      throw const FormatException(
+        'McpTool requires one of server_url, connector_id, or tunnel_id',
+      );
+    }
+    return McpTool(
       serverLabel: json['server_label'] as String,
-      serverUrl: json['server_url'] as String?,
-      connectorId: json['connector_id'] as String?,
-      tunnelId: json['tunnel_id'] as String?,
+      serverUrl: serverUrl,
+      connectorId: connectorId,
+      tunnelId: tunnelId,
       allowedTools: (json['allowed_tools'] as List?)?.cast<String>(),
       requireApproval: json['require_approval'] as String?,
       deferLoading: json['defer_loading'] as bool?,

--- a/packages/openai_dart/specs/openapi.json
+++ b/packages/openai_dart/specs/openapi.json
@@ -125,6 +125,19 @@
             "format": "unixtime",
             "type": "integer"
           },
+          "expires_at": {
+            "anyOf": [
+              {
+                "description": "The Unix timestamp (in seconds) of when the API key expires",
+                "example": 1714063533,
+                "format": "unixtime",
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "id": {
             "description": "The identifier, which can be referenced in API endpoints",
             "example": "key_abc",
@@ -209,6 +222,7 @@
           "object",
           "redacted_value",
           "created_at",
+          "expires_at",
           "id",
           "owner"
         ],
@@ -2251,6 +2265,62 @@
             },
             "type": "object"
           },
+          "role.bound_to_resource": {
+            "description": "The details for events with this `type`.",
+            "properties": {
+              "connector_id": {
+                "description": "The connector ID for a ChatGPT workspace connector resource.",
+                "type": "string"
+              },
+              "connector_name": {
+                "description": "The connector display name for a ChatGPT workspace connector resource, or the connector ID when the display name could not be resolved.",
+                "type": "string"
+              },
+              "enabled": {
+                "description": "Whether the connector is enabled for the role.",
+                "type": "boolean"
+              },
+              "id": {
+                "description": "The ID of the resource the role was bound to. ChatGPT workspace connector resources use `<workspace_id>__<connector_id>`.",
+                "type": "string"
+              },
+              "permissions": {
+                "description": "The permissions granted to the role for the resource.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "resource_id": {
+                "description": "The ID of the resource the role was bound to.",
+                "type": "string"
+              },
+              "resource_type": {
+                "description": "The type of resource the role was bound to.",
+                "type": "string"
+              },
+              "role_id": {
+                "description": "The ID of the role that was bound to the resource.",
+                "type": "string"
+              },
+              "source": {
+                "description": "The connector role mutation path that produced the event.",
+                "enum": [
+                  "role_toggle",
+                  "role_connector_update",
+                  "role_delete",
+                  "workspace_permissions",
+                  "connector_publish"
+                ],
+                "type": "string"
+              },
+              "workspace_id": {
+                "description": "The workspace ID for a ChatGPT workspace connector resource.",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
           "role.created": {
             "description": "The details for events with this `type`.",
             "properties": {
@@ -2285,6 +2355,62 @@
             "properties": {
               "id": {
                 "description": "The role ID.",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "role.unbound_from_resource": {
+            "description": "The details for events with this `type`.",
+            "properties": {
+              "connector_id": {
+                "description": "The connector ID for a ChatGPT workspace connector resource.",
+                "type": "string"
+              },
+              "connector_name": {
+                "description": "The connector display name for a ChatGPT workspace connector resource, or the connector ID when the display name could not be resolved.",
+                "type": "string"
+              },
+              "enabled": {
+                "description": "Whether the connector is enabled for the role.",
+                "type": "boolean"
+              },
+              "id": {
+                "description": "The ID of the resource the role was unbound from. ChatGPT workspace connector resources use `<workspace_id>__<connector_id>`.",
+                "type": "string"
+              },
+              "permissions": {
+                "description": "The permissions remaining for the role after the change.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "resource_id": {
+                "description": "The ID of the resource the role was unbound from.",
+                "type": "string"
+              },
+              "resource_type": {
+                "description": "The type of resource the role was unbound from.",
+                "type": "string"
+              },
+              "role_id": {
+                "description": "The ID of the role that was unbound from the resource.",
+                "type": "string"
+              },
+              "source": {
+                "description": "The connector role mutation path that produced the event.",
+                "enum": [
+                  "role_toggle",
+                  "role_connector_update",
+                  "role_delete",
+                  "workspace_permissions",
+                  "connector_publish"
+                ],
+                "type": "string"
+              },
+              "workspace_id": {
+                "description": "The workspace ID for a ChatGPT workspace connector resource.",
                 "type": "string"
               }
             },
@@ -2708,6 +2834,8 @@
           "role.deleted",
           "role.assignment.created",
           "role.assignment.deleted",
+          "role.bound_to_resource",
+          "role.unbound_from_resource",
           "scim.enabled",
           "scim.disabled",
           "service_account.created",
@@ -10427,6 +10555,16 @@
                   }
                 ]
               },
+              "reasoning": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/Reasoning"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "store": {
                 "anyOf": [
                   {
@@ -10453,6 +10591,23 @@
               },
               "stream_options": {
                 "$ref": "#/components/schemas/ResponseStreamOptions"
+              },
+              "truncation": {
+                "anyOf": [
+                  {
+                    "default": "disabled",
+                    "description": "The truncation strategy to use for the model response.\n- `auto`: If the input to this Response exceeds\n  the model's context window size, the model will truncate the\n  response to fit the context window by dropping items from the beginning of the conversation.\n- `disabled` (default): If the input size will exceed the context window\n  size for a model, the request will fail with a 400 error.\n",
+                    "enum": [
+                      "auto",
+                      "disabled"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "deprecated": true
               }
             },
             "type": "object"
@@ -11950,7 +12105,8 @@
                 "type": "string"
               },
               {
-                "$ref": "#/components/schemas/VideoReferenceInputParam"
+                "$ref": "#/components/schemas/VideoReferenceInputParam",
+                "description": "Reference to the completed video to edit."
               }
             ]
           }
@@ -12066,7 +12222,8 @@
                 "type": "string"
               },
               {
-                "$ref": "#/components/schemas/ImageRefParam-2"
+                "$ref": "#/components/schemas/ImageRefParam-2",
+                "description": "Optional reference asset upload or reference object that guides generation. Provide exactly one of `image_url` or `file_id` when using an object."
               }
             ]
           },
@@ -20850,7 +21007,7 @@
             "type": "string"
           },
           "connector_id": {
-            "description": "Identifier for service connectors, like those available in ChatGPT. One of\n`server_url` or `connector_id` must be provided. Learn more about service\nconnectors [here](https://platform.openai.com/docs/guides/tools-remote-mcp#connectors).\n\nCurrently supported `connector_id` values are:\n\n- Dropbox: `connector_dropbox`\n- Gmail: `connector_gmail`\n- Google Calendar: `connector_googlecalendar`\n- Google Drive: `connector_googledrive`\n- Microsoft Teams: `connector_microsoftteams`\n- Outlook Calendar: `connector_outlookcalendar`\n- Outlook Email: `connector_outlookemail`\n- SharePoint: `connector_sharepoint`\n",
+            "description": "Identifier for service connectors, like those available in ChatGPT. One of\n`server_url`, `connector_id`, or `tunnel_id` must be provided. Learn more\nabout service connectors [here](https://platform.openai.com/docs/guides/tools-remote-mcp#connectors).\n\nCurrently supported `connector_id` values are:\n\n- Dropbox: `connector_dropbox`\n- Gmail: `connector_gmail`\n- Google Calendar: `connector_googlecalendar`\n- Google Drive: `connector_googledrive`\n- Microsoft Teams: `connector_microsoftteams`\n- Outlook Calendar: `connector_outlookcalendar`\n- Outlook Email: `connector_outlookemail`\n- SharePoint: `connector_sharepoint`\n",
             "enum": [
               "connector_dropbox",
               "connector_gmail",
@@ -20926,8 +21083,13 @@
             "type": "string"
           },
           "server_url": {
-            "description": "The URL for the MCP server. One of `server_url` or `connector_id` must be\nprovided.\n",
+            "description": "The URL for the MCP server. One of `server_url`, `connector_id`, or\n`tunnel_id` must be provided.\n",
             "format": "uri",
+            "type": "string"
+          },
+          "tunnel_id": {
+            "description": "The Secure MCP Tunnel ID to use instead of a direct server URL. One of\n`server_url`, `connector_id`, or `tunnel_id` must be provided.\n",
+            "pattern": "^tunnel_[a-z0-9]{32}$",
             "type": "string"
           },
           "type": {
@@ -33571,6 +33733,22 @@
       "Reasoning": {
         "description": "**gpt-5 and o-series models only**\n\nConfiguration options for\n[reasoning models](https://platform.openai.com/docs/guides/reasoning).\n",
         "properties": {
+          "context": {
+            "anyOf": [
+              {
+                "description": "Controls which reasoning items are rendered back to the model on later turns.\nWhen returned on a response, this is the effective reasoning context mode\nused for the response.\n",
+                "enum": [
+                  "auto",
+                  "current_turn",
+                  "all_turns"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "effort": {
             "$ref": "#/components/schemas/ReasoningEffort"
           },
@@ -33884,6 +34062,16 @@
                 "description": "Whether to allow the model to run tool calls in parallel.\n",
                 "type": "boolean"
               },
+              "reasoning": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/Reasoning"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "status": {
                 "description": "The status of the response generation. One of `completed`, `failed`,\n`in_progress`, `cancelled`, `queued`, or `incomplete`.\n",
                 "enum": [
@@ -33895,6 +34083,22 @@
                   "incomplete"
                 ],
                 "type": "string"
+              },
+              "truncation": {
+                "anyOf": [
+                  {
+                    "default": "disabled",
+                    "description": "The truncation strategy to use for the model response.\n- `auto`: If the input to this Response exceeds\n  the model's context window size, the model will truncate the\n  response to fit the context window by dropping items from the beginning of the conversation.\n- `disabled` (default): If the input size will exceed the context window\n  size for a model, the request will fail with a 400 error.\n",
+                    "enum": [
+                      "auto",
+                      "disabled"
+                    ],
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
               "usage": {
                 "$ref": "#/components/schemas/ResponseUsage"
@@ -35831,16 +36035,6 @@
           "prompt": {
             "$ref": "#/components/schemas/Prompt"
           },
-          "reasoning": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Reasoning"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
           "text": {
             "$ref": "#/components/schemas/ResponseTextParam"
           },
@@ -35849,22 +36043,6 @@
           },
           "tools": {
             "$ref": "#/components/schemas/ToolsArray"
-          },
-          "truncation": {
-            "anyOf": [
-              {
-                "default": "disabled",
-                "description": "The truncation strategy to use for the model response.\n- `auto`: If the input to this Response exceeds\n  the model's context window size, the model will truncate the\n  response to fit the context window by dropping items from the beginning of the conversation.\n- `disabled` (default): If the input size will exceed the context window\n  size for a model, the request will fail with a 400 error.\n",
-                "enum": [
-                  "auto",
-                  "disabled"
-                ],
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
           }
         },
         "type": "object"
@@ -40225,6 +40403,7 @@
           },
           "truncation": {
             "$ref": "#/components/schemas/TruncationEnum",
+            "deprecated": true,
             "description": "The truncation strategy to use for the model response. - `auto`: If the input to this Response exceeds the model's context window size, the model will truncate the response to fit the context window by dropping items from the beginning of the conversation. - `disabled` (default): If the input size will exceed the context window size for a model, the request will fail with a 400 error."
           }
         },
@@ -50689,7 +50868,7 @@
             "request": {
               "curl": "curl https://api.openai.com/v1/organization/admin_api_keys?after=key_abc&limit=20 \\\n  -H \"Authorization: Bearer $OPENAI_ADMIN_KEY\" \\\n  -H \"Content-Type: application/json\"\n"
             },
-            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"object\": \"organization.admin_api_key\",\n      \"id\": \"key_abc\",\n      \"name\": \"Main Admin Key\",\n      \"redacted_value\": \"sk-admin...def\",\n      \"created_at\": 1711471533,\n      \"last_used_at\": 1711471534,\n      \"owner\": {\n        \"type\": \"service_account\",\n        \"object\": \"organization.service_account\",\n        \"id\": \"sa_456\",\n        \"name\": \"My Service Account\",\n        \"created_at\": 1711471533,\n        \"role\": \"member\"\n      }\n    }\n  ],\n  \"first_id\": \"key_abc\",\n  \"last_id\": \"key_abc\",\n  \"has_more\": false\n}\n"
+            "response": "{\n  \"object\": \"list\",\n  \"data\": [\n    {\n      \"object\": \"organization.admin_api_key\",\n      \"id\": \"key_abc\",\n      \"name\": \"Main Admin Key\",\n      \"redacted_value\": \"sk-admin...def\",\n      \"created_at\": 1711471533,\n      \"expires_at\": 1714063533,\n      \"last_used_at\": 1711471534,\n      \"owner\": {\n        \"type\": \"service_account\",\n        \"object\": \"organization.service_account\",\n        \"id\": \"sa_456\",\n        \"name\": \"My Service Account\",\n        \"created_at\": 1711471533,\n        \"role\": \"member\"\n      }\n    }\n  ],\n  \"first_id\": \"key_abc\",\n  \"last_id\": \"key_abc\",\n  \"has_more\": false\n}\n"
           },
           "group": "administration",
           "name": "List all organization and project API keys."
@@ -50703,6 +50882,13 @@
             "application/json": {
               "schema": {
                 "properties": {
+                  "expires_in_seconds": {
+                    "description": "The number of seconds until the API key expires. Omit this field for a key that does not expire.",
+                    "example": 2592000,
+                    "maximum": 31536000,
+                    "minimum": 1,
+                    "type": "integer"
+                  },
                   "name": {
                     "example": "New Admin Key",
                     "type": "string"
@@ -50738,9 +50924,9 @@
         "x-oaiMeta": {
           "examples": {
             "request": {
-              "curl": "curl -X POST https://api.openai.com/v1/organization/admin_api_keys \\\n  -H \"Authorization: Bearer $OPENAI_ADMIN_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n      \"name\": \"New Admin Key\"\n  }'\n"
+              "curl": "curl -X POST https://api.openai.com/v1/organization/admin_api_keys \\\n  -H \"Authorization: Bearer $OPENAI_ADMIN_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\n      \"name\": \"New Admin Key\",\n      \"expires_in_seconds\": 2592000\n  }'\n"
             },
-            "response": "{\n  \"object\": \"organization.admin_api_key\",\n  \"id\": \"key_xyz\",\n  \"name\": \"New Admin Key\",\n  \"redacted_value\": \"sk-admin...xyz\",\n  \"created_at\": 1711471533,\n  \"last_used_at\": 1711471534,\n  \"owner\": {\n    \"type\": \"user\",\n    \"object\": \"organization.user\",\n    \"id\": \"user_123\",\n    \"name\": \"John Doe\",\n    \"created_at\": 1711471533,\n    \"role\": \"owner\"\n  },\n  \"value\": \"sk-admin-1234abcd\"\n}\n"
+            "response": "{\n  \"object\": \"organization.admin_api_key\",\n  \"id\": \"key_xyz\",\n  \"name\": \"New Admin Key\",\n  \"redacted_value\": \"sk-admin...xyz\",\n  \"created_at\": 1711471533,\n  \"expires_at\": 1714063533,\n  \"last_used_at\": 1711471534,\n  \"owner\": {\n    \"type\": \"user\",\n    \"object\": \"organization.user\",\n    \"id\": \"user_123\",\n    \"name\": \"John Doe\",\n    \"created_at\": 1711471533,\n    \"role\": \"owner\"\n  },\n  \"value\": \"sk-admin-1234abcd\"\n}\n"
           },
           "group": "administration",
           "name": "Create admin API key"
@@ -50939,7 +51125,7 @@
             }
           },
           {
-            "description": "Return only events performed on these targets. For example, a project ID updated.",
+            "description": "Return only events performed on these targets. For example, a project ID updated. For ChatGPT connector role events, use the workspace connector resource ID shown in `details.id`, such as `<workspace_id>__<connector_id>`.",
             "in": "query",
             "name": "resource_ids[]",
             "required": false,
@@ -50948,6 +51134,16 @@
                 "type": "string"
               },
               "type": "array"
+            }
+          },
+          {
+            "description": "Return only tenant-scoped events associated with this organization. Required for tenant-scoped events such as `role.bound_to_resource` and `role.unbound_from_resource`. When `true`, all supplied event types must be tenant-scoped.",
+            "in": "query",
+            "name": "tenant_only",
+            "required": false,
+            "schema": {
+              "default": false,
+              "type": "boolean"
             }
           },
           {
@@ -54544,6 +54740,61 @@
           "name": "Delete project spend alert"
         }
       },
+      "get": {
+        "description": "Retrieves a project spend alert.",
+        "operationId": "retrieve-project-spend-alert",
+        "parameters": [
+          {
+            "description": "The ID of the project.",
+            "in": "path",
+            "name": "project_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "The ID of the spend alert to retrieve.",
+            "in": "path",
+            "name": "alert_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectSpendAlert"
+                }
+              }
+            },
+            "description": "Project spend alert retrieved successfully."
+          }
+        },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
+        "summary": "Retrieve project spend alert",
+        "tags": [
+          "Spend alerts"
+        ],
+        "x-oaiMeta": {
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/organization/projects/proj_abc/spend_alerts/alert_abc123 \\\n  -H \"Authorization: Bearer $OPENAI_ADMIN_KEY\" \\\n  -H \"Content-Type: application/json\"\n"
+            },
+            "response": "{\n    \"id\": \"alert_abc123\",\n    \"object\": \"project.spend_alert\",\n    \"threshold_amount\": 150000,\n    \"currency\": \"USD\",\n    \"interval\": \"month\",\n    \"notification_channel\": {\n        \"type\": \"email\",\n        \"recipients\": [\"finance@example.com\"],\n        \"subject_prefix\": \"OpenAI spend alert\"\n    }\n}\n"
+          },
+          "group": "administration",
+          "name": "Retrieve project spend alert"
+        }
+      },
       "post": {
         "description": "Updates a project spend alert.",
         "operationId": "update-project-spend-alert",
@@ -55397,6 +55648,52 @@
           },
           "group": "administration",
           "name": "Delete organization spend alert"
+        }
+      },
+      "get": {
+        "description": "Retrieves an organization spend alert.",
+        "operationId": "retrieve-organization-spend-alert",
+        "parameters": [
+          {
+            "description": "The ID of the spend alert to retrieve.",
+            "in": "path",
+            "name": "alert_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationSpendAlert"
+                }
+              }
+            },
+            "description": "Organization spend alert retrieved successfully."
+          }
+        },
+        "security": [
+          {
+            "AdminApiKeyAuth": []
+          }
+        ],
+        "summary": "Retrieve organization spend alert",
+        "tags": [
+          "Spend alerts"
+        ],
+        "x-oaiMeta": {
+          "examples": {
+            "request": {
+              "curl": "curl https://api.openai.com/v1/organization/spend_alerts/alert_abc123 \\\n  -H \"Authorization: Bearer $OPENAI_ADMIN_KEY\" \\\n  -H \"Content-Type: application/json\"\n"
+            },
+            "response": "{\n    \"id\": \"alert_abc123\",\n    \"object\": \"organization.spend_alert\",\n    \"threshold_amount\": 150000,\n    \"currency\": \"USD\",\n    \"interval\": \"month\",\n    \"notification_channel\": {\n        \"type\": \"email\",\n        \"recipients\": [\"finance@example.com\"],\n        \"subject_prefix\": \"OpenAI spend alert\"\n    }\n}\n"
+          },
+          "group": "administration",
+          "name": "Retrieve organization spend alert"
         }
       },
       "post": {
@@ -58906,11 +59203,6 @@
               "schema": {
                 "$ref": "#/components/schemas/CompactResponseMethodPublicBody"
               }
-            },
-            "application/x-www-form-urlencoded": {
-              "schema": {
-                "$ref": "#/components/schemas/CompactResponseMethodPublicBody"
-              }
             }
           }
         },
@@ -58949,11 +59241,6 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TokenCountsBody"
-              }
-            },
-            "application/x-www-form-urlencoded": {
               "schema": {
                 "$ref": "#/components/schemas/TokenCountsBody"
               }
@@ -59432,11 +59719,6 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SetDefaultSkillVersionBody"
-              }
-            },
-            "application/x-www-form-urlencoded": {
               "schema": {
                 "$ref": "#/components/schemas/SetDefaultSkillVersionBody"
               }

--- a/packages/openai_dart/specs/spec_metadata.json
+++ b/packages/openai_dart/specs/spec_metadata.json
@@ -2,8 +2,8 @@
   "specs": {
     "main": {
       "current_version": "2.3.0",
-      "last_fetched": "2026-06-05T14:05:05.024506Z",
-      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-0161cb2a0faadedfc17ff59c7fcad9671962dbd170f83811003c23702148cf36.yml",
+      "last_fetched": "2026-06-20T14:45:09.941722Z",
+      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-b5b621065906a2579dc180db1236ee3b08a4fca9539accc2fbbf88da0ca3923f.yml",
       "title": "OpenAI API",
       "version_history": [
         {
@@ -20,8 +20,14 @@
         },
         {
           "fetched_at": "2026-06-02T11:45:18.699766Z",
-          "note": "a6fedde… replaced by 0161cb2… on 2026-06-05 to pick up moderation scores on the Responses API (Moderation) and Chat Completions API (ChatCompletionModeration): the `moderation` request param (ModerationParam) plus input/output moderation results, including on chat completion stream chunks.",
+          "note": "a6fedde\u2026 replaced by 0161cb2\u2026 on 2026-06-05 to pick up moderation scores on the Responses API (Moderation) and Chat Completions API (ChatCompletionModeration): the `moderation` request param (ModerationParam) plus input/output moderation results, including on chat completion stream chunks.",
           "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-a6fedde02dc6241719ebb2589062ba2892baa8dbe928a2d718643beede85e7b3.yml",
+          "version": "2.3.0"
+        },
+        {
+          "fetched_at": "2026-06-05T14:05:05.024506Z",
+          "note": "0161cb2\u2026 replaced by b5b6210\u2026 on 2026-06-20 to pick up the Responses API reasoning context mode (Reasoning.context \u2014 which reasoning items are rendered back to the model on later turns) and the MCP tool Secure Tunnel ID (MCPTool.tunnel_id; connector_id also modeled, server_url now optional). Administration-only changes (AdminApiKey.expires_at, audit-log event types + tenant_only, spend-alert lookups) are excluded from coverage.",
+          "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/openai/openai-0161cb2a0faadedfc17ff59c7fcad9671962dbd170f83811003c23702148cf36.yml",
           "version": "2.3.0"
         }
       ]

--- a/packages/openai_dart/test/unit/models/responses_test.dart
+++ b/packages/openai_dart/test/unit/models/responses_test.dart
@@ -3971,6 +3971,13 @@ void main() {
       expect(() => ResponseTool.mcp(serverLabel: 'test'), throwsArgumentError);
     });
 
+    test('fromJson throws FormatException when no address is present', () {
+      expect(
+        () => McpTool.fromJson(const {'type': 'mcp', 'server_label': 'test'}),
+        throwsFormatException,
+      );
+    });
+
     test('ResponseTool.mcp accepts a tunnelId alone', () {
       final tool = ResponseTool.mcp(
         serverLabel: 'test',
@@ -4001,6 +4008,23 @@ void main() {
       expect(roundTrip.reasoning?.context, ReasoningContext.currentTurn);
       expect(roundTrip.truncation, Truncation.auto);
       expect(roundTrip, equals(response));
+    });
+
+    test('toString includes reasoning and truncation', () {
+      const response = Response(
+        id: 'resp_1',
+        object: 'response',
+        createdAt: 1234567890,
+        status: ResponseStatus.completed,
+        output: [],
+        reasoning: ReasoningConfig(context: ReasoningContext.allTurns),
+        truncation: Truncation.disabled,
+      );
+
+      final str = response.toString();
+      expect(str, contains('truncation: Truncation.disabled'));
+      expect(str, contains('reasoning: ReasoningConfig('));
+      expect(str, contains('context: ReasoningContext.allTurns'));
     });
   });
 }

--- a/packages/openai_dart/test/unit/models/responses_test.dart
+++ b/packages/openai_dart/test/unit/models/responses_test.dart
@@ -3904,4 +3904,101 @@ void main() {
       expect(updated.param, isNull);
     });
   });
+
+  group('ReasoningConfig context', () {
+    test('round-trips context', () {
+      const config = ReasoningConfig(
+        effort: ReasoningEffort.high,
+        summary: ReasoningSummary.auto,
+        context: ReasoningContext.currentTurn,
+      );
+
+      final json = config.toJson();
+      expect(json['context'], 'current_turn');
+
+      final restored = ReasoningConfig.fromJson(json);
+      expect(restored.context, ReasoningContext.currentTurn);
+      expect(restored, equals(config));
+    });
+
+    test('falls back to unknown for unrecognized context', () {
+      final restored = ReasoningConfig.fromJson(const {'context': 'future_mode'});
+      expect(restored.context, ReasoningContext.unknown);
+    });
+
+    test('omits context when null', () {
+      const config = ReasoningConfig(effort: ReasoningEffort.low);
+      expect(config.toJson().containsKey('context'), isFalse);
+    });
+  });
+
+  group('McpTool tunnelId / connectorId', () {
+    test('tunnel-only tool omits server_url and round-trips', () {
+      const tool = McpTool(
+        serverLabel: 'test',
+        tunnelId: 'tunnel_0123456789abcdef0123456789abcdef',
+      );
+
+      final json = tool.toJson();
+      expect(json.containsKey('server_url'), isFalse);
+      expect(json['tunnel_id'], 'tunnel_0123456789abcdef0123456789abcdef');
+
+      final restored = McpTool.fromJson(json);
+      expect(restored.serverUrl, isNull);
+      expect(restored.tunnelId, 'tunnel_0123456789abcdef0123456789abcdef');
+      expect(restored, equals(tool));
+    });
+
+    test('fromJson preserves connector_id losslessly (no server_url)', () {
+      final json = {
+        'type': 'mcp',
+        'server_label': 'gmail',
+        'connector_id': 'connector_gmail',
+      };
+
+      final tool = McpTool.fromJson(json);
+      expect(tool.connectorId, 'connector_gmail');
+      expect(tool.serverUrl, isNull);
+      expect(tool.tunnelId, isNull);
+
+      // Re-serializing must not lose the connector address.
+      expect(tool.toJson()['connector_id'], 'connector_gmail');
+    });
+
+    test('ResponseTool.mcp throws when no address is provided', () {
+      expect(() => ResponseTool.mcp(serverLabel: 'test'), throwsArgumentError);
+    });
+
+    test('ResponseTool.mcp accepts a tunnelId alone', () {
+      final tool = ResponseTool.mcp(
+        serverLabel: 'test',
+        tunnelId: 'tunnel_0123456789abcdef0123456789abcdef',
+      );
+      expect(tool.tunnelId, 'tunnel_0123456789abcdef0123456789abcdef');
+    });
+  });
+
+  group('Response reasoning / truncation', () {
+    test('parses and round-trips reasoning.context + truncation', () {
+      final json = {
+        'id': 'resp_1',
+        'object': 'response',
+        'created_at': 1234567890,
+        'status': 'completed',
+        'output': <Map<String, dynamic>>[],
+        'reasoning': {'effort': 'high', 'context': 'current_turn'},
+        'truncation': 'auto',
+      };
+
+      final response = Response.fromJson(json);
+      expect(response.reasoning?.context, ReasoningContext.currentTurn);
+      expect(response.reasoning?.effort, ReasoningEffort.high);
+      expect(response.truncation, Truncation.auto);
+
+      final roundTrip = Response.fromJson(response.toJson());
+      expect(roundTrip.reasoning?.context, ReasoningContext.currentTurn);
+      expect(roundTrip.truncation, Truncation.auto);
+      expect(roundTrip, equals(response));
+    });
+  });
 }

--- a/packages/openai_dart/test/unit/models/responses_test.dart
+++ b/packages/openai_dart/test/unit/models/responses_test.dart
@@ -3922,7 +3922,9 @@ void main() {
     });
 
     test('falls back to unknown for unrecognized context', () {
-      final restored = ReasoningConfig.fromJson(const {'context': 'future_mode'});
+      final restored = ReasoningConfig.fromJson(const {
+        'context': 'future_mode',
+      });
       expect(restored.context, ReasoningContext.unknown);
     });
 


### PR DESCRIPTION
## Summary
- Sync `openai_dart` to the latest OpenAI OpenAPI spec (`0161cb2…` → `b5b6210…`).
- **Reasoning context mode**: `ReasoningConfig.context` (new `ReasoningContext` enum — `auto`/`currentTurn`/`allTurns`) controls which reasoning items render back to the model on later turns, and reflects the effective mode returned on a response.
- **MCP Secure Tunnel + connectors**: `McpTool.tunnelId` and `McpTool.connectorId` added; `serverUrl` is now optional so the spec's `server_url`/`connector_id`/`tunnel_id` one-of can be expressed.
- **Response now carries `reasoning` + `truncation`**, so the effective reasoning context returned on a response is no longer silently dropped.
- Administration-API changes in the new spec (`AdminApiKey.expires_at`, audit-log event types + `tenant_only`, spend-alert endpoints) are out of coverage and acknowledged in the manifest.

## Details

`ReasoningContext` follows the existing `unknown`-fallback enum pattern (`reasoning_summary.dart`), so unrecognised values deserialize to `unknown` rather than throwing.

`McpTool` now models all three address alternatives. To honor the spec's one-of contract while staying robust:

```dart
// Tunnel-only tool (no server URL):
final tool = ResponseTool.mcp(
  serverLabel: 'docs',
  tunnelId: 'tunnel_0123456789abcdef0123456789abcdef',
);

// Throws ArgumentError — none of serverUrl/connectorId/tunnelId provided:
ResponseTool.mcp(serverLabel: 'docs');
```

- `ResponseTool.mcp(...)` (non-const) throws `ArgumentError` at runtime in all build modes when no address is supplied; the `const McpTool(...)` constructor carries the same check as an `assert` (debug/test) so it can stay `const`.
- `McpTool.fromJson` routes through a private unchecked constructor and is intentionally lenient — server-originated tools (including `connector_id`-only) always parse and round-trip **losslessly** (`connector_id` is modeled as `String?` to preserve any value).

`connector_id` is modeled as `String?` (not a closed enum) specifically so future connectors round-trip without being coerced to `unknown`.

## Breaking Changes

`McpTool.serverUrl` is now optional/nullable (`String?`) instead of a required `String`.

```dart
// Before — serverUrl required, getter non-nullable
final tool = McpTool(serverLabel: 'x', serverUrl: 'https://mcp.example.com');
final String url = tool.serverUrl;

// After — provide any one of serverUrl / connectorId / tunnelId; getter is nullable
final tool = McpTool(serverLabel: 'x', tunnelId: 'tunnel_…');
final String? url = tool.serverUrl;
```

Callers reading `McpTool.serverUrl` must handle `null`. Existing code that always passed `serverUrl` continues to compile and behave the same.

## References

- [OpenAI Remote MCP tools guide](https://platform.openai.com/docs/guides/tools-remote-mcp) — server URLs, connectors, and tunnels for MCP tools.

## Test Plan

- [x] Unit tests pass for `openai_dart` (`dart test test/unit/` — 1321 passed)
- [x] New tests added: `ReasoningConfig.context` round-trip + `unknown` fallback; `McpTool` tunnel-only `toJson`; `ResponseTool.mcp` `throwsArgumentError`; lossless `connector_id` round-trip; `Response.fromJson` reasoning.context + truncation
- [x] Enum changes include round-trip + unrecognized-value fallback tests
- [x] `fromJson`/`toJson` round-trip serialization verified
- [x] `==`/`hashCode` contract verified (same fields in both for `ReasoningConfig`, `McpTool`, `Response`)
- [x] api-toolkit `review` (`error_count: 0`) and `verify --checks all --scope all` (`failing_checks: []`) pass
- [x] `dart analyze --fatal-infos` clean; `dart format` clean