### PR TITLE
feat(anthropic_sdk_dart)!: fallback refusal trigger + code-exec tool

### DIFF
--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
@@ -1641,7 +1641,7 @@
           "MemoryTool20250818": "memory_20250818",
           "ToolSearchToolBm25": "tool_search_tool_bm25, tool_search_tool_bm25_20251119",
           "ToolSearchToolRegex": "tool_search_tool_regex, tool_search_tool_regex_20251119",
-          "CodeExecutionTool20250522": "code_execution_20250522, code_execution_20250825, code_execution_20260120",
+          "CodeExecutionTool20250522": "code_execution_20250522, code_execution_20250825, code_execution_20260120, code_execution_20260521",
           "ComputerUseTool (beta)": "computer_* prefix",
           "McpToolset (beta)": "mcp_* prefix",
           "AdvisorTool (beta)": "advisor_* prefix"
@@ -1761,6 +1761,50 @@
       "excluded_properties": [
         "name"
       ]
+    },
+    "BetaCodeExecutionTool_20260521": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "CodeExecutionBuiltInTool",
+      "file": "lib/src/models/tools/built_in_tools.dart",
+      "schema": "BetaCodeExecutionTool_20260521",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Versioned variant of the code_execution tool — covered by CodeExecutionBuiltInTool (GA) and CodeExecutionTool (beta) via the `type` discriminator; see CodeExecutionTool20250522."
+    },
+    "CodeExecutionTool_20260521": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "CodeExecutionBuiltInTool",
+      "file": "lib/src/models/tools/built_in_tools.dart",
+      "schema": "CodeExecutionTool_20260521",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Non-beta GA variant of the code_execution tool — covered by CodeExecutionBuiltInTool via the `type` discriminator; see CodeExecutionTool20250522."
+    },
+    "AllowedCaller": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "CodeExecutionBuiltInTool",
+      "file": "lib/src/models/tools/built_in_tools.dart",
+      "schema": "AllowedCaller",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Modeled as open-ended `List<String> allowedCallers` across built-in tool classes — caller identifiers (direct, code_execution_*) are not generated as a closed Dart enum."
+    },
+    "BetaAllowedCaller": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "CodeExecutionBuiltInTool",
+      "file": "lib/src/models/tools/built_in_tools.dart",
+      "schema": "BetaAllowedCaller",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Modeled as open-ended `List<String> allowedCallers` across built-in tool classes — caller identifiers (direct, code_execution_*) are not generated as a closed Dart enum."
     },
     "ComputerUseTool (beta)": {
       "spec": "main",
@@ -2033,6 +2077,24 @@
         "acknowledged"
       ],
       "note": "Unified with non-beta RefusalStopDetails \u2014 identical schema."
+    },
+    "RefusalCategory": {
+      "spec": "main",
+      "kind": "enum",
+      "dart_class": "RefusalCategory",
+      "file": "lib/src/models/metadata/stop_reason.dart",
+      "schema": "RefusalCategory"
+    },
+    "BetaRefusalCategory": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "RefusalCategory",
+      "file": "lib/src/models/metadata/stop_reason.dart",
+      "schema": "BetaRefusalCategory",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Unified with non-beta RefusalCategory \u2014 identical values (bio, cyber, frontier_llm, reasoning_extraction)."
     },
     "FileScope": {
       "spec": "main",
@@ -4041,6 +4103,14 @@
       "schema": "BetaWebhookSessionCreatedEventData",
       "parent": "WebhookEventData"
     },
+    "WebhookSessionUpdatedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookSessionUpdatedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookSessionUpdatedEventData",
+      "parent": "WebhookEventData"
+    },
     "WebhookSessionDeletedEventData": {
       "spec": "main",
       "kind": "sealed_variant",
@@ -4465,6 +4535,16 @@
       "file": "lib/src/models/content/input_content_block.dart",
       "schema": "BetaRequestFallbackBlock",
       "parent": "InputContentBlock"
+    },
+    "BetaFallbackRefusalTrigger": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "FallbackRefusalTrigger",
+      "file": "lib/src/models/messages/fallback_config.dart",
+      "schema": "BetaFallbackRefusalTrigger",
+      "excluded_properties": [
+        "type"
+      ]
     },
     "BetaModelInfo": {
       "spec": "main",

--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/specs.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/specs.json
@@ -31,9 +31,9 @@
       "fetch_mode": "remote",
       "local_file": "openapi.yaml",
       "name": "Anthropic API",
-      "pinned_hash": "04d2899e1e4dd48e29347b98f1265e6345ee20b75e29c12eca1068a8f7c61095",
+      "pinned_hash": "2ecf157aa324d82fa8f3636a325aea5bd96ecab93193f6e37864ebe665c48685",
       "requires_auth": false,
-      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-04d2899e1e4dd48e29347b98f1265e6345ee20b75e29c12eca1068a8f7c61095.yml"
+      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-2ecf157aa324d82fa8f3636a325aea5bd96ecab93193f6e37864ebe665c48685.yml"
     }
   },
   "specs_dir": "packages/anthropic_sdk_dart/specs"

--- a/packages/anthropic_sdk_dart/example/fallback_example.dart
+++ b/packages/anthropic_sdk_dart/example/fallback_example.dart
@@ -36,7 +36,12 @@ void main() async {
     // iteration.
     for (final block in response.content) {
       if (block is FallbackBlock) {
-        print('Fallback hop: ${block.from.model} -> ${block.to.model}');
+        // `trigger` explains why `from` handed over — e.g. a policy refusal in
+        // a named category (or `null` when uncategorized).
+        print(
+          'Fallback hop: ${block.from.model} -> ${block.to.model} '
+          '(trigger: ${block.trigger.category?.value ?? 'uncategorized'})',
+        );
       }
       if (block is TextBlock) {
         print('Response: ${block.text}');

--- a/packages/anthropic_sdk_dart/lib/src/models/beta/tools/code_execution_tool.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/beta/tools/code_execution_tool.dart
@@ -28,7 +28,7 @@ class CodeExecutionTool {
 
   /// Creates a [CodeExecutionTool].
   const CodeExecutionTool({
-    this.type = 'code_execution_20250825',
+    this.type = 'code_execution_20260521',
     this.cacheControl,
     this.container,
     this.allowedCallers,

--- a/packages/anthropic_sdk_dart/lib/src/models/beta/tools/code_execution_tool.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/beta/tools/code_execution_tool.dart
@@ -70,6 +70,22 @@ class CodeExecutionTool {
     );
   }
 
+  /// Creates a [CodeExecutionTool] with version 2026-05-21.
+  factory CodeExecutionTool.v20260521({
+    CacheControlEphemeral? cacheControl,
+    List<String>? allowedCallers,
+    bool? deferLoading,
+    bool? strict,
+  }) {
+    return CodeExecutionTool(
+      type: 'code_execution_20260521',
+      cacheControl: cacheControl,
+      allowedCallers: allowedCallers,
+      deferLoading: deferLoading,
+      strict: strict,
+    );
+  }
+
   /// Creates a [CodeExecutionTool] from JSON.
   factory CodeExecutionTool.fromJson(Map<String, dynamic> json) {
     return CodeExecutionTool(

--- a/packages/anthropic_sdk_dart/lib/src/models/common/equality_helpers.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/common/equality_helpers.dart
@@ -126,3 +126,33 @@ int _valueDeepHashCode(dynamic value) {
   }
   return value.hashCode;
 }
+
+// ============================================================================
+// Deep immutability helpers
+// ============================================================================
+
+/// Returns a deeply-unmodifiable copy of a decoded-JSON map.
+///
+/// Recursively copies nested [Map]s and [List]s into unmodifiable views, so the
+/// result cannot be mutated at any depth. Use this to freeze free-form JSON
+/// stored on an `@immutable` model — `Map.unmodifiable` alone only protects the
+/// outer map, leaving nested containers aliased and mutable, which would let the
+/// model's deep `==`/`hashCode` and serialized output change after construction.
+Map<String, dynamic> deepUnmodifiableMap(Map<String, dynamic> map) {
+  return Map<String, dynamic>.unmodifiable(
+    map.map((key, value) => MapEntry(key, _deepUnmodifiableValue(value))),
+  );
+}
+
+dynamic _deepUnmodifiableValue(dynamic value) {
+  if (value is Map) {
+    return Map<String, dynamic>.unmodifiable(
+      value.map(
+        (key, v) => MapEntry(key.toString(), _deepUnmodifiableValue(v)),
+      ),
+    );
+  } else if (value is List) {
+    return List<dynamic>.unmodifiable(value.map(_deepUnmodifiableValue));
+  }
+  return value;
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/content/content_block.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/content_block.dart
@@ -388,8 +388,15 @@ class FallbackBlock extends ContentBlock {
   /// The fallback model producing the content that follows this block.
   final FallbackHopInfo to;
 
+  /// What caused the `from` model to hand over at this hop.
+  final FallbackRefusalTrigger trigger;
+
   /// Creates a [FallbackBlock].
-  const FallbackBlock({required this.from, required this.to});
+  const FallbackBlock({
+    required this.from,
+    required this.to,
+    required this.trigger,
+  });
 
   /// Object type. Always "fallback".
   String get type => 'fallback';
@@ -405,6 +412,9 @@ class FallbackBlock extends ContentBlock {
     return FallbackBlock(
       from: FallbackHopInfo.fromJson(json['from'] as Map<String, dynamic>),
       to: FallbackHopInfo.fromJson(json['to'] as Map<String, dynamic>),
+      trigger: FallbackRefusalTrigger.fromJson(
+        json['trigger'] as Map<String, dynamic>,
+      ),
     );
   }
 
@@ -413,11 +423,20 @@ class FallbackBlock extends ContentBlock {
     'type': type,
     'from': from.toJson(),
     'to': to.toJson(),
+    'trigger': trigger.toJson(),
   };
 
   /// Creates a copy with replaced values.
-  FallbackBlock copyWith({FallbackHopInfo? from, FallbackHopInfo? to}) {
-    return FallbackBlock(from: from ?? this.from, to: to ?? this.to);
+  FallbackBlock copyWith({
+    FallbackHopInfo? from,
+    FallbackHopInfo? to,
+    FallbackRefusalTrigger? trigger,
+  }) {
+    return FallbackBlock(
+      from: from ?? this.from,
+      to: to ?? this.to,
+      trigger: trigger ?? this.trigger,
+    );
   }
 
   @override
@@ -426,13 +445,14 @@ class FallbackBlock extends ContentBlock {
       other is FallbackBlock &&
           runtimeType == other.runtimeType &&
           from == other.from &&
-          to == other.to;
+          to == other.to &&
+          trigger == other.trigger;
 
   @override
-  int get hashCode => Object.hash(from, to);
+  int get hashCode => Object.hash(from, to, trigger);
 
   @override
-  String toString() => 'FallbackBlock(from: $from, to: $to)';
+  String toString() => 'FallbackBlock(from: $from, to: $to, trigger: $trigger)';
 }
 
 /// Web search tool result block.

--- a/packages/anthropic_sdk_dart/lib/src/models/content/input_content_block.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/input_content_block.dart
@@ -1631,8 +1631,9 @@ class FallbackInputBlock extends InputContentBlock {
   /// The response block's `trigger`, echoed back verbatim.
   ///
   /// Free-form and ignored by the server — any JSON object or `null` is
-  /// accepted. Stored unmodifiable. `null` with [hasTrigger] `true` preserves an
-  /// explicit `null`; with [hasTrigger] `false` the key is omitted entirely.
+  /// accepted. Stored deeply unmodifiable (nested maps and lists are frozen
+  /// too). `null` with [hasTrigger] `true` preserves an explicit `null`; with
+  /// [hasTrigger] `false` the key is omitted entirely.
   final Map<String, dynamic>? trigger;
 
   /// Creates a [FallbackInputBlock].
@@ -1646,7 +1647,7 @@ class FallbackInputBlock extends InputContentBlock {
   }) : hasTrigger = trigger != unsetCopyWithValue,
        trigger = (trigger == unsetCopyWithValue || trigger == null)
            ? null
-           : Map<String, dynamic>.unmodifiable(trigger as Map<String, dynamic>);
+           : deepUnmodifiableMap(trigger as Map<String, dynamic>);
 
   /// Object type. Always "fallback".
   String get type => 'fallback';

--- a/packages/anthropic_sdk_dart/lib/src/models/content/input_content_block.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/input_content_block.dart
@@ -159,7 +159,8 @@ sealed class InputContentBlock {
   factory InputContentBlock.fallback({
     required FallbackHopInfo from,
     required FallbackHopInfo to,
-  }) = FallbackInputBlock;
+    Object? trigger = unsetCopyWithValue,
+  }) => FallbackInputBlock(from: from, to: to, trigger: trigger);
 
   /// Creates an [InputContentBlock] from JSON.
   factory InputContentBlock.fromJson(Map<String, dynamic> json) {
@@ -1621,8 +1622,31 @@ class FallbackInputBlock extends InputContentBlock {
   /// The fallback model producing the content that follows this block.
   final FallbackHopInfo to;
 
+  /// Whether a `trigger` value was present.
+  ///
+  /// Distinguishes an absent key from an explicit `null`, so an echoed response
+  /// block round-trips verbatim.
+  final bool hasTrigger;
+
+  /// The response block's `trigger`, echoed back verbatim.
+  ///
+  /// Free-form and ignored by the server — any JSON object or `null` is
+  /// accepted. Stored unmodifiable. `null` with [hasTrigger] `true` preserves an
+  /// explicit `null`; with [hasTrigger] `false` the key is omitted entirely.
+  final Map<String, dynamic>? trigger;
+
   /// Creates a [FallbackInputBlock].
-  const FallbackInputBlock({required this.from, required this.to});
+  ///
+  /// Omit [trigger] to leave the key absent; pass `null` to echo an explicit
+  /// `null`; pass a map to echo it verbatim.
+  FallbackInputBlock({
+    required this.from,
+    required this.to,
+    Object? trigger = unsetCopyWithValue,
+  }) : hasTrigger = trigger != unsetCopyWithValue,
+       trigger = (trigger == unsetCopyWithValue || trigger == null)
+           ? null
+           : Map<String, dynamic>.unmodifiable(trigger as Map<String, dynamic>);
 
   /// Object type. Always "fallback".
   String get type => 'fallback';
@@ -1638,6 +1662,9 @@ class FallbackInputBlock extends InputContentBlock {
     return FallbackInputBlock(
       from: FallbackHopInfo.fromJson(json['from'] as Map<String, dynamic>),
       to: FallbackHopInfo.fromJson(json['to'] as Map<String, dynamic>),
+      trigger: json.containsKey('trigger')
+          ? json['trigger']
+          : unsetCopyWithValue,
     );
   }
 
@@ -1646,11 +1673,22 @@ class FallbackInputBlock extends InputContentBlock {
     'type': type,
     'from': from.toJson(),
     'to': to.toJson(),
+    if (hasTrigger) 'trigger': trigger,
   };
 
   /// Creates a copy with replaced values.
-  FallbackInputBlock copyWith({FallbackHopInfo? from, FallbackHopInfo? to}) {
-    return FallbackInputBlock(from: from ?? this.from, to: to ?? this.to);
+  FallbackInputBlock copyWith({
+    FallbackHopInfo? from,
+    FallbackHopInfo? to,
+    Object? trigger = unsetCopyWithValue,
+  }) {
+    return FallbackInputBlock(
+      from: from ?? this.from,
+      to: to ?? this.to,
+      trigger: trigger == unsetCopyWithValue
+          ? (hasTrigger ? this.trigger : unsetCopyWithValue)
+          : trigger,
+    );
   }
 
   @override
@@ -1659,13 +1697,18 @@ class FallbackInputBlock extends InputContentBlock {
       other is FallbackInputBlock &&
           runtimeType == other.runtimeType &&
           from == other.from &&
-          to == other.to;
+          to == other.to &&
+          hasTrigger == other.hasTrigger &&
+          mapsDeepEqual(trigger, other.trigger);
 
   @override
-  int get hashCode => Object.hash(from, to);
+  int get hashCode =>
+      Object.hash(from, to, hasTrigger, mapDeepHashCode(trigger));
 
   @override
-  String toString() => 'FallbackInputBlock(from: $from, to: $to)';
+  String toString() =>
+      'FallbackInputBlock(from: $from, to: $to, hasTrigger: $hasTrigger, '
+      'trigger: $trigger)';
 }
 
 /// Advisor tool result block in input (for multi-turn conversations).

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/webhooks/webhook_event.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/webhooks/webhook_event.dart
@@ -144,6 +144,7 @@ sealed class WebhookEventData {
       ),
       'session.thread_terminated' =>
         WebhookSessionThreadTerminatedEventData.fromJson(json),
+      'session.updated' => WebhookSessionUpdatedEventData.fromJson(json),
       'vault.created' => WebhookVaultCreatedEventData.fromJson(json),
       'vault.archived' => WebhookVaultArchivedEventData.fromJson(json),
       'vault.deleted' => WebhookVaultDeletedEventData.fromJson(json),
@@ -300,6 +301,83 @@ class WebhookSessionCreatedEventData extends WebhookEventData {
   @override
   String toString() =>
       'WebhookSessionCreatedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a session was updated.
+@immutable
+class WebhookSessionUpdatedEventData extends WebhookEventData {
+  /// The event-data type, always 'session.updated'.
+  String get type => 'session.updated';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookSessionUpdatedEventData].
+  const WebhookSessionUpdatedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookSessionUpdatedEventData] from JSON.
+  factory WebhookSessionUpdatedEventData.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'session.updated') {
+      throw FormatException(
+        'WebhookSessionUpdatedEventData: expected type "session.updated", '
+        'got "$type"',
+      );
+    }
+    return WebhookSessionUpdatedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookSessionUpdatedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookSessionUpdatedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookSessionUpdatedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookSessionUpdatedEventData(id: $id, organizationId: $organizationId, '
       'workspaceId: $workspaceId)';
 }
 

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/webhooks/webhook_event.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/webhooks/webhook_event.dart
@@ -98,6 +98,7 @@ class WebhookEvent {
 /// - [WebhookSessionThreadCreatedEventData] — `session.thread_created`.
 /// - [WebhookSessionThreadIdledEventData] — `session.thread_idled`.
 /// - [WebhookSessionThreadTerminatedEventData] — `session.thread_terminated`.
+/// - [WebhookSessionUpdatedEventData] — `session.updated`.
 /// - [WebhookVaultCreatedEventData] — `vault.created`.
 /// - [WebhookVaultArchivedEventData] — `vault.archived`.
 /// - [WebhookVaultDeletedEventData] — `vault.deleted`.

--- a/packages/anthropic_sdk_dart/lib/src/models/messages/fallback_config.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/messages/fallback_config.dart
@@ -4,6 +4,7 @@ import '../beta/config/output_config.dart';
 import '../common/copy_with_sentinel.dart';
 import '../common/equality_helpers.dart';
 import '../metadata/speed.dart';
+import '../metadata/stop_reason.dart';
 import 'thinking_config.dart';
 
 /// One entry in the `fallbacks` chain on a message create request.
@@ -185,4 +186,73 @@ class FallbackHopInfo {
 
   @override
   String toString() => 'FallbackHopInfo(model: $model)';
+}
+
+/// What caused the `from` model to hand over at a fallback hop.
+///
+/// Currently the only trigger is a policy refusal by the `from` model.
+@immutable
+class FallbackRefusalTrigger {
+  /// The raw policy-category string from the API.
+  ///
+  /// Preserved for round-trip fidelity — unrecognized categories are stored
+  /// verbatim and serialized back unchanged. `null` when the refusal doesn't
+  /// map to a named category.
+  final String? rawCategory;
+
+  /// The parsed policy category that triggered the `from` model's refusal at
+  /// this hop, derived from [rawCategory].
+  ///
+  /// `null` when [rawCategory] is `null`. Same vocabulary as
+  /// `stop_details.category`.
+  RefusalCategory? get category =>
+      rawCategory == null ? null : RefusalCategory.fromJson(rawCategory!);
+
+  /// Object type. Always "refusal".
+  String get type => 'refusal';
+
+  /// Creates a [FallbackRefusalTrigger].
+  const FallbackRefusalTrigger({this.rawCategory});
+
+  /// Creates a [FallbackRefusalTrigger] from JSON.
+  factory FallbackRefusalTrigger.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'refusal') {
+      throw FormatException(
+        'FallbackRefusalTrigger: expected type "refusal", got "$type"',
+      );
+    }
+    if (!json.containsKey('category')) {
+      throw const FormatException(
+        'FallbackRefusalTrigger: missing required field "category"',
+      );
+    }
+    return FallbackRefusalTrigger(rawCategory: json['category'] as String?);
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {'type': type, 'category': rawCategory};
+
+  /// Creates a copy with replaced values.
+  FallbackRefusalTrigger copyWith({Object? rawCategory = unsetCopyWithValue}) {
+    return FallbackRefusalTrigger(
+      rawCategory: rawCategory == unsetCopyWithValue
+          ? this.rawCategory
+          : rawCategory as String?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FallbackRefusalTrigger &&
+          runtimeType == other.runtimeType &&
+          rawCategory == other.rawCategory;
+
+  @override
+  int get hashCode => rawCategory.hashCode;
+
+  @override
+  String toString() =>
+      'FallbackRefusalTrigger(category: $category, rawCategory: $rawCategory)';
 }

--- a/packages/anthropic_sdk_dart/lib/src/models/tools/built_in_tools.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/tools/built_in_tools.dart
@@ -245,6 +245,7 @@ sealed class BuiltInTool {
       'code_execution_20250522' => CodeExecutionBuiltInTool.fromJson(json),
       'code_execution_20250825' => CodeExecutionBuiltInTool.fromJson(json),
       'code_execution_20260120' => CodeExecutionBuiltInTool.fromJson(json),
+      'code_execution_20260521' => CodeExecutionBuiltInTool.fromJson(json),
       // Beta tools
       final String t when t.startsWith('advisor_') => AdvisorTool.fromJson(
         json,

--- a/packages/anthropic_sdk_dart/lib/src/models/tools/built_in_tools.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/tools/built_in_tools.dart
@@ -1460,12 +1460,12 @@ class CodeExecutionBuiltInTool extends BuiltInTool {
     this.allowedCallers,
     this.deferLoading,
     this.strict,
-  }) : type = type ?? 'code_execution_20260120';
+  }) : type = type ?? 'code_execution_20260521';
 
   /// Creates a [CodeExecutionBuiltInTool] from JSON.
   factory CodeExecutionBuiltInTool.fromJson(Map<String, dynamic> json) {
     return CodeExecutionBuiltInTool(
-      type: json['type'] as String? ?? 'code_execution_20260120',
+      type: json['type'] as String? ?? 'code_execution_20260521',
       cacheControl: json['cache_control'] != null
           ? CacheControlEphemeral.fromJson(
               json['cache_control'] as Map<String, dynamic>,

--- a/packages/anthropic_sdk_dart/llms.txt
+++ b/packages/anthropic_sdk_dart/llms.txt
@@ -5,7 +5,7 @@
 ## Docs
 
 - [README](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/README.md) (~5.3k tokens): Primary package documentation with installation, configuration, and usage examples.
-- [CHANGELOG](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/CHANGELOG.md) (~9.7k tokens): Release history and version-by-version changes.
+- [CHANGELOG](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/CHANGELOG.md) (~10.1k tokens): Release history and version-by-version changes.
 - [MIGRATION](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/MIGRATION.md) (~6.1k tokens): Upgrade notes and breaking-change guidance.
 
 ## Examples
@@ -28,12 +28,12 @@
 - [advisor_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/advisor_example.dart) (~967 tokens): Advisor tool (beta).
 - [computer_use_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/computer_use_example.dart) (~866 tokens): Computer use tool.
 - [diagnostics_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/diagnostics_example.dart) (~660 tokens): Prompt-cache diagnostics: why the cache prefix diverged (beta).
-- [fallback_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/fallback_example.dart) (~726 tokens): Server-side fallback chain and refusal credit-token retry (beta).
+- [fallback_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/fallback_example.dart) (~784 tokens): Server-side fallback chain and refusal credit-token retry (beta).
 - [document_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/document_example.dart) (~937 tokens): Document inputs with citations.
 - [search_result_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/search_result_example.dart) (~710 tokens): Supplying your own cited `search_result` blocks (RAG).
 - [mcp_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/mcp_example.dart) (~904 tokens): MCP tool integration.
 - [session_threads_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/session_threads_example.dart) (~816 tokens): Session threads: list, retrieve, stream events, archive (beta).
-- [deployments_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/deployments_example.dart) (~604 tokens): Scheduled deployments and deployment runs: cron schedule, pause/resume, run-now (beta).
+- [deployments_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/deployments_example.dart) (~609 tokens): Scheduled deployments and deployment runs: cron schedule, pause/resume, run-now (beta).
 - [user_profiles_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/user_profiles_example.dart) (~649 tokens): User profiles and enrollment URLs (beta).
 - [anthropic_sdk_dart_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/anthropic_sdk_dart_example.dart) (~670 tokens): Quick-start overview.
 
@@ -41,4 +41,4 @@
 
 - [Package directory](https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/anthropic_sdk_dart): Source tree, pubspec, and package-local files.
 
-**Total: ~43.2k tokens**
+**Total: ~43.8k tokens**

--- a/packages/anthropic_sdk_dart/specs/openapi.yaml
+++ b/packages/anthropic_sdk_dart/specs/openapi.yaml
@@ -23,11 +23,12 @@
         "type": "object"
       },
       "AllowedCaller": {
-        "description": "Specifies who can invoke a tool.\n\nValues:\n    direct: The model can call this tool directly.\n    code_execution_20250825: The tool can be called from the code execution environment (v1).\n    code_execution_20260120: The tool can be called from the code execution environment (v2 with persistence).",
+        "description": "Specifies who can invoke a tool.\n\nValues:\n    direct: The model can call this tool directly.\n    code_execution_20250825: The tool can be called from the code execution environment (v1).\n    code_execution_20260120: The tool can be called from the code execution environment (v2 with persistence).\n    code_execution_20260521: The tool can be called from the code execution environment (v2 with persistence).",
         "enum": [
           "direct",
           "code_execution_20250825",
-          "code_execution_20260120"
+          "code_execution_20260120",
+          "code_execution_20260521"
         ],
         "title": "AllowedCaller",
         "type": "string"
@@ -462,11 +463,12 @@
         "type": "object"
       },
       "BetaAllowedCaller": {
-        "description": "Specifies who can invoke a tool.\n\nValues:\n    direct: The model can call this tool directly.\n    code_execution_20250825: The tool can be called from the code execution environment (v1).\n    code_execution_20260120: The tool can be called from the code execution environment (v2 with persistence).",
+        "description": "Specifies who can invoke a tool.\n\nValues:\n    direct: The model can call this tool directly.\n    code_execution_20250825: The tool can be called from the code execution environment (v1).\n    code_execution_20260120: The tool can be called from the code execution environment (v2 with persistence).\n    code_execution_20260521: The tool can be called from the code execution environment (v2 with persistence).",
         "enum": [
           "direct",
           "code_execution_20250825",
-          "code_execution_20260120"
+          "code_execution_20260120",
+          "code_execution_20260521"
         ],
         "title": "AllowedCaller",
         "type": "string"
@@ -1543,6 +1545,68 @@
           "type"
         ],
         "title": "CodeExecutionTool_20260120",
+        "type": "object"
+      },
+      "BetaCodeExecutionTool_20260521": {
+        "additionalProperties": false,
+        "description": "Code execution tool with REPL state persistence.",
+        "properties": {
+          "allowed_callers": {
+            "items": {
+              "$ref": "#/components/schemas/BetaAllowedCaller"
+            },
+            "title": "Allowed Callers",
+            "type": "array"
+          },
+          "cache_control": {
+            "anyOf": [
+              {
+                "discriminator": {
+                  "mapping": {
+                    "ephemeral": "#/components/schemas/BetaCacheControlEphemeral"
+                  },
+                  "propertyName": "type"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/BetaCacheControlEphemeral"
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Create a cache control breakpoint at this content block.",
+            "title": "Cache Control"
+          },
+          "defer_loading": {
+            "description": "If true, tool will not be included in initial system prompt. Only loaded when returned via tool_reference from tool search.",
+            "title": "Defer Loading",
+            "type": "boolean"
+          },
+          "name": {
+            "const": "code_execution",
+            "description": "Name of the tool.\n\nThis is how the tool will be called by the model and in `tool_use` blocks.",
+            "title": "Name",
+            "type": "string"
+          },
+          "strict": {
+            "description": "When true, guarantees schema validation on tool names and inputs",
+            "title": "Strict",
+            "type": "boolean"
+          },
+          "type": {
+            "const": "code_execution_20260521",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ],
+        "title": "CodeExecutionTool_20260521",
         "type": "object"
       },
       "BetaCompact20260112": {
@@ -2629,6 +2693,9 @@
                   "$ref": "#/components/schemas/BetaCodeExecutionTool_20260120"
                 },
                 {
+                  "$ref": "#/components/schemas/BetaCodeExecutionTool_20260521"
+                },
+                {
                   "$ref": "#/components/schemas/BetaComputerUseTool_20241022"
                 },
                 {
@@ -3031,6 +3098,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/BetaCodeExecutionTool_20260120"
+                },
+                {
+                  "$ref": "#/components/schemas/BetaCodeExecutionTool_20260521"
                 },
                 {
                   "$ref": "#/components/schemas/BetaComputerUseTool_20241022"
@@ -4120,6 +4190,40 @@
           "type"
         ],
         "title": "FallbackMessageIterationUsage",
+        "type": "object"
+      },
+      "BetaFallbackRefusalTrigger": {
+        "description": "The `from` model declined for policy reasons.",
+        "properties": {
+          "category": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BetaRefusalCategory"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "The policy category that triggered the `from` model's refusal at this hop. `null` when the refusal doesn't map to a named category. Same vocabulary as `stop_details.category`.",
+            "x-stainless-naming": {
+              "csharp": {
+                "type_name": "BetaFallbackRefusalTriggerCategory"
+              }
+            }
+          },
+          "type": {
+            "const": "refusal",
+            "default": "refusal",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "category",
+          "type"
+        ],
+        "title": "FallbackRefusalTrigger",
         "type": "object"
       },
       "BetaFileDeleteResponse": {
@@ -18774,27 +18878,31 @@
         "title": "RateLimitError",
         "type": "object"
       },
+      "BetaRefusalCategory": {
+        "description": "The policy category that triggered a refusal.",
+        "enum": [
+          "cyber",
+          "bio",
+          "frontier_llm",
+          "reasoning_extraction"
+        ],
+        "title": "RefusalCategory",
+        "type": "string"
+      },
       "BetaRefusalStopDetails": {
         "description": "Structured information about a refusal.",
         "properties": {
           "category": {
             "anyOf": [
               {
-                "enum": [
-                  "cyber",
-                  "bio",
-                  "frontier_llm",
-                  "reasoning_extraction"
-                ],
-                "type": "string"
+                "$ref": "#/components/schemas/BetaRefusalCategory"
               },
               {
                 "type": "null"
               }
             ],
             "default": null,
-            "description": "The policy category that triggered the refusal.\n\n`null` when the refusal doesn't map to a named category.",
-            "title": "Category"
+            "description": "The policy category that triggered the refusal.\n\n`null` when the refusal doesn't map to a named category."
           },
           "explanation": {
             "anyOf": [
@@ -19701,13 +19809,17 @@
       },
       "BetaRequestFallbackBlock": {
         "additionalProperties": false,
-        "description": "A `fallback` block echoed back from a prior response.\n\nAccepted in `messages[].content` and never rendered into the prompt,\nnot validated against the request's `fallbacks` chain or top-level\n`model`, and stripped before the sticky-routing cache key is computed.\n\nCallers should echo the assistant turn verbatim \u2014 block included. The\nblock's position is load-bearing for thinking verification: the thinking\nruns on either side of a fallback hop carry independently-rooted\nverification hash chains, and this block is the only record of where one\nchain ends and the next begins. When thinking runs flank the boundary,\nomitting the block merges the runs into one contiguous span whose hashes\ncannot verify (the request is rejected), and moving it into the middle of\na single run splits that run's chain and is likewise rejected; between\nnon-thinking blocks the block's placement has no verification effect.",
+        "description": "A `fallback` block echoed back from a prior response.\n\nAccepted in `messages[].content` and not rendered into the prompt; not\nvalidated against the request's `fallbacks` chain or top-level `model`.\n\nEcho the assistant turn back verbatim, including this block in its\noriginal position. The block marks the boundary between content produced\nbefore and after a fallback hop, and the server relies on that boundary\nto validate the turn: when thinking runs flank the boundary, omitting\nthe block merges them into one span the server cannot validate (the\nrequest is rejected), and moving it into the middle of a single run is\nlikewise rejected; between non-thinking blocks the block's placement has\nno validation effect.",
         "properties": {
           "from": {
             "$ref": "#/components/schemas/BetaRequestFallbackHopInfo"
           },
           "to": {
             "$ref": "#/components/schemas/BetaRequestFallbackHopInfo"
+          },
+          "trigger": {
+            "description": "The response block's `trigger`, echoed verbatim. Accepted and ignored by the server; any object or `null` is allowed.",
+            "title": "Trigger"
           },
           "type": {
             "const": "fallback",
@@ -22087,7 +22199,7 @@
         "type": "object"
       },
       "BetaResponseFallbackBlock": {
-        "description": "Marks the point in `content` where one model's output gives way to the next.\n\nOne block appears per hop where a preceding model actually ran this turn and\ndeclined. A turn routed directly by the sticky decision has no such boundary\nand carries no block \u2014 the signal for whether a fallback model served the\nresponse is the presence of a `fallback_message` entry in\n`usage.iterations`, not this block.\n\nThe block is treated like a server-tool content block for streaming: it\narrives via the standard `content_block_start` / `content_block_stop`\npair and carries no deltas.",
+        "description": "Marks the point in `content` where one model's output gives way to the next.\n\nOne block appears per hop where a preceding model actually ran this turn and\ndeclined. A turn where no preceding model ran and declined has no such\nboundary and carries no block \u2014 the signal for whether a fallback model\nserved the response is the presence of a `fallback_message` entry in\n`usage.iterations`, not this block.\n\nThe block is treated like a server-tool content block for streaming: it\narrives via the standard `content_block_start` / `content_block_stop`\npair and carries no deltas.",
         "properties": {
           "from": {
             "$ref": "#/components/schemas/BetaResponseFallbackHopInfo",
@@ -22096,6 +22208,10 @@
           "to": {
             "$ref": "#/components/schemas/BetaResponseFallbackHopInfo",
             "description": "The fallback model producing the content that follows this block. Its `model` is always the canonical id."
+          },
+          "trigger": {
+            "$ref": "#/components/schemas/BetaFallbackRefusalTrigger",
+            "description": "What caused the `from` model to hand over at this hop."
           },
           "type": {
             "const": "fallback",
@@ -22107,6 +22223,7 @@
         "required": [
           "from",
           "to",
+          "trigger",
           "type"
         ],
         "title": "ResponseFallbackBlock",
@@ -26064,6 +26181,7 @@
             "session.thread_created": "#/components/schemas/BetaWebhookSessionThreadCreatedEventData",
             "session.thread_idled": "#/components/schemas/BetaWebhookSessionThreadIdledEventData",
             "session.thread_terminated": "#/components/schemas/BetaWebhookSessionThreadTerminatedEventData",
+            "session.updated": "#/components/schemas/BetaWebhookSessionUpdatedEventData",
             "vault.archived": "#/components/schemas/BetaWebhookVaultArchivedEventData",
             "vault.created": "#/components/schemas/BetaWebhookVaultCreatedEventData",
             "vault.deleted": "#/components/schemas/BetaWebhookVaultDeletedEventData",
@@ -26140,6 +26258,9 @@
           },
           {
             "$ref": "#/components/schemas/BetaWebhookVaultCredentialRefreshFailedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookSessionUpdatedEventData"
           }
         ],
         "title": "BetaWebhookEventData"
@@ -26583,6 +26704,32 @@
           "session_thread_id"
         ],
         "title": "BetaWebhookSessionThreadTerminatedEventData",
+        "type": "object"
+      },
+      "BetaWebhookSessionUpdatedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the session that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "session.updated",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookSessionUpdatedEventData",
         "type": "object"
       },
       "BetaWebhookVaultArchivedEventData": {
@@ -27214,6 +27361,68 @@
         "title": "CodeExecutionTool_20260120",
         "type": "object"
       },
+      "CodeExecutionTool_20260521": {
+        "additionalProperties": false,
+        "description": "Code execution tool with REPL state persistence.",
+        "properties": {
+          "allowed_callers": {
+            "items": {
+              "$ref": "#/components/schemas/AllowedCaller"
+            },
+            "title": "Allowed Callers",
+            "type": "array"
+          },
+          "cache_control": {
+            "anyOf": [
+              {
+                "discriminator": {
+                  "mapping": {
+                    "ephemeral": "#/components/schemas/CacheControlEphemeral"
+                  },
+                  "propertyName": "type"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CacheControlEphemeral"
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Create a cache control breakpoint at this content block.",
+            "title": "Cache Control"
+          },
+          "defer_loading": {
+            "description": "If true, tool will not be included in initial system prompt. Only loaded when returned via tool_reference from tool search.",
+            "title": "Defer Loading",
+            "type": "boolean"
+          },
+          "name": {
+            "const": "code_execution",
+            "description": "Name of the tool.\n\nThis is how the tool will be called by the model and in `tool_use` blocks.",
+            "title": "Name",
+            "type": "string"
+          },
+          "strict": {
+            "description": "When true, guarantees schema validation on tool names and inputs",
+            "title": "Strict",
+            "type": "boolean"
+          },
+          "type": {
+            "const": "code_execution_20260521",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ],
+        "title": "CodeExecutionTool_20260521",
+        "type": "object"
+      },
       "CompletionRequest": {
         "additionalProperties": false,
         "examples": [
@@ -27833,6 +28042,9 @@
                   "$ref": "#/components/schemas/CodeExecutionTool_20260120"
                 },
                 {
+                  "$ref": "#/components/schemas/CodeExecutionTool_20260521"
+                },
+                {
                   "$ref": "#/components/schemas/MemoryTool_20250818"
                 },
                 {
@@ -28116,6 +28328,9 @@
                   "$ref": "#/components/schemas/CodeExecutionTool_20260120"
                 },
                 {
+                  "$ref": "#/components/schemas/CodeExecutionTool_20260521"
+                },
+                {
                   "$ref": "#/components/schemas/MemoryTool_20250818"
                 },
                 {
@@ -28371,6 +28586,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/CodeExecutionTool_20260120"
+                },
+                {
+                  "$ref": "#/components/schemas/CodeExecutionTool_20260521"
                 },
                 {
                   "$ref": "#/components/schemas/MemoryTool_20250818"
@@ -30125,27 +30343,31 @@
         "title": "RateLimitError",
         "type": "object"
       },
+      "RefusalCategory": {
+        "description": "The policy category that triggered a refusal.",
+        "enum": [
+          "cyber",
+          "bio",
+          "frontier_llm",
+          "reasoning_extraction"
+        ],
+        "title": "RefusalCategory",
+        "type": "string"
+      },
       "RefusalStopDetails": {
         "description": "Structured information about a refusal.",
         "properties": {
           "category": {
             "anyOf": [
               {
-                "enum": [
-                  "cyber",
-                  "bio",
-                  "frontier_llm",
-                  "reasoning_extraction"
-                ],
-                "type": "string"
+                "$ref": "#/components/schemas/RefusalCategory"
               },
               {
                 "type": "null"
               }
             ],
             "default": null,
-            "description": "The policy category that triggered the refusal.\n\n`null` when the refusal doesn't map to a named category.",
-            "title": "Category"
+            "description": "The policy category that triggered the refusal.\n\n`null` when the refusal doesn't map to a named category."
           },
           "explanation": {
             "anyOf": [
@@ -55462,6 +55684,27 @@
           }
         },
         "summary": "session.thread_terminated webhook"
+      }
+    },
+    "session.updated": {
+      "post": {
+        "operationId": "BetaSessionUpdatedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "session.updated webhook"
       }
     },
     "vault.archived": {

--- a/packages/anthropic_sdk_dart/specs/spec_metadata.json
+++ b/packages/anthropic_sdk_dart/specs/spec_metadata.json
@@ -2,8 +2,8 @@
   "specs": {
     "main": {
       "current_version": "unknown",
-      "last_fetched": "2026-06-16T07:52:14.536177Z",
-      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-04d2899e1e4dd48e29347b98f1265e6345ee20b75e29c12eca1068a8f7c61095.yml",
+      "last_fetched": "2026-06-20T15:44:08.770812Z",
+      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-2ecf157aa324d82fa8f3636a325aea5bd96ecab93193f6e37864ebe665c48685.yml",
       "title": "Anthropic API",
       "version_history": [
         {

--- a/packages/anthropic_sdk_dart/test/unit/models/fallback_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/fallback_test.dart
@@ -13,12 +13,14 @@ void main() {
         'type': 'fallback',
         'from': {'model': 'claude-opus-4-8'},
         'to': {'model': 'claude-sonnet-4-6'},
+        'trigger': {'type': 'refusal', 'category': 'frontier_llm'},
       };
 
       final block = FallbackBlock.fromJson(json);
       expect(block.from, const FallbackHopInfo(model: 'claude-opus-4-8'));
       expect(block.to, const FallbackHopInfo(model: 'claude-sonnet-4-6'));
       expect(block.type, 'fallback');
+      expect(block.trigger.category, RefusalCategory.frontierLlm);
       expect(block.toJson(), json);
     });
 
@@ -27,12 +29,14 @@ void main() {
         'type': 'fallback',
         'from': {'model': 'claude-opus-4-8'},
         'to': {'model': 'claude-sonnet-4-6'},
+        'trigger': {'type': 'refusal', 'category': null},
       });
 
       expect(block, isA<FallbackBlock>());
       final fallback = block as FallbackBlock;
       expect(fallback.from.model, 'claude-opus-4-8');
       expect(fallback.to.model, 'claude-sonnet-4-6');
+      expect(fallback.trigger.category, isNull);
     });
 
     test('fromJson rejects a mismatched discriminator', () {
@@ -46,19 +50,83 @@ void main() {
       );
     });
 
-    test('copyWith replaces hop info', () {
+    test('copyWith replaces hop info and trigger', () {
       const original = FallbackBlock(
         from: FallbackHopInfo(model: 'a'),
         to: FallbackHopInfo(model: 'b'),
+        trigger: FallbackRefusalTrigger(rawCategory: 'cyber'),
       );
-      final modified = original.copyWith(to: const FallbackHopInfo(model: 'c'));
+      final modified = original.copyWith(
+        to: const FallbackHopInfo(model: 'c'),
+        trigger: const FallbackRefusalTrigger(rawCategory: 'bio'),
+      );
       expect(modified.from.model, 'a');
       expect(modified.to.model, 'c');
+      expect(modified.trigger.category, RefusalCategory.bio);
+    });
+  });
+
+  group('FallbackRefusalTrigger', () {
+    test('round-trips a known category', () {
+      final json = {'type': 'refusal', 'category': 'cyber'};
+      final trigger = FallbackRefusalTrigger.fromJson(json);
+      expect(trigger.type, 'refusal');
+      expect(trigger.category, RefusalCategory.cyber);
+      expect(trigger.rawCategory, 'cyber');
+      expect(trigger.toJson(), json);
+    });
+
+    test('round-trips a null category', () {
+      final json = {'type': 'refusal', 'category': null};
+      final trigger = FallbackRefusalTrigger.fromJson(json);
+      expect(trigger.category, isNull);
+      expect(trigger.rawCategory, isNull);
+      expect(trigger.toJson(), json);
+    });
+
+    test('preserves an unrecognized category verbatim', () {
+      final json = {'type': 'refusal', 'category': 'future_policy'};
+      final trigger = FallbackRefusalTrigger.fromJson(json);
+      // The typed getter degrades to unknown...
+      expect(trigger.category, RefusalCategory.unknown);
+      // ...but the raw wire value round-trips unchanged.
+      expect(trigger.rawCategory, 'future_policy');
+      expect(trigger.toJson()['category'], 'future_policy');
+    });
+
+    test('copyWith clears category to null vs preserves on omission', () {
+      const trigger = FallbackRefusalTrigger(rawCategory: 'cyber');
+      expect(trigger.copyWith(rawCategory: null).rawCategory, isNull);
+      expect(trigger.copyWith().rawCategory, 'cyber');
+    });
+
+    test('fromJson throws on a wrong discriminator', () {
+      expect(
+        () => FallbackRefusalTrigger.fromJson(const {
+          'type': 'other',
+          'category': null,
+        }),
+        throwsFormatException,
+      );
+    });
+
+    test('fromJson throws when the type is missing', () {
+      expect(
+        () => FallbackRefusalTrigger.fromJson(const {'category': null}),
+        throwsFormatException,
+      );
+    });
+
+    test('fromJson throws when the required category key is absent', () {
+      expect(
+        () => FallbackRefusalTrigger.fromJson(const {'type': 'refusal'}),
+        throwsFormatException,
+      );
     });
   });
 
   group('FallbackInputBlock (request)', () {
-    test('fromJson/toJson round-trip', () {
+    test('fromJson/toJson round-trip (no trigger)', () {
       final json = {
         'type': 'fallback',
         'from': {'model': 'claude-opus-4-8'},
@@ -69,6 +137,7 @@ void main() {
       expect(block.from.model, 'claude-opus-4-8');
       expect(block.to.model, 'claude-sonnet-4-6');
       expect(block.type, 'fallback');
+      expect(block.hasTrigger, isFalse);
       expect(block.toJson(), json);
     });
 
@@ -94,6 +163,66 @@ void main() {
         'from': {'model': 'claude-opus-4-8'},
         'to': {'model': 'claude-sonnet-4-6'},
       });
+    });
+
+    test('echoes a free-form trigger map verbatim', () {
+      final json = {
+        'type': 'fallback',
+        'from': {'model': 'a'},
+        'to': {'model': 'b'},
+        'trigger': {'type': 'refusal', 'category': 'frontier_llm'},
+      };
+      final block = FallbackInputBlock.fromJson(json);
+      expect(block.hasTrigger, isTrue);
+      expect(block.trigger, {'type': 'refusal', 'category': 'frontier_llm'});
+      expect(block.toJson(), json);
+    });
+
+    test('preserves an explicit null trigger', () {
+      final json = {
+        'type': 'fallback',
+        'from': {'model': 'a'},
+        'to': {'model': 'b'},
+        'trigger': null,
+      };
+      final block = FallbackInputBlock.fromJson(json);
+      expect(block.hasTrigger, isTrue);
+      expect(block.trigger, isNull);
+      expect(block.toJson().containsKey('trigger'), isTrue);
+      expect(block.toJson()['trigger'], isNull);
+    });
+
+    test('omits an absent trigger key', () {
+      final json = {
+        'type': 'fallback',
+        'from': {'model': 'a'},
+        'to': {'model': 'b'},
+      };
+      final block = FallbackInputBlock.fromJson(json);
+      expect(block.hasTrigger, isFalse);
+      expect(block.trigger, isNull);
+      expect(block.toJson().containsKey('trigger'), isFalse);
+    });
+
+    test('stores the trigger map unmodifiable', () {
+      final block = FallbackInputBlock(
+        from: const FallbackHopInfo(model: 'a'),
+        to: const FallbackHopInfo(model: 'b'),
+        trigger: const {'type': 'refusal', 'category': 'cyber'},
+      );
+      expect(() => block.trigger!['x'] = 1, throwsUnsupportedError);
+    });
+
+    test('copyWith preserves trigger presence on omission', () {
+      final block = FallbackInputBlock(
+        from: const FallbackHopInfo(model: 'a'),
+        to: const FallbackHopInfo(model: 'b'),
+        trigger: const {'k': 'v'},
+      );
+      final copy = block.copyWith(to: const FallbackHopInfo(model: 'c'));
+      expect(copy.hasTrigger, isTrue);
+      expect(copy.trigger, {'k': 'v'});
+      expect(copy.toString(), contains('hasTrigger: true'));
     });
   });
 

--- a/packages/anthropic_sdk_dart/test/unit/models/fallback_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/fallback_test.dart
@@ -204,13 +204,47 @@ void main() {
       expect(block.toJson().containsKey('trigger'), isFalse);
     });
 
-    test('stores the trigger map unmodifiable', () {
+    test('stores the trigger map deeply unmodifiable', () {
       final block = FallbackInputBlock(
         from: const FallbackHopInfo(model: 'a'),
         to: const FallbackHopInfo(model: 'b'),
-        trigger: const {'type': 'refusal', 'category': 'cyber'},
+        trigger: const {
+          'type': 'refusal',
+          'meta': {'nested': 1},
+          'list': [
+            {'k': 'v'},
+          ],
+        },
       );
+      // Outer map is frozen...
       expect(() => block.trigger!['x'] = 1, throwsUnsupportedError);
+      // ...and so are nested maps and lists.
+      expect(
+        () => (block.trigger!['meta'] as Map)['nested'] = 2,
+        throwsUnsupportedError,
+      );
+      expect(
+        () => (block.trigger!['list'] as List).add('z'),
+        throwsUnsupportedError,
+      );
+      expect(
+        () => ((block.trigger!['list'] as List)[0] as Map)['k'] = 'w',
+        throwsUnsupportedError,
+      );
+    });
+
+    test('freezing a trigger does not alias the source nested maps', () {
+      final source = {
+        'meta': {'nested': 1},
+      };
+      final block = FallbackInputBlock(
+        from: const FallbackHopInfo(model: 'a'),
+        to: const FallbackHopInfo(model: 'b'),
+        trigger: source,
+      );
+      // Mutating the original nested map must not change the frozen copy.
+      (source['meta']! as Map)['nested'] = 99;
+      expect((block.trigger!['meta'] as Map)['nested'], 1);
     });
 
     test('copyWith preserves trigger presence on omission', () {

--- a/packages/anthropic_sdk_dart/test/unit/models/tools/tool_definition_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/tools/tool_definition_test.dart
@@ -202,6 +202,42 @@ void main() {
         expect(builtIn, isA<CodeExecutionBuiltInTool>());
       });
 
+      test('parses code_execution_20260521 built-in tool', () {
+        final json = {
+          'type': 'code_execution_20260521',
+          'name': 'code_execution',
+        };
+
+        final definition = ToolDefinition.fromJson(json);
+
+        expect(definition, isA<BuiltInToolDefinition>());
+        final builtIn = (definition as BuiltInToolDefinition).tool;
+        expect(builtIn, isA<CodeExecutionBuiltInTool>());
+        expect(
+          (builtIn as CodeExecutionBuiltInTool).type,
+          'code_execution_20260521',
+        );
+      });
+
+      test('CodeExecutionTool.v20260521 carries the new version and '
+          'round-trips', () {
+        final tool = CodeExecutionTool.v20260521(
+          allowedCallers: const ['direct', 'code_execution_20260521'],
+        );
+
+        expect(tool.type, 'code_execution_20260521');
+        expect(tool.container, isNull);
+
+        final json = tool.toJson();
+        expect(json['type'], 'code_execution_20260521');
+        expect(json['name'], 'code_execution');
+        expect(json['allowed_callers'], ['direct', 'code_execution_20260521']);
+        expect(CodeExecutionTool.fromJson(json).allowedCallers, [
+          'direct',
+          'code_execution_20260521',
+        ]);
+      });
+
       test('parses computer_use built-in tool', () {
         final json = {
           'type': 'computer_20250124',

--- a/packages/anthropic_sdk_dart/test/unit/models/tools/tool_definition_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/tools/tool_definition_test.dart
@@ -219,6 +219,21 @@ void main() {
         );
       });
 
+      test('code execution tools default to the latest version', () {
+        // Bumped to the latest GA version in the breaking spec refresh.
+        expect(
+          const CodeExecutionBuiltInTool().type,
+          'code_execution_20260521',
+        );
+        expect(
+          CodeExecutionBuiltInTool.fromJson(const {
+            'name': 'code_execution',
+          }).type,
+          'code_execution_20260521',
+        );
+        expect(const CodeExecutionTool().type, 'code_execution_20260521');
+      });
+
       test('CodeExecutionTool.v20260521 carries the new version and '
           'round-trips', () {
         final tool = CodeExecutionTool.v20260521(

--- a/packages/anthropic_sdk_dart/test/unit/models/tools/tool_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/tools/tool_test.dart
@@ -67,7 +67,7 @@ void main() {
             },
           },
           'cache_control': {'type': 'ephemeral'},
-          'allowed_callers': ['direct', 'code_execution_20260120'],
+          'allowed_callers': ['direct', 'code_execution_20260521'],
           'defer_loading': true,
           'strict': true,
           'input_examples': [
@@ -82,7 +82,7 @@ void main() {
         expect(tool.name, 'search');
         expect(tool.description, 'Search the web');
         expect(tool.cacheControl, isNotNull);
-        expect(tool.allowedCallers, ['direct', 'code_execution_20260120']);
+        expect(tool.allowedCallers, ['direct', 'code_execution_20260521']);
         expect(tool.deferLoading, isTrue);
         expect(tool.strict, isTrue);
         expect(tool.inputExamples, [

--- a/packages/anthropic_sdk_dart/test/unit/models/webhook_event_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/webhook_event_test.dart
@@ -47,6 +47,7 @@ void main() {
       false,
       isA<WebhookSessionThreadTerminatedEventData>(),
     ),
+    ('session.updated', false, isA<WebhookSessionUpdatedEventData>()),
     ('vault.created', false, isA<WebhookVaultCreatedEventData>()),
     ('vault.archived', false, isA<WebhookVaultArchivedEventData>()),
     ('vault.deleted', false, isA<WebhookVaultDeletedEventData>()),
@@ -86,8 +87,8 @@ void main() {
   }
 
   group('WebhookEventData dispatch', () {
-    test('covers all 22 spec variants', () {
-      expect(variants, hasLength(22));
+    test('covers all 23 spec variants', () {
+      expect(variants, hasLength(23));
     });
 
     for (final (type, withVault, matcher) in variants) {
@@ -98,6 +99,24 @@ void main() {
         expect(data.toJson(), json);
       });
     }
+
+    test('WebhookSessionUpdatedEventData.fromJson parses directly', () {
+      final json = dataJson('session.updated', withVault: false);
+      final data = WebhookSessionUpdatedEventData.fromJson(json);
+      expect(data.id, 'res_123');
+      expect(data.organizationId, 'org_123');
+      expect(data.workspaceId, 'wrkspc_123');
+      expect(data.toJson(), json);
+    });
+
+    test('WebhookSessionUpdatedEventData.fromJson rejects a wrong type', () {
+      expect(
+        () => WebhookSessionUpdatedEventData.fromJson(
+          dataJson('session.created', withVault: false),
+        ),
+        throwsFormatException,
+      );
+    });
 
     test('unknown type falls back to UnknownWebhookEventData', () {
       final json = {'type': 'mystery.event', 'foo': 'bar'};


### PR DESCRIPTION
## Summary
- Sync `anthropic_sdk_dart` to Anthropic OpenAPI spec `2ecf157a` (from `04d2899e`), cross-checked field-for-field against `anthropic-sdk-python@main` on the same spec hash.
- Add the **`code_execution_20260521`** code-execution tool version, and **default** both the GA and beta code-execution tools to it.
- Add the **fallback refusal trigger**: `FallbackBlock.trigger` (new required `FallbackRefusalTrigger`) explains why a model handed over at a fallback hop, and `FallbackInputBlock` gains a free-form echoed `trigger`.
- Add the **`session.updated`** webhook event (`WebhookSessionUpdatedEventData`).
- Register the newly-extracted `RefusalCategory` / `BetaRefusalCategory` named enum schemas in the api-toolkit manifest.

## Details

**Code execution `code_execution_20260521`** — structurally identical to `_20260120` (no `container`). Available on the GA tool via `BuiltInTool.codeExecution(...)` and on the beta tool via the new `CodeExecutionTool.v20260521()` factory. Both the GA `CodeExecutionBuiltInTool` and the beta `CodeExecutionTool` now **default to `code_execution_20260521`** when constructed without an explicit `type` — bumped here since the release is already breaking, to avoid a separate future breaking change just for the default.

**Fallback refusal trigger** — `FallbackRefusalTrigger` (`type` const `refusal`, nullable `category`) follows the round-trip-fidelity pattern of `AdvisorToolResultError`: the raw category string is stored and the typed `RefusalCategory` is derived via a getter, so unrecognized future categories serialize back verbatim instead of collapsing to `unknown`.

```dart
for (final block in response.content) {
  if (block is FallbackBlock) {
    print('${block.from.model} -> ${block.to.model} '
        '(${block.trigger.category?.value ?? 'uncategorized'})');
  }
}
```

The request-side `FallbackInputBlock.trigger` is free-form (the server ignores it; any object or `null`). It is stored **deeply** unmodifiable (a recursive `deepUnmodifiableMap` freezes nested maps/lists too) and presence-tracked via `hasTrigger`, so an explicit `null` round-trips distinctly from an absent key.

**Webhook `session.updated`** — mirrors the sibling session event classes; its `fromJson` additionally validates the `session.updated` discriminator (a deliberate hardening over the existing variants, which rely solely on the union dispatch).

**Spec promotion** — `specs/openapi.yaml` promoted; `config/specs.json` `url`/`pinned_hash` and `specs/spec_metadata.json` advanced to `2ecf157a`; `llms.txt` regenerated.

## Breaking Changes

- `FallbackBlock` now requires a `trigger` argument (it mirrors the spec, where `trigger` became required on the response block). `FallbackBlock` is normally consumed via `fromJson`, so most callers are unaffected.

  ```dart
  // Before
  const FallbackBlock(from: from, to: to);

  // After
  const FallbackBlock(
    from: from,
    to: to,
    trigger: FallbackRefusalTrigger(rawCategory: 'cyber'),
  );
  ```

- `FallbackInputBlock`'s constructor is no longer `const` (the echoed trigger map is stored unmodifiable).

- Code-execution tools constructed **without an explicit `type`** now default to `code_execution_20260521`:
  - `BuiltInTool.codeExecution()` / `CodeExecutionBuiltInTool()`: `code_execution_20260120` → `code_execution_20260521`
  - beta `CodeExecutionTool()`: `code_execution_20250825` → `code_execution_20260521`

  ```dart
  // Pin an older version by passing `type` explicitly:
  BuiltInTool.codeExecution(type: 'code_execution_20260120');
  ```

## Test Plan

- [x] Unit tests pass for `anthropic_sdk_dart` (`dart test test/unit/` — 1247 passing, 4 skipped/env-gated)
- [x] New tests added: fallback trigger round-trip + unknown-category fidelity + null-clearing `copyWith` + missing/wrong discriminator; request trigger present-null vs absent + deep-unmodifiable (nested) + no source aliasing; `session.updated` dispatch + direct `fromJson`; `code_execution_20260521` parse + `v20260521()` factory + default-version assertions
- [x] Sealed class/enum changes include variant, round-trip, and error tests
- [x] `fromJson`/`toJson` round-trip serialization verified
- [x] `==`/`hashCode` contract verified (same fields in both)
- [x] api-toolkit `review` + `verify --checks all --scope all` clean (0 errors, 0 missing, no coverage gaps)
- [x] `dart analyze --fatal-infos` clean; `dart format --set-exit-if-changed` clean