### PR TITLE
chore: migrate melos scripts to 8.x exec.command format

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,8 +51,8 @@ melos:
   scripts:
     test:
       description: Run all Dart tests
-      run: dart test
       exec:
+        command: dart test
         concurrency: 1
         failFast: true
       packageFilters:
@@ -60,8 +60,8 @@ melos:
 
     test:diff:
       description: Run tests for changed packages
-      run: dart test
       exec:
+        command: dart test
         concurrency: 1
         failFast: true
       packageFilters:


### PR DESCRIPTION
## Summary
- Migrate the Melos `test` and `test:diff` scripts to the Melos 8 configuration format. As of Melos 8.0.0, `run` and `exec` are mutually exclusive — a script either runs once in the workspace root (`run`) or across packages (`exec`) — and the command for `exec` now lives under `exec.command`. The previous `run: dart test` + `exec:` options combo caused Melos 8 to error out at config-parse time (`melos list`, `melos run`, etc. all failed).

## Details

Melos was already bumped to `^8.0.0` (installed 8.1.0) in #265, but the `melos.scripts` config in the root `pubspec.yaml` still used the Melos 7 shape. Both `test` and `test:diff` combined a top-level `run:` with an `exec:` options block, which Melos 8 rejects:

> The script "test" specifies both "run" and "exec", which is no longer supported as of Melos 8.0.0. [...] Move the command into "exec" under the new "command" key.

The fix moves `dart test` into `exec.command`; `packageFilters`, `concurrency`, and `failFast` are unchanged:

```yaml
# Before (Melos 7)
test:
  run: dart test
  exec:
    concurrency: 1
    failFast: true
  packageFilters:
    dirExists: test

# After (Melos 8)
test:
  exec:
    command: dart test
    concurrency: 1
    failFast: true
  packageFilters:
    dirExists: test
```

Reviewed the Melos 8.0.0 changelog for other config-affecting breaking changes — the only two are the `exec.command` change (fixed here) and build-number retention during versioning (behavioral, no config change). The `melos.command` block (version/bootstrap settings) remains valid under Melos 8.

CI is unaffected: `.github/workflows/test.yaml` runs `dart test` directly rather than invoking these Melos scripts. The scripts are for local developer use (`melos run test` / `melos run test:diff`).

## Test Plan
- [x] `melos list` succeeds (previously failed on config parse)
- [x] `melos run` lists both `test` and `test:diff` scripts with descriptions
- [x] `melos run test:diff` resolves to `melos exec --concurrency 1 --fail-fast -- "dart test"`, confirming `exec.command` is wired correctly
- [x] `dart pub get` resolves the workspace cleanly