### PR TITLE
feat(ollama_dart): add "max" thinking level

### DIFF
--- a/packages/ollama_dart/MIGRATION.md
+++ b/packages/ollama_dart/MIGRATION.md
@@ -676,7 +676,7 @@ final request = ChatRequest(
 
 Available classes:
 - `ThinkEnabled(bool)` - Enable/disable thinking
-- `ThinkWithLevel(ThinkLevel)` - Set thinking level (`ThinkLevel.high`, `ThinkLevel.medium`, `ThinkLevel.low`)
+- `ThinkWithLevel(ThinkLevel)` - Set thinking level (`ThinkLevel.high`, `ThinkLevel.medium`, `ThinkLevel.low`, `ThinkLevel.max`)
 
 ### ResponseFormat Sealed Class
 

--- a/packages/ollama_dart/lib/src/models/common/think_value.dart
+++ b/packages/ollama_dart/lib/src/models/common/think_value.dart
@@ -10,12 +10,15 @@ enum ThinkLevel {
 
   /// Low level of thinking/reasoning.
   low,
+
+  /// Maximum level of thinking/reasoning.
+  max,
 }
 
 /// Value for the think parameter.
 ///
 /// Controls whether thinking/reasoning models will think before responding.
-/// Can be either a boolean (enabled/disabled) or a level (high/medium/low).
+/// Can be either a boolean (enabled/disabled) or a level (high/medium/low/max).
 @immutable
 sealed class ThinkValue {
   const ThinkValue();
@@ -36,6 +39,7 @@ sealed class ThinkValue {
       'high' => const ThinkWithLevel(ThinkLevel.high),
       'medium' => const ThinkWithLevel(ThinkLevel.medium),
       'low' => const ThinkWithLevel(ThinkLevel.low),
+      'max' => const ThinkWithLevel(ThinkLevel.max),
       _ => null,
     };
   }
@@ -86,6 +90,7 @@ class ThinkWithLevel extends ThinkValue {
       ThinkLevel.high => 'high',
       ThinkLevel.medium => 'medium',
       ThinkLevel.low => 'low',
+      ThinkLevel.max => 'max',
     };
   }
 

--- a/packages/ollama_dart/specs/openapi.json
+++ b/packages/ollama_dart/specs/openapi.json
@@ -100,7 +100,7 @@
             "type": "boolean"
           },
           "think": {
-            "description": "When true, returns separate thinking output in addition to content. Can be a boolean (true/false) or a string (\"high\", \"medium\", \"low\") for supported models.",
+            "description": "When true, returns separate thinking output in addition to content. Can be a boolean (true/false) or a string (\"high\", \"medium\", \"low\", \"max\") for supported models, with \"max\" requesting the highest thinking level.",
             "oneOf": [
               {
                 "type": "boolean"
@@ -109,7 +109,8 @@
                 "enum": [
                   "high",
                   "medium",
-                  "low"
+                  "low",
+                  "max"
                 ],
                 "type": "string"
               }
@@ -503,7 +504,7 @@
             "type": "string"
           },
           "think": {
-            "description": "When true, returns separate thinking output in addition to content. Can be a boolean (true/false) or a string (\"high\", \"medium\", \"low\") for supported models.",
+            "description": "When true, returns separate thinking output in addition to content. Can be a boolean (true/false) or a string (\"high\", \"medium\", \"low\", \"max\") for supported models, with \"max\" requesting the highest thinking level.",
             "oneOf": [
               {
                 "type": "boolean"
@@ -512,7 +513,8 @@
                 "enum": [
                   "high",
                   "medium",
-                  "low"
+                  "low",
+                  "max"
                 ],
                 "type": "string"
               }
@@ -1192,7 +1194,7 @@
                     "content": "Hello! How can I help you today?",
                     "role": "assistant"
                   },
-                  "model": "gemma3",
+                  "model": "gemma4",
                   "prompt_eval_count": 11,
                   "prompt_eval_duration": 13074791,
                   "total_duration": 174560334
@@ -1215,17 +1217,17 @@
           {
             "label": "Default",
             "lang": "bash",
-            "source": "curl http://localhost:11434/api/chat -d '{\n  \"model\": \"gemma3\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"why is the sky blue?\"\n    }\n  ]\n}'\n"
+            "source": "curl http://localhost:11434/api/chat -d '{\n  \"model\": \"gemma4\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"why is the sky blue?\"\n    }\n  ]\n}'\n"
           },
           {
             "label": "Non-streaming",
             "lang": "bash",
-            "source": "curl http://localhost:11434/api/chat -d '{\n  \"model\": \"gemma3\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"why is the sky blue?\"\n    }\n  ],\n  \"stream\": false\n}'\n"
+            "source": "curl http://localhost:11434/api/chat -d '{\n  \"model\": \"gemma4\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"why is the sky blue?\"\n    }\n  ],\n  \"stream\": false\n}'\n"
           },
           {
             "label": "Structured outputs",
             "lang": "bash",
-            "source": "curl -X POST http://localhost:11434/api/chat -H \"Content-Type: application/json\" -d '{\n  \"model\": \"gemma3\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What are the populations of the United States and Canada?\"\n    }\n  ],\n  \"stream\": false,\n  \"format\": {\n    \"type\": \"object\",\n    \"properties\": {\n      \"countries\": {\n        \"type\": \"array\",\n        \"items\": {\n          \"type\": \"object\",\n          \"properties\": {\n            \"country\": {\"type\": \"string\"},\n            \"population\": {\"type\": \"integer\"}\n          },\n          \"required\": [\"country\", \"population\"]\n        }\n      }\n    },\n    \"required\": [\"countries\"]\n  }\n}'\n"
+            "source": "curl -X POST http://localhost:11434/api/chat -H \"Content-Type: application/json\" -d '{\n  \"model\": \"gemma4\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What are the populations of the United States and Canada?\"\n    }\n  ],\n  \"stream\": false,\n  \"format\": {\n    \"type\": \"object\",\n    \"properties\": {\n      \"countries\": {\n        \"type\": \"array\",\n        \"items\": {\n          \"type\": \"object\",\n          \"properties\": {\n            \"country\": {\"type\": \"string\"},\n            \"population\": {\"type\": \"integer\"}\n          },\n          \"required\": [\"country\", \"population\"]\n        }\n      }\n    },\n    \"required\": [\"countries\"]\n  }\n}'\n"
           },
           {
             "label": "Tool calling",
@@ -1240,7 +1242,7 @@
           {
             "label": "Images",
             "lang": "bash",
-            "source": "curl http://localhost:11434/api/chat -d '{\n  \"model\": \"gemma3\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is in this image?\",\n      \"images\": [\n        \"iVBORw0KGgoAAAANSUhEUgAAAG0AAABmCAYAAADBPx+VAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAA3VSURBVHgB7Z27r0zdG8fX743i1bi1ikMoFMQloXRpKFFIqI7LH4BEQ+NWIkjQuSWCRIEoULk0gsK1kCBI0IhrQVT7tz/7zZo888yz1r7MnDl7z5xvsjkzs2fP3uu71nNfa7lkAsm7d++Sffv2JbNmzUqcc8m0adOSzZs3Z+/XES4ZckAWJEGWPiCxjsQNLWmQsWjRIpMseaxcuTKpG/7HP27I8P79e7dq1ars/yL4/v27S0ejqwv+cUOGEGGpKHR37tzJCEpHV9tnT58+dXXCJDdECBE2Ojrqjh071hpNECjx4cMHVycM1Uhbv359B2F79+51586daxN/+pyRkRFXKyRDAqxEp4yMlDDzXG1NPnnyJKkThoK0VFd1ELZu3TrzXKxKfW7dMBQ6bcuWLW2v0VlHjx41z717927ba22U9APcw7Nnz1oGEPeL3m3p2mTAYYnFmMOMXybPPXv2bNIPpFZr1NHn4HMw0KRBjg9NuRw95s8PEcz/6DZELQd/09C9QGq5RsmSRybqkwHGjh07OsJSsYYm3ijPpyHzoiacg35MLdDSIS/O1yM778jOTwYUkKNHWUzUWaOsylE00MyI0fcnOwIdjvtNdW/HZwNLGg+sR1kMepSNJXmIwxBZiG8tDTpEZzKg0GItNsosY8USkxDhD0Rinuiko2gfL/RbiD2LZAjU9zKQJj8RDR0vJBR1/Phx9+PHj9Z7REF4nTZkxzX4LCXHrV271qXkBAPGfP/atWvu/PnzHe4C97F48eIsRLZ9+3a3f/9+87dwP1JxaF7/3r17ba+5l4EcaVo0lj3SBq5kGTJSQmLWMjgYNei2GPT1MuMqGTDEFHzeQSP2wi/jGnkmPJ/nhccs44jvDAxpVcxnq0F6eT8h4ni/iIWpR5lPyA6ETkNXoSukvpJAD3AsXLiwpZs49+fPn5ke4j10TqYvegSfn0OnafC+Tv9ooA/JPkgQysqQNBzagXY55nO/oa1F7qvIPWkRL12WRpMWUvpVDYmxAPehxWSe8ZEXL20sadYIozfmNch4QJPAfeJgW3rNsnzphBKNJM2KKODo1rVOMRYik5ETy3ix4qWNI81qAAirizgMIc+yhTytx0JWZuNI03qsrgWlGtwjoS9XwgUhWGyhUaRZZQNNIEwCiXD16tXcAHUs79co0vSD8rrJCIW98pzvxpAWyyo3HYwqS0+H0BjStClcZJT5coMm6D2LOF8TolGJtK9fvyZpyiC5ePFi9nc/oJU4eiEP0jVoAnHa9wyJycITMP78+eMeP37sXrx44d6+fdt6f82aNdkx1pg9e3Zb5W+RSRE+n+VjksQWifvVaTKFhn5O8my63K8Qabdv33b379/PiAP//vuvW7BggZszZ072/+TJk91YgkafPn166zXB1rQHFvouAWHq9z3SEevSUerqCn2/dDCeta2jxYbr69evk4MHDyY7d+7MjhMnTiTPnz9Pfv/+nfQT2ggpO2dMF8cghuoM7Ygj5iWCqRlGFml0QC/ftGmTmzt3rmsaKDsgBSPh0/8yPeLLBihLkOKJc0jp8H8vUzcxIA1k6QJ/c78tWEyj5P3o4u9+jywNPdJi5rAH9x0KHcl4Hg570eQp3+vHXGyrmEeigzQsQsjavXt38ujRo44LQuDDhw+TW7duRS1HGgMxhNXHgflaNTOsHyKvHK5Ijo2jbFjJBQK9YwFd6RVMzfgRBmEfP37suBBm/p49e1qjEP2mwTViNRo0VJWH1deMXcNK08uUjVUu7s/zRaL+oLNxz1bpANco4npUgX4G2eFbpDFyQoQxojBCpEGSytmOH8qrH5Q9vuzD6ofQylkCUmh8DBAr+q8JCyVNtWQIidKQE9wNtLSQnS4jDSsxNHogzFuQBw4cyM61UKVsjfr3ooBkPSqqQHesUPWVtzi9/vQi1T+rJj7WiTz4Pt/l3LxUkr5P2VYZaZ4URpsE+st/dujQoaBBYokbrz/8TJNQYLSonrPS9kUaSkPeZyj1AWSj+d+VBoy1pIWVNed8P0Ll/ee5HdGRhrHhR5GGN0r4LGZBaj8oFDJitBTJzIZgFcmU0Y8ytWMZMzJOaXUSrUs5RxKnrxmbb5YXO9VGUhtpXldhEUogFr3IzIsvlpmdosVcGVGXFWp2oU9kLFL3dEkSz6NHEY1sjSRdIuDFWEhd8KxFqsRi1uM/nz9/zpxnwlESONdg6dKlbsaMGS4EHFHtjFIDHwKOo46l4TxSuxgDzi+rE2jg+BaFruOX4HXa0Nnf1lwAPufZeF8/r6zD97WK2qFnGjBxTw5qNGPxT+5T/r7/7RawFC3j4vTp09koCxkeHjqbHJqArmH5UrFKKksnxrK7FuRIs8STfBZv+luugXZ2pR/pP9Ois4z+TiMzUUkUjD0iEi1fzX8GmXyuxUBRcaUfykV0YZnlJGKQpOiGB76x5GeWkWWJc3mOrK6S7xdND+W5N6XyaRgtWJFe13GkaZnKOsYqGdOVVVbGupsyA/l7emTLHi7vwTdirNEt0qxnzAvBFcnQF16xh/TMpUuXHDowhlA9vQVraQhkudRdzOnK+04ZSP3DUhVSP61YsaLtd/ks7ZgtPcXqPqEafHkdqa84X6aCeL7YWlv6edGFHb+ZFICPlljHhg0bKuk0CSvVznWsotRu433alNdFrqG45ejoaPCaUkWERpLXjzFL2Rpllp7PJU2a/v7Ab8N05/9t27Z16KUqoFGsxnI9EosS2niSYg9SpU6B4JgTrvVW1flt1sT+0ADIJU2maXzcUTraGCRaL1Wp9rUMk16PMom8QhruxzvZIegJjFU7LLCePfS8uaQdPny4jTTL0dbee5mYokQsXTIWNY46kuMbnt8Kmec+LGWtOVIl9cT1rCB0V8WqkjAsRwta93TbwNYoGKsUSChN44lgBNCoHLHzquYKrU6qZ8lolCIN0Rh6cP0Q3U6I6IXILYOQI513hJaSKAorFpuHXJNfVlpRtmYBk1Su1obZr5dnKAO+L10Hrj3WZW+E3qh6IszE37F6EB+68mGpvKm4eb9bFrlzrok7fvr0Kfv727dvWRmdVTJHw0qiiCUSZ6wCK+7XL/AcsgNyL74DQQ730sv78Su7+t/A36MdY0sW5o40ahslXr58aZ5HtZB8GH64m9EmMZ7FpYw4T6QnrZfgenrhFxaSiSGXtPnz57e9TkNZLvTjeqhr734CNtrK41L40sUQckmj1lGKQ0rC37x544r8eNXRpnVE3ZZY7zXo8NomiO0ZUCj2uHz58rbXoZ6gc0uA+F6ZeKS/jhRDUq8MKrTho9fEkihMmhxtBI1DxKFY9XLpVcSkfoi8JGnToZO5sU5aiDQIW716ddt7ZLYtMQlhECdBGXZZMWldY5BHm5xgAroWj4C0hbYkSc/jBmggIrXJWlZM6pSETsEPGqZOndr2uuuR5rF169a2HoHPdurUKZM4CO1WTPqaDaAd+GFGKdIQkxAn9RuEWcTRyN2KSUgiSgF5aWzPTeA/lN5rZubMmR2bE4SIC4nJoltgAV/dVefZm72AtctUCJU2CMJ327hxY9t7EHbkyJFseq+EJSY16RPo3Dkq1kkr7+q0bNmyDuLQcZBEPYmHVdOBiJyIlrRDq41YPWfXOxUysi5fvtyaj+2BpcnsUV/oSoEMOk2CQGlr4ckhBwaetBhjCwH0ZHtJROPJkyc7UjcYLDjmrH7ADTEBXFfOYmB0k9oYBOjJ8b4aOYSe7QkKcYhFlq3QYLQhSidNmtS2RATwy8YOM3EQJsUjKiaWZ+vZToUQgzhkHXudb/PW5YMHD9yZM2faPsMwoc7RciYJXbGuBqJ1UIGKKLv915jsvgtJxCZDubdXr165mzdvtr1Hz5LONA8jrUwKPqsmVesKa49S3Q4WxmRPUEYdTjgiUcfUwLx589ySJUva3oMkP6IYddq6HMS4o55xBJBUeRjzfa4Zdeg56QZ43LhxoyPo7Lf1kNt7oO8wWAbNwaYjIv5lhyS7kRf96dvm5Jah8vfvX3flyhX35cuX6HfzFHOToS1H4BenCaHvO8pr8iDuwoUL7tevX+b5ZdbBair0xkFIlFDlW4ZknEClsp/TzXyAKVOmmHWFVSbDNw1l1+4f90U6IY/q4V27dpnE9bJ+v87QEydjqx/UamVVPRG+mwkNTYN+9tjkwzEx+atCm/X9WvWtDtAb68Wy9LXa1UmvCDDIpPkyOQ5ZwSzJ4jMrvFcr0rSjOUh+GcT4LSg5ugkW1Io0/SCDQBojh0hPlaJdah+tkVYrnTZowP8iq1F1TgMBBauufyB33x1v+NWFYmT5KmppgHC+NkAgbmRkpD3yn9QIseXymoTQFGQmIOKTxiZIWpvAatenVqRVXf2nTrAWMsPnKrMZHz6bJq5jvce6QK8J1cQNgKxlJapMPdZSR64/UivS9NztpkVEdKcrs5alhhWP9NeqlfWopzhZScI6QxseegZRGeg5a8C3Re1Mfl1ScP36ddcUaMuv24iOJtz7sbUjTS4qBvKmstYJoUauiuD3k5qhyr7QdUHMeCgLa1Ear9NquemdXgmum4fvJ6w1lqsuDhNrg1qSpleJK7K3TF0Q2jSd94uSZ60kK1e3qyVpQK6PVWXp2/FC3mp6jBhKKOiY2h3gtUV64TWM6wDETRPLDfSakXmH3w8g9Jlug8ZtTt4kVF0kLUYYmCCtD/DrQ5YhMGbA9L3ucdjh0y8kOHW5gU/VEEmJTcL4Pz/f7mgoAbYkAAAAAElFTkSuQmCC\"\n      ]\n    }\n  ]\n}'\n"
+            "source": "curl http://localhost:11434/api/chat -d '{\n  \"model\": \"gemma4\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is in this image?\",\n      \"images\": [\n        \"iVBORw0KGgoAAAANSUhEUgAAAG0AAABmCAYAAADBPx+VAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAA3VSURBVHgB7Z27r0zdG8fX743i1bi1ikMoFMQloXRpKFFIqI7LH4BEQ+NWIkjQuSWCRIEoULk0gsK1kCBI0IhrQVT7tz/7zZo888yz1r7MnDl7z5xvsjkzs2fP3uu71nNfa7lkAsm7d++Sffv2JbNmzUqcc8m0adOSzZs3Z+/XES4ZckAWJEGWPiCxjsQNLWmQsWjRIpMseaxcuTKpG/7HP27I8P79e7dq1ars/yL4/v27S0ejqwv+cUOGEGGpKHR37tzJCEpHV9tnT58+dXXCJDdECBE2Ojrqjh071hpNECjx4cMHVycM1Uhbv359B2F79+51586daxN/+pyRkRFXKyRDAqxEp4yMlDDzXG1NPnnyJKkThoK0VFd1ELZu3TrzXKxKfW7dMBQ6bcuWLW2v0VlHjx41z717927ba22U9APcw7Nnz1oGEPeL3m3p2mTAYYnFmMOMXybPPXv2bNIPpFZr1NHn4HMw0KRBjg9NuRw95s8PEcz/6DZELQd/09C9QGq5RsmSRybqkwHGjh07OsJSsYYm3ijPpyHzoiacg35MLdDSIS/O1yM778jOTwYUkKNHWUzUWaOsylE00MyI0fcnOwIdjvtNdW/HZwNLGg+sR1kMepSNJXmIwxBZiG8tDTpEZzKg0GItNsosY8USkxDhD0Rinuiko2gfL/RbiD2LZAjU9zKQJj8RDR0vJBR1/Phx9+PHj9Z7REF4nTZkxzX4LCXHrV271qXkBAPGfP/atWvu/PnzHe4C97F48eIsRLZ9+3a3f/9+87dwP1JxaF7/3r17ba+5l4EcaVo0lj3SBq5kGTJSQmLWMjgYNei2GPT1MuMqGTDEFHzeQSP2wi/jGnkmPJ/nhccs44jvDAxpVcxnq0F6eT8h4ni/iIWpR5lPyA6ETkNXoSukvpJAD3AsXLiwpZs49+fPn5ke4j10TqYvegSfn0OnafC+Tv9ooA/JPkgQysqQNBzagXY55nO/oa1F7qvIPWkRL12WRpMWUvpVDYmxAPehxWSe8ZEXL20sadYIozfmNch4QJPAfeJgW3rNsnzphBKNJM2KKODo1rVOMRYik5ETy3ix4qWNI81qAAirizgMIc+yhTytx0JWZuNI03qsrgWlGtwjoS9XwgUhWGyhUaRZZQNNIEwCiXD16tXcAHUs79co0vSD8rrJCIW98pzvxpAWyyo3HYwqS0+H0BjStClcZJT5coMm6D2LOF8TolGJtK9fvyZpyiC5ePFi9nc/oJU4eiEP0jVoAnHa9wyJycITMP78+eMeP37sXrx44d6+fdt6f82aNdkx1pg9e3Zb5W+RSRE+n+VjksQWifvVaTKFhn5O8my63K8Qabdv33b379/PiAP//vuvW7BggZszZ072/+TJk91YgkafPn166zXB1rQHFvouAWHq9z3SEevSUerqCn2/dDCeta2jxYbr69evk4MHDyY7d+7MjhMnTiTPnz9Pfv/+nfQT2ggpO2dMF8cghuoM7Ygj5iWCqRlGFml0QC/ftGmTmzt3rmsaKDsgBSPh0/8yPeLLBihLkOKJc0jp8H8vUzcxIA1k6QJ/c78tWEyj5P3o4u9+jywNPdJi5rAH9x0KHcl4Hg570eQp3+vHXGyrmEeigzQsQsjavXt38ujRo44LQuDDhw+TW7duRS1HGgMxhNXHgflaNTOsHyKvHK5Ijo2jbFjJBQK9YwFd6RVMzfgRBmEfP37suBBm/p49e1qjEP2mwTViNRo0VJWH1deMXcNK08uUjVUu7s/zRaL+oLNxz1bpANco4npUgX4G2eFbpDFyQoQxojBCpEGSytmOH8qrH5Q9vuzD6ofQylkCUmh8DBAr+q8JCyVNtWQIidKQE9wNtLSQnS4jDSsxNHogzFuQBw4cyM61UKVsjfr3ooBkPSqqQHesUPWVtzi9/vQi1T+rJj7WiTz4Pt/l3LxUkr5P2VYZaZ4URpsE+st/dujQoaBBYokbrz/8TJNQYLSonrPS9kUaSkPeZyj1AWSj+d+VBoy1pIWVNed8P0Ll/ee5HdGRhrHhR5GGN0r4LGZBaj8oFDJitBTJzIZgFcmU0Y8ytWMZMzJOaXUSrUs5RxKnrxmbb5YXO9VGUhtpXldhEUogFr3IzIsvlpmdosVcGVGXFWp2oU9kLFL3dEkSz6NHEY1sjSRdIuDFWEhd8KxFqsRi1uM/nz9/zpxnwlESONdg6dKlbsaMGS4EHFHtjFIDHwKOo46l4TxSuxgDzi+rE2jg+BaFruOX4HXa0Nnf1lwAPufZeF8/r6zD97WK2qFnGjBxTw5qNGPxT+5T/r7/7RawFC3j4vTp09koCxkeHjqbHJqArmH5UrFKKksnxrK7FuRIs8STfBZv+luugXZ2pR/pP9Ois4z+TiMzUUkUjD0iEi1fzX8GmXyuxUBRcaUfykV0YZnlJGKQpOiGB76x5GeWkWWJc3mOrK6S7xdND+W5N6XyaRgtWJFe13GkaZnKOsYqGdOVVVbGupsyA/l7emTLHi7vwTdirNEt0qxnzAvBFcnQF16xh/TMpUuXHDowhlA9vQVraQhkudRdzOnK+04ZSP3DUhVSP61YsaLtd/ks7ZgtPcXqPqEafHkdqa84X6aCeL7YWlv6edGFHb+ZFICPlljHhg0bKuk0CSvVznWsotRu433alNdFrqG45ejoaPCaUkWERpLXjzFL2Rpllp7PJU2a/v7Ab8N05/9t27Z16KUqoFGsxnI9EosS2niSYg9SpU6B4JgTrvVW1flt1sT+0ADIJU2maXzcUTraGCRaL1Wp9rUMk16PMom8QhruxzvZIegJjFU7LLCePfS8uaQdPny4jTTL0dbee5mYokQsXTIWNY46kuMbnt8Kmec+LGWtOVIl9cT1rCB0V8WqkjAsRwta93TbwNYoGKsUSChN44lgBNCoHLHzquYKrU6qZ8lolCIN0Rh6cP0Q3U6I6IXILYOQI513hJaSKAorFpuHXJNfVlpRtmYBk1Su1obZr5dnKAO+L10Hrj3WZW+E3qh6IszE37F6EB+68mGpvKm4eb9bFrlzrok7fvr0Kfv727dvWRmdVTJHw0qiiCUSZ6wCK+7XL/AcsgNyL74DQQ730sv78Su7+t/A36MdY0sW5o40ahslXr58aZ5HtZB8GH64m9EmMZ7FpYw4T6QnrZfgenrhFxaSiSGXtPnz57e9TkNZLvTjeqhr734CNtrK41L40sUQckmj1lGKQ0rC37x544r8eNXRpnVE3ZZY7zXo8NomiO0ZUCj2uHz58rbXoZ6gc0uA+F6ZeKS/jhRDUq8MKrTho9fEkihMmhxtBI1DxKFY9XLpVcSkfoi8JGnToZO5sU5aiDQIW716ddt7ZLYtMQlhECdBGXZZMWldY5BHm5xgAroWj4C0hbYkSc/jBmggIrXJWlZM6pSETsEPGqZOndr2uuuR5rF169a2HoHPdurUKZM4CO1WTPqaDaAd+GFGKdIQkxAn9RuEWcTRyN2KSUgiSgF5aWzPTeA/lN5rZubMmR2bE4SIC4nJoltgAV/dVefZm72AtctUCJU2CMJ327hxY9t7EHbkyJFseq+EJSY16RPo3Dkq1kkr7+q0bNmyDuLQcZBEPYmHVdOBiJyIlrRDq41YPWfXOxUysi5fvtyaj+2BpcnsUV/oSoEMOk2CQGlr4ckhBwaetBhjCwH0ZHtJROPJkyc7UjcYLDjmrH7ADTEBXFfOYmB0k9oYBOjJ8b4aOYSe7QkKcYhFlq3QYLQhSidNmtS2RATwy8YOM3EQJsUjKiaWZ+vZToUQgzhkHXudb/PW5YMHD9yZM2faPsMwoc7RciYJXbGuBqJ1UIGKKLv915jsvgtJxCZDubdXr165mzdvtr1Hz5LONA8jrUwKPqsmVesKa49S3Q4WxmRPUEYdTjgiUcfUwLx589ySJUva3oMkP6IYddq6HMS4o55xBJBUeRjzfa4Zdeg56QZ43LhxoyPo7Lf1kNt7oO8wWAbNwaYjIv5lhyS7kRf96dvm5Jah8vfvX3flyhX35cuX6HfzFHOToS1H4BenCaHvO8pr8iDuwoUL7tevX+b5ZdbBair0xkFIlFDlW4ZknEClsp/TzXyAKVOmmHWFVSbDNw1l1+4f90U6IY/q4V27dpnE9bJ+v87QEydjqx/UamVVPRG+mwkNTYN+9tjkwzEx+atCm/X9WvWtDtAb68Wy9LXa1UmvCDDIpPkyOQ5ZwSzJ4jMrvFcr0rSjOUh+GcT4LSg5ugkW1Io0/SCDQBojh0hPlaJdah+tkVYrnTZowP8iq1F1TgMBBauufyB33x1v+NWFYmT5KmppgHC+NkAgbmRkpD3yn9QIseXymoTQFGQmIOKTxiZIWpvAatenVqRVXf2nTrAWMsPnKrMZHz6bJq5jvce6QK8J1cQNgKxlJapMPdZSR64/UivS9NztpkVEdKcrs5alhhWP9NeqlfWopzhZScI6QxseegZRGeg5a8C3Re1Mfl1ScP36ddcUaMuv24iOJtz7sbUjTS4qBvKmstYJoUauiuD3k5qhyr7QdUHMeCgLa1Ear9NquemdXgmum4fvJ6w1lqsuDhNrg1qSpleJK7K3TF0Q2jSd94uSZ60kK1e3qyVpQK6PVWXp2/FC3mp6jBhKKOiY2h3gtUV64TWM6wDETRPLDfSakXmH3w8g9Jlug8ZtTt4kVF0kLUYYmCCtD/DrQ5YhMGbA9L3ucdjh0y8kOHW5gU/VEEmJTcL4Pz/f7mgoAbYkAAAAAElFTkSuQmCC\"\n      ]\n    }\n  ]\n}'\n"
           }
         ],
         "x-mint": {
@@ -1255,8 +1257,8 @@
           "content": {
             "application/json": {
               "example": {
-                "destination": "gemma3-backup",
-                "source": "gemma3"
+                "destination": "gemma4-backup",
+                "source": "gemma4"
               },
               "schema": {
                 "$ref": "#/components/schemas/CopyRequest"
@@ -1275,7 +1277,7 @@
           {
             "label": "Copy a model to a new name",
             "lang": "bash",
-            "source": "curl http://localhost:11434/api/copy -d '{\n  \"source\": \"gemma3\",\n  \"destination\": \"gemma3-backup\"\n}'\n"
+            "source": "curl http://localhost:11434/api/copy -d '{\n  \"source\": \"gemma4\",\n  \"destination\": \"gemma4-backup\"\n}'\n"
           }
         ],
         "x-mint": {
@@ -1290,7 +1292,7 @@
           "content": {
             "application/json": {
               "example": {
-                "from": "gemma3",
+                "from": "gemma4",
                 "model": "mario",
                 "system": "You are Mario from Super Mario Bros."
               },
@@ -1329,12 +1331,12 @@
           {
             "label": "Default",
             "lang": "bash",
-            "source": "curl http://localhost:11434/api/create -d '{\n  \"from\": \"gemma3\",\n  \"model\": \"alpaca\",\n  \"system\": \"You are Alpaca, a helpful AI assistant. You only answer with Emojis.\"\n}'\n"
+            "source": "curl http://localhost:11434/api/create -d '{\n  \"from\": \"gemma4\",\n  \"model\": \"alpaca\",\n  \"system\": \"You are Alpaca, a helpful AI assistant. You only answer with Emojis.\"\n}'\n"
           },
           {
             "label": "Create from existing",
             "lang": "bash",
-            "source": "curl http://localhost:11434/api/create -d '{\n  \"model\": \"ollama\",\n  \"from\": \"gemma3\",\n  \"system\": \"You are Ollama the llama.\"\n}'\n"
+            "source": "curl http://localhost:11434/api/create -d '{\n  \"model\": \"ollama\",\n  \"from\": \"gemma4\",\n  \"system\": \"You are Ollama the llama.\"\n}'\n"
           },
           {
             "label": "Quantize",
@@ -1354,7 +1356,7 @@
           "content": {
             "application/json": {
               "example": {
-                "model": "gemma3"
+                "model": "gemma4"
               },
               "schema": {
                 "$ref": "#/components/schemas/DeleteRequest"
@@ -1373,7 +1375,7 @@
           {
             "label": "Delete model",
             "lang": "bash",
-            "source": "curl -X DELETE http://localhost:11434/api/delete -d '{\n  \"model\": \"gemma3\"\n}'\n"
+            "source": "curl -X DELETE http://localhost:11434/api/delete -d '{\n  \"model\": \"gemma4\"\n}'\n"
           }
         ],
         "x-mint": {
@@ -1467,7 +1469,7 @@
           "content": {
             "application/json": {
               "example": {
-                "model": "gemma3",
+                "model": "gemma4",
                 "prompt": "Why is the sky blue?"
               },
               "schema": {
@@ -1488,7 +1490,7 @@
                   "eval_count": 18,
                   "eval_duration": 52479709,
                   "load_duration": 101397084,
-                  "model": "gemma3",
+                  "model": "gemma4",
                   "prompt_eval_count": 11,
                   "prompt_eval_duration": 13074791,
                   "response": "Hello! How can I help you today?",
@@ -1512,37 +1514,37 @@
           {
             "label": "Default",
             "lang": "bash",
-            "source": "curl http://localhost:11434/api/generate -d '{\n  \"model\": \"gemma3\",\n  \"prompt\": \"Why is the sky blue?\"\n}'\n"
+            "source": "curl http://localhost:11434/api/generate -d '{\n  \"model\": \"gemma4\",\n  \"prompt\": \"Why is the sky blue?\"\n}'\n"
           },
           {
             "label": "Non-streaming",
             "lang": "bash",
-            "source": "curl http://localhost:11434/api/generate -d '{\n  \"model\": \"gemma3\",\n  \"prompt\": \"Why is the sky blue?\",\n  \"stream\": false\n}'\n"
+            "source": "curl http://localhost:11434/api/generate -d '{\n  \"model\": \"gemma4\",\n  \"prompt\": \"Why is the sky blue?\",\n  \"stream\": false\n}'\n"
           },
           {
             "label": "With options",
             "lang": "bash",
-            "source": "curl http://localhost:11434/api/generate -d '{\n  \"model\": \"gemma3\",\n  \"prompt\": \"Why is the sky blue?\",\n  \"options\": {\n    \"temperature\": 0.8,\n    \"top_p\": 0.9,\n    \"seed\": 42\n  }\n}'\n"
+            "source": "curl http://localhost:11434/api/generate -d '{\n  \"model\": \"gemma4\",\n  \"prompt\": \"Why is the sky blue?\",\n  \"options\": {\n    \"temperature\": 0.8,\n    \"top_p\": 0.9,\n    \"seed\": 42\n  }\n}'\n"
           },
           {
             "label": "Structured outputs",
             "lang": "bash",
-            "source": "curl http://localhost:11434/api/generate -d '{\n  \"model\": \"gemma3\",\n  \"prompt\": \"What are the populations of the United States and Canada?\",\n  \"stream\": false,\n  \"format\": {\n    \"type\": \"object\",\n    \"properties\": {\n      \"countries\": {\n        \"type\": \"array\",\n        \"items\": {\n          \"type\": \"object\",\n          \"properties\": {\n            \"country\": {\"type\": \"string\"},\n            \"population\": {\"type\": \"integer\"}\n          },\n          \"required\": [\"country\", \"population\"]\n        }\n      }\n    },\n    \"required\": [\"countries\"]\n  }\n}'\n"
+            "source": "curl http://localhost:11434/api/generate -d '{\n  \"model\": \"gemma4\",\n  \"prompt\": \"What are the populations of the United States and Canada?\",\n  \"stream\": false,\n  \"format\": {\n    \"type\": \"object\",\n    \"properties\": {\n      \"countries\": {\n        \"type\": \"array\",\n        \"items\": {\n          \"type\": \"object\",\n          \"properties\": {\n            \"country\": {\"type\": \"string\"},\n            \"population\": {\"type\": \"integer\"}\n          },\n          \"required\": [\"country\", \"population\"]\n        }\n      }\n    },\n    \"required\": [\"countries\"]\n  }\n}'\n"
           },
           {
             "label": "With images",
             "lang": "bash",
-            "source": "curl http://localhost:11434/api/generate -d '{\n  \"model\": \"gemma3\",\n  \"prompt\": \"What is in this picture?\",\n  \"images\": [\"iVBORw0KGgoAAAANSUhEUgAAAG0AAABmCAYAAADBPx+VAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAA3VSURBVHgB7Z27r0zdG8fX743i1bi1ikMoFMQloXRpKFFIqI7LH4BEQ+NWIkjQuSWCRIEoULk0gsK1kCBI0IhrQVT7tz/7zZo888yz1r7MnDl7z5xvsjkzs2fP3uu71nNfa7lkAsm7d++Sffv2JbNmzUqcc8m0adOSzZs3Z+/XES4ZckAWJEGWPiCxjsQNLWmQsWjRIpMseaxcuTKpG/7HP27I8P79e7dq1ars/yL4/v27S0ejqwv+cUOGEGGpKHR37tzJCEpHV9tnT58+dXXCJDdECBE2Ojrqjh071hpNECjx4cMHVycM1Uhbv359B2F79+51586daxN/+pyRkRFXKyRDAqxEp4yMlDDzXG1NPnnyJKkThoK0VFd1ELZu3TrzXKxKfW7dMBQ6bcuWLW2v0VlHjx41z717927ba22U9APcw7Nnz1oGEPeL3m3p2mTAYYnFmMOMXybPPXv2bNIPpFZr1NHn4HMw0KRBjg9NuRw95s8PEcz/6DZELQd/09C9QGq5RsmSRybqkwHGjh07OsJSsYYm3ijPpyHzoiacg35MLdDSIS/O1yM778jOTwYUkKNHWUzUWaOsylE00MyI0fcnOwIdjvtNdW/HZwNLGg+sR1kMepSNJXmIwxBZiG8tDTpEZzKg0GItNsosY8USkxDhD0Rinuiko2gfL/RbiD2LZAjU9zKQJj8RDR0vJBR1/Phx9+PHj9Z7REF4nTZkxzX4LCXHrV271qXkBAPGfP/atWvu/PnzHe4C97F48eIsRLZ9+3a3f/9+87dwP1JxaF7/3r17ba+5l4EcaVo0lj3SBq5kGTJSQmLWMjgYNei2GPT1MuMqGTDEFHzeQSP2wi/jGnkmPJ/nhccs44jvDAxpVcxnq0F6eT8h4ni/iIWpR5lPyA6ETkNXoSukvpJAD3AsXLiwpZs49+fPn5ke4j10TqYvegSfn0OnafC+Tv9ooA/JPkgQysqQNBzagXY55nO/oa1F7qvIPWkRL12WRpMWUvpVDYmxAPehxWSe8ZEXL20sadYIozfmNch4QJPAfeJgW3rNsnzphBKNJM2KKODo1rVOMRYik5ETy3ix4qWNI81qAAirizgMIc+yhTytx0JWZuNI03qsrgWlGtwjoS9XwgUhWGyhUaRZZQNNIEwCiXD16tXcAHUs79co0vSD8rrJCIW98pzvxpAWyyo3HYwqS0+H0BjStClcZJT5coMm6D2LOF8TolGJtK9fvyZpyiC5ePFi9nc/oJU4eiEP0jVoAnHa9wyJycITMP78+eMeP37sXrx44d6+fdt6f82aNdkx1pg9e3Zb5W+RSRE+n+VjksQWifvVaTKFhn5O8my63K8Qabdv33b379/PiAP//vuvW7BggZszZ072/+TJk91YgkafPn166zXB1rQHFvouAWHq9z3SEevSUerqCn2/dDCeta2jxYbr69evk4MHDyY7d+7MjhMnTiTPnz9Pfv/+nfQT2ggpO2dMF8cghuoM7Ygj5iWCqRlGFml0QC/ftGmTmzt3rmsaKDsgBSPh0/8yPeLLBihLkOKJc0jp8H8vUzcxIA1k6QJ/c78tWEyj5P3o4u9+jywNPdJi5rAH9x0KHcl4Hg570eQp3+vHXGyrmEeigzQsQsjavXt38ujRo44LQuDDhw+TW7duRS1HGgMxhNXHgflaNTOsHyKvHK5Ijo2jbFjJBQK9YwFd6RVMzfgRBmEfP37suBBm/p49e1qjEP2mwTViNRo0VJWH1deMXcNK08uUjVUu7s/zRaL+oLNxz1bpANco4npUgX4G2eFbpDFyQoQxojBCpEGSytmOH8qrH5Q9vuzD6ofQylkCUmh8DBAr+q8JCyVNtWQIidKQE9wNtLSQnS4jDSsxNHogzFuQBw4cyM61UKVsjfr3ooBkPSqqQHesUPWVtzi9/vQi1T+rJj7WiTz4Pt/l3LxUkr5P2VYZaZ4URpsE+st/dujQoaBBYokbrz/8TJNQYLSonrPS9kUaSkPeZyj1AWSj+d+VBoy1pIWVNed8P0Ll/ee5HdGRhrHhR5GGN0r4LGZBaj8oFDJitBTJzIZgFcmU0Y8ytWMZMzJOaXUSrUs5RxKnrxmbb5YXO9VGUhtpXldhEUogFr3IzIsvlpmdosVcGVGXFWp2oU9kLFL3dEkSz6NHEY1sjSRdIuDFWEhd8KxFqsRi1uM/nz9/zpxnwlESONdg6dKlbsaMGS4EHFHtjFIDHwKOo46l4TxSuxgDzi+rE2jg+BaFruOX4HXa0Nnf1lwAPufZeF8/r6zD97WK2qFnGjBxTw5qNGPxT+5T/r7/7RawFC3j4vTp09koCxkeHjqbHJqArmH5UrFKKksnxrK7FuRIs8STfBZv+luugXZ2pR/pP9Ois4z+TiMzUUkUjD0iEi1fzX8GmXyuxUBRcaUfykV0YZnlJGKQpOiGB76x5GeWkWWJc3mOrK6S7xdND+W5N6XyaRgtWJFe13GkaZnKOsYqGdOVVVbGupsyA/l7emTLHi7vwTdirNEt0qxnzAvBFcnQF16xh/TMpUuXHDowhlA9vQVraQhkudRdzOnK+04ZSP3DUhVSP61YsaLtd/ks7ZgtPcXqPqEafHkdqa84X6aCeL7YWlv6edGFHb+ZFICPlljHhg0bKuk0CSvVznWsotRu433alNdFrqG45ejoaPCaUkWERpLXjzFL2Rpllp7PJU2a/v7Ab8N05/9t27Z16KUqoFGsxnI9EosS2niSYg9SpU6B4JgTrvVW1flt1sT+0ADIJU2maXzcUTraGCRaL1Wp9rUMk16PMom8QhruxzvZIegJjFU7LLCePfS8uaQdPny4jTTL0dbee5mYokQsXTIWNY46kuMbnt8Kmec+LGWtOVIl9cT1rCB0V8WqkjAsRwta93TbwNYoGKsUSChN44lgBNCoHLHzquYKrU6qZ8lolCIN0Rh6cP0Q3U6I6IXILYOQI513hJaSKAorFpuHXJNfVlpRtmYBk1Su1obZr5dnKAO+L10Hrj3WZW+E3qh6IszE37F6EB+68mGpvKm4eb9bFrlzrok7fvr0Kfv727dvWRmdVTJHw0qiiCUSZ6wCK+7XL/AcsgNyL74DQQ730sv78Su7+t/A36MdY0sW5o40ahslXr58aZ5HtZB8GH64m9EmMZ7FpYw4T6QnrZfgenrhFxaSiSGXtPnz57e9TkNZLvTjeqhr734CNtrK41L40sUQckmj1lGKQ0rC37x544r8eNXRpnVE3ZZY7zXo8NomiO0ZUCj2uHz58rbXoZ6gc0uA+F6ZeKS/jhRDUq8MKrTho9fEkihMmhxtBI1DxKFY9XLpVcSkfoi8JGnToZO5sU5aiDQIW716ddt7ZLYtMQlhECdBGXZZMWldY5BHm5xgAroWj4C0hbYkSc/jBmggIrXJWlZM6pSETsEPGqZOndr2uuuR5rF169a2HoHPdurUKZM4CO1WTPqaDaAd+GFGKdIQkxAn9RuEWcTRyN2KSUgiSgF5aWzPTeA/lN5rZubMmR2bE4SIC4nJoltgAV/dVefZm72AtctUCJU2CMJ327hxY9t7EHbkyJFseq+EJSY16RPo3Dkq1kkr7+q0bNmyDuLQcZBEPYmHVdOBiJyIlrRDq41YPWfXOxUysi5fvtyaj+2BpcnsUV/oSoEMOk2CQGlr4ckhBwaetBhjCwH0ZHtJROPJkyc7UjcYLDjmrH7ADTEBXFfOYmB0k9oYBOjJ8b4aOYSe7QkKcYhFlq3QYLQhSidNmtS2RATwy8YOM3EQJsUjKiaWZ+vZToUQgzhkHXudb/PW5YMHD9yZM2faPsMwoc7RciYJXbGuBqJ1UIGKKLv915jsvgtJxCZDubdXr165mzdvtr1Hz5LONA8jrUwKPqsmVesKa49S3Q4WxmRPUEYdTjgiUcfUwLx589ySJUva3oMkP6IYddq6HMS4o55xBJBUeRjzfa4Zdeg56QZ43LhxoyPo7Lf1kNt7oO8wWAbNwaYjIv5lhyS7kRf96dvm5Jah8vfvX3flyhX35cuX6HfzFHOToS1H4BenCaHvO8pr8iDuwoUL7tevX+b5ZdbBair0xkFIlFDlW4ZknEClsp/TzXyAKVOmmHWFVSbDNw1l1+4f90U6IY/q4V27dpnE9bJ+v87QEydjqx/UamVVPRG+mwkNTYN+9tjkwzEx+atCm/X9WvWtDtAb68Wy9LXa1UmvCDDIpPkyOQ5ZwSzJ4jMrvFcr0rSjOUh+GcT4LSg5ugkW1Io0/SCDQBojh0hPlaJdah+tkVYrnTZowP8iq1F1TgMBBauufyB33x1v+NWFYmT5KmppgHC+NkAgbmRkpD3yn9QIseXymoTQFGQmIOKTxiZIWpvAatenVqRVXf2nTrAWMsPnKrMZHz6bJq5jvce6QK8J1cQNgKxlJapMPdZSR64/UivS9NztpkVEdKcrs5alhhWP9NeqlfWopzhZScI6QxseegZRGeg5a8C3Re1Mfl1ScP36ddcUaMuv24iOJtz7sbUjTS4qBvKmstYJoUauiuD3k5qhyr7QdUHMeCgLa1Ear9NquemdXgmum4fvJ6w1lqsuDhNrg1qSpleJK7K3TF0Q2jSd94uSZ60kK1e3qyVpQK6PVWXp2/FC3mp6jBhKKOiY2h3gtUV64TWM6wDETRPLDfSakXmH3w8g9Jlug8ZtTt4kVF0kLUYYmCCtD/DrQ5YhMGbA9L3ucdjh0y8kOHW5gU/VEEmJTcL4Pz/f7mgoAbYkAAAAAElFTkSuQmCC\"]\n}'\n"
+            "source": "curl http://localhost:11434/api/generate -d '{\n  \"model\": \"gemma4\",\n  \"prompt\": \"What is in this picture?\",\n  \"images\": [\"iVBORw0KGgoAAAANSUhEUgAAAG0AAABmCAYAAADBPx+VAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAA3VSURBVHgB7Z27r0zdG8fX743i1bi1ikMoFMQloXRpKFFIqI7LH4BEQ+NWIkjQuSWCRIEoULk0gsK1kCBI0IhrQVT7tz/7zZo888yz1r7MnDl7z5xvsjkzs2fP3uu71nNfa7lkAsm7d++Sffv2JbNmzUqcc8m0adOSzZs3Z+/XES4ZckAWJEGWPiCxjsQNLWmQsWjRIpMseaxcuTKpG/7HP27I8P79e7dq1ars/yL4/v27S0ejqwv+cUOGEGGpKHR37tzJCEpHV9tnT58+dXXCJDdECBE2Ojrqjh071hpNECjx4cMHVycM1Uhbv359B2F79+51586daxN/+pyRkRFXKyRDAqxEp4yMlDDzXG1NPnnyJKkThoK0VFd1ELZu3TrzXKxKfW7dMBQ6bcuWLW2v0VlHjx41z717927ba22U9APcw7Nnz1oGEPeL3m3p2mTAYYnFmMOMXybPPXv2bNIPpFZr1NHn4HMw0KRBjg9NuRw95s8PEcz/6DZELQd/09C9QGq5RsmSRybqkwHGjh07OsJSsYYm3ijPpyHzoiacg35MLdDSIS/O1yM778jOTwYUkKNHWUzUWaOsylE00MyI0fcnOwIdjvtNdW/HZwNLGg+sR1kMepSNJXmIwxBZiG8tDTpEZzKg0GItNsosY8USkxDhD0Rinuiko2gfL/RbiD2LZAjU9zKQJj8RDR0vJBR1/Phx9+PHj9Z7REF4nTZkxzX4LCXHrV271qXkBAPGfP/atWvu/PnzHe4C97F48eIsRLZ9+3a3f/9+87dwP1JxaF7/3r17ba+5l4EcaVo0lj3SBq5kGTJSQmLWMjgYNei2GPT1MuMqGTDEFHzeQSP2wi/jGnkmPJ/nhccs44jvDAxpVcxnq0F6eT8h4ni/iIWpR5lPyA6ETkNXoSukvpJAD3AsXLiwpZs49+fPn5ke4j10TqYvegSfn0OnafC+Tv9ooA/JPkgQysqQNBzagXY55nO/oa1F7qvIPWkRL12WRpMWUvpVDYmxAPehxWSe8ZEXL20sadYIozfmNch4QJPAfeJgW3rNsnzphBKNJM2KKODo1rVOMRYik5ETy3ix4qWNI81qAAirizgMIc+yhTytx0JWZuNI03qsrgWlGtwjoS9XwgUhWGyhUaRZZQNNIEwCiXD16tXcAHUs79co0vSD8rrJCIW98pzvxpAWyyo3HYwqS0+H0BjStClcZJT5coMm6D2LOF8TolGJtK9fvyZpyiC5ePFi9nc/oJU4eiEP0jVoAnHa9wyJycITMP78+eMeP37sXrx44d6+fdt6f82aNdkx1pg9e3Zb5W+RSRE+n+VjksQWifvVaTKFhn5O8my63K8Qabdv33b379/PiAP//vuvW7BggZszZ072/+TJk91YgkafPn166zXB1rQHFvouAWHq9z3SEevSUerqCn2/dDCeta2jxYbr69evk4MHDyY7d+7MjhMnTiTPnz9Pfv/+nfQT2ggpO2dMF8cghuoM7Ygj5iWCqRlGFml0QC/ftGmTmzt3rmsaKDsgBSPh0/8yPeLLBihLkOKJc0jp8H8vUzcxIA1k6QJ/c78tWEyj5P3o4u9+jywNPdJi5rAH9x0KHcl4Hg570eQp3+vHXGyrmEeigzQsQsjavXt38ujRo44LQuDDhw+TW7duRS1HGgMxhNXHgflaNTOsHyKvHK5Ijo2jbFjJBQK9YwFd6RVMzfgRBmEfP37suBBm/p49e1qjEP2mwTViNRo0VJWH1deMXcNK08uUjVUu7s/zRaL+oLNxz1bpANco4npUgX4G2eFbpDFyQoQxojBCpEGSytmOH8qrH5Q9vuzD6ofQylkCUmh8DBAr+q8JCyVNtWQIidKQE9wNtLSQnS4jDSsxNHogzFuQBw4cyM61UKVsjfr3ooBkPSqqQHesUPWVtzi9/vQi1T+rJj7WiTz4Pt/l3LxUkr5P2VYZaZ4URpsE+st/dujQoaBBYokbrz/8TJNQYLSonrPS9kUaSkPeZyj1AWSj+d+VBoy1pIWVNed8P0Ll/ee5HdGRhrHhR5GGN0r4LGZBaj8oFDJitBTJzIZgFcmU0Y8ytWMZMzJOaXUSrUs5RxKnrxmbb5YXO9VGUhtpXldhEUogFr3IzIsvlpmdosVcGVGXFWp2oU9kLFL3dEkSz6NHEY1sjSRdIuDFWEhd8KxFqsRi1uM/nz9/zpxnwlESONdg6dKlbsaMGS4EHFHtjFIDHwKOo46l4TxSuxgDzi+rE2jg+BaFruOX4HXa0Nnf1lwAPufZeF8/r6zD97WK2qFnGjBxTw5qNGPxT+5T/r7/7RawFC3j4vTp09koCxkeHjqbHJqArmH5UrFKKksnxrK7FuRIs8STfBZv+luugXZ2pR/pP9Ois4z+TiMzUUkUjD0iEi1fzX8GmXyuxUBRcaUfykV0YZnlJGKQpOiGB76x5GeWkWWJc3mOrK6S7xdND+W5N6XyaRgtWJFe13GkaZnKOsYqGdOVVVbGupsyA/l7emTLHi7vwTdirNEt0qxnzAvBFcnQF16xh/TMpUuXHDowhlA9vQVraQhkudRdzOnK+04ZSP3DUhVSP61YsaLtd/ks7ZgtPcXqPqEafHkdqa84X6aCeL7YWlv6edGFHb+ZFICPlljHhg0bKuk0CSvVznWsotRu433alNdFrqG45ejoaPCaUkWERpLXjzFL2Rpllp7PJU2a/v7Ab8N05/9t27Z16KUqoFGsxnI9EosS2niSYg9SpU6B4JgTrvVW1flt1sT+0ADIJU2maXzcUTraGCRaL1Wp9rUMk16PMom8QhruxzvZIegJjFU7LLCePfS8uaQdPny4jTTL0dbee5mYokQsXTIWNY46kuMbnt8Kmec+LGWtOVIl9cT1rCB0V8WqkjAsRwta93TbwNYoGKsUSChN44lgBNCoHLHzquYKrU6qZ8lolCIN0Rh6cP0Q3U6I6IXILYOQI513hJaSKAorFpuHXJNfVlpRtmYBk1Su1obZr5dnKAO+L10Hrj3WZW+E3qh6IszE37F6EB+68mGpvKm4eb9bFrlzrok7fvr0Kfv727dvWRmdVTJHw0qiiCUSZ6wCK+7XL/AcsgNyL74DQQ730sv78Su7+t/A36MdY0sW5o40ahslXr58aZ5HtZB8GH64m9EmMZ7FpYw4T6QnrZfgenrhFxaSiSGXtPnz57e9TkNZLvTjeqhr734CNtrK41L40sUQckmj1lGKQ0rC37x544r8eNXRpnVE3ZZY7zXo8NomiO0ZUCj2uHz58rbXoZ6gc0uA+F6ZeKS/jhRDUq8MKrTho9fEkihMmhxtBI1DxKFY9XLpVcSkfoi8JGnToZO5sU5aiDQIW716ddt7ZLYtMQlhECdBGXZZMWldY5BHm5xgAroWj4C0hbYkSc/jBmggIrXJWlZM6pSETsEPGqZOndr2uuuR5rF169a2HoHPdurUKZM4CO1WTPqaDaAd+GFGKdIQkxAn9RuEWcTRyN2KSUgiSgF5aWzPTeA/lN5rZubMmR2bE4SIC4nJoltgAV/dVefZm72AtctUCJU2CMJ327hxY9t7EHbkyJFseq+EJSY16RPo3Dkq1kkr7+q0bNmyDuLQcZBEPYmHVdOBiJyIlrRDq41YPWfXOxUysi5fvtyaj+2BpcnsUV/oSoEMOk2CQGlr4ckhBwaetBhjCwH0ZHtJROPJkyc7UjcYLDjmrH7ADTEBXFfOYmB0k9oYBOjJ8b4aOYSe7QkKcYhFlq3QYLQhSidNmtS2RATwy8YOM3EQJsUjKiaWZ+vZToUQgzhkHXudb/PW5YMHD9yZM2faPsMwoc7RciYJXbGuBqJ1UIGKKLv915jsvgtJxCZDubdXr165mzdvtr1Hz5LONA8jrUwKPqsmVesKa49S3Q4WxmRPUEYdTjgiUcfUwLx589ySJUva3oMkP6IYddq6HMS4o55xBJBUeRjzfa4Zdeg56QZ43LhxoyPo7Lf1kNt7oO8wWAbNwaYjIv5lhyS7kRf96dvm5Jah8vfvX3flyhX35cuX6HfzFHOToS1H4BenCaHvO8pr8iDuwoUL7tevX+b5ZdbBair0xkFIlFDlW4ZknEClsp/TzXyAKVOmmHWFVSbDNw1l1+4f90U6IY/q4V27dpnE9bJ+v87QEydjqx/UamVVPRG+mwkNTYN+9tjkwzEx+atCm/X9WvWtDtAb68Wy9LXa1UmvCDDIpPkyOQ5ZwSzJ4jMrvFcr0rSjOUh+GcT4LSg5ugkW1Io0/SCDQBojh0hPlaJdah+tkVYrnTZowP8iq1F1TgMBBauufyB33x1v+NWFYmT5KmppgHC+NkAgbmRkpD3yn9QIseXymoTQFGQmIOKTxiZIWpvAatenVqRVXf2nTrAWMsPnKrMZHz6bJq5jvce6QK8J1cQNgKxlJapMPdZSR64/UivS9NztpkVEdKcrs5alhhWP9NeqlfWopzhZScI6QxseegZRGeg5a8C3Re1Mfl1ScP36ddcUaMuv24iOJtz7sbUjTS4qBvKmstYJoUauiuD3k5qhyr7QdUHMeCgLa1Ear9NquemdXgmum4fvJ6w1lqsuDhNrg1qSpleJK7K3TF0Q2jSd94uSZ60kK1e3qyVpQK6PVWXp2/FC3mp6jBhKKOiY2h3gtUV64TWM6wDETRPLDfSakXmH3w8g9Jlug8ZtTt4kVF0kLUYYmCCtD/DrQ5YhMGbA9L3ucdjh0y8kOHW5gU/VEEmJTcL4Pz/f7mgoAbYkAAAAAElFTkSuQmCC\"]\n}'\n"
           },
           {
             "label": "Load model",
             "lang": "bash",
-            "source": "curl http://localhost:11434/api/generate -d '{\n  \"model\": \"gemma3\"\n}'\n"
+            "source": "curl http://localhost:11434/api/generate -d '{\n  \"model\": \"gemma4\"\n}'\n"
           },
           {
             "label": "Unload model",
             "lang": "bash",
-            "source": "curl http://localhost:11434/api/generate -d '{\n  \"model\": \"gemma3\",\n  \"keep_alive\": 0\n}'\n"
+            "source": "curl http://localhost:11434/api/generate -d '{\n  \"model\": \"gemma4\",\n  \"keep_alive\": 0\n}'\n"
           }
         ],
         "x-mint": {
@@ -1564,18 +1566,18 @@
                       "context_length": 4096,
                       "details": {
                         "families": [
-                          "gemma3"
+                          "gemma4"
                         ],
-                        "family": "gemma3",
+                        "family": "gemma4",
                         "format": "gguf",
-                        "parameter_size": "4.3B",
+                        "parameter_size": "8.0B",
                         "parent_model": "",
                         "quantization_level": "Q4_K_M"
                       },
-                      "digest": "a2af6cc3eb7fa8be8504abaf9b04e88f17a119ec3f04a3addf55f92841195f5a",
+                      "digest": "c6eb396dbd5992bbe3f5cdb947e8bbc0ee413d7c17e2beaae69f5d569cf982eb",
                       "expires_at": "2025-10-17T16:47:07.93355-07:00",
-                      "model": "gemma3",
-                      "name": "gemma3",
+                      "model": "gemma4",
+                      "name": "gemma4",
                       "size": 6591830464,
                       "size_vram": 5333539264
                     }
@@ -1609,7 +1611,7 @@
           "content": {
             "application/json": {
               "example": {
-                "model": "gemma3"
+                "model": "gemma4"
               },
               "schema": {
                 "$ref": "#/components/schemas/PullRequest"
@@ -1646,12 +1648,12 @@
           {
             "label": "Default",
             "lang": "bash",
-            "source": "curl http://localhost:11434/api/pull -d '{\n  \"model\": \"gemma3\"\n}'\n"
+            "source": "curl http://localhost:11434/api/pull -d '{\n  \"model\": \"gemma4\"\n}'\n"
           },
           {
             "label": "Non-streaming",
             "lang": "bash",
-            "source": "curl http://localhost:11434/api/pull -d '{\n  \"model\": \"gemma3\",\n  \"stream\": false\n}'\n"
+            "source": "curl http://localhost:11434/api/pull -d '{\n  \"model\": \"gemma4\",\n  \"stream\": false\n}'\n"
           }
         ],
         "x-mint": {
@@ -1723,7 +1725,7 @@
           "content": {
             "application/json": {
               "example": {
-                "model": "gemma3"
+                "model": "gemma4"
               },
               "schema": {
                 "$ref": "#/components/schemas/ShowRequest"
@@ -1743,48 +1745,69 @@
                   ],
                   "details": {
                     "families": [
-                      "gemma3"
+                      "gemma4"
                     ],
-                    "family": "gemma3",
+                    "family": "gemma4",
                     "format": "gguf",
-                    "parameter_size": "4.3B",
+                    "parameter_size": "8.0B",
                     "parent_model": "",
                     "quantization_level": "Q4_K_M"
                   },
                   "license": "Gemma Terms of Use \n\nLast modified: February 21, 2024...",
                   "model_info": {
-                    "gemma3.attention.head_count": 8,
-                    "gemma3.attention.head_count_kv": 4,
-                    "gemma3.attention.key_length": 256,
-                    "gemma3.attention.sliding_window": 1024,
-                    "gemma3.attention.value_length": 256,
-                    "gemma3.block_count": 34,
-                    "gemma3.context_length": 131072,
-                    "gemma3.embedding_length": 2560,
-                    "gemma3.feed_forward_length": 10240,
-                    "gemma3.mm.tokens_per_image": 256,
-                    "gemma3.vision.attention.head_count": 16,
-                    "gemma3.vision.attention.layer_norm_epsilon": 1e-06,
-                    "gemma3.vision.block_count": 27,
-                    "gemma3.vision.embedding_length": 1152,
-                    "gemma3.vision.feed_forward_length": 4304,
-                    "gemma3.vision.image_size": 896,
-                    "gemma3.vision.num_channels": 3,
-                    "gemma3.vision.patch_size": 14,
-                    "general.architecture": "gemma3",
+                    "gemma4.attention.head_count": 8,
+                    "gemma4.attention.head_count_kv": 2,
+                    "gemma4.attention.key_length": 512,
+                    "gemma4.attention.key_length_swa": 256,
+                    "gemma4.attention.layer_norm_rms_epsilon": 1e-06,
+                    "gemma4.attention.shared_kv_layers": 18,
+                    "gemma4.attention.sliding_window": 512,
+                    "gemma4.attention.value_length": 512,
+                    "gemma4.attention.value_length_swa": 256,
+                    "gemma4.audio.attention.head_count": 8,
+                    "gemma4.audio.attention.layer_norm_epsilon": 1e-06,
+                    "gemma4.audio.block_count": 12,
+                    "gemma4.audio.conv_kernel_size": 5,
+                    "gemma4.audio.embedding_length": 1024,
+                    "gemma4.audio.feed_forward_length": 4096,
+                    "gemma4.block_count": 42,
+                    "gemma4.context_length": 131072,
+                    "gemma4.embedding_length": 2560,
+                    "gemma4.embedding_length_per_layer_input": 256,
+                    "gemma4.feed_forward_length": 10240,
+                    "gemma4.final_logit_softcapping": 30,
+                    "gemma4.rope.dimension_count": 512,
+                    "gemma4.rope.dimension_count_swa": 256,
+                    "gemma4.rope.freq_base": 1000000,
+                    "gemma4.rope.freq_base_swa": 10000,
+                    "gemma4.vision.attention.head_count": 12,
+                    "gemma4.vision.attention.layer_norm_epsilon": 1e-06,
+                    "gemma4.vision.block_count": 16,
+                    "gemma4.vision.embedding_length": 768,
+                    "gemma4.vision.feed_forward_length": 3072,
+                    "gemma4.vision.num_channels": 3,
+                    "gemma4.vision.patch_size": 16,
+                    "gemma4.vision.projector.scale_factor": 3,
+                    "general.architecture": "gemma4",
                     "general.file_type": 15,
-                    "general.parameter_count": 4299915632,
                     "general.quantization_version": 2,
-                    "tokenizer.ggml.add_bos_token": true,
+                    "tokenizer.ggml.add_bos_token": false,
                     "tokenizer.ggml.add_eos_token": false,
+                    "tokenizer.ggml.add_mask_token": false,
                     "tokenizer.ggml.add_padding_token": false,
                     "tokenizer.ggml.add_unknown_token": false,
                     "tokenizer.ggml.bos_token_id": 2,
                     "tokenizer.ggml.eos_token_id": 1,
+                    "tokenizer.ggml.eos_token_ids": [
+                      1,
+                      106,
+                      50
+                    ],
+                    "tokenizer.ggml.mask_token_id": 4,
                     "tokenizer.ggml.merges": null,
                     "tokenizer.ggml.model": "llama",
                     "tokenizer.ggml.padding_token_id": 0,
-                    "tokenizer.ggml.pre": "default",
+                    "tokenizer.ggml.pre": "gemma4",
                     "tokenizer.ggml.scores": null,
                     "tokenizer.ggml.token_type": null,
                     "tokenizer.ggml.tokens": null,
@@ -1806,12 +1829,12 @@
           {
             "label": "Default",
             "lang": "bash",
-            "source": "curl http://localhost:11434/api/show -d '{\n  \"model\": \"gemma3\"\n}'\n"
+            "source": "curl http://localhost:11434/api/show -d '{\n  \"model\": \"gemma4\"\n}'\n"
           },
           {
             "label": "Verbose",
             "lang": "bash",
-            "source": "curl http://localhost:11434/api/show -d '{\n  \"model\": \"gemma3\",\n  \"verbose\": true\n}'\n"
+            "source": "curl http://localhost:11434/api/show -d '{\n  \"model\": \"gemma4\",\n  \"verbose\": true\n}'\n"
           }
         ]
       }
@@ -1829,18 +1852,18 @@
                     {
                       "details": {
                         "families": [
-                          "gemma"
+                          "gemma4"
                         ],
-                        "family": "gemma",
+                        "family": "gemma4",
                         "format": "gguf",
-                        "parameter_size": "4.3B",
+                        "parameter_size": "8.0B",
                         "quantization_level": "Q4_K_M"
                       },
-                      "digest": "a2af6cc3eb7fa8be8504abaf9b04e88f17a119ec3f04a3addf55f92841195f5a",
-                      "model": "gemma3",
+                      "digest": "c6eb396dbd5992bbe3f5cdb947e8bbc0ee413d7c17e2beaae69f5d569cf982eb",
+                      "model": "gemma4",
                       "modified_at": "2025-10-03T23:34:03.409490317-07:00",
-                      "name": "gemma3",
-                      "size": 3338801804
+                      "name": "gemma4",
+                      "size": 9608350245
                     }
                   ]
                 },

--- a/packages/ollama_dart/specs/spec_metadata.json
+++ b/packages/ollama_dart/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "0.1.0",
-      "last_fetched": "2026-06-05T18:16:46.435579Z",
+      "last_fetched": "2026-07-04T11:08:16.594466Z",
       "source_url": "https://raw.githubusercontent.com/ollama/ollama/refs/heads/main/docs/openapi.yaml",
       "title": "Ollama API",
       "version_history": []

--- a/packages/ollama_dart/test/unit/models/think_value_test.dart
+++ b/packages/ollama_dart/test/unit/models/think_value_test.dart
@@ -26,6 +26,11 @@ void main() {
         (ThinkValue.fromJson('low')! as ThinkWithLevel).level,
         ThinkLevel.low,
       );
+      expect(ThinkValue.fromJson('max'), isA<ThinkWithLevel>());
+      expect(
+        (ThinkValue.fromJson('max')! as ThinkWithLevel).level,
+        ThinkLevel.max,
+      );
     });
 
     test('ThinkValue.fromJson returns null for unknown values', () {
@@ -43,6 +48,7 @@ void main() {
       expect(const ThinkWithLevel(ThinkLevel.high).toJson(), 'high');
       expect(const ThinkWithLevel(ThinkLevel.medium).toJson(), 'medium');
       expect(const ThinkWithLevel(ThinkLevel.low).toJson(), 'low');
+      expect(const ThinkWithLevel(ThinkLevel.max).toJson(), 'max');
     });
 
     test('ThinkValue equality works correctly', () {
@@ -150,6 +156,50 @@ void main() {
       final request = GenerateRequest.fromJson(json);
       expect(request.think, isA<ThinkWithLevel>());
       expect((request.think! as ThinkWithLevel).level, ThinkLevel.low);
+    });
+
+    test('ChatRequest serializes ThinkLevel.max correctly', () {
+      const request = ChatRequest(
+        model: 'llama3.2',
+        messages: [ChatMessage.user('Hello')],
+        think: ThinkWithLevel(ThinkLevel.max),
+      );
+
+      final json = request.toJson();
+      expect(json['think'], 'max');
+    });
+
+    test('ChatRequest deserializes ThinkLevel.max correctly', () {
+      final json = {
+        'model': 'llama3.2',
+        'messages': [
+          {'role': 'user', 'content': 'Hello'},
+        ],
+        'think': 'max',
+      };
+
+      final request = ChatRequest.fromJson(json);
+      expect(request.think, isA<ThinkWithLevel>());
+      expect((request.think! as ThinkWithLevel).level, ThinkLevel.max);
+    });
+
+    test('GenerateRequest serializes ThinkLevel.max correctly', () {
+      const request = GenerateRequest(
+        model: 'llama3.2',
+        prompt: 'Hello',
+        think: ThinkWithLevel(ThinkLevel.max),
+      );
+
+      final json = request.toJson();
+      expect(json['think'], 'max');
+    });
+
+    test('GenerateRequest deserializes ThinkLevel.max correctly', () {
+      final json = {'model': 'llama3.2', 'prompt': 'Hello', 'think': 'max'};
+
+      final request = GenerateRequest.fromJson(json);
+      expect(request.think, isA<ThinkWithLevel>());
+      expect((request.think! as ThinkWithLevel).level, ThinkLevel.max);
     });
   });
 }


### PR DESCRIPTION
## Summary
- Add the new `max` thinking level to `ThinkLevel`, matching Ollama's OpenAPI spec update that added `"max"` to the `think` string-enum on `ChatRequest` and `GenerateRequest`. `"max"` requests the highest thinking level on supported reasoning models.
- Refresh the checked-in spec (`specs/openapi.json`) to track upstream `docs/openapi.yaml` faithfully.

## Details

`think` is modeled as the sealed `ThinkValue` (`ThinkEnabled` bool | `ThinkWithLevel` enum). The change adds a `ThinkLevel.max` member and wires it through both dispatch sites, mirroring the existing `high`/`medium`/`low` levels:

```dart
final response = await client.chat.generate(
  request: const ChatRequest(
    model: 'gpt-oss',
    messages: [ChatMessage.user('Solve this step by step: ...')],
    think: ThinkWithLevel(ThinkLevel.max), // highest reasoning effort
  ),
);
```

- `ThinkValue.fromJson`: `'max'` → `ThinkWithLevel(ThinkLevel.max)`. The existing `_ => null` fallback for unrecognized values is preserved, so forward-compatibility is unchanged.
- `ThinkWithLevel.toJson`: emits `'max'`. The switch is exhaustive over `ThinkLevel`, so the analyzer enforces the new branch.

The rest of the `specs/openapi.json` diff is cosmetic upstream example churn (`gemma3` → `gemma4` across examples/code-samples/`model_info`) with no code impact. The api-toolkit `verify --checks all --scope all` stays clean (0 errors / 0 warnings), and no `manifest.json` change is needed — enum values inside a `oneOf` are not manifest-tracked.

> Note: adding a member to the public `ThinkLevel` enum makes any consumer's *exhaustive* `switch` over it non-exhaustive at compile time. This repo treats enum growth as a non-breaking `feat`.

## References

- [Ollama OpenAPI spec (docs/openapi.yaml)](https://raw.githubusercontent.com/ollama/ollama/refs/heads/main/docs/openapi.yaml) — upstream source; `think` enum now `["high", "medium", "low", "max"]`.

## Test Plan

- [x] Unit tests pass for `ollama_dart` (`dart test test/unit/`)
- [x] New tests added: `fromJson`/`toJson` for `max`, plus `max` serialize+deserialize round-trips through both `ChatRequest` and `GenerateRequest`
- [x] `fromJson`/`toJson` round-trip serialization verified
- [x] Enum change covered (parse, serialize, and request-level dispatch)
- [x] `dart analyze --fatal-infos` clean; `dart format` clean
- [x] api-toolkit `review` (0 changed types) and `verify --checks all --scope all` (0 errors / 0 warnings) pass