### PR TITLE
feat(anthropic_sdk_dart)!: Sonnet 5, web tool 20260318 & Managed Agents parity

### DIFF
--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
@@ -80,6 +80,24 @@
     ]
   },
   "types": {
+    "BetaWebSearchToolResultErrorCode": {
+      "spec": "main",
+      "kind": "enum",
+      "dart_class": "WebSearchToolResultErrorCode",
+      "file": "lib/src/models/content/content_block.dart",
+      "schema": "BetaWebSearchToolResultErrorCode"
+    },
+    "WebSearchToolResultErrorCode": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "WebSearchToolResultErrorCode",
+      "file": "lib/src/models/content/content_block.dart",
+      "schema": "WebSearchToolResultErrorCode",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Non-beta GA variant of the web_search tool result error code - covered by the WebSearchToolResultErrorCode enum; see BetaWebSearchToolResultErrorCode."
+    },
     "WebSearchTool_20260318": {
       "spec": "main",
       "kind": "skip",

--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
@@ -75,10 +75,356 @@
     "resource_aliases": {},
     "excluded_resources": [
       "complete",
-      "environments"
+      "environments",
+      "tunnels"
     ]
   },
   "types": {
+    "WebSearchTool_20260318": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "WebSearchTool",
+      "file": "lib/src/models/tools/built_in_tools.dart",
+      "schema": "WebSearchTool_20260318",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Non-beta GA variant of the web_search tool - covered by WebSearchTool via the `type` discriminator; see WebSearchTool20250305."
+    },
+    "BetaWebSearchTool_20260318": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "WebSearchTool",
+      "file": "lib/src/models/tools/built_in_tools.dart",
+      "schema": "BetaWebSearchTool_20260318",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Versioned variant of the web_search tool - covered by WebSearchTool via the `type` discriminator; see WebSearchTool20250305."
+    },
+    "WebFetchTool_20260318": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "WebFetchTool",
+      "file": "lib/src/models/tools/built_in_tools.dart",
+      "schema": "WebFetchTool_20260318",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Non-beta GA variant of the web_fetch tool - covered by WebFetchTool via the `type` discriminator; see WebFetchTool20250910."
+    },
+    "BetaWebFetchTool_20260318": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "WebFetchTool",
+      "file": "lib/src/models/tools/built_in_tools.dart",
+      "schema": "BetaWebFetchTool_20260318",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Versioned variant of the web_fetch tool - covered by WebFetchTool via the `type` discriminator; see WebFetchTool20250910."
+    },
+    "EventStartEvent": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "EventStartEvent",
+      "file": "lib/src/models/managed_agents/events/session_event.dart",
+      "schema": "BetaManagedAgentsEventStartEvent",
+      "parent": "SessionEvent"
+    },
+    "EventDeltaEvent": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "EventDeltaEvent",
+      "file": "lib/src/models/managed_agents/events/session_event.dart",
+      "schema": "BetaManagedAgentsEventDeltaEvent",
+      "parent": "SessionEvent"
+    },
+    "EventStartPreview": {
+      "spec": "main",
+      "kind": "sealed_parent",
+      "dart_class": "EventStartPreview",
+      "file": "lib/src/models/managed_agents/events/session_event.dart",
+      "schema": "BetaManagedAgentsEventStartEvent_Event"
+    },
+    "AgentMessagePreview": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "AgentMessagePreview",
+      "file": "lib/src/models/managed_agents/events/session_event.dart",
+      "schema": "BetaManagedAgentsEventStartEvent_AgentMessagePreview",
+      "parent": "EventStartPreview"
+    },
+    "AgentThinkingPreview": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "AgentThinkingPreview",
+      "file": "lib/src/models/managed_agents/events/session_event.dart",
+      "schema": "BetaManagedAgentsEventStartEvent_AgentThinkingPreview",
+      "parent": "EventStartPreview"
+    },
+    "EventDelta": {
+      "spec": "main",
+      "kind": "sealed_parent",
+      "dart_class": "EventDelta",
+      "file": "lib/src/models/managed_agents/events/session_event.dart",
+      "schema": "BetaManagedAgentsEventDeltaEvent_Delta"
+    },
+    "ContentDelta": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "ContentDelta",
+      "file": "lib/src/models/managed_agents/events/session_event.dart",
+      "schema": "BetaManagedAgentsEventDeltaEvent_ContentDelta",
+      "parent": "EventDelta"
+    },
+    "BetaManagedAgentsEventDeltaType": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "file": null,
+      "schema": "BetaManagedAgentsEventDeltaType",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "EventDeltaType enum (agent.message/agent.thinking) modeled as raw String values of the `event_deltas[]` stream query parameter; not a Dart enum."
+    },
+    "InjectionLocation": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "InjectionLocation",
+      "file": "lib/src/models/managed_agents/credentials/injection_location.dart",
+      "schema": "BetaManagedAgentsInjectionLocationParams"
+    },
+    "InjectionLocationResponse": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "InjectionLocationResponse",
+      "file": "lib/src/models/managed_agents/credentials/injection_location.dart",
+      "schema": "BetaManagedAgentsInjectionLocationResponse"
+    },
+    "BetaManagedAgentsInjectionLocationUpdateParams": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "InjectionLocation",
+      "file": "lib/src/models/managed_agents/credentials/injection_location.dart",
+      "schema": "BetaManagedAgentsInjectionLocationUpdateParams",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Update injection-location params share the same shape and Dart class as InjectionLocation (create/update params)."
+    },
+    "AgentParamsWithOverrides": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "AgentParamsWithOverrides",
+      "file": "lib/src/models/managed_agents/sessions/create_session_params.dart",
+      "schema": "BetaManagedAgentsAgentWithOverridesParams",
+      "parent": "AgentParams"
+    },
+    "BetaManagedAgentsCreateSessionAgentUnionParams": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "AgentParams",
+      "file": "lib/src/models/managed_agents/sessions/create_session_params.dart",
+      "schema": "BetaManagedAgentsCreateSessionAgentUnionParams",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Session agent union (string | agent | agent_with_overrides) - covered by the AgentParams sealed class and its variants."
+    },
+    "WebhookAgentCreatedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookAgentCreatedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookAgentCreatedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookAgentUpdatedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookAgentUpdatedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookAgentUpdatedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookAgentDeletedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookAgentDeletedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookAgentDeletedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookAgentArchivedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookAgentArchivedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookAgentArchivedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookDeploymentCreatedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookDeploymentCreatedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookDeploymentCreatedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookDeploymentUpdatedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookDeploymentUpdatedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookDeploymentUpdatedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookDeploymentDeletedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookDeploymentDeletedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookDeploymentDeletedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookDeploymentArchivedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookDeploymentArchivedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookDeploymentArchivedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookDeploymentPausedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookDeploymentPausedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookDeploymentPausedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookDeploymentUnpausedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookDeploymentUnpausedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookDeploymentUnpausedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookDeploymentRunStartedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookDeploymentRunStartedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookDeploymentRunStartedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookDeploymentRunSucceededEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookDeploymentRunSucceededEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookDeploymentRunSucceededEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookDeploymentRunFailedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookDeploymentRunFailedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookDeploymentRunFailedEventData",
+      "parent": "WebhookEventData"
+    },
+    "BetaTunnel": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "file": null,
+      "schema": "BetaTunnel",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Tunnels research-preview management API - out of scope, not covered by the SDK (resource excluded via coverage.excluded_resources)."
+    },
+    "BetaTunnelCertificate": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "file": null,
+      "schema": "BetaTunnelCertificate",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Tunnels research-preview management API - out of scope, not covered by the SDK (resource excluded via coverage.excluded_resources)."
+    },
+    "BetaTunnelToken": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "file": null,
+      "schema": "BetaTunnelToken",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Tunnels research-preview management API - out of scope, not covered by the SDK (resource excluded via coverage.excluded_resources)."
+    },
+    "BetaCreateTunnelRequest": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "file": null,
+      "schema": "BetaCreateTunnelRequest",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Tunnels research-preview management API - out of scope, not covered by the SDK (resource excluded via coverage.excluded_resources)."
+    },
+    "BetaCreateTunnelCertificateRequestBody": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "file": null,
+      "schema": "BetaCreateTunnelCertificateRequestBody",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Tunnels research-preview management API - out of scope, not covered by the SDK (resource excluded via coverage.excluded_resources)."
+    },
+    "BetaListTunnelsResponse": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "file": null,
+      "schema": "BetaListTunnelsResponse",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Tunnels research-preview management API - out of scope, not covered by the SDK (resource excluded via coverage.excluded_resources)."
+    },
+    "BetaListTunnelCertificatesResponse": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "file": null,
+      "schema": "BetaListTunnelCertificatesResponse",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Tunnels research-preview management API - out of scope, not covered by the SDK (resource excluded via coverage.excluded_resources)."
+    },
+    "BetaRotateTunnelTokenRequestBody": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": null,
+      "file": null,
+      "schema": "BetaRotateTunnelTokenRequestBody",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Tunnels research-preview management API - out of scope, not covered by the SDK (resource excluded via coverage.excluded_resources)."
+    },
     "DiagnosticsParam": {
       "spec": "main",
       "kind": "object",

--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/specs.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/specs.json
@@ -31,9 +31,9 @@
       "fetch_mode": "remote",
       "local_file": "openapi.yaml",
       "name": "Anthropic API",
-      "pinned_hash": "2ecf157aa324d82fa8f3636a325aea5bd96ecab93193f6e37864ebe665c48685",
+      "pinned_hash": "506a5ad71d522b4ae56ac3429380486647af1f92eddde80603480fb592d62b54",
       "requires_auth": false,
-      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-2ecf157aa324d82fa8f3636a325aea5bd96ecab93193f6e37864ebe665c48685.yml"
+      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-506a5ad71d522b4ae56ac3429380486647af1f92eddde80603480fb592d62b54.yml"
     }
   },
   "specs_dir": "packages/anthropic_sdk_dart/specs"

--- a/packages/anthropic_sdk_dart/example/user_profiles_example.dart
+++ b/packages/anthropic_sdk_dart/example/user_profiles_example.dart
@@ -28,7 +28,20 @@ void main() async {
     );
     print('Created ${profile.id} (external_id: ${profile.externalId})');
 
-    // 2. List user profiles (paginated).
+    // 2. Send a message attributed to this user. The profile ID is sent as the
+    //    `anthropic-user-profile-id` header, not as a request-body field.
+    print('\n=== Send message attributed to the profile ===');
+    final reply = await client.messages.create(
+      MessageCreateRequest(
+        model: 'claude-opus-4-8',
+        maxTokens: 256,
+        messages: [InputMessage.user('Hello!')],
+      ),
+      userProfileId: profile.id,
+    );
+    print('Model replied: ${reply.content.first.runtimeType}');
+
+    // 3. List user profiles (paginated).
     print('\n=== List ===');
     final page = await client.userProfiles.list(
       limit: 10,
@@ -36,7 +49,7 @@ void main() async {
     );
     print('Returned ${page.data.length} profile(s); nextPage=${page.nextPage}');
 
-    // 3. Retrieve the profile and inspect trust grants.
+    // 4. Retrieve the profile and inspect trust grants.
     print('\n=== Retrieve ===');
     final fetched = await client.userProfiles.retrieve(profile.id);
     for (final entry in fetched.trustGrants.entries) {
@@ -46,7 +59,7 @@ void main() async {
       print('  (no trust grants)');
     }
 
-    // 4. Update metadata. Empty-string values remove a key server-side.
+    // 5. Update metadata. Empty-string values remove a key server-side.
     print('\n=== Update ===');
     final updated = await client.userProfiles.update(
       profile.id,
@@ -56,7 +69,7 @@ void main() async {
     );
     print('Updated metadata: ${updated.metadata}');
 
-    // 5. Generate an enrollment URL to send to the end user.
+    // 6. Generate an enrollment URL to send to the end user.
     print('\n=== Enrollment URL ===');
     final enrollment = await client.userProfiles.createEnrollmentUrl(
       profile.id,

--- a/packages/anthropic_sdk_dart/example/user_profiles_example.dart
+++ b/packages/anthropic_sdk_dart/example/user_profiles_example.dart
@@ -28,19 +28,7 @@ void main() async {
     );
     print('Created ${profile.id} (external_id: ${profile.externalId})');
 
-    // 2. Send a message scoped to this user.
-    print('\n=== Send message with user_profile_id ===');
-    final reply = await client.messages.create(
-      MessageCreateRequest(
-        model: 'claude-opus-4-8',
-        maxTokens: 256,
-        userProfileId: profile.id,
-        messages: [InputMessage.user('Hello!')],
-      ),
-    );
-    print('Model replied: ${reply.content.first.runtimeType}');
-
-    // 3. List user profiles (paginated).
+    // 2. List user profiles (paginated).
     print('\n=== List ===');
     final page = await client.userProfiles.list(
       limit: 10,
@@ -48,7 +36,7 @@ void main() async {
     );
     print('Returned ${page.data.length} profile(s); nextPage=${page.nextPage}');
 
-    // 4. Retrieve the profile and inspect trust grants.
+    // 3. Retrieve the profile and inspect trust grants.
     print('\n=== Retrieve ===');
     final fetched = await client.userProfiles.retrieve(profile.id);
     for (final entry in fetched.trustGrants.entries) {
@@ -58,7 +46,7 @@ void main() async {
       print('  (no trust grants)');
     }
 
-    // 5. Update metadata. Empty-string values remove a key server-side.
+    // 4. Update metadata. Empty-string values remove a key server-side.
     print('\n=== Update ===');
     final updated = await client.userProfiles.update(
       profile.id,
@@ -68,7 +56,7 @@ void main() async {
     );
     print('Updated metadata: ${updated.metadata}');
 
-    // 6. Generate an enrollment URL to send to the end user.
+    // 5. Generate an enrollment URL to send to the end user.
     print('\n=== Enrollment URL ===');
     final enrollment = await client.userProfiles.createEnrollmentUrl(
       profile.id,

--- a/packages/anthropic_sdk_dart/lib/anthropic_sdk_dart.dart
+++ b/packages/anthropic_sdk_dart/lib/anthropic_sdk_dart.dart
@@ -209,6 +209,7 @@ export 'src/models/tokens/token_count.dart';
 // Models - Tools
 export 'src/models/tools/built_in_tools.dart';
 export 'src/models/tools/input_schema.dart';
+export 'src/models/tools/response_inclusion.dart';
 export 'src/models/tools/tool.dart';
 export 'src/models/tools/tool_caller.dart';
 export 'src/models/tools/tool_choice.dart';

--- a/packages/anthropic_sdk_dart/lib/anthropic_sdk_dart.dart
+++ b/packages/anthropic_sdk_dart/lib/anthropic_sdk_dart.dart
@@ -109,6 +109,7 @@ export 'src/models/managed_agents/credentials/credential_auth.dart';
 export 'src/models/managed_agents/credentials/credential_list_response.dart';
 export 'src/models/managed_agents/credentials/credential_networking.dart';
 export 'src/models/managed_agents/credentials/credential_validation.dart';
+export 'src/models/managed_agents/credentials/injection_location.dart';
 export 'src/models/managed_agents/credentials/update_credential_params.dart';
 export 'src/models/managed_agents/deployments/create_deployment_params.dart';
 export 'src/models/managed_agents/deployments/deployment.dart';

--- a/packages/anthropic_sdk_dart/lib/src/models/content/content_block.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/content_block.dart
@@ -1067,21 +1067,28 @@ class WebSearchResultItem {
 /// Web search error result.
 @immutable
 class WebSearchResultError extends WebSearchResult {
-  /// Error code.
-  final String errorCode;
+  /// The raw error code string from the API.
+  ///
+  /// Preserved for round-trip fidelity — unrecognized codes are stored
+  /// verbatim and serialized back unchanged.
+  final String rawErrorCode;
+
+  /// The parsed error code, derived from [rawErrorCode].
+  WebSearchToolResultErrorCode get errorCode =>
+      WebSearchToolResultErrorCode.fromJson(rawErrorCode);
 
   /// Creates a [WebSearchResultError].
-  const WebSearchResultError({required this.errorCode});
+  const WebSearchResultError({required this.rawErrorCode});
 
   /// Creates a [WebSearchResultError] from JSON.
   factory WebSearchResultError.fromJson(Map<String, dynamic> json) {
-    return WebSearchResultError(errorCode: json['error_code'] as String);
+    return WebSearchResultError(rawErrorCode: json['error_code'] as String);
   }
 
   @override
   Map<String, dynamic> toJson() => {
     'type': 'web_search_tool_result_error',
-    'error_code': errorCode,
+    'error_code': rawErrorCode,
   };
 
   @override
@@ -1089,13 +1096,13 @@ class WebSearchResultError extends WebSearchResult {
       identical(this, other) ||
       other is WebSearchResultError &&
           runtimeType == other.runtimeType &&
-          errorCode == other.errorCode;
+          rawErrorCode == other.rawErrorCode;
 
   @override
-  int get hashCode => errorCode.hashCode;
+  int get hashCode => rawErrorCode.hashCode;
 
   @override
-  String toString() => 'WebSearchResultError(errorCode: $errorCode)';
+  String toString() => 'WebSearchResultError(rawErrorCode: $rawErrorCode)';
 }
 
 /// Citation for text content.
@@ -2259,6 +2266,57 @@ enum AdvisorToolResultErrorCode {
     promptTooLong => 'prompt_too_long',
     tooManyRequests => 'too_many_requests',
     unavailable => 'unavailable',
+    unknown => 'unknown',
+  };
+}
+
+/// Error codes for web search tool result errors.
+enum WebSearchToolResultErrorCode {
+  /// The tool input failed validation.
+  invalidToolInput,
+
+  /// The web search service was unavailable.
+  unavailable,
+
+  /// The request reached the max_uses cap.
+  maxUsesExceeded,
+
+  /// The request was rate-limited.
+  tooManyRequests,
+
+  /// The search query exceeded the maximum length.
+  queryTooLong,
+
+  /// The request payload was too large.
+  requestTooLarge,
+
+  /// Forward-compatible fallback for unrecognized error codes.
+  unknown;
+
+  /// Creates a [WebSearchToolResultErrorCode] from JSON.
+  factory WebSearchToolResultErrorCode.fromJson(String value) =>
+      switch (value) {
+        'invalid_tool_input' => invalidToolInput,
+        'unavailable' => unavailable,
+        'max_uses_exceeded' => maxUsesExceeded,
+        'too_many_requests' => tooManyRequests,
+        'query_too_long' => queryTooLong,
+        'request_too_large' => requestTooLarge,
+        _ => unknown,
+      };
+
+  /// Converts to a known JSON string.
+  ///
+  /// Returns `'unknown'` for [unknown] — this is lossy for unrecognized codes.
+  /// For round-trip serialization, use [WebSearchResultError.rawErrorCode]
+  /// instead of `errorCode.toJson()`.
+  String toJson() => switch (this) {
+    invalidToolInput => 'invalid_tool_input',
+    unavailable => 'unavailable',
+    maxUsesExceeded => 'max_uses_exceeded',
+    tooManyRequests => 'too_many_requests',
+    queryTooLong => 'query_too_long',
+    requestTooLarge => 'request_too_large',
     unknown => 'unknown',
   };
 }

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/credentials/credential_auth.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/credentials/credential_auth.dart
@@ -3,6 +3,7 @@ import 'package:meta/meta.dart';
 import '../../common/copy_with_sentinel.dart';
 import '../../common/equality_helpers.dart';
 import 'credential_networking.dart';
+import 'injection_location.dart';
 
 // ============================================================================
 // Response types — returned from the API
@@ -49,6 +50,7 @@ sealed class CredentialAuth {
     String type,
     required String secretName,
     required CredentialNetworkingResponse networking,
+    required InjectionLocationResponse injectionLocation,
   }) = EnvironmentVariableAuthResponse;
 
   /// Converts to JSON.
@@ -210,11 +212,15 @@ class EnvironmentVariableAuthResponse extends CredentialAuth {
   /// Outbound hosts the secret value is substituted on.
   final CredentialNetworkingResponse networking;
 
+  /// Where in the outbound request the secret value is substituted.
+  final InjectionLocationResponse injectionLocation;
+
   /// Creates an [EnvironmentVariableAuthResponse].
   const EnvironmentVariableAuthResponse({
     this.type = 'environment_variable',
     required this.secretName,
     required this.networking,
+    required this.injectionLocation,
   });
 
   /// Creates an [EnvironmentVariableAuthResponse] from JSON.
@@ -225,6 +231,9 @@ class EnvironmentVariableAuthResponse extends CredentialAuth {
       networking: CredentialNetworkingResponse.fromJson(
         json['networking'] as Map<String, dynamic>,
       ),
+      injectionLocation: InjectionLocationResponse.fromJson(
+        json['injection_location'] as Map<String, dynamic>,
+      ),
     );
   }
 
@@ -233,6 +242,7 @@ class EnvironmentVariableAuthResponse extends CredentialAuth {
     'type': type,
     'secret_name': secretName,
     'networking': networking.toJson(),
+    'injection_location': injectionLocation.toJson(),
   };
 
   /// Creates a copy with replaced values.
@@ -240,11 +250,13 @@ class EnvironmentVariableAuthResponse extends CredentialAuth {
     String? type,
     String? secretName,
     CredentialNetworkingResponse? networking,
+    InjectionLocationResponse? injectionLocation,
   }) {
     return EnvironmentVariableAuthResponse(
       type: type ?? this.type,
       secretName: secretName ?? this.secretName,
       networking: networking ?? this.networking,
+      injectionLocation: injectionLocation ?? this.injectionLocation,
     );
   }
 
@@ -255,17 +267,20 @@ class EnvironmentVariableAuthResponse extends CredentialAuth {
           runtimeType == other.runtimeType &&
           type == other.type &&
           secretName == other.secretName &&
-          networking == other.networking;
+          networking == other.networking &&
+          injectionLocation == other.injectionLocation;
 
   @override
-  int get hashCode => Object.hash(type, secretName, networking);
+  int get hashCode =>
+      Object.hash(type, secretName, networking, injectionLocation);
 
   @override
   String toString() =>
       'EnvironmentVariableAuthResponse('
       'type: $type, '
       'secretName: $secretName, '
-      'networking: $networking)';
+      'networking: $networking, '
+      'injectionLocation: $injectionLocation)';
 }
 
 /// Unrecognized credential auth type (preserves raw JSON).
@@ -618,6 +633,7 @@ sealed class CredentialCreateAuth {
     required String secretName,
     required String secretValue,
     required CredentialNetworkingParams networking,
+    InjectionLocation? injectionLocation,
   }) = EnvironmentVariableCreateParams;
 
   /// Converts to JSON.
@@ -810,12 +826,16 @@ class EnvironmentVariableCreateParams extends CredentialCreateAuth {
   /// Outbound hosts the secret value is substituted on.
   final CredentialNetworkingParams networking;
 
+  /// Where in the outbound request the secret value may be substituted.
+  final InjectionLocation? injectionLocation;
+
   /// Creates an [EnvironmentVariableCreateParams].
   const EnvironmentVariableCreateParams({
     this.type = 'environment_variable',
     required this.secretName,
     required this.secretValue,
     required this.networking,
+    this.injectionLocation,
   });
 
   /// Creates an [EnvironmentVariableCreateParams] from JSON.
@@ -827,6 +847,11 @@ class EnvironmentVariableCreateParams extends CredentialCreateAuth {
       networking: CredentialNetworkingParams.fromJson(
         json['networking'] as Map<String, dynamic>,
       ),
+      injectionLocation: json['injection_location'] != null
+          ? InjectionLocation.fromJson(
+              json['injection_location'] as Map<String, dynamic>,
+            )
+          : null,
     );
   }
 
@@ -836,6 +861,8 @@ class EnvironmentVariableCreateParams extends CredentialCreateAuth {
     'secret_name': secretName,
     'secret_value': secretValue,
     'networking': networking.toJson(),
+    if (injectionLocation != null)
+      'injection_location': injectionLocation!.toJson(),
   };
 
   /// Creates a copy with replaced values.
@@ -844,12 +871,16 @@ class EnvironmentVariableCreateParams extends CredentialCreateAuth {
     String? secretName,
     String? secretValue,
     CredentialNetworkingParams? networking,
+    Object? injectionLocation = unsetCopyWithValue,
   }) {
     return EnvironmentVariableCreateParams(
       type: type ?? this.type,
       secretName: secretName ?? this.secretName,
       secretValue: secretValue ?? this.secretValue,
       networking: networking ?? this.networking,
+      injectionLocation: injectionLocation == unsetCopyWithValue
+          ? this.injectionLocation
+          : injectionLocation as InjectionLocation?,
     );
   }
 
@@ -861,10 +892,12 @@ class EnvironmentVariableCreateParams extends CredentialCreateAuth {
           type == other.type &&
           secretName == other.secretName &&
           secretValue == other.secretValue &&
-          networking == other.networking;
+          networking == other.networking &&
+          injectionLocation == other.injectionLocation;
 
   @override
-  int get hashCode => Object.hash(type, secretName, secretValue, networking);
+  int get hashCode =>
+      Object.hash(type, secretName, secretValue, networking, injectionLocation);
 
   @override
   String toString() =>
@@ -872,7 +905,8 @@ class EnvironmentVariableCreateParams extends CredentialCreateAuth {
       'type: $type, '
       'secretName: $secretName, '
       'secretValue: [redacted], '
-      'networking: $networking)';
+      'networking: $networking, '
+      'injectionLocation: $injectionLocation)';
 }
 
 /// Unrecognized credential create auth type (preserves raw JSON).
@@ -1267,6 +1301,7 @@ sealed class CredentialUpdateAuth {
     String type,
     String? secretValue,
     CredentialNetworkingParams? networking,
+    InjectionLocation? injectionLocation,
   }) = EnvironmentVariableUpdateParams;
 
   /// Converts to JSON.
@@ -1435,11 +1470,15 @@ class EnvironmentVariableUpdateParams extends CredentialUpdateAuth {
   /// Updated networking scope. Full replacement.
   final CredentialNetworkingParams? networking;
 
+  /// Updated injection location.
+  final InjectionLocation? injectionLocation;
+
   /// Creates an [EnvironmentVariableUpdateParams].
   const EnvironmentVariableUpdateParams({
     this.type = 'environment_variable',
     this.secretValue,
     this.networking,
+    this.injectionLocation,
   });
 
   /// Creates an [EnvironmentVariableUpdateParams] from JSON.
@@ -1452,6 +1491,11 @@ class EnvironmentVariableUpdateParams extends CredentialUpdateAuth {
               json['networking'] as Map<String, dynamic>,
             )
           : null,
+      injectionLocation: json['injection_location'] != null
+          ? InjectionLocation.fromJson(
+              json['injection_location'] as Map<String, dynamic>,
+            )
+          : null,
     );
   }
 
@@ -1460,6 +1504,8 @@ class EnvironmentVariableUpdateParams extends CredentialUpdateAuth {
     'type': type,
     if (secretValue != null) 'secret_value': secretValue,
     if (networking != null) 'networking': networking!.toJson(),
+    if (injectionLocation != null)
+      'injection_location': injectionLocation!.toJson(),
   };
 
   /// Creates a copy with replaced values.
@@ -1467,6 +1513,7 @@ class EnvironmentVariableUpdateParams extends CredentialUpdateAuth {
     String? type,
     Object? secretValue = unsetCopyWithValue,
     Object? networking = unsetCopyWithValue,
+    Object? injectionLocation = unsetCopyWithValue,
   }) {
     return EnvironmentVariableUpdateParams(
       type: type ?? this.type,
@@ -1476,6 +1523,9 @@ class EnvironmentVariableUpdateParams extends CredentialUpdateAuth {
       networking: networking == unsetCopyWithValue
           ? this.networking
           : networking as CredentialNetworkingParams?,
+      injectionLocation: injectionLocation == unsetCopyWithValue
+          ? this.injectionLocation
+          : injectionLocation as InjectionLocation?,
     );
   }
 
@@ -1486,17 +1536,20 @@ class EnvironmentVariableUpdateParams extends CredentialUpdateAuth {
           runtimeType == other.runtimeType &&
           type == other.type &&
           secretValue == other.secretValue &&
-          networking == other.networking;
+          networking == other.networking &&
+          injectionLocation == other.injectionLocation;
 
   @override
-  int get hashCode => Object.hash(type, secretValue, networking);
+  int get hashCode =>
+      Object.hash(type, secretValue, networking, injectionLocation);
 
   @override
   String toString() =>
       'EnvironmentVariableUpdateParams('
       'type: $type, '
       'secretValue: ${secretValue == null ? null : '[redacted]'}, '
-      'networking: $networking)';
+      'networking: $networking, '
+      'injectionLocation: $injectionLocation)';
 }
 
 /// Unrecognized credential update auth type (preserves raw JSON).

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/credentials/injection_location.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/credentials/injection_location.dart
@@ -1,0 +1,108 @@
+import 'package:meta/meta.dart';
+
+import '../../common/copy_with_sentinel.dart';
+
+/// Where in an environment variable credential's outbound request the secret
+/// value may be substituted (create/update params).
+///
+/// Each flag is optional; omit a flag to leave it at the server default.
+@immutable
+class InjectionLocation {
+  /// Substitute when the placeholder appears in the request body.
+  final bool? body;
+
+  /// Substitute when the placeholder appears in a request header value.
+  final bool? header;
+
+  /// Creates an [InjectionLocation].
+  const InjectionLocation({this.body, this.header});
+
+  /// Creates an [InjectionLocation] from JSON.
+  factory InjectionLocation.fromJson(Map<String, dynamic> json) {
+    return InjectionLocation(
+      body: json['body'] as bool?,
+      header: json['header'] as bool?,
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (body != null) 'body': body,
+    if (header != null) 'header': header,
+  };
+
+  /// Creates a copy with replaced values.
+  InjectionLocation copyWith({
+    Object? body = unsetCopyWithValue,
+    Object? header = unsetCopyWithValue,
+  }) {
+    return InjectionLocation(
+      body: body == unsetCopyWithValue ? this.body : body as bool?,
+      header: header == unsetCopyWithValue ? this.header : header as bool?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is InjectionLocation &&
+          runtimeType == other.runtimeType &&
+          body == other.body &&
+          header == other.header;
+
+  @override
+  int get hashCode => Object.hash(body, header);
+
+  @override
+  String toString() => 'InjectionLocation(body: $body, header: $header)';
+}
+
+/// Where in an environment variable credential's outbound request the secret
+/// value is substituted (response).
+///
+/// Both flags are always present in responses.
+@immutable
+class InjectionLocationResponse {
+  /// Whether the placeholder is substituted in the request body.
+  final bool body;
+
+  /// Whether the placeholder is substituted in request header values.
+  final bool header;
+
+  /// Creates an [InjectionLocationResponse].
+  const InjectionLocationResponse({required this.body, required this.header});
+
+  /// Creates an [InjectionLocationResponse] from JSON.
+  factory InjectionLocationResponse.fromJson(Map<String, dynamic> json) {
+    return InjectionLocationResponse(
+      body: json['body'] as bool,
+      header: json['header'] as bool,
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {'body': body, 'header': header};
+
+  /// Creates a copy with replaced values.
+  InjectionLocationResponse copyWith({bool? body, bool? header}) {
+    return InjectionLocationResponse(
+      body: body ?? this.body,
+      header: header ?? this.header,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is InjectionLocationResponse &&
+          runtimeType == other.runtimeType &&
+          body == other.body &&
+          header == other.header;
+
+  @override
+  int get hashCode => Object.hash(body, header);
+
+  @override
+  String toString() =>
+      'InjectionLocationResponse(body: $body, header: $header)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/events/session_event.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/events/session_event.dart
@@ -45,6 +45,8 @@ import 'telemetry.dart';
 /// - [SpanOutcomeEvaluationOngoingEvent] — outcome evaluation heartbeat.
 /// - [SpanOutcomeEvaluationEndEvent] — outcome evaluation cycle completed.
 /// - [UserDefineOutcomeEvent] — echo of a `user.define_outcome` input event.
+/// - [EventStartEvent] — previews an upcoming event's type and id.
+/// - [EventDeltaEvent] — previews a fragment of an event as it is generated.
 /// - [UnknownSessionEvent] — unrecognized event type.
 sealed class SessionEvent {
   const SessionEvent();
@@ -102,6 +104,8 @@ sealed class SessionEvent {
         json,
       ),
       'user.define_outcome' => UserDefineOutcomeEvent.fromJson(json),
+      'event_start' => EventStartEvent.fromJson(json),
+      'event_delta' => EventDeltaEvent.fromJson(json),
       _ => UnknownSessionEvent(rawJson: json),
     };
   }
@@ -3282,4 +3286,342 @@ class UnknownSessionEvent extends SessionEvent {
 
   @override
   String toString() => 'UnknownSessionEvent(rawJson: $rawJson)';
+}
+
+// ---------------------------------------------------------------------------
+// Event preview streaming (event_start / event_delta)
+// ---------------------------------------------------------------------------
+
+/// Previews an upcoming agent message or thinking event's type and id before
+/// the complete event arrives.
+///
+/// Emitted on the session event stream when opted in via the `event_deltas[]`
+/// query parameter.
+@immutable
+class EventStartEvent extends SessionEvent {
+  /// The event type, always 'event_start'.
+  String get type => 'event_start';
+
+  /// The previewed event's type and id.
+  final EventStartPreview event;
+
+  /// Creates an [EventStartEvent].
+  const EventStartEvent({required this.event});
+
+  /// Creates an [EventStartEvent] from JSON.
+  factory EventStartEvent.fromJson(Map<String, dynamic> json) {
+    return EventStartEvent(
+      event: EventStartPreview.fromJson(json['event'] as Map<String, dynamic>),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {'type': type, 'event': event.toJson()};
+
+  /// Creates a copy with replaced values.
+  EventStartEvent copyWith({EventStartPreview? event}) {
+    return EventStartEvent(event: event ?? this.event);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is EventStartEvent &&
+          runtimeType == other.runtimeType &&
+          event == other.event;
+
+  @override
+  int get hashCode => event.hashCode;
+
+  @override
+  String toString() => 'EventStartEvent(event: $event)';
+}
+
+/// The previewed event's type and id in an [EventStartEvent].
+///
+/// Variants:
+/// - [AgentMessagePreview] — preview of a buffered `agent.message`.
+/// - [AgentThinkingPreview] — preview of a buffered `agent.thinking`.
+/// - [UnknownEventStartPreview] — unrecognized preview type.
+sealed class EventStartPreview {
+  const EventStartPreview();
+
+  /// Creates an [EventStartPreview] from JSON.
+  factory EventStartPreview.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    return switch (type) {
+      'agent.message' => AgentMessagePreview.fromJson(json),
+      'agent.thinking' => AgentThinkingPreview.fromJson(json),
+      _ => UnknownEventStartPreview(rawJson: json),
+    };
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson();
+}
+
+/// Preview of a buffered `agent.message` event.
+@immutable
+class AgentMessagePreview extends EventStartPreview {
+  /// The preview type, always 'agent.message'.
+  String get type => 'agent.message';
+
+  /// The id the buffered `agent.message` will carry once complete.
+  final String id;
+
+  /// Creates an [AgentMessagePreview].
+  const AgentMessagePreview({required this.id});
+
+  /// Creates an [AgentMessagePreview] from JSON.
+  factory AgentMessagePreview.fromJson(Map<String, dynamic> json) {
+    return AgentMessagePreview(id: json['id'] as String);
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {'type': type, 'id': id};
+
+  /// Creates a copy with replaced values.
+  AgentMessagePreview copyWith({String? id}) {
+    return AgentMessagePreview(id: id ?? this.id);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AgentMessagePreview &&
+          runtimeType == other.runtimeType &&
+          id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
+
+  @override
+  String toString() => 'AgentMessagePreview(id: $id)';
+}
+
+/// Preview of a buffered `agent.thinking` event.
+@immutable
+class AgentThinkingPreview extends EventStartPreview {
+  /// The preview type, always 'agent.thinking'.
+  String get type => 'agent.thinking';
+
+  /// The id the buffered `agent.thinking` will carry once complete.
+  final String id;
+
+  /// Creates an [AgentThinkingPreview].
+  const AgentThinkingPreview({required this.id});
+
+  /// Creates an [AgentThinkingPreview] from JSON.
+  factory AgentThinkingPreview.fromJson(Map<String, dynamic> json) {
+    return AgentThinkingPreview(id: json['id'] as String);
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {'type': type, 'id': id};
+
+  /// Creates a copy with replaced values.
+  AgentThinkingPreview copyWith({String? id}) {
+    return AgentThinkingPreview(id: id ?? this.id);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AgentThinkingPreview &&
+          runtimeType == other.runtimeType &&
+          id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
+
+  @override
+  String toString() => 'AgentThinkingPreview(id: $id)';
+}
+
+/// Unrecognized event-start preview type — preserves raw JSON for forward
+/// compatibility.
+@immutable
+class UnknownEventStartPreview extends EventStartPreview {
+  /// The raw JSON.
+  final Map<String, dynamic> rawJson;
+
+  /// Creates an [UnknownEventStartPreview].
+  const UnknownEventStartPreview({required this.rawJson});
+
+  @override
+  Map<String, dynamic> toJson() => rawJson;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnknownEventStartPreview &&
+          runtimeType == other.runtimeType &&
+          mapsDeepEqual(rawJson, other.rawJson);
+
+  @override
+  int get hashCode => mapDeepHashCode(rawJson);
+
+  @override
+  String toString() => 'UnknownEventStartPreview(rawJson: $rawJson)';
+}
+
+/// Previews a fragment of an event's content as it is generated.
+///
+/// Emitted on the session event stream when opted in via the `event_deltas[]`
+/// query parameter.
+@immutable
+class EventDeltaEvent extends SessionEvent {
+  /// The event type, always 'event_delta'.
+  String get type => 'event_delta';
+
+  /// The id of the event being previewed. Matches the eventual event's id.
+  final String eventId;
+
+  /// One fragment of the previewed event.
+  final EventDelta delta;
+
+  /// Creates an [EventDeltaEvent].
+  const EventDeltaEvent({required this.eventId, required this.delta});
+
+  /// Creates an [EventDeltaEvent] from JSON.
+  factory EventDeltaEvent.fromJson(Map<String, dynamic> json) {
+    return EventDeltaEvent(
+      eventId: json['event_id'] as String,
+      delta: EventDelta.fromJson(json['delta'] as Map<String, dynamic>),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'event_id': eventId,
+    'delta': delta.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  EventDeltaEvent copyWith({String? eventId, EventDelta? delta}) {
+    return EventDeltaEvent(
+      eventId: eventId ?? this.eventId,
+      delta: delta ?? this.delta,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is EventDeltaEvent &&
+          runtimeType == other.runtimeType &&
+          eventId == other.eventId &&
+          delta == other.delta;
+
+  @override
+  int get hashCode => Object.hash(eventId, delta);
+
+  @override
+  String toString() => 'EventDeltaEvent(eventId: $eventId, delta: $delta)';
+}
+
+/// One fragment of a previewed event in an [EventDeltaEvent].
+///
+/// Variants:
+/// - [ContentDelta] — a partial element of the previewed content array.
+/// - [UnknownEventDelta] — unrecognized delta type.
+sealed class EventDelta {
+  const EventDelta();
+
+  /// Creates an [EventDelta] from JSON.
+  factory EventDelta.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    return switch (type) {
+      'content_delta' => ContentDelta.fromJson(json),
+      _ => UnknownEventDelta(rawJson: json),
+    };
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson();
+}
+
+/// A partial element of the previewed event's content array.
+@immutable
+class ContentDelta extends EventDelta {
+  /// The delta type, always 'content_delta'.
+  String get type => 'content_delta';
+
+  /// A partial element of the content array at [index], typed like the element
+  /// itself (the same shape the buffered `agent.message` carries).
+  final Map<String, dynamic> content;
+
+  /// Which entry in the previewed event's content array this fragment updates.
+  final int? index;
+
+  /// Creates a [ContentDelta].
+  const ContentDelta({required this.content, this.index});
+
+  /// Creates a [ContentDelta] from JSON.
+  factory ContentDelta.fromJson(Map<String, dynamic> json) {
+    return ContentDelta(
+      content: json['content'] as Map<String, dynamic>,
+      index: json['index'] as int?,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'content': content,
+    if (index != null) 'index': index,
+  };
+
+  /// Creates a copy with replaced values.
+  ContentDelta copyWith({
+    Map<String, dynamic>? content,
+    Object? index = unsetCopyWithValue,
+  }) {
+    return ContentDelta(
+      content: content ?? this.content,
+      index: index == unsetCopyWithValue ? this.index : index as int?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ContentDelta &&
+          runtimeType == other.runtimeType &&
+          mapsDeepEqual(content, other.content) &&
+          index == other.index;
+
+  @override
+  int get hashCode => Object.hash(mapDeepHashCode(content), index);
+
+  @override
+  String toString() => 'ContentDelta(content: $content, index: $index)';
+}
+
+/// Unrecognized event-delta type — preserves raw JSON for forward
+/// compatibility.
+@immutable
+class UnknownEventDelta extends EventDelta {
+  /// The raw JSON.
+  final Map<String, dynamic> rawJson;
+
+  /// Creates an [UnknownEventDelta].
+  const UnknownEventDelta({required this.rawJson});
+
+  @override
+  Map<String, dynamic> toJson() => rawJson;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnknownEventDelta &&
+          runtimeType == other.runtimeType &&
+          mapsDeepEqual(rawJson, other.rawJson);
+
+  @override
+  int get hashCode => mapDeepHashCode(rawJson);
+
+  @override
+  String toString() => 'UnknownEventDelta(rawJson: $rawJson)';
 }

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/events/telemetry.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/events/telemetry.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../../common/copy_with_sentinel.dart';
 import '../../common/equality_helpers.dart';
+import '../config/model_config.dart' show AgentSpeed;
 
 /// Token usage for a single model request.
 @immutable
@@ -19,7 +20,7 @@ class SpanModelUsage {
   final int cacheReadInputTokens;
 
   /// Inference speed tier this request ran at.
-  final String? speed;
+  final AgentSpeed? speed;
 
   /// Creates a [SpanModelUsage].
   const SpanModelUsage({
@@ -37,7 +38,9 @@ class SpanModelUsage {
       outputTokens: json['output_tokens'] as int,
       cacheCreationInputTokens: json['cache_creation_input_tokens'] as int,
       cacheReadInputTokens: json['cache_read_input_tokens'] as int,
-      speed: json['speed'] as String?,
+      speed: json['speed'] != null
+          ? AgentSpeed.fromJson(json['speed'] as String)
+          : null,
     );
   }
 
@@ -47,7 +50,7 @@ class SpanModelUsage {
     'output_tokens': outputTokens,
     'cache_creation_input_tokens': cacheCreationInputTokens,
     'cache_read_input_tokens': cacheReadInputTokens,
-    if (speed != null) 'speed': speed,
+    if (speed != null) 'speed': speed!.toJson(),
   };
 
   /// Creates a copy with replaced values.
@@ -64,7 +67,7 @@ class SpanModelUsage {
       cacheCreationInputTokens:
           cacheCreationInputTokens ?? this.cacheCreationInputTokens,
       cacheReadInputTokens: cacheReadInputTokens ?? this.cacheReadInputTokens,
-      speed: speed == unsetCopyWithValue ? this.speed : speed as String?,
+      speed: speed == unsetCopyWithValue ? this.speed : speed as AgentSpeed?,
     );
   }
 

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/create_session_params.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/create_session_params.dart
@@ -2,26 +2,40 @@ import 'package:meta/meta.dart';
 
 import '../../common/copy_with_sentinel.dart';
 import '../../common/equality_helpers.dart';
+import '../config/agent_skill.dart';
+import '../config/agent_tool.dart';
+import '../config/mcp_server.dart';
+import '../config/model_config.dart';
 import '../resources/session_resource_params.dart';
 
-/// Agent parameter — either a plain agent ID string or an object with id,
-/// type, and optional version.
+/// Private sentinel to distinguish "not provided" from explicit `null`.
+const Object _notSet = Object();
+
+/// Agent parameter for a session — a plain agent ID string, an agent
+/// reference, or an agent reference with per-session overrides.
 ///
 /// Variants:
 /// - [AgentParamsId] — a plain agent ID string.
 /// - [AgentParamsObject] — an object with id, type, and optional version.
+/// - [AgentParamsWithOverrides] — an agent reference whose model, system
+///   prompt, tools, MCP servers, or skills are overridden for this session.
 sealed class AgentParams {
   const AgentParams();
 
   /// Creates an [AgentParams] from JSON.
   ///
-  /// If [json] is a [String], returns [AgentParamsId].
-  /// Otherwise expects a [Map] and returns [AgentParamsObject].
+  /// If [json] is a [String], returns [AgentParamsId]. Otherwise dispatches on
+  /// the `type` discriminator: `agent_with_overrides` yields
+  /// [AgentParamsWithOverrides], anything else yields [AgentParamsObject].
   static AgentParams fromJson(Object json) {
     if (json is String) {
       return AgentParamsId(id: json);
     }
-    return AgentParamsObject.fromJson(json as Map<String, dynamic>);
+    final map = json as Map<String, dynamic>;
+    return switch (map['type'] as String?) {
+      'agent_with_overrides' => AgentParamsWithOverrides.fromJson(map),
+      _ => AgentParamsObject.fromJson(map),
+    };
   }
 
   /// Converts to JSON.
@@ -117,6 +131,157 @@ class AgentParamsObject extends AgentParams {
   @override
   String toString() =>
       'AgentParamsObject(id: $id, type: $type, version: $version)';
+}
+
+/// An agent reference with per-session configuration overrides.
+///
+/// Replaces the agent's model, system prompt, tools, MCP servers, or skills
+/// for a single session. The agent itself is unchanged. Omit an override to
+/// keep the agent's configured value; set [system] to `null` to clear the
+/// agent's system prompt for the session.
+@immutable
+class AgentParamsWithOverrides extends AgentParams {
+  /// The agent ID.
+  final String id;
+
+  /// The object type. Always "agent_with_overrides".
+  final String type;
+
+  /// The specific agent version to use. Omit to use the latest.
+  final int? version;
+
+  /// Replacement model. Omit to keep the agent's model.
+  final ModelParams? model;
+
+  /// Replacement system prompt (up to 100,000 characters).
+  ///
+  /// Omit to keep the agent's system prompt; set to `null` to clear it.
+  String? get system => _system == _notSet ? null : _system as String?;
+  final Object? _system;
+
+  /// Replacement tool list. Full replacement. Omit to keep the agent's tools.
+  final List<AgentToolParams>? tools;
+
+  /// Replacement MCP server list. Full replacement. Omit to keep the agent's
+  /// MCP servers.
+  final List<MCPServerParams>? mcpServers;
+
+  /// Replacement skill list. Full replacement. Omit to keep the agent's skills.
+  final List<AgentSkillParams>? skills;
+
+  /// Creates an [AgentParamsWithOverrides].
+  const AgentParamsWithOverrides({
+    required this.id,
+    this.type = 'agent_with_overrides',
+    this.version,
+    this.model,
+    Object? system = _notSet,
+    this.tools,
+    this.mcpServers,
+    this.skills,
+  }) : _system = system;
+
+  /// Creates an [AgentParamsWithOverrides] from JSON.
+  factory AgentParamsWithOverrides.fromJson(Map<String, dynamic> json) {
+    return AgentParamsWithOverrides(
+      id: json['id'] as String,
+      type: json['type'] as String? ?? 'agent_with_overrides',
+      version: json['version'] as int?,
+      model: json['model'] != null
+          ? ModelParams.fromJson(json['model'] as Object)
+          : null,
+      system: json.containsKey('system') ? json['system'] as String? : _notSet,
+      tools: (json['tools'] as List?)
+          ?.map((e) => AgentToolParams.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      mcpServers: (json['mcp_servers'] as List?)
+          ?.map((e) => MCPServerParams.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      skills: (json['skills'] as List?)
+          ?.map((e) => AgentSkillParams.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    if (version != null) 'version': version,
+    if (model != null) 'model': model!.toJson(),
+    if (_system != _notSet) 'system': _system,
+    if (tools != null) 'tools': tools!.map((e) => e.toJson()).toList(),
+    if (mcpServers != null)
+      'mcp_servers': mcpServers!.map((e) => e.toJson()).toList(),
+    if (skills != null) 'skills': skills!.map((e) => e.toJson()).toList(),
+  };
+
+  /// Creates a copy with replaced values.
+  AgentParamsWithOverrides copyWith({
+    String? id,
+    String? type,
+    Object? version = unsetCopyWithValue,
+    Object? model = unsetCopyWithValue,
+    Object? system = unsetCopyWithValue,
+    Object? tools = unsetCopyWithValue,
+    Object? mcpServers = unsetCopyWithValue,
+    Object? skills = unsetCopyWithValue,
+  }) {
+    return AgentParamsWithOverrides(
+      id: id ?? this.id,
+      type: type ?? this.type,
+      version: version == unsetCopyWithValue ? this.version : version as int?,
+      model: model == unsetCopyWithValue ? this.model : model as ModelParams?,
+      system: system == unsetCopyWithValue ? _system : system,
+      tools: tools == unsetCopyWithValue
+          ? this.tools
+          : tools as List<AgentToolParams>?,
+      mcpServers: mcpServers == unsetCopyWithValue
+          ? this.mcpServers
+          : mcpServers as List<MCPServerParams>?,
+      skills: skills == unsetCopyWithValue
+          ? this.skills
+          : skills as List<AgentSkillParams>?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AgentParamsWithOverrides &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          type == other.type &&
+          version == other.version &&
+          model == other.model &&
+          _system == other._system &&
+          listsEqual(tools, other.tools) &&
+          listsEqual(mcpServers, other.mcpServers) &&
+          listsEqual(skills, other.skills);
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    type,
+    version,
+    model,
+    _system,
+    listHash(tools),
+    listHash(mcpServers),
+    listHash(skills),
+  );
+
+  @override
+  String toString() =>
+      'AgentParamsWithOverrides('
+      'id: $id, '
+      'type: $type, '
+      'version: $version, '
+      'model: $model, '
+      'system: $system, '
+      'tools: $tools, '
+      'mcpServers: $mcpServers, '
+      'skills: $skills)';
 }
 
 /// Request parameters for creating a session.

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/session_list_response.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/session_list_response.dart
@@ -13,8 +13,18 @@ class ListSessionsResponse {
   /// Opaque cursor for the next page. Null when no more results.
   final String? nextPage;
 
+  /// Opaque cursor for the previous page.
+  ///
+  /// Null when on the first page. Pass as the `page` parameter to navigate
+  /// backward.
+  final String? prevPage;
+
   /// Creates a [ListSessionsResponse].
-  const ListSessionsResponse({required this.data, this.nextPage});
+  const ListSessionsResponse({
+    required this.data,
+    this.nextPage,
+    this.prevPage,
+  });
 
   /// Creates a [ListSessionsResponse] from JSON.
   factory ListSessionsResponse.fromJson(Map<String, dynamic> json) {
@@ -23,6 +33,7 @@ class ListSessionsResponse {
           .map((e) => Session.fromJson(e as Map<String, dynamic>))
           .toList(),
       nextPage: json['next_page'] as String?,
+      prevPage: json['prev_page'] as String?,
     );
   }
 
@@ -30,18 +41,23 @@ class ListSessionsResponse {
   Map<String, dynamic> toJson() => {
     'data': data.map((e) => e.toJson()).toList(),
     if (nextPage != null) 'next_page': nextPage,
+    if (prevPage != null) 'prev_page': prevPage,
   };
 
   /// Creates a copy with replaced values.
   ListSessionsResponse copyWith({
     List<Session>? data,
     Object? nextPage = unsetCopyWithValue,
+    Object? prevPage = unsetCopyWithValue,
   }) {
     return ListSessionsResponse(
       data: data ?? this.data,
       nextPage: nextPage == unsetCopyWithValue
           ? this.nextPage
           : nextPage as String?,
+      prevPage: prevPage == unsetCopyWithValue
+          ? this.prevPage
+          : prevPage as String?,
     );
   }
 
@@ -51,11 +67,14 @@ class ListSessionsResponse {
       other is ListSessionsResponse &&
           runtimeType == other.runtimeType &&
           listsEqual(data, other.data) &&
-          nextPage == other.nextPage;
+          nextPage == other.nextPage &&
+          prevPage == other.prevPage;
 
   @override
-  int get hashCode => Object.hash(listHash(data), nextPage);
+  int get hashCode => Object.hash(listHash(data), nextPage, prevPage);
 
   @override
-  String toString() => 'ListSessionsResponse(data: $data, nextPage: $nextPage)';
+  String toString() =>
+      'ListSessionsResponse(data: $data, nextPage: $nextPage, '
+      'prevPage: $prevPage)';
 }

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/webhooks/webhook_event.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/webhooks/webhook_event.dart
@@ -106,6 +106,19 @@ class WebhookEvent {
 /// - [WebhookVaultCredentialArchivedEventData] — `vault_credential.archived`.
 /// - [WebhookVaultCredentialDeletedEventData] — `vault_credential.deleted`.
 /// - [WebhookVaultCredentialRefreshFailedEventData] — `vault_credential.refresh_failed`.
+/// - [WebhookAgentCreatedEventData] — `agent.created`.
+/// - [WebhookAgentUpdatedEventData] — `agent.updated`.
+/// - [WebhookAgentDeletedEventData] — `agent.deleted`.
+/// - [WebhookAgentArchivedEventData] — `agent.archived`.
+/// - [WebhookDeploymentCreatedEventData] — `deployment.created`.
+/// - [WebhookDeploymentUpdatedEventData] — `deployment.updated`.
+/// - [WebhookDeploymentDeletedEventData] — `deployment.deleted`.
+/// - [WebhookDeploymentArchivedEventData] — `deployment.archived`.
+/// - [WebhookDeploymentPausedEventData] — `deployment.paused`.
+/// - [WebhookDeploymentUnpausedEventData] — `deployment.unpaused`.
+/// - [WebhookDeploymentRunStartedEventData] — `deployment_run.started`.
+/// - [WebhookDeploymentRunSucceededEventData] — `deployment_run.succeeded`.
+/// - [WebhookDeploymentRunFailedEventData] — `deployment_run.failed`.
 /// - [UnknownWebhookEventData] — unrecognized event-data type, for forward
 ///   compatibility.
 sealed class WebhookEventData {
@@ -157,6 +170,28 @@ sealed class WebhookEventData {
         WebhookVaultCredentialDeletedEventData.fromJson(json),
       'vault_credential.refresh_failed' =>
         WebhookVaultCredentialRefreshFailedEventData.fromJson(json),
+      'agent.created' => WebhookAgentCreatedEventData.fromJson(json),
+      'agent.updated' => WebhookAgentUpdatedEventData.fromJson(json),
+      'agent.deleted' => WebhookAgentDeletedEventData.fromJson(json),
+      'agent.archived' => WebhookAgentArchivedEventData.fromJson(json),
+      'deployment.created' => WebhookDeploymentCreatedEventData.fromJson(json),
+      'deployment.updated' => WebhookDeploymentUpdatedEventData.fromJson(json),
+      'deployment.deleted' => WebhookDeploymentDeletedEventData.fromJson(json),
+      'deployment.archived' => WebhookDeploymentArchivedEventData.fromJson(
+        json,
+      ),
+      'deployment.paused' => WebhookDeploymentPausedEventData.fromJson(json),
+      'deployment.unpaused' => WebhookDeploymentUnpausedEventData.fromJson(
+        json,
+      ),
+      'deployment_run.started' => WebhookDeploymentRunStartedEventData.fromJson(
+        json,
+      ),
+      'deployment_run.succeeded' =>
+        WebhookDeploymentRunSucceededEventData.fromJson(json),
+      'deployment_run.failed' => WebhookDeploymentRunFailedEventData.fromJson(
+        json,
+      ),
       _ => UnknownWebhookEventData(rawJson: json),
     };
   }
@@ -1872,6 +1907,932 @@ class WebhookVaultCredentialRefreshFailedEventData extends WebhookEventData {
   String toString() =>
       'WebhookVaultCredentialRefreshFailedEventData(id: $id, organizationId: $organizationId, '
       'workspaceId: $workspaceId, vaultId: $vaultId)';
+}
+
+/// Webhook event data signalling an agent was created.
+@immutable
+class WebhookAgentCreatedEventData extends WebhookEventData {
+  /// The event-data type, always 'agent.created'.
+  String get type => 'agent.created';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookAgentCreatedEventData].
+  const WebhookAgentCreatedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookAgentCreatedEventData] from JSON.
+  factory WebhookAgentCreatedEventData.fromJson(Map<String, dynamic> json) {
+    return WebhookAgentCreatedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookAgentCreatedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookAgentCreatedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookAgentCreatedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookAgentCreatedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling an agent was updated.
+@immutable
+class WebhookAgentUpdatedEventData extends WebhookEventData {
+  /// The event-data type, always 'agent.updated'.
+  String get type => 'agent.updated';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookAgentUpdatedEventData].
+  const WebhookAgentUpdatedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookAgentUpdatedEventData] from JSON.
+  factory WebhookAgentUpdatedEventData.fromJson(Map<String, dynamic> json) {
+    return WebhookAgentUpdatedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookAgentUpdatedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookAgentUpdatedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookAgentUpdatedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookAgentUpdatedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling an agent was deleted.
+@immutable
+class WebhookAgentDeletedEventData extends WebhookEventData {
+  /// The event-data type, always 'agent.deleted'.
+  String get type => 'agent.deleted';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookAgentDeletedEventData].
+  const WebhookAgentDeletedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookAgentDeletedEventData] from JSON.
+  factory WebhookAgentDeletedEventData.fromJson(Map<String, dynamic> json) {
+    return WebhookAgentDeletedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookAgentDeletedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookAgentDeletedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookAgentDeletedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookAgentDeletedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling an agent was archived.
+@immutable
+class WebhookAgentArchivedEventData extends WebhookEventData {
+  /// The event-data type, always 'agent.archived'.
+  String get type => 'agent.archived';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookAgentArchivedEventData].
+  const WebhookAgentArchivedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookAgentArchivedEventData] from JSON.
+  factory WebhookAgentArchivedEventData.fromJson(Map<String, dynamic> json) {
+    return WebhookAgentArchivedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookAgentArchivedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookAgentArchivedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookAgentArchivedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookAgentArchivedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a deployment was created.
+@immutable
+class WebhookDeploymentCreatedEventData extends WebhookEventData {
+  /// The event-data type, always 'deployment.created'.
+  String get type => 'deployment.created';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookDeploymentCreatedEventData].
+  const WebhookDeploymentCreatedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookDeploymentCreatedEventData] from JSON.
+  factory WebhookDeploymentCreatedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookDeploymentCreatedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookDeploymentCreatedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookDeploymentCreatedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookDeploymentCreatedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookDeploymentCreatedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a deployment was updated.
+@immutable
+class WebhookDeploymentUpdatedEventData extends WebhookEventData {
+  /// The event-data type, always 'deployment.updated'.
+  String get type => 'deployment.updated';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookDeploymentUpdatedEventData].
+  const WebhookDeploymentUpdatedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookDeploymentUpdatedEventData] from JSON.
+  factory WebhookDeploymentUpdatedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookDeploymentUpdatedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookDeploymentUpdatedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookDeploymentUpdatedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookDeploymentUpdatedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookDeploymentUpdatedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a deployment was deleted.
+@immutable
+class WebhookDeploymentDeletedEventData extends WebhookEventData {
+  /// The event-data type, always 'deployment.deleted'.
+  String get type => 'deployment.deleted';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookDeploymentDeletedEventData].
+  const WebhookDeploymentDeletedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookDeploymentDeletedEventData] from JSON.
+  factory WebhookDeploymentDeletedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookDeploymentDeletedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookDeploymentDeletedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookDeploymentDeletedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookDeploymentDeletedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookDeploymentDeletedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a deployment was archived.
+@immutable
+class WebhookDeploymentArchivedEventData extends WebhookEventData {
+  /// The event-data type, always 'deployment.archived'.
+  String get type => 'deployment.archived';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookDeploymentArchivedEventData].
+  const WebhookDeploymentArchivedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookDeploymentArchivedEventData] from JSON.
+  factory WebhookDeploymentArchivedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookDeploymentArchivedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookDeploymentArchivedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookDeploymentArchivedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookDeploymentArchivedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookDeploymentArchivedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a deployment was paused.
+@immutable
+class WebhookDeploymentPausedEventData extends WebhookEventData {
+  /// The event-data type, always 'deployment.paused'.
+  String get type => 'deployment.paused';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookDeploymentPausedEventData].
+  const WebhookDeploymentPausedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookDeploymentPausedEventData] from JSON.
+  factory WebhookDeploymentPausedEventData.fromJson(Map<String, dynamic> json) {
+    return WebhookDeploymentPausedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookDeploymentPausedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookDeploymentPausedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookDeploymentPausedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookDeploymentPausedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a deployment was unpaused.
+@immutable
+class WebhookDeploymentUnpausedEventData extends WebhookEventData {
+  /// The event-data type, always 'deployment.unpaused'.
+  String get type => 'deployment.unpaused';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookDeploymentUnpausedEventData].
+  const WebhookDeploymentUnpausedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookDeploymentUnpausedEventData] from JSON.
+  factory WebhookDeploymentUnpausedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookDeploymentUnpausedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookDeploymentUnpausedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookDeploymentUnpausedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookDeploymentUnpausedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookDeploymentUnpausedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a deployment run started.
+@immutable
+class WebhookDeploymentRunStartedEventData extends WebhookEventData {
+  /// The event-data type, always 'deployment_run.started'.
+  String get type => 'deployment_run.started';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookDeploymentRunStartedEventData].
+  const WebhookDeploymentRunStartedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookDeploymentRunStartedEventData] from JSON.
+  factory WebhookDeploymentRunStartedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookDeploymentRunStartedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookDeploymentRunStartedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookDeploymentRunStartedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookDeploymentRunStartedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookDeploymentRunStartedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a deployment run succeeded.
+@immutable
+class WebhookDeploymentRunSucceededEventData extends WebhookEventData {
+  /// The event-data type, always 'deployment_run.succeeded'.
+  String get type => 'deployment_run.succeeded';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookDeploymentRunSucceededEventData].
+  const WebhookDeploymentRunSucceededEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookDeploymentRunSucceededEventData] from JSON.
+  factory WebhookDeploymentRunSucceededEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookDeploymentRunSucceededEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookDeploymentRunSucceededEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookDeploymentRunSucceededEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookDeploymentRunSucceededEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookDeploymentRunSucceededEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a deployment run failed.
+@immutable
+class WebhookDeploymentRunFailedEventData extends WebhookEventData {
+  /// The event-data type, always 'deployment_run.failed'.
+  String get type => 'deployment_run.failed';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookDeploymentRunFailedEventData].
+  const WebhookDeploymentRunFailedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookDeploymentRunFailedEventData] from JSON.
+  factory WebhookDeploymentRunFailedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookDeploymentRunFailedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookDeploymentRunFailedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookDeploymentRunFailedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookDeploymentRunFailedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookDeploymentRunFailedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
 }
 
 /// Unrecognized webhook event-data type — preserves raw JSON for forward

--- a/packages/anthropic_sdk_dart/lib/src/models/messages/message_create_request.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/messages/message_create_request.dart
@@ -214,9 +214,6 @@ class MessageCreateRequest {
   /// in the request.
   final CacheControlEphemeral? cacheControl;
 
-  /// Optional identifier of the end-user profile this request belongs to.
-  final String? userProfileId;
-
   /// Cache diagnostics configuration.
   ///
   /// Opts the request into prompt-cache diagnostics. Requires the
@@ -256,7 +253,6 @@ class MessageCreateRequest {
     this.container,
     this.speed,
     this.cacheControl,
-    this.userProfileId,
     this.diagnostics,
     this.fallbacks,
     this.fallbackCreditToken,
@@ -306,7 +302,6 @@ class MessageCreateRequest {
               json['cache_control'] as Map<String, dynamic>,
             )
           : null,
-      userProfileId: json['user_profile_id'] as String?,
       diagnostics: json['diagnostics'] != null
           ? DiagnosticsParam.fromJson(
               json['diagnostics'] as Map<String, dynamic>,
@@ -340,7 +335,6 @@ class MessageCreateRequest {
     if (container != null) 'container': container,
     if (speed != null) 'speed': speed!.toJson(),
     if (cacheControl != null) 'cache_control': cacheControl!.toJson(),
-    if (userProfileId != null) 'user_profile_id': userProfileId,
     if (diagnostics != null) 'diagnostics': diagnostics!.toJson(),
     if (fallbacks != null)
       'fallbacks': fallbacks!.map((e) => e.toJson()).toList(),
@@ -369,7 +363,6 @@ class MessageCreateRequest {
     Object? container = unsetCopyWithValue,
     Object? speed = unsetCopyWithValue,
     Object? cacheControl = unsetCopyWithValue,
-    Object? userProfileId = unsetCopyWithValue,
     Object? diagnostics = unsetCopyWithValue,
     Object? fallbacks = unsetCopyWithValue,
     Object? fallbackCreditToken = unsetCopyWithValue,
@@ -418,9 +411,6 @@ class MessageCreateRequest {
       cacheControl: cacheControl == unsetCopyWithValue
           ? this.cacheControl
           : cacheControl as CacheControlEphemeral?,
-      userProfileId: userProfileId == unsetCopyWithValue
-          ? this.userProfileId
-          : userProfileId as String?,
       diagnostics: diagnostics == unsetCopyWithValue
           ? this.diagnostics
           : diagnostics as DiagnosticsParam?,
@@ -457,7 +447,6 @@ class MessageCreateRequest {
           container == other.container &&
           speed == other.speed &&
           cacheControl == other.cacheControl &&
-          userProfileId == other.userProfileId &&
           diagnostics == other.diagnostics &&
           listsEqual(fallbacks, other.fallbacks) &&
           fallbackCreditToken == other.fallbackCreditToken;
@@ -483,7 +472,6 @@ class MessageCreateRequest {
     container,
     speed,
     cacheControl,
-    userProfileId,
     diagnostics,
     listHash(fallbacks),
     fallbackCreditToken,
@@ -498,7 +486,7 @@ class MessageCreateRequest {
       'toolChoice: $toolChoice, tools: $tools, topP: $topP, topK: $topK, '
       'inferenceGeo: $inferenceGeo, outputConfig: $outputConfig, '
       'container: $container, speed: $speed, cacheControl: $cacheControl, '
-      'userProfileId: $userProfileId, diagnostics: $diagnostics, '
+      'diagnostics: $diagnostics, '
       'fallbacks: ${fallbacks == null ? null : '${fallbacks!.length} items'}, '
       'fallbackCreditToken: '
       '${fallbackCreditToken == null ? null : '[redacted]'})';

--- a/packages/anthropic_sdk_dart/lib/src/models/tools/built_in_tools.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/tools/built_in_tools.dart
@@ -4,6 +4,7 @@ import '../common/copy_with_sentinel.dart';
 import '../common/equality_helpers.dart';
 import '../content/citations_config.dart';
 import '../metadata/cache_control.dart';
+import 'response_inclusion.dart';
 
 // RequestCitationsConfig now lives in content/citations_config.dart but is part
 // of this library's API surface (e.g. WebFetchTool.citations), so re-export it
@@ -131,7 +132,7 @@ sealed class BuiltInTool {
     List<String>? allowedCallers,
     bool? deferLoading,
     bool? strict,
-    String? responseInclusion,
+    ResponseInclusion? responseInclusion,
   }) = WebSearchTool;
 
   /// Creates a web fetch tool.
@@ -147,7 +148,7 @@ sealed class BuiltInTool {
     bool? deferLoading,
     bool? strict,
     bool? useCache,
-    String? responseInclusion,
+    ResponseInclusion? responseInclusion,
   }) = WebFetchTool;
 
   /// Creates a memory tool.
@@ -810,7 +811,7 @@ class WebSearchTool extends BuiltInTool {
   /// `full` returns the complete content (default); `excluded` drops the nested
   /// server_tool_use and result block pair entirely. Only supported for
   /// `web_search_20260318` and normalized to `null` for other versions.
-  final String? responseInclusion;
+  final ResponseInclusion? responseInclusion;
 
   /// Creates a [WebSearchTool].
   ///
@@ -826,7 +827,7 @@ class WebSearchTool extends BuiltInTool {
     this.allowedCallers,
     this.deferLoading,
     this.strict,
-    String? responseInclusion,
+    ResponseInclusion? responseInclusion,
   }) : type = type ?? 'web_search_20250305',
        responseInclusion = type == 'web_search_20260318'
            ? responseInclusion
@@ -850,7 +851,9 @@ class WebSearchTool extends BuiltInTool {
       allowedCallers: (json['allowed_callers'] as List?)?.cast<String>(),
       deferLoading: json['defer_loading'] as bool?,
       strict: json['strict'] as bool?,
-      responseInclusion: json['response_inclusion'] as String?,
+      responseInclusion: json['response_inclusion'] != null
+          ? ResponseInclusion.fromJson(json['response_inclusion'] as String)
+          : null,
     );
   }
 
@@ -866,7 +869,8 @@ class WebSearchTool extends BuiltInTool {
     if (allowedCallers != null) 'allowed_callers': allowedCallers,
     if (deferLoading != null) 'defer_loading': deferLoading,
     if (strict != null) 'strict': strict,
-    if (responseInclusion != null) 'response_inclusion': responseInclusion,
+    if (responseInclusion != null)
+      'response_inclusion': responseInclusion!.toJson(),
   };
 
   /// Creates a copy with replaced values.
@@ -906,7 +910,7 @@ class WebSearchTool extends BuiltInTool {
       strict: strict == unsetCopyWithValue ? this.strict : strict as bool?,
       responseInclusion: responseInclusion == unsetCopyWithValue
           ? this.responseInclusion
-          : responseInclusion as String?,
+          : responseInclusion as ResponseInclusion?,
     );
   }
 
@@ -995,7 +999,7 @@ class WebFetchTool extends BuiltInTool {
   /// `full` returns the complete content (default); `excluded` drops the nested
   /// server_tool_use and result block pair entirely. Only supported for
   /// `web_fetch_20260318` and normalized to `null` for other versions.
-  final String? responseInclusion;
+  final ResponseInclusion? responseInclusion;
 
   /// Creates a [WebFetchTool].
   ///
@@ -1015,7 +1019,7 @@ class WebFetchTool extends BuiltInTool {
     this.deferLoading,
     this.strict,
     bool? useCache,
-    String? responseInclusion,
+    ResponseInclusion? responseInclusion,
   }) : type = type ?? 'web_fetch_20260309',
        useCache =
            (type == null ||
@@ -1049,7 +1053,9 @@ class WebFetchTool extends BuiltInTool {
       deferLoading: json['defer_loading'] as bool?,
       strict: json['strict'] as bool?,
       useCache: json['use_cache'] as bool?,
-      responseInclusion: json['response_inclusion'] as String?,
+      responseInclusion: json['response_inclusion'] != null
+          ? ResponseInclusion.fromJson(json['response_inclusion'] as String)
+          : null,
     );
   }
 
@@ -1069,7 +1075,8 @@ class WebFetchTool extends BuiltInTool {
     if (useCache != null &&
         (type == 'web_fetch_20260309' || type == 'web_fetch_20260318'))
       'use_cache': useCache,
-    if (responseInclusion != null) 'response_inclusion': responseInclusion,
+    if (responseInclusion != null)
+      'response_inclusion': responseInclusion!.toJson(),
   };
 
   @override
@@ -1135,7 +1142,7 @@ class WebFetchTool extends BuiltInTool {
           : useCache as bool?,
       responseInclusion: responseInclusion == unsetCopyWithValue
           ? this.responseInclusion
-          : responseInclusion as String?,
+          : responseInclusion as ResponseInclusion?,
     );
   }
 

--- a/packages/anthropic_sdk_dart/lib/src/models/tools/built_in_tools.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/tools/built_in_tools.dart
@@ -131,6 +131,7 @@ sealed class BuiltInTool {
     List<String>? allowedCallers,
     bool? deferLoading,
     bool? strict,
+    String? responseInclusion,
   }) = WebSearchTool;
 
   /// Creates a web fetch tool.
@@ -146,6 +147,7 @@ sealed class BuiltInTool {
     bool? deferLoading,
     bool? strict,
     bool? useCache,
+    String? responseInclusion,
   }) = WebFetchTool;
 
   /// Creates a memory tool.
@@ -234,9 +236,11 @@ sealed class BuiltInTool {
       'text_editor_20250728' => TextEditorTool.fromJson(json),
       'web_search_20250305' => WebSearchTool.fromJson(json),
       'web_search_20260209' => WebSearchTool.fromJson(json),
+      'web_search_20260318' => WebSearchTool.fromJson(json),
       'web_fetch_20250910' => WebFetchTool.fromJson(json),
       'web_fetch_20260209' => WebFetchTool.fromJson(json),
       'web_fetch_20260309' => WebFetchTool.fromJson(json),
+      'web_fetch_20260318' => WebFetchTool.fromJson(json),
       'memory_20250818' => MemoryTool.fromJson(json),
       'tool_search_tool_bm25' => ToolSearchToolBm25.fromJson(json),
       'tool_search_tool_bm25_20251119' => ToolSearchToolBm25.fromJson(json),
@@ -800,7 +804,18 @@ class WebSearchTool extends BuiltInTool {
   /// Whether strict schema validation is enabled.
   final bool? strict;
 
+  /// How this tool's result blocks appear in the API response when consumed by
+  /// a completed `code_execution` call in the same turn.
+  ///
+  /// `full` returns the complete content (default); `excluded` drops the nested
+  /// server_tool_use and result block pair entirely. Only supported for
+  /// `web_search_20260318` and normalized to `null` for other versions.
+  final String? responseInclusion;
+
   /// Creates a [WebSearchTool].
+  ///
+  /// [responseInclusion] is only supported for `web_search_20260318` and is
+  /// normalized to `null` for other versions.
   const WebSearchTool({
     String? type,
     this.allowedDomains,
@@ -811,7 +826,11 @@ class WebSearchTool extends BuiltInTool {
     this.allowedCallers,
     this.deferLoading,
     this.strict,
-  }) : type = type ?? 'web_search_20250305';
+    String? responseInclusion,
+  }) : type = type ?? 'web_search_20250305',
+       responseInclusion = type == 'web_search_20260318'
+           ? responseInclusion
+           : null;
 
   /// Creates a [WebSearchTool] from JSON.
   factory WebSearchTool.fromJson(Map<String, dynamic> json) {
@@ -831,6 +850,7 @@ class WebSearchTool extends BuiltInTool {
       allowedCallers: (json['allowed_callers'] as List?)?.cast<String>(),
       deferLoading: json['defer_loading'] as bool?,
       strict: json['strict'] as bool?,
+      responseInclusion: json['response_inclusion'] as String?,
     );
   }
 
@@ -846,6 +866,7 @@ class WebSearchTool extends BuiltInTool {
     if (allowedCallers != null) 'allowed_callers': allowedCallers,
     if (deferLoading != null) 'defer_loading': deferLoading,
     if (strict != null) 'strict': strict,
+    if (responseInclusion != null) 'response_inclusion': responseInclusion,
   };
 
   /// Creates a copy with replaced values.
@@ -859,6 +880,7 @@ class WebSearchTool extends BuiltInTool {
     Object? allowedCallers = unsetCopyWithValue,
     Object? deferLoading = unsetCopyWithValue,
     Object? strict = unsetCopyWithValue,
+    Object? responseInclusion = unsetCopyWithValue,
   }) {
     return WebSearchTool(
       type: type ?? this.type,
@@ -882,6 +904,9 @@ class WebSearchTool extends BuiltInTool {
           ? this.deferLoading
           : deferLoading as bool?,
       strict: strict == unsetCopyWithValue ? this.strict : strict as bool?,
+      responseInclusion: responseInclusion == unsetCopyWithValue
+          ? this.responseInclusion
+          : responseInclusion as String?,
     );
   }
 
@@ -898,7 +923,8 @@ class WebSearchTool extends BuiltInTool {
           userLocation == other.userLocation &&
           listsEqual(allowedCallers, other.allowedCallers) &&
           deferLoading == other.deferLoading &&
-          strict == other.strict;
+          strict == other.strict &&
+          responseInclusion == other.responseInclusion;
 
   @override
   int get hashCode => Object.hash(
@@ -911,6 +937,7 @@ class WebSearchTool extends BuiltInTool {
     listHash(allowedCallers),
     deferLoading,
     strict,
+    responseInclusion,
   );
 
   @override
@@ -919,7 +946,7 @@ class WebSearchTool extends BuiltInTool {
       'blockedDomains: $blockedDomains, cacheControl: $cacheControl, '
       'maxUses: $maxUses, userLocation: $userLocation, '
       'allowedCallers: $allowedCallers, deferLoading: $deferLoading, '
-      'strict: $strict)';
+      'strict: $strict, responseInclusion: $responseInclusion)';
 }
 
 /// Web fetch built-in tool.
@@ -962,10 +989,20 @@ class WebFetchTool extends BuiltInTool {
   /// rapidly-changing sources.
   final bool? useCache;
 
+  /// How this tool's result blocks appear in the API response when consumed by
+  /// a completed `code_execution` call in the same turn.
+  ///
+  /// `full` returns the complete content (default); `excluded` drops the nested
+  /// server_tool_use and result block pair entirely. Only supported for
+  /// `web_fetch_20260318` and normalized to `null` for other versions.
+  final String? responseInclusion;
+
   /// Creates a [WebFetchTool].
   ///
-  /// [useCache] is only supported for `web_fetch_20260309` and is normalized
-  /// to `null` for other versions.
+  /// [useCache] is only supported for `web_fetch_20260309` and
+  /// `web_fetch_20260318` and is normalized to `null` for other versions.
+  /// [responseInclusion] is only supported for `web_fetch_20260318` and is
+  /// normalized to `null` for other versions.
   const WebFetchTool({
     String? type,
     this.allowedDomains,
@@ -978,9 +1015,16 @@ class WebFetchTool extends BuiltInTool {
     this.deferLoading,
     this.strict,
     bool? useCache,
+    String? responseInclusion,
   }) : type = type ?? 'web_fetch_20260309',
-       useCache = (type == null || type == 'web_fetch_20260309')
+       useCache =
+           (type == null ||
+               type == 'web_fetch_20260309' ||
+               type == 'web_fetch_20260318')
            ? useCache
+           : null,
+       responseInclusion = type == 'web_fetch_20260318'
+           ? responseInclusion
            : null;
 
   /// Creates a [WebFetchTool] from JSON.
@@ -1005,6 +1049,7 @@ class WebFetchTool extends BuiltInTool {
       deferLoading: json['defer_loading'] as bool?,
       strict: json['strict'] as bool?,
       useCache: json['use_cache'] as bool?,
+      responseInclusion: json['response_inclusion'] as String?,
     );
   }
 
@@ -1021,7 +1066,10 @@ class WebFetchTool extends BuiltInTool {
     if (allowedCallers != null) 'allowed_callers': allowedCallers,
     if (deferLoading != null) 'defer_loading': deferLoading,
     if (strict != null) 'strict': strict,
-    if (useCache != null && type == 'web_fetch_20260309') 'use_cache': useCache,
+    if (useCache != null &&
+        (type == 'web_fetch_20260309' || type == 'web_fetch_20260318'))
+      'use_cache': useCache,
+    if (responseInclusion != null) 'response_inclusion': responseInclusion,
   };
 
   @override
@@ -1039,7 +1087,8 @@ class WebFetchTool extends BuiltInTool {
           listsEqual(allowedCallers, other.allowedCallers) &&
           deferLoading == other.deferLoading &&
           strict == other.strict &&
-          useCache == other.useCache;
+          useCache == other.useCache &&
+          responseInclusion == other.responseInclusion;
 
   /// Creates a copy with replaced values.
   WebFetchTool copyWith({
@@ -1054,6 +1103,7 @@ class WebFetchTool extends BuiltInTool {
     Object? deferLoading = unsetCopyWithValue,
     Object? strict = unsetCopyWithValue,
     Object? useCache = unsetCopyWithValue,
+    Object? responseInclusion = unsetCopyWithValue,
   }) {
     return WebFetchTool(
       type: type ?? this.type,
@@ -1083,6 +1133,9 @@ class WebFetchTool extends BuiltInTool {
       useCache: useCache == unsetCopyWithValue
           ? this.useCache
           : useCache as bool?,
+      responseInclusion: responseInclusion == unsetCopyWithValue
+          ? this.responseInclusion
+          : responseInclusion as String?,
     );
   }
 
@@ -1099,6 +1152,7 @@ class WebFetchTool extends BuiltInTool {
     deferLoading,
     strict,
     useCache,
+    responseInclusion,
   );
 
   @override
@@ -1107,7 +1161,8 @@ class WebFetchTool extends BuiltInTool {
       'blockedDomains: $blockedDomains, cacheControl: $cacheControl, '
       'maxUses: $maxUses, maxContentTokens: $maxContentTokens, '
       'citations: $citations, allowedCallers: $allowedCallers, '
-      'deferLoading: $deferLoading, strict: $strict, useCache: $useCache)';
+      'deferLoading: $deferLoading, strict: $strict, useCache: $useCache, '
+      'responseInclusion: $responseInclusion)';
 }
 
 /// Memory built-in tool.

--- a/packages/anthropic_sdk_dart/lib/src/models/tools/response_inclusion.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/tools/response_inclusion.dart
@@ -1,0 +1,28 @@
+/// How a web tool's result blocks appear in the API response when the result
+/// was consumed by a completed `code_execution` call in the same turn.
+///
+/// Only supported for the `web_search_20260318` and `web_fetch_20260318` tool
+/// versions. Results from direct calls, or from `code_execution` calls that
+/// paused before completing, are always returned in full.
+enum ResponseInclusion {
+  /// Return the complete content (default).
+  full('full'),
+
+  /// Drop the nested `server_tool_use` and result block pair entirely.
+  excluded('excluded');
+
+  const ResponseInclusion(this.value);
+
+  /// JSON value for this response-inclusion mode.
+  final String value;
+
+  /// Parses a [ResponseInclusion] from JSON.
+  static ResponseInclusion fromJson(String value) => switch (value) {
+    'full' => ResponseInclusion.full,
+    'excluded' => ResponseInclusion.excluded,
+    _ => throw FormatException('Unknown ResponseInclusion: $value'),
+  };
+
+  /// Converts this response-inclusion mode to JSON.
+  String toJson() => value;
+}

--- a/packages/anthropic_sdk_dart/lib/src/resources/message_batches_resource.dart
+++ b/packages/anthropic_sdk_dart/lib/src/resources/message_batches_resource.dart
@@ -27,14 +27,22 @@ class MessageBatchesResource extends ResourceBase {
   ///
   /// Send a list of requests to be processed asynchronously.
   ///
+  /// [userProfileId] attributes the requests in this batch to an end-user
+  /// profile; it is sent as the `anthropic-user-profile-id` header.
+  ///
   /// The optional [abortTrigger] allows canceling the request.
   Future<MessageBatch> create(
     MessageBatchCreateRequest request, {
     Future<void>? abortTrigger,
+    String? userProfileId,
   }) async {
     ensureNotClosed?.call();
     final url = requestBuilder.buildUrl('/v1/messages/batches');
-    final headers = requestBuilder.buildHeaders();
+    final headers = requestBuilder.buildHeaders(
+      additionalHeaders: userProfileId != null
+          ? {'anthropic-user-profile-id': userProfileId}
+          : null,
+    );
     final httpRequest = http.Request('POST', url)
       ..headers.addAll(headers)
       ..body = jsonEncode(request.toJson());

--- a/packages/anthropic_sdk_dart/lib/src/resources/messages_resource.dart
+++ b/packages/anthropic_sdk_dart/lib/src/resources/messages_resource.dart
@@ -42,17 +42,24 @@ class MessagesResource extends ResourceBase with StreamingResource {
   /// Send a structured list of input messages with text and/or image content,
   /// and the model will generate the next message in the conversation.
   ///
+  /// [userProfileId] attributes this request to an end-user profile; it is sent
+  /// as the `anthropic-user-profile-id` header.
+  ///
   /// The optional [abortTrigger] allows canceling the request.
   Future<Message> create(
     MessageCreateRequest request, {
     Future<void>? abortTrigger,
     List<String> betas = const [],
+    String? userProfileId,
   }) async {
     ensureNotClosed?.call();
     final body = request.toJson()..remove('stream'); // Ensure non-streaming
     final url = requestBuilder.buildUrl('/v1/messages');
     final headers = requestBuilder.buildHeaders(
-      additionalHeaders: _betaHeaders(betas),
+      additionalHeaders: _requestHeaders(
+        betas: betas,
+        userProfileId: userProfileId,
+      ),
     );
     final httpRequest = http.Request('POST', url)
       ..headers.addAll(headers)
@@ -70,11 +77,15 @@ class MessagesResource extends ResourceBase with StreamingResource {
   ///
   /// Returns a stream of [MessageStreamEvent]s as the response is generated.
   ///
+  /// [userProfileId] attributes this request to an end-user profile; it is sent
+  /// as the `anthropic-user-profile-id` header.
+  ///
   /// The optional [abortTrigger] allows canceling the stream.
   Stream<MessageStreamEvent> createStream(
     MessageCreateRequest request, {
     Future<void>? abortTrigger,
     List<String> betas = const [],
+    String? userProfileId,
   }) async* {
     final body = request.toJson();
     body['stream'] = true;
@@ -82,7 +93,7 @@ class MessagesResource extends ResourceBase with StreamingResource {
     final eventStream = postStream(
       '/v1/messages',
       body: body,
-      headers: _betaHeaders(betas),
+      headers: _requestHeaders(betas: betas, userProfileId: userProfileId),
       abortTrigger: abortTrigger,
     );
 
@@ -95,16 +106,23 @@ class MessagesResource extends ResourceBase with StreamingResource {
   ///
   /// Returns the count of input tokens for the given request.
   ///
+  /// [userProfileId] attributes this request to an end-user profile; it is sent
+  /// as the `anthropic-user-profile-id` header.
+  ///
   /// The optional [abortTrigger] allows canceling the request.
   Future<TokenCountResponse> countTokens(
     TokenCountRequest request, {
     Future<void>? abortTrigger,
     List<String> betas = const [],
+    String? userProfileId,
   }) async {
     ensureNotClosed?.call();
     final url = requestBuilder.buildUrl('/v1/messages/count_tokens');
     final headers = requestBuilder.buildHeaders(
-      additionalHeaders: _betaHeaders(betas),
+      additionalHeaders: _requestHeaders(
+        betas: betas,
+        userProfileId: userProfileId,
+      ),
     );
     final httpRequest = http.Request('POST', url)
       ..headers.addAll(headers)
@@ -120,11 +138,20 @@ class MessagesResource extends ResourceBase with StreamingResource {
     );
   }
 
-  /// Builds the `anthropic-beta` header map from a list of beta feature names.
+  /// Builds the per-request header map from the [betas] feature list and an
+  /// optional [userProfileId].
   ///
-  /// Returns `null` if [betas] is empty, so that no extra header is sent.
-  static Map<String, String>? _betaHeaders(List<String> betas) {
-    if (betas.isEmpty) return null;
-    return {'anthropic-beta': betas.join(',')};
+  /// Sets `anthropic-beta` when [betas] is non-empty and
+  /// `anthropic-user-profile-id` when [userProfileId] is provided. Returns
+  /// `null` when neither applies, so that no extra header is sent.
+  static Map<String, String>? _requestHeaders({
+    List<String> betas = const [],
+    String? userProfileId,
+  }) {
+    final headers = <String, String>{
+      if (betas.isNotEmpty) 'anthropic-beta': betas.join(','),
+      'anthropic-user-profile-id': ?userProfileId,
+    };
+    return headers.isEmpty ? null : headers;
   }
 }

--- a/packages/anthropic_sdk_dart/lib/src/resources/session_events_resource.dart
+++ b/packages/anthropic_sdk_dart/lib/src/resources/session_events_resource.dart
@@ -114,23 +114,35 @@ class SessionEventsResource extends ResourceBase with StreamingResource {
   ///
   /// Parameters:
   /// - [lastEventId]: Resume streaming from after this event ID.
+  /// - [eventDeltas]: Event types to preview incrementally via [EventStartEvent]
+  ///   and [EventDeltaEvent] before the complete event arrives. Accepts
+  ///   `agent.message` and `agent.thinking`.
   /// - [abortTrigger]: Allows canceling the stream.
   ///
   /// Uses the eager-guard wrapper pattern so `ensureNotClosed()` runs at call
   /// time rather than on `.listen()`.
   Stream<SessionEvent> stream({
     String? lastEventId,
+    List<String>? eventDeltas,
     Future<void>? abortTrigger,
   }) {
     ensureNotClosed?.call();
-    return _streamImpl(lastEventId: lastEventId, abortTrigger: abortTrigger);
+    return _streamImpl(
+      lastEventId: lastEventId,
+      eventDeltas: eventDeltas,
+      abortTrigger: abortTrigger,
+    );
   }
 
   Stream<SessionEvent> _streamImpl({
     String? lastEventId,
+    List<String>? eventDeltas,
     Future<void>? abortTrigger,
   }) async* {
-    final queryParams = <String, dynamic>{'last_event_id': ?lastEventId};
+    final queryParams = <String, dynamic>{
+      'last_event_id': ?lastEventId,
+      'event_deltas[]': ?eventDeltas,
+    };
 
     final eventStream = getStream(
       '/v1/sessions/$sessionId/events/stream',

--- a/packages/anthropic_sdk_dart/llms.txt
+++ b/packages/anthropic_sdk_dart/llms.txt
@@ -5,8 +5,8 @@
 ## Docs
 
 - [README](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/README.md) (~5.3k tokens): Primary package documentation with installation, configuration, and usage examples.
-- [CHANGELOG](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/CHANGELOG.md) (~10.1k tokens): Release history and version-by-version changes.
-- [MIGRATION](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/MIGRATION.md) (~6.1k tokens): Upgrade notes and breaking-change guidance.
+- [CHANGELOG](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/CHANGELOG.md) (~10.4k tokens): Release history and version-by-version changes.
+- [MIGRATION](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/MIGRATION.md) (~6.7k tokens): Upgrade notes and breaking-change guidance.
 
 ## Examples
 
@@ -34,11 +34,11 @@
 - [mcp_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/mcp_example.dart) (~904 tokens): MCP tool integration.
 - [session_threads_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/session_threads_example.dart) (~816 tokens): Session threads: list, retrieve, stream events, archive (beta).
 - [deployments_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/deployments_example.dart) (~609 tokens): Scheduled deployments and deployment runs: cron schedule, pause/resume, run-now (beta).
-- [user_profiles_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/user_profiles_example.dart) (~649 tokens): User profiles and enrollment URLs (beta).
+- [user_profiles_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/user_profiles_example.dart) (~552 tokens): User profiles and enrollment URLs (beta).
 - [anthropic_sdk_dart_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/anthropic_sdk_dart_example.dart) (~670 tokens): Quick-start overview.
 
 ## Optional
 
 - [Package directory](https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/anthropic_sdk_dart): Source tree, pubspec, and package-local files.
 
-**Total: ~43.8k tokens**
+**Total: ~44.6k tokens**

--- a/packages/anthropic_sdk_dart/llms.txt
+++ b/packages/anthropic_sdk_dart/llms.txt
@@ -34,11 +34,11 @@
 - [mcp_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/mcp_example.dart) (~904 tokens): MCP tool integration.
 - [session_threads_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/session_threads_example.dart) (~816 tokens): Session threads: list, retrieve, stream events, archive (beta).
 - [deployments_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/deployments_example.dart) (~609 tokens): Scheduled deployments and deployment runs: cron schedule, pause/resume, run-now (beta).
-- [user_profiles_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/user_profiles_example.dart) (~552 tokens): User profiles and enrollment URLs (beta).
+- [user_profiles_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/user_profiles_example.dart) (~676 tokens): User profiles and enrollment URLs (beta).
 - [anthropic_sdk_dart_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/anthropic_sdk_dart_example.dart) (~670 tokens): Quick-start overview.
 
 ## Optional
 
 - [Package directory](https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/anthropic_sdk_dart): Source tree, pubspec, and package-local files.
 
-**Total: ~44.6k tokens**
+**Total: ~44.7k tokens**

--- a/packages/anthropic_sdk_dart/specs/openapi.yaml
+++ b/packages/anthropic_sdk_dart/specs/openapi.yaml
@@ -67,7 +67,8 @@
               "cache-diagnosis-2026-04-07",
               "thinking-token-count-2026-05-13",
               "server-side-fallback-2026-06-01",
-              "fallback-credit-2026-06-01"
+              "fallback-credit-2026-06-01",
+              "agent-memory-2026-07-22"
             ],
             "type": "string",
             "x-stainless-nominal": false
@@ -742,50 +743,36 @@
             "title": "Display Title"
           },
           "files": {
-            "anyOf": [
-              {
-                "items": {
-                  "format": "binary",
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null",
-                "x-stainless-skip": [
-                  "cli"
-                ]
-              }
-            ],
             "description": "Files to upload for the skill.\n\nAll files must be in the same top-level directory and must include a SKILL.md file at the root of that directory.",
-            "title": "Files"
+            "items": {
+              "format": "binary",
+              "type": "string"
+            },
+            "title": "Files",
+            "type": "array"
           }
         },
+        "required": [
+          "files"
+        ],
         "title": "Body_create_skill_v1_skills_post",
         "type": "object"
       },
       "BetaBody_create_skill_version_v1_skills__skill_id__versions_post": {
         "properties": {
           "files": {
-            "anyOf": [
-              {
-                "items": {
-                  "format": "binary",
-                  "type": "string"
-                },
-                "type": "array"
-              },
-              {
-                "type": "null",
-                "x-stainless-skip": [
-                  "cli"
-                ]
-              }
-            ],
             "description": "Files to upload for the skill.\n\nAll files must be in the same top-level directory and must include a SKILL.md file at the root of that directory.",
-            "title": "Files"
+            "items": {
+              "format": "binary",
+              "type": "string"
+            },
+            "title": "Files",
+            "type": "array"
           }
         },
+        "required": [
+          "files"
+        ],
         "title": "Body_create_skill_version_v1_skills__skill_id__versions_post",
         "type": "object"
       },
@@ -793,7 +780,7 @@
         "additionalProperties": false,
         "properties": {
           "ttl": {
-            "description": "The time-to-live for the cache control breakpoint.\n\nThis may be one the following values:\n- `5m`: 5 minutes\n- `1h`: 1 hour\n\nDefaults to `5m`.",
+            "description": "The time-to-live for the cache control breakpoint.\n\nThis may be one the following values:\n- `5m`: 5 minutes\n- `1h`: 1 hour\n\nDefaults to `5m`. See [prompt caching pricing](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) for details.",
             "enum": [
               "5m",
               "1h"
@@ -2581,7 +2568,7 @@
             "type": "array"
           },
           "messages": {
-            "description": "Input messages.\n\nOur models are trained to operate on alternating `user` and `assistant` conversational turns. When creating a new `Message`, you specify the prior conversational turns with the `messages` parameter, and the model then generates the next `Message` in the conversation. Consecutive `user` or `assistant` turns in your request will be combined into a single turn.\n\nEach input message must be an object with a `role` and `content`. You can specify a single `user`-role message, or you can include multiple `user` and `assistant` messages.\n\nIf the final message uses the `assistant` role, the response content will continue immediately from the content in that message. This can be used to constrain part of the model's response.\n\nExample with a single `user` message:\n\n```json\n[{\"role\": \"user\", \"content\": \"Hello, Claude\"}]\n```\n\nExample with multiple conversational turns:\n\n```json\n[\n  {\"role\": \"user\", \"content\": \"Hello there.\"},\n  {\"role\": \"assistant\", \"content\": \"Hi, I'm Claude. How can I help you?\"},\n  {\"role\": \"user\", \"content\": \"Can you explain LLMs in plain English?\"},\n]\n```\n\nExample with a partially-filled response from Claude:\n\n```json\n[\n  {\"role\": \"user\", \"content\": \"What's the Greek name for Sun? (A) Sol (B) Helios (C) Sun\"},\n  {\"role\": \"assistant\", \"content\": \"The best answer is (\"},\n]\n```\n\nEach input message `content` may be either a single `string` or an array of content blocks, where each block has a specific `type`. Using a `string` for `content` is shorthand for an array of one content block of type `\"text\"`. The following input messages are equivalent:\n\n```json\n{\"role\": \"user\", \"content\": \"Hello, Claude\"}\n```\n\n```json\n{\"role\": \"user\", \"content\": [{\"type\": \"text\", \"text\": \"Hello, Claude\"}]}\n```\n\nSee [input examples](https://docs.claude.com/en/api/messages-examples).\n\nNote that if you want to include a [system prompt](https://docs.claude.com/en/docs/system-prompts), you can use the top-level `system` parameter \u2014 there is no `\"system\"` role for input messages in the Messages API.\n\nThere is a limit of 100,000 messages in a single request.",
+            "description": "Input messages.\n\nOur models are trained to operate on alternating `user` and `assistant` conversational turns. When creating a new `Message`, you specify the prior conversational turns with the `messages` parameter, and the model then generates the next `Message` in the conversation. Consecutive `user` or `assistant` turns in your request will be combined into a single turn.\n\nEach input message must be an object with a `role` and `content`. You can specify a single `user`-role message, or you can include multiple `user` and `assistant` messages.\n\nIf the final message uses the `assistant` role, the response content will continue immediately from the content in that message. This can be used to constrain part of the model's response.\n\nExample with a single `user` message:\n\n```json\n[{\"role\": \"user\", \"content\": \"Hello, Claude\"}]\n```\n\nExample with multiple conversational turns:\n\n```json\n[\n  {\"role\": \"user\", \"content\": \"Hello there.\"},\n  {\"role\": \"assistant\", \"content\": \"Hi, I'm Claude. How can I help you?\"},\n  {\"role\": \"user\", \"content\": \"Can you explain LLMs in plain English?\"},\n]\n```\n\nExample with a partially-filled response from Claude:\n\n```json\n[\n  {\"role\": \"user\", \"content\": \"What's the Greek name for Sun? (A) Sol (B) Helios (C) Sun\"},\n  {\"role\": \"assistant\", \"content\": \"The best answer is (\"},\n]\n```\n\nEach input message `content` may be either a single `string` or an array of content blocks, where each block has a specific `type`. Using a `string` for `content` is shorthand for an array of one content block of type `\"text\"`. The following input messages are equivalent:\n\n```json\n{\"role\": \"user\", \"content\": \"Hello, Claude\"}\n```\n\n```json\n{\"role\": \"user\", \"content\": [{\"type\": \"text\", \"text\": \"Hello, Claude\"}]}\n```\n\nSee [input examples](https://platform.claude.com/docs/en/build-with-claude/working-with-messages).\n\nNote that if you want to include a [system prompt](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices#give-claude-a-role), you can use the top-level `system` parameter \u2014 there is no `\"system\"` role for input messages in the Messages API.\n\nThere is a limit of 100,000 messages in a single request.",
             "items": {
               "$ref": "#/components/schemas/BetaInputMessage"
             },
@@ -2630,7 +2617,7 @@
                 "type": "array"
               }
             ],
-            "description": "System prompt.\n\nA system prompt is a way of providing context and instructions to Claude, such as specifying a particular goal or role. See our [guide to system prompts](https://docs.claude.com/en/docs/system-prompts).",
+            "description": "System prompt.\n\nA system prompt is a way of providing context and instructions to Claude, such as specifying a particular goal or role. See our [guide to system prompts](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices#give-claude-a-role).",
             "examples": [
               [
                 {
@@ -2649,7 +2636,7 @@
             "$ref": "#/components/schemas/BetaToolChoice"
           },
           "tools": {
-            "description": "Definitions of tools that the model may use.\n\nIf you include `tools` in your API request, the model may return `tool_use` content blocks that represent the model's use of those tools. You can then run those tools using the tool input generated by the model and then optionally return results back to the model using `tool_result` content blocks.\n\nThere are two types of tools: **client tools** and **server tools**. The behavior described below applies to client tools. For [server tools](https://docs.claude.com/en/docs/agents-and-tools/tool-use/overview#server-tools), see their individual documentation as each has its own behavior (e.g., the [web search tool](https://docs.claude.com/en/docs/agents-and-tools/tool-use/web-search-tool)).\n\nEach tool definition includes:\n\n* `name`: Name of the tool.\n* `description`: Optional, but strongly-recommended description of the tool.\n* `input_schema`: [JSON schema](https://json-schema.org/draft/2020-12) for the tool `input` shape that the model will produce in `tool_use` output content blocks.\n\nFor example, if you defined `tools` as:\n\n```json\n[\n  {\n    \"name\": \"get_stock_price\",\n    \"description\": \"Get the current stock price for a given ticker symbol.\",\n    \"input_schema\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"ticker\": {\n          \"type\": \"string\",\n          \"description\": \"The stock ticker symbol, e.g. AAPL for Apple Inc.\"\n        }\n      },\n      \"required\": [\"ticker\"]\n    }\n  }\n]\n```\n\nAnd then asked the model \"What's the S&P 500 at today?\", the model might produce `tool_use` content blocks in the response like this:\n\n```json\n[\n  {\n    \"type\": \"tool_use\",\n    \"id\": \"toolu_01D7FLrfh4GYq7yT1ULFeyMV\",\n    \"name\": \"get_stock_price\",\n    \"input\": { \"ticker\": \"^GSPC\" }\n  }\n]\n```\n\nYou might then run your `get_stock_price` tool with `{\"ticker\": \"^GSPC\"}` as an input, and return the following back to the model in a subsequent `user` message:\n\n```json\n[\n  {\n    \"type\": \"tool_result\",\n    \"tool_use_id\": \"toolu_01D7FLrfh4GYq7yT1ULFeyMV\",\n    \"content\": \"259.75 USD\"\n  }\n]\n```\n\nTools can be used for workflows that include running client-side tools and functions, or more generally whenever you want the model to produce a particular JSON structure of output.\n\nSee our [guide](https://docs.claude.com/en/docs/tool-use) for more details.",
+            "description": "Definitions of tools that the model may use.\n\nIf you include `tools` in your API request, the model may return `tool_use` content blocks that represent the model's use of those tools. You can then run those tools using the tool input generated by the model and then optionally return results back to the model using `tool_result` content blocks.\n\nThere are two types of tools: **client tools** and **server tools**. The behavior described below applies to client tools. For [server tools](https://platform.claude.com/docs/en/agents-and-tools/tool-use/server-tools), see their individual documentation as each has its own behavior (e.g., the [web search tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool)).\n\nEach tool definition includes:\n\n* `name`: Name of the tool.\n* `description`: Optional, but strongly-recommended description of the tool.\n* `input_schema`: [JSON schema](https://json-schema.org/draft/2020-12) for the tool `input` shape that the model will produce in `tool_use` output content blocks.\n\nFor example, if you defined `tools` as:\n\n```json\n[\n  {\n    \"name\": \"get_stock_price\",\n    \"description\": \"Get the current stock price for a given ticker symbol.\",\n    \"input_schema\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"ticker\": {\n          \"type\": \"string\",\n          \"description\": \"The stock ticker symbol, e.g. AAPL for Apple Inc.\"\n        }\n      },\n      \"required\": [\"ticker\"]\n    }\n  }\n]\n```\n\nAnd then asked the model \"What's the S&P 500 at today?\", the model might produce `tool_use` content blocks in the response like this:\n\n```json\n[\n  {\n    \"type\": \"tool_use\",\n    \"id\": \"toolu_01D7FLrfh4GYq7yT1ULFeyMV\",\n    \"name\": \"get_stock_price\",\n    \"input\": { \"ticker\": \"^GSPC\" }\n  }\n]\n```\n\nYou might then run your `get_stock_price` tool with `{\"ticker\": \"^GSPC\"}` as an input, and return the following back to the model in a subsequent `user` message:\n\n```json\n[\n  {\n    \"type\": \"tool_result\",\n    \"tool_use_id\": \"toolu_01D7FLrfh4GYq7yT1ULFeyMV\",\n    \"content\": \"259.75 USD\"\n  }\n]\n```\n\nTools can be used for workflows that include running client-side tools and functions, or more generally whenever you want the model to produce a particular JSON structure of output.\n\nSee our [guide](https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview) for more details.",
             "examples": [
               {
                 "description": "Get the current weather in a given location",
@@ -2733,6 +2720,12 @@
                 },
                 {
                   "$ref": "#/components/schemas/BetaWebFetchTool_20260309"
+                },
+                {
+                  "$ref": "#/components/schemas/BetaWebSearchTool_20260318"
+                },
+                {
+                  "$ref": "#/components/schemas/BetaWebFetchTool_20260318"
                 },
                 {
                   "$ref": "#/components/schemas/BetaAdvisorTool_20260301"
@@ -2929,7 +2922,7 @@
             "title": "Inference Geo"
           },
           "max_tokens": {
-            "description": "The maximum number of tokens to generate before stopping.\n\nNote that our models may stop _before_ reaching this maximum. This parameter only specifies the absolute maximum number of tokens to generate.\n\nSet to `0` to populate the [prompt cache](https://docs.claude.com/en/docs/build-with-claude/prompt-caching#pre-warming-the-cache) without generating a response.\n\nDifferent models have different maximum values for this parameter.  See [models](https://docs.claude.com/en/docs/models-overview) for details.",
+            "description": "The maximum number of tokens to generate before stopping.\n\nNote that our models may stop _before_ reaching this maximum. This parameter only specifies the absolute maximum number of tokens to generate.\n\nSet to `0` to populate the [prompt cache](https://platform.claude.com/docs/en/build-with-claude/prompt-caching#pre-warming-the-cache) without generating a response.\n\nDifferent models have different maximum values for this parameter.  See [models](https://platform.claude.com/docs/en/about-claude/models/overview) for details.",
             "examples": [
               1024
             ],
@@ -2947,7 +2940,7 @@
             "type": "array"
           },
           "messages": {
-            "description": "Input messages.\n\nOur models are trained to operate on alternating `user` and `assistant` conversational turns. When creating a new `Message`, you specify the prior conversational turns with the `messages` parameter, and the model then generates the next `Message` in the conversation. Consecutive `user` or `assistant` turns in your request will be combined into a single turn.\n\nEach input message must be an object with a `role` and `content`. You can specify a single `user`-role message, or you can include multiple `user` and `assistant` messages.\n\nIf the final message uses the `assistant` role, the response content will continue immediately from the content in that message. This can be used to constrain part of the model's response.\n\nExample with a single `user` message:\n\n```json\n[{\"role\": \"user\", \"content\": \"Hello, Claude\"}]\n```\n\nExample with multiple conversational turns:\n\n```json\n[\n  {\"role\": \"user\", \"content\": \"Hello there.\"},\n  {\"role\": \"assistant\", \"content\": \"Hi, I'm Claude. How can I help you?\"},\n  {\"role\": \"user\", \"content\": \"Can you explain LLMs in plain English?\"},\n]\n```\n\nExample with a partially-filled response from Claude:\n\n```json\n[\n  {\"role\": \"user\", \"content\": \"What's the Greek name for Sun? (A) Sol (B) Helios (C) Sun\"},\n  {\"role\": \"assistant\", \"content\": \"The best answer is (\"},\n]\n```\n\nEach input message `content` may be either a single `string` or an array of content blocks, where each block has a specific `type`. Using a `string` for `content` is shorthand for an array of one content block of type `\"text\"`. The following input messages are equivalent:\n\n```json\n{\"role\": \"user\", \"content\": \"Hello, Claude\"}\n```\n\n```json\n{\"role\": \"user\", \"content\": [{\"type\": \"text\", \"text\": \"Hello, Claude\"}]}\n```\n\nSee [input examples](https://docs.claude.com/en/api/messages-examples).\n\nNote that if you want to include a [system prompt](https://docs.claude.com/en/docs/system-prompts), you can use the top-level `system` parameter \u2014 there is no `\"system\"` role for input messages in the Messages API.\n\nThere is a limit of 100,000 messages in a single request.",
+            "description": "Input messages.\n\nOur models are trained to operate on alternating `user` and `assistant` conversational turns. When creating a new `Message`, you specify the prior conversational turns with the `messages` parameter, and the model then generates the next `Message` in the conversation. Consecutive `user` or `assistant` turns in your request will be combined into a single turn.\n\nEach input message must be an object with a `role` and `content`. You can specify a single `user`-role message, or you can include multiple `user` and `assistant` messages.\n\nIf the final message uses the `assistant` role, the response content will continue immediately from the content in that message. This can be used to constrain part of the model's response.\n\nExample with a single `user` message:\n\n```json\n[{\"role\": \"user\", \"content\": \"Hello, Claude\"}]\n```\n\nExample with multiple conversational turns:\n\n```json\n[\n  {\"role\": \"user\", \"content\": \"Hello there.\"},\n  {\"role\": \"assistant\", \"content\": \"Hi, I'm Claude. How can I help you?\"},\n  {\"role\": \"user\", \"content\": \"Can you explain LLMs in plain English?\"},\n]\n```\n\nExample with a partially-filled response from Claude:\n\n```json\n[\n  {\"role\": \"user\", \"content\": \"What's the Greek name for Sun? (A) Sol (B) Helios (C) Sun\"},\n  {\"role\": \"assistant\", \"content\": \"The best answer is (\"},\n]\n```\n\nEach input message `content` may be either a single `string` or an array of content blocks, where each block has a specific `type`. Using a `string` for `content` is shorthand for an array of one content block of type `\"text\"`. The following input messages are equivalent:\n\n```json\n{\"role\": \"user\", \"content\": \"Hello, Claude\"}\n```\n\n```json\n{\"role\": \"user\", \"content\": [{\"type\": \"text\", \"text\": \"Hello, Claude\"}]}\n```\n\nSee [input examples](https://platform.claude.com/docs/en/build-with-claude/working-with-messages).\n\nNote that if you want to include a [system prompt](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices#give-claude-a-role), you can use the top-level `system` parameter \u2014 there is no `\"system\"` role for input messages in the Messages API.\n\nThere is a limit of 100,000 messages in a single request.",
             "items": {
               "$ref": "#/components/schemas/BetaInputMessage"
             },
@@ -2978,7 +2971,7 @@
             "description": "Deprecated: Use `output_config.format` instead. See [structured outputs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs)\n\nA schema to specify Claude's output format in responses. This parameter will be removed in a future release."
           },
           "service_tier": {
-            "description": "Determines whether to use priority capacity (if available) or standard capacity for this request.\n\nAnthropic offers different levels of service for your API requests. See [service-tiers](https://docs.claude.com/en/api/service-tiers) for details.",
+            "description": "Determines whether to use priority capacity (if available) or standard capacity for this request.\n\nAnthropic offers different levels of service for your API requests. See [service-tiers](https://platform.claude.com/docs/en/api/service-tiers) for details.",
             "enum": [
               "auto",
               "standard_only"
@@ -3006,7 +2999,8 @@
             "type": "array"
           },
           "stream": {
-            "description": "Whether to incrementally stream the response using server-sent events.\n\nSee [streaming](https://docs.claude.com/en/api/messages-streaming) for details.",
+            "description": "Whether to incrementally stream the response using server-sent events.\n\nSee [streaming](https://platform.claude.com/docs/en/build-with-claude/streaming) for details.",
+            "example": false,
             "title": "Stream",
             "type": "boolean"
           },
@@ -3025,7 +3019,7 @@
                 "type": "array"
               }
             ],
-            "description": "System prompt.\n\nA system prompt is a way of providing context and instructions to Claude, such as specifying a particular goal or role. See our [guide to system prompts](https://docs.claude.com/en/docs/system-prompts).",
+            "description": "System prompt.\n\nA system prompt is a way of providing context and instructions to Claude, such as specifying a particular goal or role. See our [guide to system prompts](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices#give-claude-a-role).",
             "examples": [
               [
                 {
@@ -3056,7 +3050,7 @@
             "$ref": "#/components/schemas/BetaToolChoice"
           },
           "tools": {
-            "description": "Definitions of tools that the model may use.\n\nIf you include `tools` in your API request, the model may return `tool_use` content blocks that represent the model's use of those tools. You can then run those tools using the tool input generated by the model and then optionally return results back to the model using `tool_result` content blocks.\n\nThere are two types of tools: **client tools** and **server tools**. The behavior described below applies to client tools. For [server tools](https://docs.claude.com/en/docs/agents-and-tools/tool-use/overview#server-tools), see their individual documentation as each has its own behavior (e.g., the [web search tool](https://docs.claude.com/en/docs/agents-and-tools/tool-use/web-search-tool)).\n\nEach tool definition includes:\n\n* `name`: Name of the tool.\n* `description`: Optional, but strongly-recommended description of the tool.\n* `input_schema`: [JSON schema](https://json-schema.org/draft/2020-12) for the tool `input` shape that the model will produce in `tool_use` output content blocks.\n\nFor example, if you defined `tools` as:\n\n```json\n[\n  {\n    \"name\": \"get_stock_price\",\n    \"description\": \"Get the current stock price for a given ticker symbol.\",\n    \"input_schema\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"ticker\": {\n          \"type\": \"string\",\n          \"description\": \"The stock ticker symbol, e.g. AAPL for Apple Inc.\"\n        }\n      },\n      \"required\": [\"ticker\"]\n    }\n  }\n]\n```\n\nAnd then asked the model \"What's the S&P 500 at today?\", the model might produce `tool_use` content blocks in the response like this:\n\n```json\n[\n  {\n    \"type\": \"tool_use\",\n    \"id\": \"toolu_01D7FLrfh4GYq7yT1ULFeyMV\",\n    \"name\": \"get_stock_price\",\n    \"input\": { \"ticker\": \"^GSPC\" }\n  }\n]\n```\n\nYou might then run your `get_stock_price` tool with `{\"ticker\": \"^GSPC\"}` as an input, and return the following back to the model in a subsequent `user` message:\n\n```json\n[\n  {\n    \"type\": \"tool_result\",\n    \"tool_use_id\": \"toolu_01D7FLrfh4GYq7yT1ULFeyMV\",\n    \"content\": \"259.75 USD\"\n  }\n]\n```\n\nTools can be used for workflows that include running client-side tools and functions, or more generally whenever you want the model to produce a particular JSON structure of output.\n\nSee our [guide](https://docs.claude.com/en/docs/tool-use) for more details.",
+            "description": "Definitions of tools that the model may use.\n\nIf you include `tools` in your API request, the model may return `tool_use` content blocks that represent the model's use of those tools. You can then run those tools using the tool input generated by the model and then optionally return results back to the model using `tool_result` content blocks.\n\nThere are two types of tools: **client tools** and **server tools**. The behavior described below applies to client tools. For [server tools](https://platform.claude.com/docs/en/agents-and-tools/tool-use/server-tools), see their individual documentation as each has its own behavior (e.g., the [web search tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool)).\n\nEach tool definition includes:\n\n* `name`: Name of the tool.\n* `description`: Optional, but strongly-recommended description of the tool.\n* `input_schema`: [JSON schema](https://json-schema.org/draft/2020-12) for the tool `input` shape that the model will produce in `tool_use` output content blocks.\n\nFor example, if you defined `tools` as:\n\n```json\n[\n  {\n    \"name\": \"get_stock_price\",\n    \"description\": \"Get the current stock price for a given ticker symbol.\",\n    \"input_schema\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"ticker\": {\n          \"type\": \"string\",\n          \"description\": \"The stock ticker symbol, e.g. AAPL for Apple Inc.\"\n        }\n      },\n      \"required\": [\"ticker\"]\n    }\n  }\n]\n```\n\nAnd then asked the model \"What's the S&P 500 at today?\", the model might produce `tool_use` content blocks in the response like this:\n\n```json\n[\n  {\n    \"type\": \"tool_use\",\n    \"id\": \"toolu_01D7FLrfh4GYq7yT1ULFeyMV\",\n    \"name\": \"get_stock_price\",\n    \"input\": { \"ticker\": \"^GSPC\" }\n  }\n]\n```\n\nYou might then run your `get_stock_price` tool with `{\"ticker\": \"^GSPC\"}` as an input, and return the following back to the model in a subsequent `user` message:\n\n```json\n[\n  {\n    \"type\": \"tool_result\",\n    \"tool_use_id\": \"toolu_01D7FLrfh4GYq7yT1ULFeyMV\",\n    \"content\": \"259.75 USD\"\n  }\n]\n```\n\nTools can be used for workflows that include running client-side tools and functions, or more generally whenever you want the model to produce a particular JSON structure of output.\n\nSee our [guide](https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview) for more details.",
             "examples": [
               {
                 "description": "Get the current weather in a given location",
@@ -3142,6 +3136,12 @@
                   "$ref": "#/components/schemas/BetaWebFetchTool_20260309"
                 },
                 {
+                  "$ref": "#/components/schemas/BetaWebSearchTool_20260318"
+                },
+                {
+                  "$ref": "#/components/schemas/BetaWebFetchTool_20260318"
+                },
+                {
                   "$ref": "#/components/schemas/BetaAdvisorTool_20260301"
                 },
                 {
@@ -3180,18 +3180,6 @@
             "title": "Top P",
             "type": "number",
             "x-stainless-deprecation-message": "Deprecated. Models released after Claude Opus 4.6 do not support setting top_p. A value >= 0.99 will be accepted for backwards compatibility, all other values will be rejected with a 400 error."
-          },
-          "user_profile_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The user profile ID to attribute this request to. Use when acting on behalf of a party other than your organization.",
-            "title": "User Profile Id"
           }
         },
         "required": [
@@ -3361,6 +3349,34 @@
           "version"
         ],
         "title": "CreateSkillVersionResponse",
+        "type": "object"
+      },
+      "BetaCreateTunnelCertificateRequestBody": {
+        "additionalProperties": false,
+        "properties": {
+          "ca_certificate_pem": {
+            "description": "PEM-encoded X.509 CA certificate. Must contain exactly one certificate and no private-key material. Maximum 8KB.",
+            "maxLength": 8192,
+            "type": "string"
+          }
+        },
+        "required": [
+          "ca_certificate_pem"
+        ],
+        "type": "object"
+      },
+      "BetaCreateTunnelRequest": {
+        "additionalProperties": false,
+        "description": "Request parameters for creating a tunnel.",
+        "properties": {
+          "display_name": {
+            "description": "Optional human-readable name for the tunnel (1-255 characters).",
+            "maxLength": 255,
+            "minLength": 1,
+            "nullable": true,
+            "type": "string"
+          }
+        },
         "type": "object"
       },
       "BetaCreateUserProfileRequest": {
@@ -5261,6 +5277,52 @@
         "title": "ListSkillsResponse",
         "type": "object"
       },
+      "BetaListTunnelCertificatesResponse": {
+        "additionalProperties": false,
+        "description": "The tunnel's certificates.",
+        "properties": {
+          "data": {
+            "description": "List of certificates, ordered by created_at descending.",
+            "items": {
+              "$ref": "#/components/schemas/BetaTunnelCertificate"
+            },
+            "type": "array"
+          },
+          "next_page": {
+            "description": "Pagination cursor for the next page, or null if no more results.",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "data",
+          "next_page"
+        ],
+        "type": "object"
+      },
+      "BetaListTunnelsResponse": {
+        "additionalProperties": false,
+        "description": "A paginated list of tunnels.",
+        "properties": {
+          "data": {
+            "description": "List of tunnels, ordered by created_at descending.",
+            "items": {
+              "$ref": "#/components/schemas/BetaTunnel"
+            },
+            "type": "array"
+          },
+          "next_page": {
+            "description": "Pagination cursor for the next page, or null if no more results.",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "data",
+          "next_page"
+        ],
+        "type": "object"
+      },
       "BetaListUserProfilesResponse": {
         "additionalProperties": false,
         "example": {
@@ -6655,6 +6717,69 @@
           }
         ]
       },
+      "BetaManagedAgentsAgentWithOverridesParams": {
+        "additionalProperties": false,
+        "description": "Reference to an `agent` plus optional configuration overrides. Each provided field replaces the agent's value for the caller's use; the agent resource is unchanged.",
+        "properties": {
+          "id": {
+            "description": "The `agent` ID.",
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "mcp_servers": {
+            "description": "Replacement MCP server list. Full replacement: the provided array becomes the MCP servers. Send an empty array to clear; omit to preserve the agent's servers.",
+            "items": {
+              "$ref": "#/components/schemas/BetaManagedAgentsMCPServerParams"
+            },
+            "type": "array"
+          },
+          "model": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsModelParams"
+              }
+            ],
+            "description": "Replacement model. Accepts the model string, e.g. `claude-opus-4-6`, or a `model_config` object. Omit to use the agent's model."
+          },
+          "skills": {
+            "description": "Replacement skill list. Full replacement: the provided array becomes the skills. Send an empty array to clear; omit to preserve the agent's skills.",
+            "items": {
+              "$ref": "#/components/schemas/BetaManagedAgentsSkillParams"
+            },
+            "type": "array"
+          },
+          "system": {
+            "description": "Replacement system prompt. Up to 100,000 characters. Set to null to clear the agent's system prompt; omit to preserve it.",
+            "maxLength": 100000,
+            "nullable": true,
+            "type": "string"
+          },
+          "tools": {
+            "description": "Replacement tool list. Full replacement: the provided array becomes the tool configuration. Send an empty array to clear; omit to preserve the agent's tools.",
+            "items": {
+              "$ref": "#/components/schemas/BetaManagedAgentsAgentToolParams"
+            },
+            "type": "array"
+          },
+          "type": {
+            "enum": [
+              "agent_with_overrides"
+            ],
+            "type": "string"
+          },
+          "version": {
+            "description": "The specific `agent` version to use. Omit to use the latest version.",
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "type",
+          "id"
+        ],
+        "type": "object"
+      },
       "BetaManagedAgentsAlwaysAllowPolicy": {
         "additionalProperties": false,
         "description": "Tool calls are automatically approved without user confirmation.",
@@ -7029,7 +7154,7 @@
             "type": "string"
           },
           "mcp_servers": {
-            "description": "MCP servers this agent connects to. Maximum 20. Names must be unique within the array.",
+            "description": "MCP servers this agent connects to. Maximum 20. Names must be unique within the array. Every server must be referenced by an `mcp_toolset` in `tools`; unreferenced servers are rejected. See the [MCP connector guide](https://platform.claude.com/docs/en/managed-agents/mcp-connector).",
             "items": {
               "$ref": "#/components/schemas/BetaManagedAgentsMCPServerParams"
             },
@@ -7310,6 +7435,30 @@
         ],
         "type": "object"
       },
+      "BetaManagedAgentsCreateSessionAgentUnionParams": {
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "discriminator": {
+              "mapping": {
+                "agent": "#/components/schemas/BetaManagedAgentsAgentParams",
+                "agent_with_overrides": "#/components/schemas/BetaManagedAgentsAgentWithOverridesParams"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsAgentParams"
+              },
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsAgentWithOverridesParams"
+              }
+            ]
+          }
+        ]
+      },
       "BetaManagedAgentsCreateSessionParams": {
         "additionalProperties": false,
         "description": "Request parameters for creating a `session`.",
@@ -7322,7 +7471,7 @@
           "agent": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/BetaManagedAgentsAgentUnionParams"
+                "$ref": "#/components/schemas/BetaManagedAgentsCreateSessionAgentUnionParams"
               }
             ],
             "description": "Agent identifier. Accepts the `agent` ID string, which pins the latest version for the session, or an `agent` object with both id and version specified.",
@@ -7806,9 +7955,22 @@
       "BetaManagedAgentsCronSchedule": {
         "additionalProperties": false,
         "description": "5-field POSIX cron schedule with computed runtime timestamps.",
+        "example": {
+          "expression": "0 9 * * 1-5",
+          "last_run_at": "2026-03-16T16:00:09Z",
+          "timezone": "America/Los_Angeles",
+          "type": "cron",
+          "upcoming_runs_at": [
+            "2026-03-17T16:00:00Z",
+            "2026-03-18T16:00:00Z"
+          ]
+        },
         "properties": {
           "expression": {
             "description": "5-field POSIX cron expression: minute hour day-of-month month day-of-week (e.g., \"0 9 * * 1-5\" for weekdays at 9am). Day-of-week is 0-7 where 0 and 7 both mean Sunday. Extended cron syntax - seconds or year fields, and the special characters L, W, #, and ? - is not supported, nor are predefined shortcuts (@daily).",
+            "examples": [
+              "0 9 * * 1-5"
+            ],
             "maxLength": 256,
             "minLength": 1,
             "type": "string"
@@ -7820,10 +7982,16 @@
               }
             ],
             "description": "Time the most recent scheduled run actually started. Null until one completes; preserved after the deployment is archived. Manual runs do not update this.",
+            "examples": [
+              "2026-03-16T16:00:09Z"
+            ],
             "nullable": true
           },
           "timezone": {
             "description": "IANA timezone identifier (e.g., \"America/Los_Angeles\", \"UTC\").",
+            "examples": [
+              "America/Los_Angeles"
+            ],
             "minLength": 1,
             "type": "string"
           },
@@ -7831,10 +7999,19 @@
             "enum": [
               "cron"
             ],
+            "examples": [
+              "cron"
+            ],
             "type": "string"
           },
           "upcoming_runs_at": {
             "description": "Up to 5 timestamps of upcoming cron occurrences. Non-empty for active and paused deployments (reflects what the schedule would do if unpaused); empty once the deployment is archived (`archived_at` set). Each fire is offset by a small per-schedule jitter, so a run will actually start at or shortly after its listed time.",
+            "examples": [
+              [
+                "2026-03-17T16:00:00Z",
+                "2026-03-18T16:00:00Z"
+              ]
+            ],
             "items": {
               "$ref": "#/components/schemas/BetaTimestamp"
             },
@@ -7851,20 +8028,34 @@
       "BetaManagedAgentsCronScheduleParams": {
         "additionalProperties": false,
         "description": "5-field POSIX cron schedule. Literal wall-clock matching in the configured timezone.",
+        "example": {
+          "expression": "0 9 * * 1-5",
+          "timezone": "America/Los_Angeles",
+          "type": "cron"
+        },
         "properties": {
           "expression": {
             "description": "5-field POSIX cron expression: minute hour day-of-month month day-of-week (e.g., \"0 9 * * 1-5\" for weekdays at 9am). Day-of-week is 0-7 where 0 and 7 both mean Sunday. Extended cron syntax - seconds or year fields, and the special characters L, W, #, and ? - is not supported, nor are predefined shortcuts (@daily).",
+            "examples": [
+              "0 9 * * 1-5"
+            ],
             "maxLength": 256,
             "minLength": 1,
             "type": "string"
           },
           "timezone": {
             "description": "Required. IANA timezone identifier (e.g., \"America/Los_Angeles\", \"UTC\"). Validated against the IANA timezone database.",
+            "examples": [
+              "America/Los_Angeles"
+            ],
             "minLength": 1,
             "type": "string"
           },
           "type": {
             "enum": [
+              "cron"
+            ],
+            "examples": [
               "cron"
             ],
             "type": "string"
@@ -8252,6 +8443,49 @@
       "BetaManagedAgentsDeployment": {
         "additionalProperties": false,
         "description": "A deployment is a configured instance of an agent \u2014 it binds the agent to everything needed to run it autonomously: an environment, credentials, initial events, and an optional schedule.",
+        "example": {
+          "agent": {
+            "id": "agent_011CZkYpogX7uDKUyvBTophP",
+            "type": "agent",
+            "version": 1
+          },
+          "archived_at": null,
+          "created_at": "2026-03-15T10:00:00Z",
+          "description": "Compiles yesterday's orders into a report every weekday morning.",
+          "environment_id": "env_011CZkZ9X2dpNyB7HsEFoRfW",
+          "id": "depl_011CZkZcDH3vPqd7xnEfwTai",
+          "initial_events": [
+            {
+              "content": [
+                {
+                  "text": "Compile yesterday's orders into report.md.",
+                  "type": "text"
+                }
+              ],
+              "type": "user.message"
+            }
+          ],
+          "metadata": {},
+          "name": "Daily order report",
+          "paused_reason": null,
+          "resources": [],
+          "schedule": {
+            "expression": "0 9 * * 1-5",
+            "last_run_at": "2026-03-16T16:00:09Z",
+            "timezone": "America/Los_Angeles",
+            "type": "cron",
+            "upcoming_runs_at": [
+              "2026-03-17T16:00:00Z",
+              "2026-03-18T16:00:00Z"
+            ]
+          },
+          "status": "active",
+          "type": "deployment",
+          "updated_at": "2026-03-15T10:00:00Z",
+          "vault_ids": [
+            "vlt_011CZkZDLs7fYzm1hXNPeRjv"
+          ]
+        },
         "properties": {
           "agent": {
             "allOf": [
@@ -8259,7 +8493,14 @@
                 "$ref": "#/components/schemas/BetaManagedAgentsAgentReference"
               }
             ],
-            "description": "Reference to the agent this deployment runs, resolved to a concrete version."
+            "description": "Reference to the agent this deployment runs, resolved to a concrete version.",
+            "examples": [
+              {
+                "id": "agent_011CZkYpogX7uDKUyvBTophP",
+                "type": "agent",
+                "version": 1
+              }
+            ]
           },
           "archived_at": {
             "allOf": [
@@ -8268,6 +8509,9 @@
               }
             ],
             "description": "Time the deployment was archived. Null if not archived.",
+            "examples": [
+              null
+            ],
             "nullable": true
           },
           "created_at": {
@@ -8276,23 +8520,48 @@
                 "$ref": "#/components/schemas/BetaTimestamp"
               }
             ],
-            "description": "Time the deployment was created."
+            "description": "Time the deployment was created.",
+            "examples": [
+              "2026-03-15T10:00:00Z"
+            ]
           },
           "description": {
             "description": "Description of what the deployment does.",
+            "examples": [
+              "Compiles yesterday's orders into a report every weekday morning."
+            ],
             "nullable": true,
             "type": "string"
           },
           "environment_id": {
             "description": "ID of the `environment` where sessions run.",
+            "examples": [
+              "env_011CZkZ9X2dpNyB7HsEFoRfW"
+            ],
             "type": "string"
           },
           "id": {
             "description": "Unique identifier for this deployment.",
+            "examples": [
+              "depl_011CZkZcDH3vPqd7xnEfwTai"
+            ],
             "type": "string"
           },
           "initial_events": {
             "description": "Events sent to each session immediately after creation.",
+            "examples": [
+              [
+                {
+                  "content": [
+                    {
+                      "text": "Compile yesterday's orders into report.md.",
+                      "type": "text"
+                    }
+                  ],
+                  "type": "user.message"
+                }
+              ]
+            ],
             "items": {
               "$ref": "#/components/schemas/BetaManagedAgentsDeploymentInitialEvent"
             },
@@ -8303,10 +8572,16 @@
               "type": "string"
             },
             "description": "Arbitrary key-value metadata. Maximum 16 pairs.",
+            "examples": [
+              {}
+            ],
             "type": "object"
           },
           "name": {
             "description": "Human-readable name.",
+            "examples": [
+              "Daily order report"
+            ],
             "type": "string"
           },
           "paused_reason": {
@@ -8316,10 +8591,16 @@
               }
             ],
             "description": "Why the deployment is paused. Non-null exactly when status is paused; null otherwise.",
+            "examples": [
+              null
+            ],
             "nullable": true
           },
           "resources": {
             "description": "Resources attached to sessions created from this deployment. Echoes the input minus write-only credentials.",
+            "examples": [
+              []
+            ],
             "items": {
               "$ref": "#/components/schemas/BetaManagedAgentsSessionResourceConfig"
             },
@@ -8332,6 +8613,18 @@
               }
             ],
             "description": "Recurring cron schedule. Presence enables scheduled execution; null means manual-only. Includes computed timestamps (next fire times, last run) on the cron variant.",
+            "examples": [
+              {
+                "expression": "0 9 * * 1-5",
+                "last_run_at": "2026-03-16T16:00:09Z",
+                "timezone": "America/Los_Angeles",
+                "type": "cron",
+                "upcoming_runs_at": [
+                  "2026-03-17T16:00:00Z",
+                  "2026-03-18T16:00:00Z"
+                ]
+              }
+            ],
             "nullable": true
           },
           "status": {
@@ -8340,10 +8633,16 @@
                 "$ref": "#/components/schemas/BetaManagedAgentsDeploymentStatus"
               }
             ],
-            "description": "Computed status of the deployment: `active` or `paused`. Archived deployments report `active` with `archived_at` set."
+            "description": "Computed status of the deployment: `active` or `paused`. Archived deployments report `active` with `archived_at` set.",
+            "examples": [
+              "active"
+            ]
           },
           "type": {
             "enum": [
+              "deployment"
+            ],
+            "examples": [
               "deployment"
             ],
             "type": "string"
@@ -8354,10 +8653,18 @@
                 "$ref": "#/components/schemas/BetaTimestamp"
               }
             ],
-            "description": "Time the deployment was last updated."
+            "description": "Time the deployment was last updated.",
+            "examples": [
+              "2026-03-15T10:00:00Z"
+            ]
           },
           "vault_ids": {
             "description": "Vault IDs supplying stored credentials for sessions created from this deployment.",
+            "examples": [
+              [
+                "vlt_011CZkZDLs7fYzm1hXNPeRjv"
+              ]
+            ],
             "items": {
               "type": "string"
             },
@@ -8817,6 +9124,14 @@
         "additionalProperties": false,
         "description": "Environment variable credential details. The secret value is never returned.",
         "properties": {
+          "injection_location": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsInjectionLocationResponse"
+              }
+            ],
+            "description": "Where in the outbound request the secret value is substituted."
+          },
           "networking": {
             "allOf": [
               {
@@ -8839,7 +9154,8 @@
         "required": [
           "type",
           "secret_name",
-          "networking"
+          "networking",
+          "injection_location"
         ],
         "type": "object"
       },
@@ -8847,6 +9163,14 @@
         "additionalProperties": false,
         "description": "Parameters for creating an environment variable credential.",
         "properties": {
+          "injection_location": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsInjectionLocationParams"
+              }
+            ],
+            "description": "Where in the outbound request the secret value may be substituted."
+          },
           "networking": {
             "allOf": [
               {
@@ -8886,6 +9210,14 @@
         "additionalProperties": false,
         "description": "Parameters for updating an environment variable credential. `secret_name` is immutable.",
         "properties": {
+          "injection_location": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsInjectionLocationUpdateParams"
+              }
+            ],
+            "description": "Updated injection location."
+          },
           "networking": {
             "allOf": [
               {
@@ -9015,6 +9347,87 @@
         ],
         "type": "object"
       },
+      "BetaManagedAgentsEventDeltaEvent": {
+        "additionalProperties": false,
+        "description": "An incremental update to an event that is still being streamed. Deltas are best-effort and may stop early; when the buffered event with id == event_id is produced it carries the complete content. A model request that ends early (an error or interrupt) produces no buffered event \u2014 its terminal span.model_request_end closes the preview. Only sent on stream connections that opt in via event_deltas; never appears in event history.",
+        "properties": {
+          "delta": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsEventDeltaEvent_Delta"
+              }
+            ],
+            "description": "One fragment of the previewed event. The delta type is named for the previewed event's field it streams into: agent.message events stream content_delta fragments, each a partial element of the content array."
+          },
+          "event_id": {
+            "description": "The id of the event being previewed. Matches event.id on the corresponding event_start and the buffered event that reconciles the preview.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "event_delta"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "event_id",
+          "delta"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsEventDeltaEvent_ContentDelta": {
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsTextBlock"
+              }
+            ],
+            "description": "A partial element of the content array at index, typed like the element itself \u2014 the same shape the buffered agent.message carries in content."
+          },
+          "index": {
+            "description": "Which entry in the previewed event's content array this fragment lands in. Insert content as that entry when the index is new; append to the existing entry otherwise.",
+            "format": "uint32",
+            "type": "integer"
+          },
+          "type": {
+            "enum": [
+              "content_delta"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "content"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsEventDeltaEvent_Delta": {
+        "discriminator": {
+          "mapping": {
+            "content_delta": "#/components/schemas/BetaManagedAgentsEventDeltaEvent_ContentDelta"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsEventDeltaEvent_ContentDelta"
+          }
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsEventDeltaType": {
+        "description": "EventDeltaType enum",
+        "enum": [
+          "agent.message",
+          "agent.thinking"
+        ],
+        "type": "string"
+      },
       "BetaManagedAgentsEventParams": {
         "description": "Union type for event parameters that can be sent to a session.",
         "discriminator": {
@@ -9050,6 +9463,89 @@
           },
           {
             "$ref": "#/components/schemas/BetaManagedAgentsSystemMessageEventParams"
+          }
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsEventStartEvent": {
+        "additionalProperties": false,
+        "description": "Opens a preview of a buffered event. Carries the previewed event's type and id only. Followed by zero or more event_delta events with the same event id, normally concluded by the buffered event carrying that id. If the producing model request ends without that event (an error or interrupt mid-stream), its terminal span.model_request_end closes the preview. Only sent on stream connections that opt in via event_deltas; never appears in event history.",
+        "properties": {
+          "event": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsEventStartEvent_Event"
+              }
+            ],
+            "description": "The previewed event's type and id. The event type determines which delta types the preview's event_delta events carry: agent.message events stream content_delta fragments; agent.thinking previews are start-only \u2014 no deltas follow, and the buffered agent.thinking with the same id concludes them."
+          },
+          "type": {
+            "enum": [
+              "event_start"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "event"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsEventStartEvent_AgentMessagePreview": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "description": "The id the buffered agent.message will carry if it is emitted. Matches the event_id on this preview's event_delta events.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "agent.message"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsEventStartEvent_AgentThinkingPreview": {
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "description": "The id the buffered agent.thinking will carry if it is emitted. Start-only \u2014 no event_delta events follow.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "agent.thinking"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsEventStartEvent_Event": {
+        "discriminator": {
+          "mapping": {
+            "agent.message": "#/components/schemas/BetaManagedAgentsEventStartEvent_AgentMessagePreview",
+            "agent.thinking": "#/components/schemas/BetaManagedAgentsEventStartEvent_AgentThinkingPreview"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsEventStartEvent_AgentMessagePreview"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsEventStartEvent_AgentThinkingPreview"
           }
         ],
         "type": "object"
@@ -9574,6 +10070,55 @@
         ],
         "type": "object"
       },
+      "BetaManagedAgentsInjectionLocationParams": {
+        "additionalProperties": false,
+        "description": "Where in the outbound request the secret value may be substituted.",
+        "properties": {
+          "body": {
+            "description": "Substitute when the placeholder appears in the request body.",
+            "type": "boolean"
+          },
+          "header": {
+            "description": "Substitute when the placeholder appears in a request header value.",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
+      "BetaManagedAgentsInjectionLocationResponse": {
+        "additionalProperties": false,
+        "description": "Where in the outbound request the secret value is substituted.",
+        "properties": {
+          "body": {
+            "description": "Whether the placeholder is substituted in the request body.",
+            "type": "boolean"
+          },
+          "header": {
+            "description": "Whether the placeholder is substituted in request header values.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "header",
+          "body"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsInjectionLocationUpdateParams": {
+        "additionalProperties": false,
+        "description": "Updated injection location.",
+        "properties": {
+          "body": {
+            "description": "Substitute when the placeholder appears in the request body.",
+            "type": "boolean"
+          },
+          "header": {
+            "description": "Substitute when the placeholder appears in a request header value.",
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
       "BetaManagedAgentsInputEvent": {
         "description": "Union type for events that can be sent to a session.",
         "discriminator": {
@@ -9811,9 +10356,104 @@
       "BetaManagedAgentsListDeploymentsData": {
         "additionalProperties": false,
         "description": "Paginated list of deployments.",
+        "example": {
+          "data": [
+            {
+              "agent": {
+                "id": "agent_011CZkYpogX7uDKUyvBTophP",
+                "type": "agent",
+                "version": 1
+              },
+              "archived_at": null,
+              "created_at": "2026-03-15T10:00:00Z",
+              "description": "Compiles yesterday's orders into a report every weekday morning.",
+              "environment_id": "env_011CZkZ9X2dpNyB7HsEFoRfW",
+              "id": "depl_011CZkZcDH3vPqd7xnEfwTai",
+              "initial_events": [
+                {
+                  "content": [
+                    {
+                      "text": "Compile yesterday's orders into report.md.",
+                      "type": "text"
+                    }
+                  ],
+                  "type": "user.message"
+                }
+              ],
+              "metadata": {},
+              "name": "Daily order report",
+              "paused_reason": null,
+              "resources": [],
+              "schedule": {
+                "expression": "0 9 * * 1-5",
+                "last_run_at": "2026-03-16T16:00:09Z",
+                "timezone": "America/Los_Angeles",
+                "type": "cron",
+                "upcoming_runs_at": [
+                  "2026-03-17T16:00:00Z",
+                  "2026-03-18T16:00:00Z"
+                ]
+              },
+              "status": "active",
+              "type": "deployment",
+              "updated_at": "2026-03-15T10:00:00Z",
+              "vault_ids": [
+                "vlt_011CZkZDLs7fYzm1hXNPeRjv"
+              ]
+            }
+          ],
+          "next_page": "page_MjAyNS0wNS0xNFQwMDowMDowMFo="
+        },
         "properties": {
           "data": {
             "description": "List of deployments.",
+            "examples": [
+              [
+                {
+                  "agent": {
+                    "id": "agent_011CZkYpogX7uDKUyvBTophP",
+                    "type": "agent",
+                    "version": 1
+                  },
+                  "archived_at": null,
+                  "created_at": "2026-03-15T10:00:00Z",
+                  "description": "Compiles yesterday's orders into a report every weekday morning.",
+                  "environment_id": "env_011CZkZ9X2dpNyB7HsEFoRfW",
+                  "id": "depl_011CZkZcDH3vPqd7xnEfwTai",
+                  "initial_events": [
+                    {
+                      "content": [
+                        {
+                          "text": "Compile yesterday's orders into report.md.",
+                          "type": "text"
+                        }
+                      ],
+                      "type": "user.message"
+                    }
+                  ],
+                  "metadata": {},
+                  "name": "Daily order report",
+                  "paused_reason": null,
+                  "resources": [],
+                  "schedule": {
+                    "expression": "0 9 * * 1-5",
+                    "last_run_at": "2026-03-16T16:00:09Z",
+                    "timezone": "America/Los_Angeles",
+                    "type": "cron",
+                    "upcoming_runs_at": [
+                      "2026-03-17T16:00:00Z",
+                      "2026-03-18T16:00:00Z"
+                    ]
+                  },
+                  "status": "active",
+                  "type": "deployment",
+                  "updated_at": "2026-03-15T10:00:00Z",
+                  "vault_ids": [
+                    "vlt_011CZkZDLs7fYzm1hXNPeRjv"
+                  ]
+                }
+              ]
+            ],
             "items": {
               "$ref": "#/components/schemas/BetaManagedAgentsDeployment"
             },
@@ -9824,6 +10464,9 @@
           },
           "next_page": {
             "description": "Opaque cursor for the next page. Null when no more results.",
+            "examples": [
+              "page_MjAyNS0wNS0xNFQwMDowMDowMFo="
+            ],
             "nullable": true,
             "type": "string",
             "x-stainless-pagination-property": {
@@ -9841,7 +10484,7 @@
         "description": "Response payload for [List memories](/en/api/beta/memory_stores/memories/list).",
         "properties": {
           "data": {
-            "description": "One page of results. Each item is either a `memory` object or, when `depth` was set, a `memory_prefix` rollup marker. Items appear in the requested `order_by`/`order`.",
+            "description": "One page of results. Each item is either a `memory` object or, when `depth` was set, a `memory_prefix` rollup marker. Items are returned in a stable, server-defined order.",
             "items": {
               "$ref": "#/components/schemas/BetaManagedAgentsMemoryListItem"
             },
@@ -10229,7 +10872,8 @@
         "description": "Paginated list of sessions.",
         "example": {
           "data": [],
-          "next_page": "page_MjAyNS0wNS0xNFQwMDowMDowMFo="
+          "next_page": "page_MjAyNS0wNS0xNFQwMDowMDowMFo=",
+          "prev_page": "page_MjAyNS0wNS0xM1QwMDowMDowMFo="
         },
         "properties": {
           "data": {
@@ -10255,6 +10899,14 @@
             "x-stainless-pagination-property": {
               "purpose": "next_cursor_field"
             }
+          },
+          "prev_page": {
+            "description": "Opaque cursor for the previous page. Null when on the first page. Pass as the `page` parameter to navigate backward.",
+            "examples": [
+              "page_MjAyNS0wNS0xM1QwMDowMDowMFo="
+            ],
+            "nullable": true,
+            "type": "string"
           }
         },
         "type": "object"
@@ -11461,6 +12113,11 @@
         "anyOf": [
           {
             "type": "string"
+          },
+          {
+            "const": "claude-sonnet-5",
+            "description": "High-performance model for coding and agents",
+            "x-stainless-nominal": false
           },
           {
             "const": "claude-fable-5",
@@ -15059,6 +15716,8 @@
             "agent.thread_message_sent": "#/components/schemas/BetaManagedAgentsAgentThreadMessageSentEvent",
             "agent.tool_result": "#/components/schemas/BetaManagedAgentsAgentToolResultEvent",
             "agent.tool_use": "#/components/schemas/BetaManagedAgentsAgentToolUseEvent",
+            "event_delta": "#/components/schemas/BetaManagedAgentsEventDeltaEvent",
+            "event_start": "#/components/schemas/BetaManagedAgentsEventStartEvent",
             "session.deleted": "#/components/schemas/BetaManagedAgentsSessionDeletedEvent",
             "session.error": "#/components/schemas/BetaManagedAgentsSessionErrorEvent",
             "session.status_idle": "#/components/schemas/BetaManagedAgentsSessionStatusIdleEvent",
@@ -15185,6 +15844,12 @@
           },
           {
             "$ref": "#/components/schemas/BetaManagedAgentsSessionUpdatedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsEventStartEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsEventDeltaEvent"
           },
           {
             "$ref": "#/components/schemas/BetaManagedAgentsSystemMessageEvent"
@@ -15206,6 +15871,8 @@
             "agent.thread_message_sent": "#/components/schemas/BetaManagedAgentsAgentThreadMessageSentEvent",
             "agent.tool_result": "#/components/schemas/BetaManagedAgentsAgentToolResultEvent",
             "agent.tool_use": "#/components/schemas/BetaManagedAgentsAgentToolUseEvent",
+            "event_delta": "#/components/schemas/BetaManagedAgentsEventDeltaEvent",
+            "event_start": "#/components/schemas/BetaManagedAgentsEventStartEvent",
             "session.deleted": "#/components/schemas/BetaManagedAgentsSessionDeletedEvent",
             "session.error": "#/components/schemas/BetaManagedAgentsSessionErrorEvent",
             "session.status_idle": "#/components/schemas/BetaManagedAgentsSessionStatusIdleEvent",
@@ -15332,6 +15999,12 @@
           },
           {
             "$ref": "#/components/schemas/BetaManagedAgentsSessionUpdatedEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsEventStartEvent"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsEventDeltaEvent"
           },
           {
             "$ref": "#/components/schemas/BetaManagedAgentsSystemMessageEvent"
@@ -15916,7 +16589,7 @@
             "type": "string"
           },
           "mcp_servers": {
-            "description": "MCP servers. Full replacement. Omit to preserve; send empty array or null to clear. Names must be unique. Maximum 20.",
+            "description": "MCP servers. Full replacement. Omit to preserve; send empty array or `null` to clear. Names must be unique. Maximum 20. Every server must be referenced by an `mcp_toolset` in the agent's resulting `tools`; unreferenced servers are rejected. See the [MCP connector guide](https://platform.claude.com/docs/en/managed-agents/mcp-connector).",
             "items": {
               "$ref": "#/components/schemas/BetaManagedAgentsMCPServerParams"
             },
@@ -17748,7 +18421,7 @@
           },
           "params": {
             "$ref": "#/components/schemas/BetaCreateMessageParams",
-            "description": "Messages API creation parameters for the individual request.\n\nSee the [Messages API reference](https://docs.claude.com/en/api/messages) for full documentation on available parameters."
+            "description": "Messages API creation parameters for the individual request.\n\nSee the [Messages API reference](https://platform.claude.com/docs/en/api/messages) for full documentation on available parameters."
           }
         },
         "required": [
@@ -23304,6 +23977,18 @@
         "title": "ResponseWebSearchToolResultError",
         "type": "object"
       },
+      "BetaRotateTunnelTokenRequestBody": {
+        "additionalProperties": false,
+        "properties": {
+          "reason": {
+            "description": "Optional free-text reason for the rotation, recorded for audit.",
+            "maxLength": 1024,
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "BetaSelfHostedConfig": {
         "additionalProperties": false,
         "description": "Configuration for self-hosted environments.",
@@ -24358,7 +25043,7 @@
         "additionalProperties": false,
         "properties": {
           "budget_tokens": {
-            "description": "Determines how many tokens Claude can use for its internal reasoning process. Larger budgets can enable more thorough analysis for complex problems, improving response quality.\n\nMust be \u22651024 and less than `max_tokens`.\n\nSee [extended thinking](https://docs.claude.com/en/docs/build-with-claude/extended-thinking) for details.",
+            "description": "Determines how many tokens Claude can use for its internal reasoning process. Larger budgets can enable more thorough analysis for complex problems, improving response quality.\n\nMust be \u22651024 and less than `max_tokens`.\n\nSee [extended thinking](https://platform.claude.com/docs/en/build-with-claude/extended-thinking) for details.",
             "minimum": 1024,
             "title": "Budget Tokens",
             "type": "integer"
@@ -24388,7 +25073,7 @@
         "type": "object"
       },
       "BetaThinkingConfigParam": {
-        "description": "Configuration for enabling Claude's extended thinking.\n\nWhen enabled, responses include `thinking` content blocks showing Claude's thinking process before the final answer. Requires a minimum budget of 1,024 tokens and counts towards your `max_tokens` limit.\n\nSee [extended thinking](https://docs.claude.com/en/docs/build-with-claude/extended-thinking) for details.",
+        "description": "Configuration for enabling Claude's extended thinking.\n\nWhen enabled, responses include `thinking` content blocks showing Claude's thinking process before the final answer. Requires a minimum budget of 1,024 tokens and counts towards your `max_tokens` limit.\n\nSee [extended thinking](https://platform.claude.com/docs/en/build-with-claude/extended-thinking) for details.",
         "discriminator": {
           "mapping": {
             "adaptive": "#/components/schemas/BetaThinkingConfigAdaptive",
@@ -24953,6 +25638,143 @@
           "value"
         ],
         "title": "ToolUsesTrigger",
+        "type": "object"
+      },
+      "BetaTunnel": {
+        "additionalProperties": false,
+        "description": "An MCP tunnel.",
+        "properties": {
+          "archived_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "RFC 3339 datetime string indicating when the tunnel was archived. Null if it is not archived.",
+            "nullable": true
+          },
+          "created_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "RFC 3339 datetime string indicating when the tunnel was created."
+          },
+          "display_name": {
+            "description": "Human-readable name for the tunnel (1-255 characters). Null if unset.",
+            "nullable": true,
+            "type": "string"
+          },
+          "domain": {
+            "description": "Anthropic-assigned hostname for the tunnel. MCP server URLs whose host is a subdomain of this value are routed through the tunnel. Globally unique and never reused, even after the tunnel is archived.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the tunnel, prefixed with `tnl_`.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "tunnel"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "domain",
+          "display_name",
+          "created_at",
+          "archived_at"
+        ],
+        "type": "object"
+      },
+      "BetaTunnelCertificate": {
+        "additionalProperties": false,
+        "description": "A CA certificate attached to a tunnel.",
+        "properties": {
+          "archived_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "RFC 3339 datetime string indicating when the certificate was archived. Null if it is still in the trusted set.",
+            "nullable": true
+          },
+          "created_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "RFC 3339 datetime string indicating when the certificate was registered."
+          },
+          "expires_at": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaTimestamp"
+              }
+            ],
+            "description": "RFC 3339 datetime string indicating when the certificate expires, or `null` if it does not expire.",
+            "nullable": true
+          },
+          "fingerprint": {
+            "description": "Lowercase hex SHA-256 fingerprint of the certificate's DER encoding.",
+            "type": "string"
+          },
+          "id": {
+            "description": "Unique identifier for the certificate, prefixed with `tcrt_`.",
+            "type": "string"
+          },
+          "tunnel_id": {
+            "description": "ID of the tunnel the certificate is registered against.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "tunnel_certificate"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "tunnel_id",
+          "fingerprint",
+          "expires_at",
+          "created_at",
+          "archived_at"
+        ],
+        "type": "object"
+      },
+      "BetaTunnelToken": {
+        "additionalProperties": false,
+        "description": "A tunnel's connector token.",
+        "properties": {
+          "id": {
+            "description": "Stable identifier for the current token value. Changes when the token is rotated.",
+            "type": "string"
+          },
+          "tunnel_token": {
+            "description": "The connector token used to run the tunnel. Treat as a credential.",
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "tunnel_token"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "tunnel_token"
+        ],
         "type": "object"
       },
       "BetaURLImageSource": {
@@ -25864,6 +26686,148 @@
         "title": "WebFetchTool_20260309",
         "type": "object"
       },
+      "BetaWebFetchTool_20260318": {
+        "additionalProperties": false,
+        "properties": {
+          "allowed_callers": {
+            "items": {
+              "$ref": "#/components/schemas/BetaAllowedCaller"
+            },
+            "title": "Allowed Callers",
+            "type": "array"
+          },
+          "allowed_domains": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "List of domains to allow fetching from",
+            "title": "Allowed Domains"
+          },
+          "blocked_domains": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "List of domains to block fetching from",
+            "title": "Blocked Domains"
+          },
+          "cache_control": {
+            "anyOf": [
+              {
+                "discriminator": {
+                  "mapping": {
+                    "ephemeral": "#/components/schemas/BetaCacheControlEphemeral"
+                  },
+                  "propertyName": "type"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/BetaCacheControlEphemeral"
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Create a cache control breakpoint at this content block.",
+            "title": "Cache Control"
+          },
+          "citations": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BetaRequestCitationsConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Citations configuration for fetched documents. Citations are disabled by default."
+          },
+          "defer_loading": {
+            "description": "If true, tool will not be included in initial system prompt. Only loaded when returned via tool_reference from tool search.",
+            "title": "Defer Loading",
+            "type": "boolean"
+          },
+          "max_content_tokens": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Maximum number of tokens used by including web page text content in the context. The limit is approximate and does not apply to binary content such as PDFs.",
+            "title": "Max Content Tokens"
+          },
+          "max_uses": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Maximum number of times the tool can be used in the API request.",
+            "title": "Max Uses"
+          },
+          "name": {
+            "const": "web_fetch",
+            "description": "Name of the tool.\n\nThis is how the tool will be called by the model and in `tool_use` blocks.",
+            "title": "Name",
+            "type": "string"
+          },
+          "response_inclusion": {
+            "description": "How this tool's result blocks appear in the API response when the result was consumed by a completed code_execution call in the same turn. 'full' returns the complete content (default). 'excluded' drops the nested server_tool_use and result block pair entirely. Results from direct calls, or from code_execution calls that paused before completing, are always returned in full so they can be sent back on the next turn.",
+            "enum": [
+              "full",
+              "excluded"
+            ],
+            "title": "Response Inclusion",
+            "type": "string"
+          },
+          "strict": {
+            "description": "When true, guarantees schema validation on tool names and inputs",
+            "title": "Strict",
+            "type": "boolean"
+          },
+          "type": {
+            "const": "web_fetch_20260318",
+            "title": "Type",
+            "type": "string"
+          },
+          "use_cache": {
+            "description": "Whether to use cached content. Set to false to bypass the cache and fetch fresh content. Only set to false when the user explicitly requests fresh content or when fetching rapidly-changing sources.",
+            "title": "Use Cache",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ],
+        "title": "WebFetchTool_20260318",
+        "type": "object"
+      },
       "BetaWebSearchToolResultErrorCode": {
         "enum": [
           "invalid_tool_input",
@@ -26106,6 +27070,468 @@
         "title": "WebSearchTool_20260209",
         "type": "object"
       },
+      "BetaWebSearchTool_20260318": {
+        "additionalProperties": false,
+        "properties": {
+          "allowed_callers": {
+            "items": {
+              "$ref": "#/components/schemas/BetaAllowedCaller"
+            },
+            "title": "Allowed Callers",
+            "type": "array"
+          },
+          "allowed_domains": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "If provided, only these domains will be included in results. Cannot be used alongside `blocked_domains`.",
+            "title": "Allowed Domains"
+          },
+          "blocked_domains": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "If provided, these domains will never appear in results. Cannot be used alongside `allowed_domains`.",
+            "title": "Blocked Domains"
+          },
+          "cache_control": {
+            "anyOf": [
+              {
+                "discriminator": {
+                  "mapping": {
+                    "ephemeral": "#/components/schemas/BetaCacheControlEphemeral"
+                  },
+                  "propertyName": "type"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/BetaCacheControlEphemeral"
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Create a cache control breakpoint at this content block.",
+            "title": "Cache Control"
+          },
+          "defer_loading": {
+            "description": "If true, tool will not be included in initial system prompt. Only loaded when returned via tool_reference from tool search.",
+            "title": "Defer Loading",
+            "type": "boolean"
+          },
+          "max_uses": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Maximum number of times the tool can be used in the API request.",
+            "title": "Max Uses"
+          },
+          "name": {
+            "const": "web_search",
+            "description": "Name of the tool.\n\nThis is how the tool will be called by the model and in `tool_use` blocks.",
+            "title": "Name",
+            "type": "string"
+          },
+          "response_inclusion": {
+            "description": "How this tool's result blocks appear in the API response when the result was consumed by a completed code_execution call in the same turn. 'full' returns the complete content (default). 'excluded' drops the nested server_tool_use and result block pair entirely. Results from direct calls, or from code_execution calls that paused before completing, are always returned in full so they can be sent back on the next turn.",
+            "enum": [
+              "full",
+              "excluded"
+            ],
+            "title": "Response Inclusion",
+            "type": "string"
+          },
+          "strict": {
+            "description": "When true, guarantees schema validation on tool names and inputs",
+            "title": "Strict",
+            "type": "boolean"
+          },
+          "type": {
+            "const": "web_search_20260318",
+            "title": "Type",
+            "type": "string"
+          },
+          "user_location": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BetaUserLocation"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Parameters for the user's location. Used to provide more relevant search results."
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ],
+        "title": "WebSearchTool_20260318",
+        "type": "object"
+      },
+      "BetaWebhookAgentArchivedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the agent that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "agent.archived",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookAgentArchivedEventData",
+        "type": "object"
+      },
+      "BetaWebhookAgentCreatedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the agent that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "agent.created",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookAgentCreatedEventData",
+        "type": "object"
+      },
+      "BetaWebhookAgentDeletedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the agent that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "agent.deleted",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookAgentDeletedEventData",
+        "type": "object"
+      },
+      "BetaWebhookAgentUpdatedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the agent that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "agent.updated",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookAgentUpdatedEventData",
+        "type": "object"
+      },
+      "BetaWebhookDeploymentArchivedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the deployment that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "deployment.archived",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookDeploymentArchivedEventData",
+        "type": "object"
+      },
+      "BetaWebhookDeploymentCreatedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the deployment that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "deployment.created",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookDeploymentCreatedEventData",
+        "type": "object"
+      },
+      "BetaWebhookDeploymentDeletedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the deployment that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "deployment.deleted",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookDeploymentDeletedEventData",
+        "type": "object"
+      },
+      "BetaWebhookDeploymentPausedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the deployment that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "deployment.paused",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookDeploymentPausedEventData",
+        "type": "object"
+      },
+      "BetaWebhookDeploymentRunFailedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the deployment run that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "deployment_run.failed",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookDeploymentRunFailedEventData",
+        "type": "object"
+      },
+      "BetaWebhookDeploymentRunStartedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the deployment run that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "deployment_run.started",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookDeploymentRunStartedEventData",
+        "type": "object"
+      },
+      "BetaWebhookDeploymentRunSucceededEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the deployment run that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "deployment_run.succeeded",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookDeploymentRunSucceededEventData",
+        "type": "object"
+      },
+      "BetaWebhookDeploymentUnpausedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the deployment that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "deployment.unpaused",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookDeploymentUnpausedEventData",
+        "type": "object"
+      },
+      "BetaWebhookDeploymentUpdatedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the deployment that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "deployment.updated",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookDeploymentUpdatedEventData",
+        "type": "object"
+      },
       "BetaWebhookEvent": {
         "example": {
           "created_at": "2026-03-15T10:00:00Z",
@@ -26166,6 +27592,19 @@
       "BetaWebhookEventData": {
         "discriminator": {
           "mapping": {
+            "agent.archived": "#/components/schemas/BetaWebhookAgentArchivedEventData",
+            "agent.created": "#/components/schemas/BetaWebhookAgentCreatedEventData",
+            "agent.deleted": "#/components/schemas/BetaWebhookAgentDeletedEventData",
+            "agent.updated": "#/components/schemas/BetaWebhookAgentUpdatedEventData",
+            "deployment.archived": "#/components/schemas/BetaWebhookDeploymentArchivedEventData",
+            "deployment.created": "#/components/schemas/BetaWebhookDeploymentCreatedEventData",
+            "deployment.deleted": "#/components/schemas/BetaWebhookDeploymentDeletedEventData",
+            "deployment.paused": "#/components/schemas/BetaWebhookDeploymentPausedEventData",
+            "deployment.unpaused": "#/components/schemas/BetaWebhookDeploymentUnpausedEventData",
+            "deployment.updated": "#/components/schemas/BetaWebhookDeploymentUpdatedEventData",
+            "deployment_run.failed": "#/components/schemas/BetaWebhookDeploymentRunFailedEventData",
+            "deployment_run.started": "#/components/schemas/BetaWebhookDeploymentRunStartedEventData",
+            "deployment_run.succeeded": "#/components/schemas/BetaWebhookDeploymentRunSucceededEventData",
             "session.archived": "#/components/schemas/BetaWebhookSessionArchivedEventData",
             "session.created": "#/components/schemas/BetaWebhookSessionCreatedEventData",
             "session.deleted": "#/components/schemas/BetaWebhookSessionDeletedEventData",
@@ -26261,6 +27700,45 @@
           },
           {
             "$ref": "#/components/schemas/BetaWebhookSessionUpdatedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookAgentCreatedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookAgentArchivedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookAgentDeletedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookDeploymentPausedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookDeploymentRunFailedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookDeploymentCreatedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookDeploymentUpdatedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookDeploymentUnpausedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookAgentUpdatedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookDeploymentArchivedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookDeploymentRunStartedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookDeploymentDeletedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookDeploymentRunSucceededEventData"
           }
         ],
         "title": "BetaWebhookEventData"
@@ -27042,7 +28520,7 @@
         "additionalProperties": false,
         "properties": {
           "ttl": {
-            "description": "The time-to-live for the cache control breakpoint.\n\nThis may be one the following values:\n- `5m`: 5 minutes\n- `1h`: 1 hour\n\nDefaults to `5m`.",
+            "description": "The time-to-live for the cache control breakpoint.\n\nThis may be one the following values:\n- `5m`: 5 minutes\n- `1h`: 1 hour\n\nDefaults to `5m`. See [prompt caching pricing](https://platform.claude.com/docs/en/build-with-claude/prompt-caching) for details.",
             "enum": [
               "5m",
               "1h"
@@ -27450,7 +28928,7 @@
             "$ref": "#/components/schemas/Model"
           },
           "prompt": {
-            "description": "The prompt that you want Claude to complete.\n\nFor proper response generation you will need to format your prompt using alternating `\\n\\nHuman:` and `\\n\\nAssistant:` conversational turns. For example:\n\n```\n\"\\n\\nHuman: {userQuestion}\\n\\nAssistant:\"\n```\n\nSee [prompt validation](https://docs.claude.com/en/api/prompt-validation) and our guide to [prompt design](https://docs.claude.com/en/docs/intro-to-prompting) for more details.",
+            "description": "The prompt that you want Claude to complete.\n\nFor proper response generation you will need to format your prompt using alternating `\\n\\nHuman:` and `\\n\\nAssistant:` conversational turns. For example:\n\n```\n\"\\n\\nHuman: {userQuestion}\\n\\nAssistant:\"\n```\n\nSee [prompt validation](https://platform.claude.com/docs/en/build-with-claude/working-with-messages) and our guide to [prompt design](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/overview) for more details.",
             "examples": [
               "\n\nHuman: Hello, world!\n\nAssistant:"
             ],
@@ -27467,7 +28945,7 @@
             "type": "array"
           },
           "stream": {
-            "description": "Whether to incrementally stream the response using server-sent events.\n\nSee [streaming](https://docs.claude.com/en/api/streaming) for details.",
+            "description": "Whether to incrementally stream the response using server-sent events.\n\nSee [streaming](https://platform.claude.com/docs/en/build-with-claude/streaming) for details.",
             "title": "Stream",
             "type": "boolean"
           },
@@ -27956,7 +29434,7 @@
             "title": "Cache Control"
           },
           "messages": {
-            "description": "Input messages.\n\nOur models are trained to operate on alternating `user` and `assistant` conversational turns. When creating a new `Message`, you specify the prior conversational turns with the `messages` parameter, and the model then generates the next `Message` in the conversation. Consecutive `user` or `assistant` turns in your request will be combined into a single turn.\n\nEach input message must be an object with a `role` and `content`. You can specify a single `user`-role message, or you can include multiple `user` and `assistant` messages.\n\nIf the final message uses the `assistant` role, the response content will continue immediately from the content in that message. This can be used to constrain part of the model's response.\n\nExample with a single `user` message:\n\n```json\n[{\"role\": \"user\", \"content\": \"Hello, Claude\"}]\n```\n\nExample with multiple conversational turns:\n\n```json\n[\n  {\"role\": \"user\", \"content\": \"Hello there.\"},\n  {\"role\": \"assistant\", \"content\": \"Hi, I'm Claude. How can I help you?\"},\n  {\"role\": \"user\", \"content\": \"Can you explain LLMs in plain English?\"},\n]\n```\n\nExample with a partially-filled response from Claude:\n\n```json\n[\n  {\"role\": \"user\", \"content\": \"What's the Greek name for Sun? (A) Sol (B) Helios (C) Sun\"},\n  {\"role\": \"assistant\", \"content\": \"The best answer is (\"},\n]\n```\n\nEach input message `content` may be either a single `string` or an array of content blocks, where each block has a specific `type`. Using a `string` for `content` is shorthand for an array of one content block of type `\"text\"`. The following input messages are equivalent:\n\n```json\n{\"role\": \"user\", \"content\": \"Hello, Claude\"}\n```\n\n```json\n{\"role\": \"user\", \"content\": [{\"type\": \"text\", \"text\": \"Hello, Claude\"}]}\n```\n\nSee [input examples](https://docs.claude.com/en/api/messages-examples).\n\nNote that if you want to include a [system prompt](https://docs.claude.com/en/docs/system-prompts), you can use the top-level `system` parameter \u2014 there is no `\"system\"` role for input messages in the Messages API.\n\nThere is a limit of 100,000 messages in a single request.",
+            "description": "Input messages.\n\nOur models are trained to operate on alternating `user` and `assistant` conversational turns. When creating a new `Message`, you specify the prior conversational turns with the `messages` parameter, and the model then generates the next `Message` in the conversation. Consecutive `user` or `assistant` turns in your request will be combined into a single turn.\n\nEach input message must be an object with a `role` and `content`. You can specify a single `user`-role message, or you can include multiple `user` and `assistant` messages.\n\nIf the final message uses the `assistant` role, the response content will continue immediately from the content in that message. This can be used to constrain part of the model's response.\n\nExample with a single `user` message:\n\n```json\n[{\"role\": \"user\", \"content\": \"Hello, Claude\"}]\n```\n\nExample with multiple conversational turns:\n\n```json\n[\n  {\"role\": \"user\", \"content\": \"Hello there.\"},\n  {\"role\": \"assistant\", \"content\": \"Hi, I'm Claude. How can I help you?\"},\n  {\"role\": \"user\", \"content\": \"Can you explain LLMs in plain English?\"},\n]\n```\n\nExample with a partially-filled response from Claude:\n\n```json\n[\n  {\"role\": \"user\", \"content\": \"What's the Greek name for Sun? (A) Sol (B) Helios (C) Sun\"},\n  {\"role\": \"assistant\", \"content\": \"The best answer is (\"},\n]\n```\n\nEach input message `content` may be either a single `string` or an array of content blocks, where each block has a specific `type`. Using a `string` for `content` is shorthand for an array of one content block of type `\"text\"`. The following input messages are equivalent:\n\n```json\n{\"role\": \"user\", \"content\": \"Hello, Claude\"}\n```\n\n```json\n{\"role\": \"user\", \"content\": [{\"type\": \"text\", \"text\": \"Hello, Claude\"}]}\n```\n\nSee [input examples](https://platform.claude.com/docs/en/build-with-claude/working-with-messages).\n\nNote that if you want to include a [system prompt](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices#give-claude-a-role), you can use the top-level `system` parameter \u2014 there is no `\"system\"` role for input messages in the Messages API.\n\nThere is a limit of 100,000 messages in a single request.",
             "items": {
               "$ref": "#/components/schemas/InputMessage"
             },
@@ -27982,7 +29460,7 @@
                 "type": "array"
               }
             ],
-            "description": "System prompt.\n\nA system prompt is a way of providing context and instructions to Claude, such as specifying a particular goal or role. See our [guide to system prompts](https://docs.claude.com/en/docs/system-prompts).",
+            "description": "System prompt.\n\nA system prompt is a way of providing context and instructions to Claude, such as specifying a particular goal or role. See our [guide to system prompts](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices#give-claude-a-role).",
             "examples": [
               [
                 {
@@ -28001,7 +29479,7 @@
             "$ref": "#/components/schemas/ToolChoice"
           },
           "tools": {
-            "description": "Definitions of tools that the model may use.\n\nIf you include `tools` in your API request, the model may return `tool_use` content blocks that represent the model's use of those tools. You can then run those tools using the tool input generated by the model and then optionally return results back to the model using `tool_result` content blocks.\n\nThere are two types of tools: **client tools** and **server tools**. The behavior described below applies to client tools. For [server tools](https://docs.claude.com/en/docs/agents-and-tools/tool-use/overview#server-tools), see their individual documentation as each has its own behavior (e.g., the [web search tool](https://docs.claude.com/en/docs/agents-and-tools/tool-use/web-search-tool)).\n\nEach tool definition includes:\n\n* `name`: Name of the tool.\n* `description`: Optional, but strongly-recommended description of the tool.\n* `input_schema`: [JSON schema](https://json-schema.org/draft/2020-12) for the tool `input` shape that the model will produce in `tool_use` output content blocks.\n\nFor example, if you defined `tools` as:\n\n```json\n[\n  {\n    \"name\": \"get_stock_price\",\n    \"description\": \"Get the current stock price for a given ticker symbol.\",\n    \"input_schema\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"ticker\": {\n          \"type\": \"string\",\n          \"description\": \"The stock ticker symbol, e.g. AAPL for Apple Inc.\"\n        }\n      },\n      \"required\": [\"ticker\"]\n    }\n  }\n]\n```\n\nAnd then asked the model \"What's the S&P 500 at today?\", the model might produce `tool_use` content blocks in the response like this:\n\n```json\n[\n  {\n    \"type\": \"tool_use\",\n    \"id\": \"toolu_01D7FLrfh4GYq7yT1ULFeyMV\",\n    \"name\": \"get_stock_price\",\n    \"input\": { \"ticker\": \"^GSPC\" }\n  }\n]\n```\n\nYou might then run your `get_stock_price` tool with `{\"ticker\": \"^GSPC\"}` as an input, and return the following back to the model in a subsequent `user` message:\n\n```json\n[\n  {\n    \"type\": \"tool_result\",\n    \"tool_use_id\": \"toolu_01D7FLrfh4GYq7yT1ULFeyMV\",\n    \"content\": \"259.75 USD\"\n  }\n]\n```\n\nTools can be used for workflows that include running client-side tools and functions, or more generally whenever you want the model to produce a particular JSON structure of output.\n\nSee our [guide](https://docs.claude.com/en/docs/tool-use) for more details.",
+            "description": "Definitions of tools that the model may use.\n\nIf you include `tools` in your API request, the model may return `tool_use` content blocks that represent the model's use of those tools. You can then run those tools using the tool input generated by the model and then optionally return results back to the model using `tool_result` content blocks.\n\nThere are two types of tools: **client tools** and **server tools**. The behavior described below applies to client tools. For [server tools](https://platform.claude.com/docs/en/agents-and-tools/tool-use/server-tools), see their individual documentation as each has its own behavior (e.g., the [web search tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool)).\n\nEach tool definition includes:\n\n* `name`: Name of the tool.\n* `description`: Optional, but strongly-recommended description of the tool.\n* `input_schema`: [JSON schema](https://json-schema.org/draft/2020-12) for the tool `input` shape that the model will produce in `tool_use` output content blocks.\n\nFor example, if you defined `tools` as:\n\n```json\n[\n  {\n    \"name\": \"get_stock_price\",\n    \"description\": \"Get the current stock price for a given ticker symbol.\",\n    \"input_schema\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"ticker\": {\n          \"type\": \"string\",\n          \"description\": \"The stock ticker symbol, e.g. AAPL for Apple Inc.\"\n        }\n      },\n      \"required\": [\"ticker\"]\n    }\n  }\n]\n```\n\nAnd then asked the model \"What's the S&P 500 at today?\", the model might produce `tool_use` content blocks in the response like this:\n\n```json\n[\n  {\n    \"type\": \"tool_use\",\n    \"id\": \"toolu_01D7FLrfh4GYq7yT1ULFeyMV\",\n    \"name\": \"get_stock_price\",\n    \"input\": { \"ticker\": \"^GSPC\" }\n  }\n]\n```\n\nYou might then run your `get_stock_price` tool with `{\"ticker\": \"^GSPC\"}` as an input, and return the following back to the model in a subsequent `user` message:\n\n```json\n[\n  {\n    \"type\": \"tool_result\",\n    \"tool_use_id\": \"toolu_01D7FLrfh4GYq7yT1ULFeyMV\",\n    \"content\": \"259.75 USD\"\n  }\n]\n```\n\nTools can be used for workflows that include running client-side tools and functions, or more generally whenever you want the model to produce a particular JSON structure of output.\n\nSee our [guide](https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview) for more details.",
             "examples": [
               {
                 "description": "Get the current weather in a given location",
@@ -28070,6 +29548,12 @@
                 },
                 {
                   "$ref": "#/components/schemas/WebFetchTool_20260309"
+                },
+                {
+                  "$ref": "#/components/schemas/WebSearchTool_20260318"
+                },
+                {
+                  "$ref": "#/components/schemas/WebFetchTool_20260318"
                 },
                 {
                   "$ref": "#/components/schemas/ToolSearchToolBM25_20251119"
@@ -28192,7 +29676,7 @@
             "title": "Inference Geo"
           },
           "max_tokens": {
-            "description": "The maximum number of tokens to generate before stopping.\n\nNote that our models may stop _before_ reaching this maximum. This parameter only specifies the absolute maximum number of tokens to generate.\n\nSet to `0` to populate the [prompt cache](https://docs.claude.com/en/docs/build-with-claude/prompt-caching#pre-warming-the-cache) without generating a response.\n\nDifferent models have different maximum values for this parameter.  See [models](https://docs.claude.com/en/docs/models-overview) for details.",
+            "description": "The maximum number of tokens to generate before stopping.\n\nNote that our models may stop _before_ reaching this maximum. This parameter only specifies the absolute maximum number of tokens to generate.\n\nSet to `0` to populate the [prompt cache](https://platform.claude.com/docs/en/build-with-claude/prompt-caching#pre-warming-the-cache) without generating a response.\n\nDifferent models have different maximum values for this parameter.  See [models](https://platform.claude.com/docs/en/about-claude/models/overview) for details.",
             "examples": [
               1024
             ],
@@ -28201,7 +29685,7 @@
             "type": "integer"
           },
           "messages": {
-            "description": "Input messages.\n\nOur models are trained to operate on alternating `user` and `assistant` conversational turns. When creating a new `Message`, you specify the prior conversational turns with the `messages` parameter, and the model then generates the next `Message` in the conversation. Consecutive `user` or `assistant` turns in your request will be combined into a single turn.\n\nEach input message must be an object with a `role` and `content`. You can specify a single `user`-role message, or you can include multiple `user` and `assistant` messages.\n\nIf the final message uses the `assistant` role, the response content will continue immediately from the content in that message. This can be used to constrain part of the model's response.\n\nExample with a single `user` message:\n\n```json\n[{\"role\": \"user\", \"content\": \"Hello, Claude\"}]\n```\n\nExample with multiple conversational turns:\n\n```json\n[\n  {\"role\": \"user\", \"content\": \"Hello there.\"},\n  {\"role\": \"assistant\", \"content\": \"Hi, I'm Claude. How can I help you?\"},\n  {\"role\": \"user\", \"content\": \"Can you explain LLMs in plain English?\"},\n]\n```\n\nExample with a partially-filled response from Claude:\n\n```json\n[\n  {\"role\": \"user\", \"content\": \"What's the Greek name for Sun? (A) Sol (B) Helios (C) Sun\"},\n  {\"role\": \"assistant\", \"content\": \"The best answer is (\"},\n]\n```\n\nEach input message `content` may be either a single `string` or an array of content blocks, where each block has a specific `type`. Using a `string` for `content` is shorthand for an array of one content block of type `\"text\"`. The following input messages are equivalent:\n\n```json\n{\"role\": \"user\", \"content\": \"Hello, Claude\"}\n```\n\n```json\n{\"role\": \"user\", \"content\": [{\"type\": \"text\", \"text\": \"Hello, Claude\"}]}\n```\n\nSee [input examples](https://docs.claude.com/en/api/messages-examples).\n\nNote that if you want to include a [system prompt](https://docs.claude.com/en/docs/system-prompts), you can use the top-level `system` parameter \u2014 there is no `\"system\"` role for input messages in the Messages API.\n\nThere is a limit of 100,000 messages in a single request.",
+            "description": "Input messages.\n\nOur models are trained to operate on alternating `user` and `assistant` conversational turns. When creating a new `Message`, you specify the prior conversational turns with the `messages` parameter, and the model then generates the next `Message` in the conversation. Consecutive `user` or `assistant` turns in your request will be combined into a single turn.\n\nEach input message must be an object with a `role` and `content`. You can specify a single `user`-role message, or you can include multiple `user` and `assistant` messages.\n\nIf the final message uses the `assistant` role, the response content will continue immediately from the content in that message. This can be used to constrain part of the model's response.\n\nExample with a single `user` message:\n\n```json\n[{\"role\": \"user\", \"content\": \"Hello, Claude\"}]\n```\n\nExample with multiple conversational turns:\n\n```json\n[\n  {\"role\": \"user\", \"content\": \"Hello there.\"},\n  {\"role\": \"assistant\", \"content\": \"Hi, I'm Claude. How can I help you?\"},\n  {\"role\": \"user\", \"content\": \"Can you explain LLMs in plain English?\"},\n]\n```\n\nExample with a partially-filled response from Claude:\n\n```json\n[\n  {\"role\": \"user\", \"content\": \"What's the Greek name for Sun? (A) Sol (B) Helios (C) Sun\"},\n  {\"role\": \"assistant\", \"content\": \"The best answer is (\"},\n]\n```\n\nEach input message `content` may be either a single `string` or an array of content blocks, where each block has a specific `type`. Using a `string` for `content` is shorthand for an array of one content block of type `\"text\"`. The following input messages are equivalent:\n\n```json\n{\"role\": \"user\", \"content\": \"Hello, Claude\"}\n```\n\n```json\n{\"role\": \"user\", \"content\": [{\"type\": \"text\", \"text\": \"Hello, Claude\"}]}\n```\n\nSee [input examples](https://platform.claude.com/docs/en/build-with-claude/working-with-messages).\n\nNote that if you want to include a [system prompt](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices#give-claude-a-role), you can use the top-level `system` parameter \u2014 there is no `\"system\"` role for input messages in the Messages API.\n\nThere is a limit of 100,000 messages in a single request.",
             "items": {
               "$ref": "#/components/schemas/InputMessage"
             },
@@ -28220,7 +29704,7 @@
             "description": "Configuration options for the model's output, such as the output format."
           },
           "service_tier": {
-            "description": "Determines whether to use priority capacity (if available) or standard capacity for this request.\n\nAnthropic offers different levels of service for your API requests. See [service-tiers](https://docs.claude.com/en/api/service-tiers) for details.",
+            "description": "Determines whether to use priority capacity (if available) or standard capacity for this request.\n\nAnthropic offers different levels of service for your API requests. See [service-tiers](https://platform.claude.com/docs/en/api/service-tiers) for details.",
             "enum": [
               "auto",
               "standard_only"
@@ -28237,7 +29721,8 @@
             "type": "array"
           },
           "stream": {
-            "description": "Whether to incrementally stream the response using server-sent events.\n\nSee [streaming](https://docs.claude.com/en/api/messages-streaming) for details.",
+            "description": "Whether to incrementally stream the response using server-sent events.\n\nSee [streaming](https://platform.claude.com/docs/en/build-with-claude/streaming) for details.",
+            "example": false,
             "title": "Stream",
             "type": "boolean"
           },
@@ -28256,7 +29741,7 @@
                 "type": "array"
               }
             ],
-            "description": "System prompt.\n\nA system prompt is a way of providing context and instructions to Claude, such as specifying a particular goal or role. See our [guide to system prompts](https://docs.claude.com/en/docs/system-prompts).",
+            "description": "System prompt.\n\nA system prompt is a way of providing context and instructions to Claude, such as specifying a particular goal or role. See our [guide to system prompts](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices#give-claude-a-role).",
             "examples": [
               [
                 {
@@ -28287,7 +29772,7 @@
             "$ref": "#/components/schemas/ToolChoice"
           },
           "tools": {
-            "description": "Definitions of tools that the model may use.\n\nIf you include `tools` in your API request, the model may return `tool_use` content blocks that represent the model's use of those tools. You can then run those tools using the tool input generated by the model and then optionally return results back to the model using `tool_result` content blocks.\n\nThere are two types of tools: **client tools** and **server tools**. The behavior described below applies to client tools. For [server tools](https://docs.claude.com/en/docs/agents-and-tools/tool-use/overview#server-tools), see their individual documentation as each has its own behavior (e.g., the [web search tool](https://docs.claude.com/en/docs/agents-and-tools/tool-use/web-search-tool)).\n\nEach tool definition includes:\n\n* `name`: Name of the tool.\n* `description`: Optional, but strongly-recommended description of the tool.\n* `input_schema`: [JSON schema](https://json-schema.org/draft/2020-12) for the tool `input` shape that the model will produce in `tool_use` output content blocks.\n\nFor example, if you defined `tools` as:\n\n```json\n[\n  {\n    \"name\": \"get_stock_price\",\n    \"description\": \"Get the current stock price for a given ticker symbol.\",\n    \"input_schema\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"ticker\": {\n          \"type\": \"string\",\n          \"description\": \"The stock ticker symbol, e.g. AAPL for Apple Inc.\"\n        }\n      },\n      \"required\": [\"ticker\"]\n    }\n  }\n]\n```\n\nAnd then asked the model \"What's the S&P 500 at today?\", the model might produce `tool_use` content blocks in the response like this:\n\n```json\n[\n  {\n    \"type\": \"tool_use\",\n    \"id\": \"toolu_01D7FLrfh4GYq7yT1ULFeyMV\",\n    \"name\": \"get_stock_price\",\n    \"input\": { \"ticker\": \"^GSPC\" }\n  }\n]\n```\n\nYou might then run your `get_stock_price` tool with `{\"ticker\": \"^GSPC\"}` as an input, and return the following back to the model in a subsequent `user` message:\n\n```json\n[\n  {\n    \"type\": \"tool_result\",\n    \"tool_use_id\": \"toolu_01D7FLrfh4GYq7yT1ULFeyMV\",\n    \"content\": \"259.75 USD\"\n  }\n]\n```\n\nTools can be used for workflows that include running client-side tools and functions, or more generally whenever you want the model to produce a particular JSON structure of output.\n\nSee our [guide](https://docs.claude.com/en/docs/tool-use) for more details.",
+            "description": "Definitions of tools that the model may use.\n\nIf you include `tools` in your API request, the model may return `tool_use` content blocks that represent the model's use of those tools. You can then run those tools using the tool input generated by the model and then optionally return results back to the model using `tool_result` content blocks.\n\nThere are two types of tools: **client tools** and **server tools**. The behavior described below applies to client tools. For [server tools](https://platform.claude.com/docs/en/agents-and-tools/tool-use/server-tools), see their individual documentation as each has its own behavior (e.g., the [web search tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool)).\n\nEach tool definition includes:\n\n* `name`: Name of the tool.\n* `description`: Optional, but strongly-recommended description of the tool.\n* `input_schema`: [JSON schema](https://json-schema.org/draft/2020-12) for the tool `input` shape that the model will produce in `tool_use` output content blocks.\n\nFor example, if you defined `tools` as:\n\n```json\n[\n  {\n    \"name\": \"get_stock_price\",\n    \"description\": \"Get the current stock price for a given ticker symbol.\",\n    \"input_schema\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"ticker\": {\n          \"type\": \"string\",\n          \"description\": \"The stock ticker symbol, e.g. AAPL for Apple Inc.\"\n        }\n      },\n      \"required\": [\"ticker\"]\n    }\n  }\n]\n```\n\nAnd then asked the model \"What's the S&P 500 at today?\", the model might produce `tool_use` content blocks in the response like this:\n\n```json\n[\n  {\n    \"type\": \"tool_use\",\n    \"id\": \"toolu_01D7FLrfh4GYq7yT1ULFeyMV\",\n    \"name\": \"get_stock_price\",\n    \"input\": { \"ticker\": \"^GSPC\" }\n  }\n]\n```\n\nYou might then run your `get_stock_price` tool with `{\"ticker\": \"^GSPC\"}` as an input, and return the following back to the model in a subsequent `user` message:\n\n```json\n[\n  {\n    \"type\": \"tool_result\",\n    \"tool_use_id\": \"toolu_01D7FLrfh4GYq7yT1ULFeyMV\",\n    \"content\": \"259.75 USD\"\n  }\n]\n```\n\nTools can be used for workflows that include running client-side tools and functions, or more generally whenever you want the model to produce a particular JSON structure of output.\n\nSee our [guide](https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview) for more details.",
             "examples": [
               {
                 "description": "Get the current weather in a given location",
@@ -28356,6 +29841,12 @@
                 },
                 {
                   "$ref": "#/components/schemas/WebFetchTool_20260309"
+                },
+                {
+                  "$ref": "#/components/schemas/WebSearchTool_20260318"
+                },
+                {
+                  "$ref": "#/components/schemas/WebFetchTool_20260318"
                 },
                 {
                   "$ref": "#/components/schemas/ToolSearchToolBM25_20251119"
@@ -28460,7 +29951,7 @@
             "title": "Inference Geo"
           },
           "max_tokens": {
-            "description": "The maximum number of tokens to generate before stopping.\n\nNote that our models may stop _before_ reaching this maximum. This parameter only specifies the absolute maximum number of tokens to generate.\n\nSet to `0` to populate the [prompt cache](https://docs.claude.com/en/docs/build-with-claude/prompt-caching#pre-warming-the-cache) without generating a response.\n\nDifferent models have different maximum values for this parameter.  See [models](https://docs.claude.com/en/docs/models-overview) for details.",
+            "description": "The maximum number of tokens to generate before stopping.\n\nNote that our models may stop _before_ reaching this maximum. This parameter only specifies the absolute maximum number of tokens to generate.\n\nSet to `0` to populate the [prompt cache](https://platform.claude.com/docs/en/build-with-claude/prompt-caching#pre-warming-the-cache) without generating a response.\n\nDifferent models have different maximum values for this parameter.  See [models](https://platform.claude.com/docs/en/about-claude/models/overview) for details.",
             "examples": [
               1024
             ],
@@ -28469,7 +29960,7 @@
             "type": "integer"
           },
           "messages": {
-            "description": "Input messages.\n\nOur models are trained to operate on alternating `user` and `assistant` conversational turns. When creating a new `Message`, you specify the prior conversational turns with the `messages` parameter, and the model then generates the next `Message` in the conversation. Consecutive `user` or `assistant` turns in your request will be combined into a single turn.\n\nEach input message must be an object with a `role` and `content`. You can specify a single `user`-role message, or you can include multiple `user` and `assistant` messages.\n\nIf the final message uses the `assistant` role, the response content will continue immediately from the content in that message. This can be used to constrain part of the model's response.\n\nExample with a single `user` message:\n\n```json\n[{\"role\": \"user\", \"content\": \"Hello, Claude\"}]\n```\n\nExample with multiple conversational turns:\n\n```json\n[\n  {\"role\": \"user\", \"content\": \"Hello there.\"},\n  {\"role\": \"assistant\", \"content\": \"Hi, I'm Claude. How can I help you?\"},\n  {\"role\": \"user\", \"content\": \"Can you explain LLMs in plain English?\"},\n]\n```\n\nExample with a partially-filled response from Claude:\n\n```json\n[\n  {\"role\": \"user\", \"content\": \"What's the Greek name for Sun? (A) Sol (B) Helios (C) Sun\"},\n  {\"role\": \"assistant\", \"content\": \"The best answer is (\"},\n]\n```\n\nEach input message `content` may be either a single `string` or an array of content blocks, where each block has a specific `type`. Using a `string` for `content` is shorthand for an array of one content block of type `\"text\"`. The following input messages are equivalent:\n\n```json\n{\"role\": \"user\", \"content\": \"Hello, Claude\"}\n```\n\n```json\n{\"role\": \"user\", \"content\": [{\"type\": \"text\", \"text\": \"Hello, Claude\"}]}\n```\n\nSee [input examples](https://docs.claude.com/en/api/messages-examples).\n\nNote that if you want to include a [system prompt](https://docs.claude.com/en/docs/system-prompts), you can use the top-level `system` parameter \u2014 there is no `\"system\"` role for input messages in the Messages API.\n\nThere is a limit of 100,000 messages in a single request.",
+            "description": "Input messages.\n\nOur models are trained to operate on alternating `user` and `assistant` conversational turns. When creating a new `Message`, you specify the prior conversational turns with the `messages` parameter, and the model then generates the next `Message` in the conversation. Consecutive `user` or `assistant` turns in your request will be combined into a single turn.\n\nEach input message must be an object with a `role` and `content`. You can specify a single `user`-role message, or you can include multiple `user` and `assistant` messages.\n\nIf the final message uses the `assistant` role, the response content will continue immediately from the content in that message. This can be used to constrain part of the model's response.\n\nExample with a single `user` message:\n\n```json\n[{\"role\": \"user\", \"content\": \"Hello, Claude\"}]\n```\n\nExample with multiple conversational turns:\n\n```json\n[\n  {\"role\": \"user\", \"content\": \"Hello there.\"},\n  {\"role\": \"assistant\", \"content\": \"Hi, I'm Claude. How can I help you?\"},\n  {\"role\": \"user\", \"content\": \"Can you explain LLMs in plain English?\"},\n]\n```\n\nExample with a partially-filled response from Claude:\n\n```json\n[\n  {\"role\": \"user\", \"content\": \"What's the Greek name for Sun? (A) Sol (B) Helios (C) Sun\"},\n  {\"role\": \"assistant\", \"content\": \"The best answer is (\"},\n]\n```\n\nEach input message `content` may be either a single `string` or an array of content blocks, where each block has a specific `type`. Using a `string` for `content` is shorthand for an array of one content block of type `\"text\"`. The following input messages are equivalent:\n\n```json\n{\"role\": \"user\", \"content\": \"Hello, Claude\"}\n```\n\n```json\n{\"role\": \"user\", \"content\": [{\"type\": \"text\", \"text\": \"Hello, Claude\"}]}\n```\n\nSee [input examples](https://platform.claude.com/docs/en/build-with-claude/working-with-messages).\n\nNote that if you want to include a [system prompt](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices#give-claude-a-role), you can use the top-level `system` parameter \u2014 there is no `\"system\"` role for input messages in the Messages API.\n\nThere is a limit of 100,000 messages in a single request.",
             "items": {
               "$ref": "#/components/schemas/InputMessage"
             },
@@ -28488,7 +29979,7 @@
             "description": "Configuration options for the model's output, such as the output format."
           },
           "service_tier": {
-            "description": "Determines whether to use priority capacity (if available) or standard capacity for this request.\n\nAnthropic offers different levels of service for your API requests. See [service-tiers](https://docs.claude.com/en/api/service-tiers) for details.",
+            "description": "Determines whether to use priority capacity (if available) or standard capacity for this request.\n\nAnthropic offers different levels of service for your API requests. See [service-tiers](https://platform.claude.com/docs/en/api/service-tiers) for details.",
             "enum": [
               "auto",
               "standard_only"
@@ -28516,7 +30007,7 @@
                 "type": "array"
               }
             ],
-            "description": "System prompt.\n\nA system prompt is a way of providing context and instructions to Claude, such as specifying a particular goal or role. See our [guide to system prompts](https://docs.claude.com/en/docs/system-prompts).",
+            "description": "System prompt.\n\nA system prompt is a way of providing context and instructions to Claude, such as specifying a particular goal or role. See our [guide to system prompts](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices#give-claude-a-role).",
             "examples": [
               [
                 {
@@ -28547,7 +30038,7 @@
             "$ref": "#/components/schemas/ToolChoice"
           },
           "tools": {
-            "description": "Definitions of tools that the model may use.\n\nIf you include `tools` in your API request, the model may return `tool_use` content blocks that represent the model's use of those tools. You can then run those tools using the tool input generated by the model and then optionally return results back to the model using `tool_result` content blocks.\n\nThere are two types of tools: **client tools** and **server tools**. The behavior described below applies to client tools. For [server tools](https://docs.claude.com/en/docs/agents-and-tools/tool-use/overview#server-tools), see their individual documentation as each has its own behavior (e.g., the [web search tool](https://docs.claude.com/en/docs/agents-and-tools/tool-use/web-search-tool)).\n\nEach tool definition includes:\n\n* `name`: Name of the tool.\n* `description`: Optional, but strongly-recommended description of the tool.\n* `input_schema`: [JSON schema](https://json-schema.org/draft/2020-12) for the tool `input` shape that the model will produce in `tool_use` output content blocks.\n\nFor example, if you defined `tools` as:\n\n```json\n[\n  {\n    \"name\": \"get_stock_price\",\n    \"description\": \"Get the current stock price for a given ticker symbol.\",\n    \"input_schema\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"ticker\": {\n          \"type\": \"string\",\n          \"description\": \"The stock ticker symbol, e.g. AAPL for Apple Inc.\"\n        }\n      },\n      \"required\": [\"ticker\"]\n    }\n  }\n]\n```\n\nAnd then asked the model \"What's the S&P 500 at today?\", the model might produce `tool_use` content blocks in the response like this:\n\n```json\n[\n  {\n    \"type\": \"tool_use\",\n    \"id\": \"toolu_01D7FLrfh4GYq7yT1ULFeyMV\",\n    \"name\": \"get_stock_price\",\n    \"input\": { \"ticker\": \"^GSPC\" }\n  }\n]\n```\n\nYou might then run your `get_stock_price` tool with `{\"ticker\": \"^GSPC\"}` as an input, and return the following back to the model in a subsequent `user` message:\n\n```json\n[\n  {\n    \"type\": \"tool_result\",\n    \"tool_use_id\": \"toolu_01D7FLrfh4GYq7yT1ULFeyMV\",\n    \"content\": \"259.75 USD\"\n  }\n]\n```\n\nTools can be used for workflows that include running client-side tools and functions, or more generally whenever you want the model to produce a particular JSON structure of output.\n\nSee our [guide](https://docs.claude.com/en/docs/tool-use) for more details.",
+            "description": "Definitions of tools that the model may use.\n\nIf you include `tools` in your API request, the model may return `tool_use` content blocks that represent the model's use of those tools. You can then run those tools using the tool input generated by the model and then optionally return results back to the model using `tool_result` content blocks.\n\nThere are two types of tools: **client tools** and **server tools**. The behavior described below applies to client tools. For [server tools](https://platform.claude.com/docs/en/agents-and-tools/tool-use/server-tools), see their individual documentation as each has its own behavior (e.g., the [web search tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/web-search-tool)).\n\nEach tool definition includes:\n\n* `name`: Name of the tool.\n* `description`: Optional, but strongly-recommended description of the tool.\n* `input_schema`: [JSON schema](https://json-schema.org/draft/2020-12) for the tool `input` shape that the model will produce in `tool_use` output content blocks.\n\nFor example, if you defined `tools` as:\n\n```json\n[\n  {\n    \"name\": \"get_stock_price\",\n    \"description\": \"Get the current stock price for a given ticker symbol.\",\n    \"input_schema\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"ticker\": {\n          \"type\": \"string\",\n          \"description\": \"The stock ticker symbol, e.g. AAPL for Apple Inc.\"\n        }\n      },\n      \"required\": [\"ticker\"]\n    }\n  }\n]\n```\n\nAnd then asked the model \"What's the S&P 500 at today?\", the model might produce `tool_use` content blocks in the response like this:\n\n```json\n[\n  {\n    \"type\": \"tool_use\",\n    \"id\": \"toolu_01D7FLrfh4GYq7yT1ULFeyMV\",\n    \"name\": \"get_stock_price\",\n    \"input\": { \"ticker\": \"^GSPC\" }\n  }\n]\n```\n\nYou might then run your `get_stock_price` tool with `{\"ticker\": \"^GSPC\"}` as an input, and return the following back to the model in a subsequent `user` message:\n\n```json\n[\n  {\n    \"type\": \"tool_result\",\n    \"tool_use_id\": \"toolu_01D7FLrfh4GYq7yT1ULFeyMV\",\n    \"content\": \"259.75 USD\"\n  }\n]\n```\n\nTools can be used for workflows that include running client-side tools and functions, or more generally whenever you want the model to produce a particular JSON structure of output.\n\nSee our [guide](https://platform.claude.com/docs/en/agents-and-tools/tool-use/overview) for more details.",
             "examples": [
               {
                 "description": "Get the current weather in a given location",
@@ -28616,6 +30107,12 @@
                 },
                 {
                   "$ref": "#/components/schemas/WebFetchTool_20260309"
+                },
+                {
+                  "$ref": "#/components/schemas/WebSearchTool_20260318"
+                },
+                {
+                  "$ref": "#/components/schemas/WebFetchTool_20260318"
                 },
                 {
                   "$ref": "#/components/schemas/ToolSearchToolBM25_20251119"
@@ -29609,7 +31106,7 @@
           },
           "params": {
             "$ref": "#/components/schemas/CreateMessageParams",
-            "description": "Messages API creation parameters for the individual request.\n\nSee the [Messages API reference](https://docs.claude.com/en/api/messages) for full documentation on available parameters."
+            "description": "Messages API creation parameters for the individual request.\n\nSee the [Messages API reference](https://platform.claude.com/docs/en/api/messages) for full documentation on available parameters."
           }
         },
         "required": [
@@ -29966,6 +31463,11 @@
         "anyOf": [
           {
             "type": "string"
+          },
+          {
+            "const": "claude-sonnet-5",
+            "description": "High-performance model for coding and agents",
+            "x-stainless-nominal": false
           },
           {
             "const": "claude-fable-5",
@@ -34343,7 +35845,7 @@
         "additionalProperties": false,
         "properties": {
           "budget_tokens": {
-            "description": "Determines how many tokens Claude can use for its internal reasoning process. Larger budgets can enable more thorough analysis for complex problems, improving response quality.\n\nMust be \u22651024 and less than `max_tokens`.\n\nSee [extended thinking](https://docs.claude.com/en/docs/build-with-claude/extended-thinking) for details.",
+            "description": "Determines how many tokens Claude can use for its internal reasoning process. Larger budgets can enable more thorough analysis for complex problems, improving response quality.\n\nMust be \u22651024 and less than `max_tokens`.\n\nSee [extended thinking](https://platform.claude.com/docs/en/build-with-claude/extended-thinking) for details.",
             "minimum": 1024,
             "title": "Budget Tokens",
             "type": "integer"
@@ -34373,7 +35875,7 @@
         "type": "object"
       },
       "ThinkingConfigParam": {
-        "description": "Configuration for enabling Claude's extended thinking.\n\nWhen enabled, responses include `thinking` content blocks showing Claude's thinking process before the final answer. Requires a minimum budget of 1,024 tokens and counts towards your `max_tokens` limit.\n\nSee [extended thinking](https://docs.claude.com/en/docs/build-with-claude/extended-thinking) for details.",
+        "description": "Configuration for enabling Claude's extended thinking.\n\nWhen enabled, responses include `thinking` content blocks showing Claude's thinking process before the final answer. Requires a minimum budget of 1,024 tokens and counts towards your `max_tokens` limit.\n\nSee [extended thinking](https://platform.claude.com/docs/en/build-with-claude/extended-thinking) for details.",
         "discriminator": {
           "mapping": {
             "adaptive": "#/components/schemas/ThinkingConfigAdaptive",
@@ -35492,6 +36994,148 @@
         "title": "WebFetchTool_20260309",
         "type": "object"
       },
+      "WebFetchTool_20260318": {
+        "additionalProperties": false,
+        "properties": {
+          "allowed_callers": {
+            "items": {
+              "$ref": "#/components/schemas/AllowedCaller"
+            },
+            "title": "Allowed Callers",
+            "type": "array"
+          },
+          "allowed_domains": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "List of domains to allow fetching from",
+            "title": "Allowed Domains"
+          },
+          "blocked_domains": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "List of domains to block fetching from",
+            "title": "Blocked Domains"
+          },
+          "cache_control": {
+            "anyOf": [
+              {
+                "discriminator": {
+                  "mapping": {
+                    "ephemeral": "#/components/schemas/CacheControlEphemeral"
+                  },
+                  "propertyName": "type"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CacheControlEphemeral"
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Create a cache control breakpoint at this content block.",
+            "title": "Cache Control"
+          },
+          "citations": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RequestCitationsConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Citations configuration for fetched documents. Citations are disabled by default."
+          },
+          "defer_loading": {
+            "description": "If true, tool will not be included in initial system prompt. Only loaded when returned via tool_reference from tool search.",
+            "title": "Defer Loading",
+            "type": "boolean"
+          },
+          "max_content_tokens": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Maximum number of tokens used by including web page text content in the context. The limit is approximate and does not apply to binary content such as PDFs.",
+            "title": "Max Content Tokens"
+          },
+          "max_uses": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Maximum number of times the tool can be used in the API request.",
+            "title": "Max Uses"
+          },
+          "name": {
+            "const": "web_fetch",
+            "description": "Name of the tool.\n\nThis is how the tool will be called by the model and in `tool_use` blocks.",
+            "title": "Name",
+            "type": "string"
+          },
+          "response_inclusion": {
+            "description": "How this tool's result blocks appear in the API response when the result was consumed by a completed code_execution call in the same turn. 'full' returns the complete content (default). 'excluded' drops the nested server_tool_use and result block pair entirely. Results from direct calls, or from code_execution calls that paused before completing, are always returned in full so they can be sent back on the next turn.",
+            "enum": [
+              "full",
+              "excluded"
+            ],
+            "title": "Response Inclusion",
+            "type": "string"
+          },
+          "strict": {
+            "description": "When true, guarantees schema validation on tool names and inputs",
+            "title": "Strict",
+            "type": "boolean"
+          },
+          "type": {
+            "const": "web_fetch_20260318",
+            "title": "Type",
+            "type": "string"
+          },
+          "use_cache": {
+            "description": "Whether to use cached content. Set to false to bypass the cache and fetch fresh content. Only set to false when the user explicitly requests fresh content or when fetching rapidly-changing sources.",
+            "title": "Use Cache",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ],
+        "title": "WebFetchTool_20260318",
+        "type": "object"
+      },
       "WebSearchToolResultErrorCode": {
         "enum": [
           "invalid_tool_input",
@@ -35732,6 +37376,130 @@
           "type"
         ],
         "title": "WebSearchTool_20260209",
+        "type": "object"
+      },
+      "WebSearchTool_20260318": {
+        "additionalProperties": false,
+        "properties": {
+          "allowed_callers": {
+            "items": {
+              "$ref": "#/components/schemas/AllowedCaller"
+            },
+            "title": "Allowed Callers",
+            "type": "array"
+          },
+          "allowed_domains": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "If provided, only these domains will be included in results. Cannot be used alongside `blocked_domains`.",
+            "title": "Allowed Domains"
+          },
+          "blocked_domains": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "If provided, these domains will never appear in results. Cannot be used alongside `allowed_domains`.",
+            "title": "Blocked Domains"
+          },
+          "cache_control": {
+            "anyOf": [
+              {
+                "discriminator": {
+                  "mapping": {
+                    "ephemeral": "#/components/schemas/CacheControlEphemeral"
+                  },
+                  "propertyName": "type"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CacheControlEphemeral"
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Create a cache control breakpoint at this content block.",
+            "title": "Cache Control"
+          },
+          "defer_loading": {
+            "description": "If true, tool will not be included in initial system prompt. Only loaded when returned via tool_reference from tool search.",
+            "title": "Defer Loading",
+            "type": "boolean"
+          },
+          "max_uses": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Maximum number of times the tool can be used in the API request.",
+            "title": "Max Uses"
+          },
+          "name": {
+            "const": "web_search",
+            "description": "Name of the tool.\n\nThis is how the tool will be called by the model and in `tool_use` blocks.",
+            "title": "Name",
+            "type": "string"
+          },
+          "response_inclusion": {
+            "description": "How this tool's result blocks appear in the API response when the result was consumed by a completed code_execution call in the same turn. 'full' returns the complete content (default). 'excluded' drops the nested server_tool_use and result block pair entirely. Results from direct calls, or from code_execution calls that paused before completing, are always returned in full so they can be sent back on the next turn.",
+            "enum": [
+              "full",
+              "excluded"
+            ],
+            "title": "Response Inclusion",
+            "type": "string"
+          },
+          "strict": {
+            "description": "When true, guarantees schema validation on tool names and inputs",
+            "title": "Strict",
+            "type": "boolean"
+          },
+          "type": {
+            "const": "web_search_20260318",
+            "title": "Type",
+            "type": "string"
+          },
+          "user_location": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UserLocation"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Parameters for the user's location. Used to provide more relevant search results."
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ],
+        "title": "WebSearchTool_20260318",
         "type": "object"
       }
     }
@@ -37093,16 +38861,16 @@
     },
     "/v1/complete": {
       "post": {
-        "description": "[Legacy] Create a Text Completion.\n\nThe Text Completions API is a legacy API. We recommend using the [Messages API](https://docs.claude.com/en/api/messages) going forward.\n\nFuture models and features will not be compatible with Text Completions. See our [migration guide](https://docs.claude.com/en/api/migrating-from-text-completions-to-messages) for guidance in migrating from Text Completions to Messages.",
+        "description": "[Legacy] Create a Text Completion.\n\nThe Text Completions API is a legacy API. We recommend using the [Messages API](https://platform.claude.com/docs/en/api/messages) going forward.\n\nFuture models and features will not be compatible with Text Completions. See our [migration guide](https://platform.claude.com/docs/en/build-with-claude/working-with-messages) for guidance in migrating from Text Completions to Messages.",
         "operationId": "complete_post",
         "parameters": [
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -37160,7 +38928,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Create a Text Completion"
@@ -37706,6 +39474,7 @@
           },
           {
             "description": "Path parameter deployment_id",
+            "example": "depl_011CZkZcDH3vPqd7xnEfwTai",
             "in": "path",
             "name": "deployment_id",
             "required": true,
@@ -37913,6 +39682,7 @@
           },
           {
             "description": "Path parameter deployment_id",
+            "example": "depl_011CZkZcDH3vPqd7xnEfwTai",
             "in": "path",
             "name": "deployment_id",
             "required": true,
@@ -38120,6 +39890,7 @@
           },
           {
             "description": "Path parameter deployment_id",
+            "example": "depl_011CZkZcDH3vPqd7xnEfwTai",
             "in": "path",
             "name": "deployment_id",
             "required": true,
@@ -38327,6 +40098,7 @@
           },
           {
             "description": "Path parameter deployment_id",
+            "example": "depl_011CZkZcDH3vPqd7xnEfwTai",
             "in": "path",
             "name": "deployment_id",
             "required": true,
@@ -38542,6 +40314,7 @@
           },
           {
             "description": "Path parameter deployment_id",
+            "example": "depl_011CZkZcDH3vPqd7xnEfwTai",
             "in": "path",
             "name": "deployment_id",
             "required": true,
@@ -38747,6 +40520,7 @@
           },
           {
             "description": "Path parameter deployment_id",
+            "example": "depl_011CZkZcDH3vPqd7xnEfwTai",
             "in": "path",
             "name": "deployment_id",
             "required": true,
@@ -39449,12 +41223,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -39479,7 +41253,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Archive Environment"
@@ -39562,12 +41336,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -39634,7 +41408,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Poll for Work"
@@ -39679,12 +41453,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -39741,7 +41515,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Get Queue Statistics"
@@ -39795,12 +41569,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -39841,7 +41615,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Acknowledge Work"
@@ -39941,12 +41715,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -39987,7 +41761,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Record Heartbeat"
@@ -40041,12 +41815,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -40097,7 +41871,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Stop Work"
@@ -40151,12 +41925,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -40197,7 +41971,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Get Work Item"
@@ -40249,12 +42023,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -40289,7 +42063,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Update Work Item"
@@ -40369,12 +42143,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -40415,7 +42189,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "List Work Items"
@@ -40460,12 +42234,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -40506,7 +42280,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Delete Environment"
@@ -40549,12 +42323,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -40595,7 +42369,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Get Environment"
@@ -40639,12 +42413,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -40679,7 +42453,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Update Environment"
@@ -40761,12 +42535,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -40807,7 +42581,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "List Environments"
@@ -40840,12 +42614,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -40880,7 +42654,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Create Environment"
@@ -40925,12 +42699,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -40966,7 +42740,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Download File"
@@ -41011,12 +42785,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -41052,7 +42826,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Delete File"
@@ -41095,12 +42869,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -41136,7 +42910,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Get File Metadata"
@@ -41217,12 +42991,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -41258,7 +43032,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "List Files"
@@ -41290,12 +43064,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -41340,7 +43114,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Upload File"
@@ -42301,7 +44075,7 @@
             }
           },
           {
-            "description": "Optional path prefix filter (raw string-prefix match; include a trailing slash for directory-scoped lists). This value appears in request URLs. Do not include secrets or personally identifiable information.",
+            "description": "Optional path prefix filter. Must end with `/` (segment-aligned), e.g., `/notes/`. This value appears in request URLs. Do not include secrets or personally identifiable information.",
             "in": "query",
             "name": "path_prefix",
             "required": false,
@@ -42310,7 +44084,7 @@
             }
           },
           {
-            "description": "Query parameter for depth",
+            "description": "`0` (or omitted) returns all descendants below `path_prefix` (recursive). `1` returns immediate children only; deeper entries roll up as `memory_prefix` items. `depth=1` behaves like `ls`; omitting `depth` behaves like `find`.",
             "in": "query",
             "name": "depth",
             "required": false,
@@ -42320,25 +44094,7 @@
             }
           },
           {
-            "description": "Query parameter for order_by",
-            "in": "query",
-            "name": "order_by",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Query parameter for order",
-            "in": "query",
-            "name": "order",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/BetaManagedAgentsListOrder"
-            }
-          },
-          {
-            "description": "Query parameter for limit",
+            "description": "Maximum number of items to return per page. Must be between 1 and 100. Defaults to 20 when omitted. Capped at 20 when `view=full`. Both `memory` and `memory_prefix` items count toward the limit.",
             "in": "query",
             "name": "limit",
             "required": false,
@@ -42348,7 +44104,7 @@
             }
           },
           {
-            "description": "Query parameter for page",
+            "description": "Opaque pagination cursor (a `page_...` value). Pass the `next_page` value from a previous response to fetch the next page; omit for the first page.",
             "in": "query",
             "name": "page",
             "required": false,
@@ -42357,7 +44113,7 @@
             }
           },
           {
-            "description": "Query parameter for view",
+            "description": "Which projection of each `memory` to return. Defaults to `basic` (content omitted). `full` populates `content` on each item and caps `limit` at 20; use this as the bulk-read path for export and sync.",
             "in": "query",
             "name": "view",
             "required": false,
@@ -44605,18 +46361,30 @@
     },
     "/v1/messages": {
       "post": {
-        "description": "Send a structured list of input messages with text and/or image content, and the model will generate the next message in the conversation.\n\nThe Messages API can be used for either single queries or stateless multi-turn conversations.\n\nLearn more about the Messages API in our [user guide](https://docs.claude.com/en/docs/initial-setup)",
+        "description": "Send a structured list of input messages with text and/or image content, and the model will generate the next message in the conversation.\n\nThe Messages API can be used for either single queries or stateless multi-turn conversations.\n\nLearn more about the Messages API in our [user guide](https://platform.claude.com/docs/en/get-started)",
         "operationId": "messages_post",
         "parameters": [
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
+            }
+          },
+          {
+            "description": "The user profile ID to attribute this request to. Use when acting on behalf of a party other than your organization. Requires the `user-profiles` beta header.",
+            "in": "header",
+            "name": "anthropic-user-profile-id",
+            "required": false,
+            "schema": {
+              "description": "The user profile ID to attribute this request to. Use when acting on behalf of a party other than your organization. Requires the `user-profiles` beta header.",
+              "title": "Anthropic-User-Profile-Id",
+              "type": "string",
+              "x-stainless-param": "user_profile_id"
             }
           }
         ],
@@ -44649,7 +46417,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Create a Message"
@@ -44657,7 +46425,7 @@
     },
     "/v1/messages/batches": {
       "get": {
-        "description": "List all Message Batches within a Workspace. Most recently created batches are returned first.\n\nLearn more about the Message Batches API in our [user guide](https://docs.claude.com/en/docs/build-with-claude/batch-processing)",
+        "description": "List all Message Batches within a Workspace. Most recently created batches are returned first.\n\nLearn more about the Message Batches API in our [user guide](https://platform.claude.com/docs/en/build-with-claude/batch-processing)",
         "operationId": "message_batches_list",
         "parameters": [
           {
@@ -44697,12 +46465,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -44738,24 +46506,36 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "List Message Batches"
       },
       "post": {
-        "description": "Send a batch of Message creation requests.\n\nThe Message Batches API can be used to process multiple Messages API requests at once. Once a Message Batch is created, it begins processing immediately. Batches can take up to 24 hours to complete.\n\nLearn more about the Message Batches API in our [user guide](https://docs.claude.com/en/docs/build-with-claude/batch-processing)",
+        "description": "Send a batch of Message creation requests.\n\nThe Message Batches API can be used to process multiple Messages API requests at once. Once a Message Batch is created, it begins processing immediately. Batches can take up to 24 hours to complete.\n\nLearn more about the Message Batches API in our [user guide](https://platform.claude.com/docs/en/build-with-claude/batch-processing)",
         "operationId": "message_batches_post",
         "parameters": [
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
+            }
+          },
+          {
+            "description": "The user profile ID to attribute the requests in this batch to. Use when acting on behalf of a party other than your organization. Requires the `user-profiles` beta header. Applies to every request in the batch; an individual request whose `user_profile_id` body field conflicts with this header is errored.",
+            "in": "header",
+            "name": "anthropic-user-profile-id",
+            "required": false,
+            "schema": {
+              "description": "The user profile ID to attribute the requests in this batch to. Use when acting on behalf of a party other than your organization. Requires the `user-profiles` beta header. Applies to every request in the batch; an individual request whose `user_profile_id` body field conflicts with this header is errored.",
+              "title": "Anthropic-User-Profile-Id",
+              "type": "string",
+              "x-stainless-param": "user_profile_id"
             }
           }
         ],
@@ -44788,7 +46568,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Create a Message Batch"
@@ -44796,7 +46576,7 @@
     },
     "/v1/messages/batches/{message_batch_id}": {
       "delete": {
-        "description": "Delete a Message Batch.\n\nMessage Batches can only be deleted once they've finished processing. If you'd like to delete an in-progress batch, you must first cancel it.\n\nLearn more about the Message Batches API in our [user guide](https://docs.claude.com/en/docs/build-with-claude/batch-processing)",
+        "description": "Delete a Message Batch.\n\nMessage Batches can only be deleted once they've finished processing. If you'd like to delete an in-progress batch, you must first cancel it.\n\nLearn more about the Message Batches API in our [user guide](https://platform.claude.com/docs/en/build-with-claude/batch-processing)",
         "operationId": "message_batches_delete",
         "parameters": [
           {
@@ -44811,12 +46591,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -44852,13 +46632,13 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Delete a Message Batch"
       },
       "get": {
-        "description": "This endpoint is idempotent and can be used to poll for Message Batch completion. To access the results of a Message Batch, make a request to the `results_url` field in the response.\n\nLearn more about the Message Batches API in our [user guide](https://docs.claude.com/en/docs/build-with-claude/batch-processing)",
+        "description": "This endpoint is idempotent and can be used to poll for Message Batch completion. To access the results of a Message Batch, make a request to the `results_url` field in the response.\n\nLearn more about the Message Batches API in our [user guide](https://platform.claude.com/docs/en/build-with-claude/batch-processing)",
         "operationId": "message_batches_retrieve",
         "parameters": [
           {
@@ -44873,12 +46653,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -44914,7 +46694,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Retrieve a Message Batch"
@@ -44922,7 +46702,7 @@
     },
     "/v1/messages/batches/{message_batch_id}/cancel": {
       "post": {
-        "description": "Batches may be canceled any time before processing ends. Once cancellation is initiated, the batch enters a `canceling` state, at which time the system may complete any in-progress, non-interruptible requests before finalizing cancellation.\n\nThe number of canceled requests is specified in `request_counts`. To determine which requests were canceled, check the individual results within the batch. Note that cancellation may not result in any canceled requests if they were non-interruptible.\n\nLearn more about the Message Batches API in our [user guide](https://docs.claude.com/en/docs/build-with-claude/batch-processing)",
+        "description": "Batches may be canceled any time before processing ends. Once cancellation is initiated, the batch enters a `canceling` state, at which time the system may complete any in-progress, non-interruptible requests before finalizing cancellation.\n\nThe number of canceled requests is specified in `request_counts`. To determine which requests were canceled, check the individual results within the batch. Note that cancellation may not result in any canceled requests if they were non-interruptible.\n\nLearn more about the Message Batches API in our [user guide](https://platform.claude.com/docs/en/build-with-claude/batch-processing)",
         "operationId": "message_batches_cancel",
         "parameters": [
           {
@@ -44937,12 +46717,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -44967,7 +46747,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Cancel a Message Batch"
@@ -44975,7 +46755,7 @@
     },
     "/v1/messages/batches/{message_batch_id}/cancel?beta=true": {
       "post": {
-        "description": "Batches may be canceled any time before processing ends. Once cancellation is initiated, the batch enters a `canceling` state, at which time the system may complete any in-progress, non-interruptible requests before finalizing cancellation.\n\nThe number of canceled requests is specified in `request_counts`. To determine which requests were canceled, check the individual results within the batch. Note that cancellation may not result in any canceled requests if they were non-interruptible.\n\nLearn more about the Message Batches API in our [user guide](https://docs.claude.com/en/docs/build-with-claude/batch-processing)",
+        "description": "Batches may be canceled any time before processing ends. Once cancellation is initiated, the batch enters a `canceling` state, at which time the system may complete any in-progress, non-interruptible requests before finalizing cancellation.\n\nThe number of canceled requests is specified in `request_counts`. To determine which requests were canceled, check the individual results within the batch. Note that cancellation may not result in any canceled requests if they were non-interruptible.\n\nLearn more about the Message Batches API in our [user guide](https://platform.claude.com/docs/en/build-with-claude/batch-processing)",
         "operationId": "beta_message_batches_cancel",
         "parameters": [
           {
@@ -45013,12 +46793,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -45043,7 +46823,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Cancel a Message Batch"
@@ -45051,7 +46831,7 @@
     },
     "/v1/messages/batches/{message_batch_id}/results": {
       "get": {
-        "description": "Streams the results of a Message Batch as a `.jsonl` file.\n\nEach line in the file is a JSON object containing the result of a single request in the Message Batch. Results are not guaranteed to be in the same order as requests. Use the `custom_id` field to match results to requests.\n\nLearn more about the Message Batches API in our [user guide](https://docs.claude.com/en/docs/build-with-claude/batch-processing)",
+        "description": "Streams the results of a Message Batch as a `.jsonl` file.\n\nEach line in the file is a JSON object containing the result of a single request in the Message Batch. Results are not guaranteed to be in the same order as requests. Use the `custom_id` field to match results to requests.\n\nLearn more about the Message Batches API in our [user guide](https://platform.claude.com/docs/en/build-with-claude/batch-processing)",
         "operationId": "message_batches_results",
         "parameters": [
           {
@@ -45066,12 +46846,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -45107,7 +46887,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Retrieve Message Batch results"
@@ -45115,7 +46895,7 @@
     },
     "/v1/messages/batches/{message_batch_id}/results?beta=true": {
       "get": {
-        "description": "Streams the results of a Message Batch as a `.jsonl` file.\n\nEach line in the file is a JSON object containing the result of a single request in the Message Batch. Results are not guaranteed to be in the same order as requests. Use the `custom_id` field to match results to requests.\n\nLearn more about the Message Batches API in our [user guide](https://docs.claude.com/en/docs/build-with-claude/batch-processing)",
+        "description": "Streams the results of a Message Batch as a `.jsonl` file.\n\nEach line in the file is a JSON object containing the result of a single request in the Message Batch. Results are not guaranteed to be in the same order as requests. Use the `custom_id` field to match results to requests.\n\nLearn more about the Message Batches API in our [user guide](https://platform.claude.com/docs/en/build-with-claude/batch-processing)",
         "operationId": "beta_message_batches_results",
         "parameters": [
           {
@@ -45153,12 +46933,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -45194,7 +46974,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Retrieve Message Batch results"
@@ -45202,7 +46982,7 @@
     },
     "/v1/messages/batches/{message_batch_id}?beta=true": {
       "delete": {
-        "description": "Delete a Message Batch.\n\nMessage Batches can only be deleted once they've finished processing. If you'd like to delete an in-progress batch, you must first cancel it.\n\nLearn more about the Message Batches API in our [user guide](https://docs.claude.com/en/docs/build-with-claude/batch-processing)",
+        "description": "Delete a Message Batch.\n\nMessage Batches can only be deleted once they've finished processing. If you'd like to delete an in-progress batch, you must first cancel it.\n\nLearn more about the Message Batches API in our [user guide](https://platform.claude.com/docs/en/build-with-claude/batch-processing)",
         "operationId": "beta_message_batches_delete",
         "parameters": [
           {
@@ -45240,12 +47020,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -45281,13 +47061,13 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Delete a Message Batch"
       },
       "get": {
-        "description": "This endpoint is idempotent and can be used to poll for Message Batch completion. To access the results of a Message Batch, make a request to the `results_url` field in the response.\n\nLearn more about the Message Batches API in our [user guide](https://docs.claude.com/en/docs/build-with-claude/batch-processing)",
+        "description": "This endpoint is idempotent and can be used to poll for Message Batch completion. To access the results of a Message Batch, make a request to the `results_url` field in the response.\n\nLearn more about the Message Batches API in our [user guide](https://platform.claude.com/docs/en/build-with-claude/batch-processing)",
         "operationId": "beta_message_batches_retrieve",
         "parameters": [
           {
@@ -45325,12 +47105,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -45366,7 +47146,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Retrieve a Message Batch"
@@ -45374,7 +47154,7 @@
     },
     "/v1/messages/batches?beta=true": {
       "get": {
-        "description": "List all Message Batches within a Workspace. Most recently created batches are returned first.\n\nLearn more about the Message Batches API in our [user guide](https://docs.claude.com/en/docs/build-with-claude/batch-processing)",
+        "description": "List all Message Batches within a Workspace. Most recently created batches are returned first.\n\nLearn more about the Message Batches API in our [user guide](https://platform.claude.com/docs/en/build-with-claude/batch-processing)",
         "operationId": "beta_message_batches_list",
         "parameters": [
           {
@@ -45437,12 +47217,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -45478,13 +47258,13 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "List Message Batches"
       },
       "post": {
-        "description": "Send a batch of Message creation requests.\n\nThe Message Batches API can be used to process multiple Messages API requests at once. Once a Message Batch is created, it begins processing immediately. Batches can take up to 24 hours to complete.\n\nLearn more about the Message Batches API in our [user guide](https://docs.claude.com/en/docs/build-with-claude/batch-processing)",
+        "description": "Send a batch of Message creation requests.\n\nThe Message Batches API can be used to process multiple Messages API requests at once. Once a Message Batch is created, it begins processing immediately. Batches can take up to 24 hours to complete.\n\nLearn more about the Message Batches API in our [user guide](https://platform.claude.com/docs/en/build-with-claude/batch-processing)",
         "operationId": "beta_message_batches_post",
         "parameters": [
           {
@@ -45511,14 +47291,26 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
+            }
+          },
+          {
+            "description": "The user profile ID to attribute the requests in this batch to. Use when acting on behalf of a party other than your organization. Requires the `user-profiles` beta header. Applies to every request in the batch; an individual request whose `user_profile_id` body field conflicts with this header is errored.",
+            "in": "header",
+            "name": "anthropic-user-profile-id",
+            "required": false,
+            "schema": {
+              "description": "The user profile ID to attribute the requests in this batch to. Use when acting on behalf of a party other than your organization. Requires the `user-profiles` beta header. Applies to every request in the batch; an individual request whose `user_profile_id` body field conflicts with this header is errored.",
+              "title": "Anthropic-User-Profile-Id",
+              "type": "string",
+              "x-stainless-param": "user_profile_id"
             }
           }
         ],
@@ -45551,7 +47343,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Create a Message Batch"
@@ -45559,18 +47351,30 @@
     },
     "/v1/messages/count_tokens": {
       "post": {
-        "description": "Count the number of tokens in a Message.\n\nThe Token Count API can be used to count the number of tokens in a Message, including tools, images, and documents, without creating it.\n\nLearn more about token counting in our [user guide](https://docs.claude.com/en/docs/build-with-claude/token-counting)",
+        "description": "Count the number of tokens in a Message.\n\nThe Token Count API can be used to count the number of tokens in a Message, including tools, images, and documents, without creating it.\n\nLearn more about token counting in our [user guide](https://platform.claude.com/docs/en/build-with-claude/token-counting)",
         "operationId": "messages_count_tokens_post",
         "parameters": [
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
+            }
+          },
+          {
+            "description": "The user profile ID to attribute this request to. Use when acting on behalf of a party other than your organization. Requires the `user-profiles` beta header.",
+            "in": "header",
+            "name": "anthropic-user-profile-id",
+            "required": false,
+            "schema": {
+              "description": "The user profile ID to attribute this request to. Use when acting on behalf of a party other than your organization. Requires the `user-profiles` beta header.",
+              "title": "Anthropic-User-Profile-Id",
+              "type": "string",
+              "x-stainless-param": "user_profile_id"
             }
           }
         ],
@@ -45603,7 +47407,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Count tokens in a Message"
@@ -45611,7 +47415,7 @@
     },
     "/v1/messages/count_tokens?beta=true": {
       "post": {
-        "description": "Count the number of tokens in a Message.\n\nThe Token Count API can be used to count the number of tokens in a Message, including tools, images, and documents, without creating it.\n\nLearn more about token counting in our [user guide](https://docs.claude.com/en/docs/build-with-claude/token-counting)",
+        "description": "Count the number of tokens in a Message.\n\nThe Token Count API can be used to count the number of tokens in a Message, including tools, images, and documents, without creating it.\n\nLearn more about token counting in our [user guide](https://platform.claude.com/docs/en/build-with-claude/token-counting)",
         "operationId": "beta_messages_count_tokens_post",
         "parameters": [
           {
@@ -45638,14 +47442,26 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
+            }
+          },
+          {
+            "description": "The user profile ID to attribute this request to. Use when acting on behalf of a party other than your organization. Requires the `user-profiles` beta header.",
+            "in": "header",
+            "name": "anthropic-user-profile-id",
+            "required": false,
+            "schema": {
+              "description": "The user profile ID to attribute this request to. Use when acting on behalf of a party other than your organization. Requires the `user-profiles` beta header.",
+              "title": "Anthropic-User-Profile-Id",
+              "type": "string",
+              "x-stainless-param": "user_profile_id"
             }
           }
         ],
@@ -45678,7 +47494,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Count tokens in a Message"
@@ -45686,7 +47502,7 @@
     },
     "/v1/messages?beta=true": {
       "post": {
-        "description": "Send a structured list of input messages with text and/or image content, and the model will generate the next message in the conversation.\n\nThe Messages API can be used for either single queries or stateless multi-turn conversations.\n\nLearn more about the Messages API in our [user guide](https://docs.claude.com/en/docs/initial-setup)",
+        "description": "Send a structured list of input messages with text and/or image content, and the model will generate the next message in the conversation.\n\nThe Messages API can be used for either single queries or stateless multi-turn conversations.\n\nLearn more about the Messages API in our [user guide](https://platform.claude.com/docs/en/get-started)",
         "operationId": "beta_messages_post",
         "parameters": [
           {
@@ -45713,14 +47529,26 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
+            }
+          },
+          {
+            "description": "The user profile ID to attribute this request to. Use when acting on behalf of a party other than your organization. Requires the `user-profiles` beta header.",
+            "in": "header",
+            "name": "anthropic-user-profile-id",
+            "required": false,
+            "schema": {
+              "description": "The user profile ID to attribute this request to. Use when acting on behalf of a party other than your organization. Requires the `user-profiles` beta header.",
+              "title": "Anthropic-User-Profile-Id",
+              "type": "string",
+              "x-stainless-param": "user_profile_id"
             }
           }
         ],
@@ -45753,7 +47581,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Create a Message"
@@ -45801,12 +47629,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -45865,7 +47693,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "List Models"
@@ -45888,12 +47716,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -45952,7 +47780,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Get a Model"
@@ -45975,12 +47803,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -46039,7 +47867,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Get a Model"
@@ -46087,12 +47915,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -46151,7 +47979,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "List Models"
@@ -46414,6 +48242,20 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "When set, this connection also receives streaming deltas (`event_start`, `event_delta`) while an event is being produced, before the event itself arrives. Deltas are best-effort; when the final event is produced it carries the complete content. A model request that ends early (an error or interrupt) produces no final event \u2014 its terminal `span.model_request_end` closes the preview. Accepts one or more event types to preview and may be repeated: `agent.message` streams `content_delta` fragments; `agent.thinking` is start-only \u2014 a signal that the agent has begun extended thinking, concluded by the `agent.thinking` event itself. Only previews of the requested event types are sent.",
+            "explode": true,
+            "in": "query",
+            "name": "event_deltas[]",
+            "required": false,
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/BetaManagedAgentsEventDeltaType"
+              },
+              "type": "array"
+            },
+            "style": "form"
           }
         ],
         "responses": {
@@ -50603,12 +52445,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -50644,7 +52486,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Download Skill Version Content"
@@ -50700,12 +52542,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -50741,7 +52583,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Delete Skill Version"
@@ -50795,12 +52637,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -50836,7 +52678,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Get Skill Version"
@@ -50920,12 +52762,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -50961,7 +52803,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "List Skill Versions"
@@ -51004,12 +52846,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -51022,7 +52864,8 @@
                 "$ref": "#/components/schemas/BetaBody_create_skill_version_v1_skills__skill_id__versions_post"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -51043,7 +52886,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Create Skill Version"
@@ -51088,12 +52931,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -51129,7 +52972,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Delete Skill"
@@ -51172,12 +53015,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -51213,7 +53056,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Get Skill"
@@ -51298,12 +53141,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -51339,7 +53182,7 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "List Skills"
@@ -51371,12 +53214,12 @@
             }
           },
           {
-            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+            "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
             "in": "header",
             "name": "anthropic-version",
             "required": false,
             "schema": {
-              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://docs.claude.com/en/api/versioning).",
+              "description": "The version of the Claude API you want to use.\n\nRead more about versioning and our version history [here](https://platform.claude.com/docs/en/api/versioning).",
               "title": "Anthropic-Version",
               "type": "string"
             }
@@ -51389,7 +53232,8 @@
                 "$ref": "#/components/schemas/BetaBody_create_skill_v1_skills_post"
               }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -51410,10 +53254,2204 @@
                 }
               }
             },
-            "description": "Error response.\n\nSee our [errors documentation](https://docs.claude.com/en/api/errors) for more details."
+            "description": "Error response.\n\nSee our [errors documentation](https://platform.claude.com/docs/en/api/errors) for more details."
           }
         },
         "summary": "Create Skill"
+      }
+    },
+    "/v1/tunnels/{tunnel_id}/archive?beta=true": {
+      "post": {
+        "description": "The Tunnels API is in research preview. It requires the `anthropic-beta: mcp-tunnels-2026-06-22` header and may change without a deprecation period. It supersedes the Admin API endpoints at `/v1/organizations/tunnels`, which remain available during a migration window.\n\nArchives a tunnel. Archival is irreversible: every non-archived certificate on the tunnel is archived in the same operation, the hostname is retired and never re-allocated, and the tunnel token is invalidated. Retrying against an already-archived tunnel returns the existing record unchanged.",
+        "operationId": "BetaArchiveTunnel",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Path parameter tunnel_id",
+            "in": "path",
+            "name": "tunnel_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaTunnel"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "Archive Tunnel"
+      }
+    },
+    "/v1/tunnels/{tunnel_id}/certificates/{certificate_id}/archive?beta=true": {
+      "post": {
+        "description": "The Tunnels API is in research preview. It requires the `anthropic-beta: mcp-tunnels-2026-06-22` header and may change without a deprecation period. It supersedes the Admin API endpoints at `/v1/organizations/tunnels`, which remain available during a migration window.\n\nArchives a tunnel certificate, removing it from the set Anthropic trusts for the tunnel. The certificate record is retained. Archiving the last non-archived certificate is permitted; the tunnel rejects MCP traffic until a new certificate is added.",
+        "operationId": "BetaArchiveTunnelCertificate",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Path parameter tunnel_id",
+            "in": "path",
+            "name": "tunnel_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Path parameter certificate_id",
+            "in": "path",
+            "name": "certificate_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaTunnelCertificate"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "Archive Tunnel Certificate"
+      }
+    },
+    "/v1/tunnels/{tunnel_id}/certificates/{certificate_id}?beta=true": {
+      "get": {
+        "description": "The Tunnels API is in research preview. It requires the `anthropic-beta: mcp-tunnels-2026-06-22` header and may change without a deprecation period. It supersedes the Admin API endpoints at `/v1/organizations/tunnels`, which remain available during a migration window.\n\nFetches a tunnel certificate by ID.",
+        "operationId": "BetaGetTunnelCertificate",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Path parameter tunnel_id",
+            "in": "path",
+            "name": "tunnel_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Path parameter certificate_id",
+            "in": "path",
+            "name": "certificate_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaTunnelCertificate"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "Get Tunnel Certificate"
+      }
+    },
+    "/v1/tunnels/{tunnel_id}/certificates?beta=true": {
+      "get": {
+        "description": "The Tunnels API is in research preview. It requires the `anthropic-beta: mcp-tunnels-2026-06-22` header and may change without a deprecation period. It supersedes the Admin API endpoints at `/v1/organizations/tunnels`, which remain available during a migration window.\n\nLists the certificates registered on a tunnel. Archived certificates are excluded unless include_archived is set.",
+        "operationId": "BetaListTunnelCertificates",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Path parameter tunnel_id",
+            "in": "path",
+            "name": "tunnel_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of certificates to return per page. Defaults to 20, maximum 1000.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Opaque pagination cursor from a previous `list_tunnel_certificates` response.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Whether to include archived certificates in the results. Defaults to false.",
+            "in": "query",
+            "name": "include_archived",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaListTunnelCertificatesResponse"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "List Tunnel Certificates"
+      },
+      "post": {
+        "description": "The Tunnels API is in research preview. It requires the `anthropic-beta: mcp-tunnels-2026-06-22` header and may change without a deprecation period. It supersedes the Admin API endpoints at `/v1/organizations/tunnels`, which remain available during a migration window.\n\nRegisters a public CA certificate on a tunnel. Anthropic verifies the gateway's server certificate against this CA when it terminates the inner TLS session. A tunnel holds at most two non-archived certificates.",
+        "operationId": "BetaCreateTunnelCertificate",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Path parameter tunnel_id",
+            "in": "path",
+            "name": "tunnel_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaCreateTunnelCertificateRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaTunnelCertificate"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "Create Tunnel Certificate"
+      }
+    },
+    "/v1/tunnels/{tunnel_id}/reveal_token?beta=true": {
+      "post": {
+        "description": "The Tunnels API is in research preview. It requires the `anthropic-beta: mcp-tunnels-2026-06-22` header and may change without a deprecation period. It supersedes the Admin API endpoints at `/v1/organizations/tunnels`, which remain available during a migration window.\n\nReveals a tunnel's connector token. The value is fetched live on each call; Anthropic does not store it. Repeated calls return the same value until the token is rotated. Exposed as POST so the token does not appear in intermediary access logs.",
+        "operationId": "BetaRevealTunnelToken",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Path parameter tunnel_id",
+            "in": "path",
+            "name": "tunnel_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaTunnelToken"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "Reveal Tunnel Token"
+      }
+    },
+    "/v1/tunnels/{tunnel_id}/rotate_token?beta=true": {
+      "post": {
+        "description": "The Tunnels API is in research preview. It requires the `anthropic-beta: mcp-tunnels-2026-06-22` header and may change without a deprecation period. It supersedes the Admin API endpoints at `/v1/organizations/tunnels`, which remain available during a migration window.\n\nRotates a tunnel's connector token. Rotation invalidates the current token for new connections and returns a fresh value; established connections are not severed. A connector restarted after rotation must use the new value.",
+        "operationId": "BetaRotateTunnelToken",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Path parameter tunnel_id",
+            "in": "path",
+            "name": "tunnel_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaRotateTunnelTokenRequestBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaTunnelToken"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "Rotate Tunnel Token"
+      }
+    },
+    "/v1/tunnels/{tunnel_id}?beta=true": {
+      "get": {
+        "description": "The Tunnels API is in research preview. It requires the `anthropic-beta: mcp-tunnels-2026-06-22` header and may change without a deprecation period. It supersedes the Admin API endpoints at `/v1/organizations/tunnels`, which remain available during a migration window.\n\nFetches a tunnel by ID.",
+        "operationId": "BetaGetTunnel",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Path parameter tunnel_id",
+            "in": "path",
+            "name": "tunnel_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaTunnel"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "Get Tunnel"
+      }
+    },
+    "/v1/tunnels?beta=true": {
+      "get": {
+        "description": "The Tunnels API is in research preview. It requires the `anthropic-beta: mcp-tunnels-2026-06-22` header and may change without a deprecation period. It supersedes the Admin API endpoints at `/v1/organizations/tunnels`, which remain available during a migration window.\n\nLists tunnels. Results are ordered by creation time, newest first; archived tunnels are excluded unless include_archived is set.",
+        "operationId": "BetaListTunnels",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Maximum number of tunnels to return per page. Defaults to 20, maximum 1000.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Opaque pagination cursor from a previous `list_tunnels` response.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Whether to include archived tunnels in the results. Defaults to false.",
+            "in": "query",
+            "name": "include_archived",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaListTunnelsResponse"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "List Tunnels"
+      },
+      "post": {
+        "description": "The Tunnels API is in research preview. It requires the `anthropic-beta: mcp-tunnels-2026-06-22` header and may change without a deprecation period. It supersedes the Admin API endpoints at `/v1/organizations/tunnels`, which remain available during a migration window.\n\nCreates a tunnel. Creation allocates a fresh hostname and provisions the tunnel; it is not idempotent. The new tunnel rejects MCP traffic until at least one CA certificate is added.",
+        "operationId": "BetaCreateTunnel",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaCreateTunnelRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaTunnel"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "Create Tunnel"
       }
     },
     "/v1/user_profiles/{user_profile_id}/enrollment_url?beta=true": {
@@ -55371,6 +59409,279 @@
     }
   ],
   "webhooks": {
+    "agent.archived": {
+      "post": {
+        "operationId": "BetaAgentArchivedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "agent.archived webhook"
+      }
+    },
+    "agent.created": {
+      "post": {
+        "operationId": "BetaAgentCreatedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "agent.created webhook"
+      }
+    },
+    "agent.deleted": {
+      "post": {
+        "operationId": "BetaAgentDeletedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "agent.deleted webhook"
+      }
+    },
+    "agent.updated": {
+      "post": {
+        "operationId": "BetaAgentUpdatedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "agent.updated webhook"
+      }
+    },
+    "deployment.archived": {
+      "post": {
+        "operationId": "BetaDeploymentArchivedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "deployment.archived webhook"
+      }
+    },
+    "deployment.created": {
+      "post": {
+        "operationId": "BetaDeploymentCreatedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "deployment.created webhook"
+      }
+    },
+    "deployment.deleted": {
+      "post": {
+        "operationId": "BetaDeploymentDeletedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "deployment.deleted webhook"
+      }
+    },
+    "deployment.paused": {
+      "post": {
+        "operationId": "BetaDeploymentPausedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "deployment.paused webhook"
+      }
+    },
+    "deployment.unpaused": {
+      "post": {
+        "operationId": "BetaDeploymentUnpausedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "deployment.unpaused webhook"
+      }
+    },
+    "deployment.updated": {
+      "post": {
+        "operationId": "BetaDeploymentUpdatedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "deployment.updated webhook"
+      }
+    },
+    "deployment_run.failed": {
+      "post": {
+        "operationId": "BetaDeploymentRunFailedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "deployment_run.failed webhook"
+      }
+    },
+    "deployment_run.started": {
+      "post": {
+        "operationId": "BetaDeploymentRunStartedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "deployment_run.started webhook"
+      }
+    },
+    "deployment_run.succeeded": {
+      "post": {
+        "operationId": "BetaDeploymentRunSucceededWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "deployment_run.succeeded webhook"
+      }
+    },
     "session.archived": {
       "post": {
         "operationId": "BetaSessionArchivedWebhook",

--- a/packages/anthropic_sdk_dart/specs/spec_metadata.json
+++ b/packages/anthropic_sdk_dart/specs/spec_metadata.json
@@ -2,8 +2,8 @@
   "specs": {
     "main": {
       "current_version": "unknown",
-      "last_fetched": "2026-06-20T15:44:08.770812Z",
-      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-2ecf157aa324d82fa8f3636a325aea5bd96ecab93193f6e37864ebe665c48685.yml",
+      "last_fetched": "2026-07-04T11:25:40.494739Z",
+      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-506a5ad71d522b4ae56ac3429380486647af1f92eddde80603480fb592d62b54.yml",
       "title": "Anthropic API",
       "version_history": [
         {

--- a/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
@@ -253,7 +253,25 @@ void main() {
         expect(result.toolUseId, 'tu_ws_err');
         expect(result.content, isA<WebSearchResultError>());
         final error = result.content as WebSearchResultError;
-        expect(error.errorCode, 'max_results_reached');
+        // Unrecognized code: raw preserved, typed getter falls back to unknown.
+        expect(error.rawErrorCode, 'max_results_reached');
+        expect(error.errorCode, WebSearchToolResultErrorCode.unknown);
+      });
+
+      test('parses a known web search error code as a typed enum', () {
+        final json = {
+          'type': 'web_search_tool_result',
+          'tool_use_id': 'tu_ws_err2',
+          'content': {
+            'type': 'web_search_tool_result_error',
+            'error_code': 'max_uses_exceeded',
+          },
+        };
+        final block = ContentBlock.fromJson(json) as WebSearchToolResultBlock;
+        final error = block.content as WebSearchResultError;
+        expect(error.rawErrorCode, 'max_uses_exceeded');
+        expect(error.errorCode, WebSearchToolResultErrorCode.maxUsesExceeded);
+        expect(block.toJson(), json);
       });
 
       test('roundtrip fromJson → toJson → fromJson (success)', () {
@@ -305,8 +323,9 @@ void main() {
 
         expect(block2.toolUseId, block.toolUseId);
         expect(block2.content, isA<WebSearchResultError>());
+        // Raw value round-trips verbatim even for unrecognized codes.
         expect(
-          (block2.content as WebSearchResultError).errorCode,
+          (block2.content as WebSearchResultError).rawErrorCode,
           'search_unavailable',
         );
       });

--- a/packages/anthropic_sdk_dart/test/unit/models/credential_networking_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/credential_networking_test.dart
@@ -138,6 +138,7 @@ void main() {
         'type': 'limited',
         'allowed_hosts': ['api.example.com'],
       },
+      'injection_location': {'header': true, 'body': false},
     };
 
     test('CredentialAuth.fromJson dispatches and round-trips', () {
@@ -155,6 +156,7 @@ void main() {
         'type': 'environment_variable',
         'secret_name': 'TOKEN',
         'networking': {'type': 'unrestricted'},
+        'injection_location': {'header': false, 'body': true},
       };
       final a = CredentialAuth.fromJson(j);
       expect(

--- a/packages/anthropic_sdk_dart/test/unit/models/managed_agents/session_streaming_and_overrides_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/managed_agents/session_streaming_and_overrides_test.dart
@@ -1,0 +1,231 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SessionEvent event_start', () {
+    test('dispatches and round-trips an agent.message preview', () {
+      final json = <String, dynamic>{
+        'type': 'event_start',
+        'event': {'type': 'agent.message', 'id': 'evt_1'},
+      };
+      final event = SessionEvent.fromJson(json);
+      expect(event, isA<EventStartEvent>());
+      final start = event as EventStartEvent;
+      expect(start.event, isA<AgentMessagePreview>());
+      expect((start.event as AgentMessagePreview).id, 'evt_1');
+      expect(start.toJson(), json);
+    });
+
+    test('parses an agent.thinking preview', () {
+      final json = <String, dynamic>{
+        'type': 'event_start',
+        'event': {'type': 'agent.thinking', 'id': 'evt_2'},
+      };
+      final start = SessionEvent.fromJson(json) as EventStartEvent;
+      expect(start.event, isA<AgentThinkingPreview>());
+      expect(start.toJson(), json);
+    });
+
+    test('unknown preview type falls back gracefully', () {
+      final json = <String, dynamic>{
+        'type': 'event_start',
+        'event': {'type': 'agent.mystery', 'id': 'evt_3'},
+      };
+      final start = SessionEvent.fromJson(json) as EventStartEvent;
+      expect(start.event, isA<UnknownEventStartPreview>());
+      expect(start.toJson(), json);
+    });
+  });
+
+  group('SessionEvent event_delta', () {
+    test('dispatches and round-trips a content_delta', () {
+      final json = <String, dynamic>{
+        'type': 'event_delta',
+        'event_id': 'evt_1',
+        'delta': {
+          'type': 'content_delta',
+          'content': {'type': 'text', 'text': 'hel'},
+          'index': 0,
+        },
+      };
+      final event = SessionEvent.fromJson(json);
+      expect(event, isA<EventDeltaEvent>());
+      final delta = event as EventDeltaEvent;
+      expect(delta.eventId, 'evt_1');
+      expect(delta.delta, isA<ContentDelta>());
+      final content = delta.delta as ContentDelta;
+      expect(content.index, 0);
+      expect(content.content['text'], 'hel');
+      expect(delta.toJson(), json);
+    });
+
+    test('omits index when absent', () {
+      final json = <String, dynamic>{
+        'type': 'event_delta',
+        'event_id': 'evt_1',
+        'delta': {
+          'type': 'content_delta',
+          'content': {'type': 'text', 'text': 'lo'},
+        },
+      };
+      final delta = SessionEvent.fromJson(json) as EventDeltaEvent;
+      expect((delta.delta as ContentDelta).index, isNull);
+      expect(delta.toJson(), json);
+    });
+
+    test('unknown delta type falls back gracefully', () {
+      final json = <String, dynamic>{
+        'type': 'event_delta',
+        'event_id': 'evt_1',
+        'delta': {'type': 'mystery_delta', 'foo': 'bar'},
+      };
+      final delta = SessionEvent.fromJson(json) as EventDeltaEvent;
+      expect(delta.delta, isA<UnknownEventDelta>());
+      expect(delta.toJson(), json);
+    });
+  });
+
+  group('InjectionLocation on env-var credentials', () {
+    test('response requires both flags and round-trips', () {
+      final json = <String, dynamic>{
+        'type': 'environment_variable',
+        'secret_name': 'API_KEY',
+        'networking': {'type': 'unrestricted'},
+        'injection_location': {'header': true, 'body': false},
+      };
+      final auth = CredentialAuth.fromJson(json);
+      expect(auth, isA<EnvironmentVariableAuthResponse>());
+      final env = auth as EnvironmentVariableAuthResponse;
+      expect(env.injectionLocation.header, isTrue);
+      expect(env.injectionLocation.body, isFalse);
+      expect(env.toJson(), json);
+    });
+
+    test('create params include injection_location when set', () {
+      final json = <String, dynamic>{
+        'type': 'environment_variable',
+        'secret_name': 'API_KEY',
+        'secret_value': 'sk-123',
+        'networking': {'type': 'unrestricted'},
+        'injection_location': {'header': true},
+      };
+      final params =
+          CredentialCreateAuth.fromJson(json)
+              as EnvironmentVariableCreateParams;
+      expect(params.injectionLocation?.header, isTrue);
+      expect(params.injectionLocation?.body, isNull);
+      expect(params.toJson(), json);
+    });
+
+    test('create params omit injection_location when absent', () {
+      final json = <String, dynamic>{
+        'type': 'environment_variable',
+        'secret_name': 'API_KEY',
+        'secret_value': 'sk-123',
+        'networking': {'type': 'unrestricted'},
+      };
+      final params =
+          CredentialCreateAuth.fromJson(json)
+              as EnvironmentVariableCreateParams;
+      expect(params.injectionLocation, isNull);
+      expect(params.toJson().containsKey('injection_location'), isFalse);
+    });
+
+    test('update params round-trip injection_location', () {
+      final json = <String, dynamic>{
+        'type': 'environment_variable',
+        'injection_location': {'body': true},
+      };
+      final params =
+          CredentialUpdateAuth.fromJson(json)
+              as EnvironmentVariableUpdateParams;
+      expect(params.injectionLocation?.body, isTrue);
+      expect(params.toJson(), json);
+    });
+  });
+
+  group('AgentParamsWithOverrides', () {
+    test('dispatches on agent_with_overrides discriminator', () {
+      final agent = AgentParams.fromJson(<String, dynamic>{
+        'type': 'agent_with_overrides',
+        'id': 'agt_1',
+      });
+      expect(agent, isA<AgentParamsWithOverrides>());
+    });
+
+    test('plain agent object still yields AgentParamsObject', () {
+      final agent = AgentParams.fromJson(<String, dynamic>{
+        'type': 'agent',
+        'id': 'agt_1',
+      });
+      expect(agent, isA<AgentParamsObject>());
+    });
+
+    test('string still yields AgentParamsId', () {
+      expect(AgentParams.fromJson('agt_1'), isA<AgentParamsId>());
+    });
+
+    test('round-trips model and version', () {
+      final json = <String, dynamic>{
+        'type': 'agent_with_overrides',
+        'id': 'agt_1',
+        'version': 3,
+        'model': 'claude-sonnet-5',
+      };
+      final agent = AgentParams.fromJson(json) as AgentParamsWithOverrides;
+      expect(agent.version, 3);
+      expect(agent.model, isNotNull);
+      expect(agent.toJson(), json);
+    });
+
+    test('system tri-state: explicit null clears', () {
+      const agent = AgentParamsWithOverrides(id: 'agt_1', system: null);
+      final json = agent.toJson();
+      expect(json.containsKey('system'), isTrue);
+      expect(json['system'], isNull);
+    });
+
+    test('system tri-state: omitted preserves (key absent)', () {
+      const agent = AgentParamsWithOverrides(id: 'agt_1');
+      expect(agent.toJson().containsKey('system'), isFalse);
+    });
+
+    test('system tri-state: value emitted', () {
+      const agent = AgentParamsWithOverrides(id: 'agt_1', system: 'be concise');
+      expect(agent.toJson()['system'], 'be concise');
+    });
+
+    test('fromJson with explicit null system round-trips', () {
+      final json = <String, dynamic>{
+        'type': 'agent_with_overrides',
+        'id': 'agt_1',
+        'system': null,
+      };
+      final agent = AgentParams.fromJson(json) as AgentParamsWithOverrides;
+      expect(agent.system, isNull);
+      expect(agent.toJson(), json);
+    });
+  });
+
+  group('ListSessionsResponse prev_page', () {
+    test('round-trips prev_page', () {
+      final json = <String, dynamic>{
+        'data': <dynamic>[],
+        'next_page': 'next_cursor',
+        'prev_page': 'prev_cursor',
+      };
+      final resp = ListSessionsResponse.fromJson(json);
+      expect(resp.prevPage, 'prev_cursor');
+      expect(resp.nextPage, 'next_cursor');
+      expect(resp.toJson(), json);
+    });
+
+    test('omits prev_page when absent', () {
+      final resp = ListSessionsResponse.fromJson(const <String, dynamic>{
+        'data': <dynamic>[],
+      });
+      expect(resp.prevPage, isNull);
+      expect(resp.toJson().containsKey('prev_page'), isFalse);
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/managed_agents/telemetry_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/managed_agents/telemetry_test.dart
@@ -1,0 +1,32 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SpanModelUsage.speed', () {
+    Map<String, dynamic> usageJson({String? speed}) => {
+      'input_tokens': 10,
+      'output_tokens': 20,
+      'cache_creation_input_tokens': 0,
+      'cache_read_input_tokens': 5,
+      'speed': ?speed,
+    };
+
+    test('parses speed as a typed AgentSpeed and round-trips', () {
+      final usage = SpanModelUsage.fromJson(usageJson(speed: 'fast'));
+      expect(usage.speed, AgentSpeed.fast);
+      expect(usage.toJson()['speed'], 'fast');
+      expect(usage.toJson(), usageJson(speed: 'fast'));
+    });
+
+    test('falls back to AgentSpeed.unknown for an unrecognized value', () {
+      final usage = SpanModelUsage.fromJson(usageJson(speed: 'turbo'));
+      expect(usage.speed, AgentSpeed.unknown);
+    });
+
+    test('omits speed when absent', () {
+      final usage = SpanModelUsage.fromJson(usageJson());
+      expect(usage.speed, isNull);
+      expect(usage.toJson().containsKey('speed'), isFalse);
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/token_task_budget_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/token_task_budget_test.dart
@@ -48,31 +48,4 @@ void main() {
       expect(parsed, equals(config));
     });
   });
-
-  group('MessageCreateRequest.userProfileId', () {
-    test('serializes user_profile_id when set', () {
-      final request = MessageCreateRequest(
-        model: 'claude-opus-4-8',
-        messages: [InputMessage.user('hi')],
-        maxTokens: 16,
-        userProfileId: 'uprof_abc123',
-      );
-
-      final json = request.toJson();
-      expect(json['user_profile_id'], 'uprof_abc123');
-
-      final parsed = MessageCreateRequest.fromJson(json);
-      expect(parsed.userProfileId, 'uprof_abc123');
-    });
-
-    test('omits user_profile_id when null', () {
-      final request = MessageCreateRequest(
-        model: 'claude-opus-4-8',
-        messages: [InputMessage.user('hi')],
-        maxTokens: 16,
-      );
-
-      expect(request.toJson().containsKey('user_profile_id'), isFalse);
-    });
-  });
 }

--- a/packages/anthropic_sdk_dart/test/unit/models/tools/web_tools_20260318_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/tools/web_tools_20260318_test.dart
@@ -1,0 +1,112 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('WebSearchTool web_search_20260318', () {
+    test('round-trips response_inclusion', () {
+      const tool = WebSearchTool(
+        type: 'web_search_20260318',
+        responseInclusion: 'excluded',
+      );
+      expect(tool.responseInclusion, 'excluded');
+      final json = tool.toJson();
+      expect(json['type'], 'web_search_20260318');
+      expect(json['response_inclusion'], 'excluded');
+
+      final parsed = WebSearchTool.fromJson(json);
+      expect(parsed.responseInclusion, 'excluded');
+      expect(parsed.toJson(), json);
+    });
+
+    test('normalizes response_inclusion to null for older versions', () {
+      const tool = WebSearchTool(
+        type: 'web_search_20260209',
+        responseInclusion: 'full',
+      );
+      expect(tool.responseInclusion, isNull);
+      expect(tool.toJson().containsKey('response_inclusion'), isFalse);
+    });
+
+    test('BuiltInTool.fromJson dispatches web_search_20260318', () {
+      final tool = BuiltInTool.fromJson({
+        'type': 'web_search_20260318',
+        'name': 'web_search',
+        'response_inclusion': 'full',
+      });
+      expect(tool, isA<WebSearchTool>());
+      expect((tool as WebSearchTool).responseInclusion, 'full');
+    });
+
+    test('BuiltInTool.webSearch factory forwards responseInclusion', () {
+      final tool =
+          BuiltInTool.webSearch(
+                type: 'web_search_20260318',
+                responseInclusion: 'excluded',
+              )
+              as WebSearchTool;
+      expect(tool.responseInclusion, 'excluded');
+    });
+  });
+
+  group('WebFetchTool web_fetch_20260318', () {
+    test('round-trips response_inclusion and use_cache', () {
+      const tool = WebFetchTool(
+        type: 'web_fetch_20260318',
+        responseInclusion: 'excluded',
+        useCache: false,
+      );
+      expect(tool.responseInclusion, 'excluded');
+      expect(tool.useCache, isFalse);
+      final json = tool.toJson();
+      expect(json['type'], 'web_fetch_20260318');
+      expect(json['response_inclusion'], 'excluded');
+      expect(json['use_cache'], false);
+
+      final parsed = WebFetchTool.fromJson(json);
+      expect(parsed.responseInclusion, 'excluded');
+      expect(parsed.useCache, isFalse);
+      expect(parsed.toJson(), json);
+    });
+
+    test('use_cache still supported for web_fetch_20260309', () {
+      const tool = WebFetchTool(type: 'web_fetch_20260309', useCache: false);
+      expect(tool.useCache, isFalse);
+      expect(tool.toJson()['use_cache'], false);
+    });
+
+    test('use_cache normalized to null for web_fetch_20260209', () {
+      const tool = WebFetchTool(type: 'web_fetch_20260209', useCache: false);
+      expect(tool.useCache, isNull);
+      expect(tool.toJson().containsKey('use_cache'), isFalse);
+    });
+
+    test('response_inclusion normalized to null for web_fetch_20260309', () {
+      const tool = WebFetchTool(
+        type: 'web_fetch_20260309',
+        responseInclusion: 'full',
+      );
+      expect(tool.responseInclusion, isNull);
+      expect(tool.toJson().containsKey('response_inclusion'), isFalse);
+    });
+
+    test('BuiltInTool.fromJson dispatches web_fetch_20260318', () {
+      final tool = BuiltInTool.fromJson({
+        'type': 'web_fetch_20260318',
+        'name': 'web_fetch',
+        'response_inclusion': 'excluded',
+      });
+      expect(tool, isA<WebFetchTool>());
+      expect((tool as WebFetchTool).responseInclusion, 'excluded');
+    });
+
+    test('BuiltInTool.webFetch factory forwards responseInclusion', () {
+      final tool =
+          BuiltInTool.webFetch(
+                type: 'web_fetch_20260318',
+                responseInclusion: 'full',
+              )
+              as WebFetchTool;
+      expect(tool.responseInclusion, 'full');
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/tools/web_tools_20260318_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/tools/web_tools_20260318_test.dart
@@ -2,26 +2,45 @@ import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
 import 'package:test/test.dart';
 
 void main() {
+  group('ResponseInclusion enum', () {
+    test('round-trips through JSON', () {
+      expect(ResponseInclusion.fromJson('full'), ResponseInclusion.full);
+      expect(
+        ResponseInclusion.fromJson('excluded'),
+        ResponseInclusion.excluded,
+      );
+      expect(ResponseInclusion.full.toJson(), 'full');
+      expect(ResponseInclusion.excluded.toJson(), 'excluded');
+    });
+
+    test('throws on an unknown value', () {
+      expect(
+        () => ResponseInclusion.fromJson('partial'),
+        throwsFormatException,
+      );
+    });
+  });
+
   group('WebSearchTool web_search_20260318', () {
     test('round-trips response_inclusion', () {
       const tool = WebSearchTool(
         type: 'web_search_20260318',
-        responseInclusion: 'excluded',
+        responseInclusion: ResponseInclusion.excluded,
       );
-      expect(tool.responseInclusion, 'excluded');
+      expect(tool.responseInclusion, ResponseInclusion.excluded);
       final json = tool.toJson();
       expect(json['type'], 'web_search_20260318');
       expect(json['response_inclusion'], 'excluded');
 
       final parsed = WebSearchTool.fromJson(json);
-      expect(parsed.responseInclusion, 'excluded');
+      expect(parsed.responseInclusion, ResponseInclusion.excluded);
       expect(parsed.toJson(), json);
     });
 
     test('normalizes response_inclusion to null for older versions', () {
       const tool = WebSearchTool(
         type: 'web_search_20260209',
-        responseInclusion: 'full',
+        responseInclusion: ResponseInclusion.full,
       );
       expect(tool.responseInclusion, isNull);
       expect(tool.toJson().containsKey('response_inclusion'), isFalse);
@@ -34,17 +53,17 @@ void main() {
         'response_inclusion': 'full',
       });
       expect(tool, isA<WebSearchTool>());
-      expect((tool as WebSearchTool).responseInclusion, 'full');
+      expect((tool as WebSearchTool).responseInclusion, ResponseInclusion.full);
     });
 
     test('BuiltInTool.webSearch factory forwards responseInclusion', () {
       final tool =
           BuiltInTool.webSearch(
                 type: 'web_search_20260318',
-                responseInclusion: 'excluded',
+                responseInclusion: ResponseInclusion.excluded,
               )
               as WebSearchTool;
-      expect(tool.responseInclusion, 'excluded');
+      expect(tool.responseInclusion, ResponseInclusion.excluded);
     });
   });
 
@@ -52,10 +71,10 @@ void main() {
     test('round-trips response_inclusion and use_cache', () {
       const tool = WebFetchTool(
         type: 'web_fetch_20260318',
-        responseInclusion: 'excluded',
+        responseInclusion: ResponseInclusion.excluded,
         useCache: false,
       );
-      expect(tool.responseInclusion, 'excluded');
+      expect(tool.responseInclusion, ResponseInclusion.excluded);
       expect(tool.useCache, isFalse);
       final json = tool.toJson();
       expect(json['type'], 'web_fetch_20260318');
@@ -63,7 +82,7 @@ void main() {
       expect(json['use_cache'], false);
 
       final parsed = WebFetchTool.fromJson(json);
-      expect(parsed.responseInclusion, 'excluded');
+      expect(parsed.responseInclusion, ResponseInclusion.excluded);
       expect(parsed.useCache, isFalse);
       expect(parsed.toJson(), json);
     });
@@ -83,7 +102,7 @@ void main() {
     test('response_inclusion normalized to null for web_fetch_20260309', () {
       const tool = WebFetchTool(
         type: 'web_fetch_20260309',
-        responseInclusion: 'full',
+        responseInclusion: ResponseInclusion.full,
       );
       expect(tool.responseInclusion, isNull);
       expect(tool.toJson().containsKey('response_inclusion'), isFalse);
@@ -96,17 +115,20 @@ void main() {
         'response_inclusion': 'excluded',
       });
       expect(tool, isA<WebFetchTool>());
-      expect((tool as WebFetchTool).responseInclusion, 'excluded');
+      expect(
+        (tool as WebFetchTool).responseInclusion,
+        ResponseInclusion.excluded,
+      );
     });
 
     test('BuiltInTool.webFetch factory forwards responseInclusion', () {
       final tool =
           BuiltInTool.webFetch(
                 type: 'web_fetch_20260318',
-                responseInclusion: 'full',
+                responseInclusion: ResponseInclusion.full,
               )
               as WebFetchTool;
-      expect(tool.responseInclusion, 'full');
+      expect(tool.responseInclusion, ResponseInclusion.full);
     });
   });
 }

--- a/packages/anthropic_sdk_dart/test/unit/models/webhook_event_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/webhook_event_test.dart
@@ -71,6 +71,31 @@ void main() {
       true,
       isA<WebhookVaultCredentialRefreshFailedEventData>(),
     ),
+    ('agent.created', false, isA<WebhookAgentCreatedEventData>()),
+    ('agent.updated', false, isA<WebhookAgentUpdatedEventData>()),
+    ('agent.deleted', false, isA<WebhookAgentDeletedEventData>()),
+    ('agent.archived', false, isA<WebhookAgentArchivedEventData>()),
+    ('deployment.created', false, isA<WebhookDeploymentCreatedEventData>()),
+    ('deployment.updated', false, isA<WebhookDeploymentUpdatedEventData>()),
+    ('deployment.deleted', false, isA<WebhookDeploymentDeletedEventData>()),
+    ('deployment.archived', false, isA<WebhookDeploymentArchivedEventData>()),
+    ('deployment.paused', false, isA<WebhookDeploymentPausedEventData>()),
+    ('deployment.unpaused', false, isA<WebhookDeploymentUnpausedEventData>()),
+    (
+      'deployment_run.started',
+      false,
+      isA<WebhookDeploymentRunStartedEventData>(),
+    ),
+    (
+      'deployment_run.succeeded',
+      false,
+      isA<WebhookDeploymentRunSucceededEventData>(),
+    ),
+    (
+      'deployment_run.failed',
+      false,
+      isA<WebhookDeploymentRunFailedEventData>(),
+    ),
   ];
 
   Map<String, dynamic> dataJson(String type, {required bool withVault}) {
@@ -87,8 +112,8 @@ void main() {
   }
 
   group('WebhookEventData dispatch', () {
-    test('covers all 23 spec variants', () {
-      expect(variants, hasLength(23));
+    test('covers all 36 spec variants', () {
+      expect(variants, hasLength(36));
     });
 
     for (final (type, withVault, matcher) in variants) {

--- a/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
@@ -558,6 +558,42 @@ void main() {
       expect(request.method, 'GET');
       expect(request.headers['anthropic-beta'], 'managed-agents-2026-04-01');
     });
+
+    test('stream sends event_deltas[] and parses preview events', () async {
+      mockHttpClient.queueStreamingResponse([
+        {
+          'type': 'event_start',
+          'event': {'type': 'agent.message', 'id': 'event_010'},
+        },
+        {
+          'type': 'event_delta',
+          'event_id': 'event_010',
+          'delta': {
+            'type': 'content_delta',
+            'content': {'type': 'text', 'text': 'Hi'},
+            'index': 0,
+          },
+        },
+      ]);
+
+      final events = await client.sessions
+          .events('session_test123')
+          .stream(eventDeltas: ['agent.message', 'agent.thinking'])
+          .toList();
+
+      expect(events, hasLength(2));
+      expect(events[0], isA<EventStartEvent>());
+      expect(events[1], isA<EventDeltaEvent>());
+      expect((events[1] as EventDeltaEvent).eventId, 'event_010');
+
+      final request = mockHttpClient.lastRequest!;
+      expect(request.url.path, '/v1/sessions/session_test123/events/stream');
+      expect(request.url.queryParametersAll['event_deltas[]'], [
+        'agent.message',
+        'agent.thinking',
+      ]);
+      expect(request.headers['anthropic-beta'], 'managed-agents-2026-04-01');
+    });
   });
 
   group('SessionThreadsResource', () {

--- a/packages/anthropic_sdk_dart/test/unit/resources/messages_resource_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/resources/messages_resource_test.dart
@@ -118,6 +118,84 @@ void main() {
       },
     );
 
+    test(
+      'create sends anthropic-user-profile-id header, not a body field',
+      () async {
+        mockHttpClient.queueJsonResponse(
+          MockResponses.message(id: 'msg_test', text: 'Hi'),
+        );
+
+        await client.messages.create(
+          MessageCreateRequest(
+            model: 'claude-sonnet-4-6',
+            maxTokens: 256,
+            messages: [InputMessage.user('Hello!')],
+          ),
+          userProfileId: 'uprof_abc123',
+        );
+
+        final request = mockHttpClient.lastRequest!;
+        expect(request.headers['anthropic-user-profile-id'], 'uprof_abc123');
+        expect(
+          (request as dynamic).body as String,
+          isNot(contains('user_profile_id')),
+        );
+      },
+    );
+
+    test('create omits anthropic-user-profile-id header when unset', () async {
+      mockHttpClient.queueJsonResponse(
+        MockResponses.message(id: 'msg_test', text: 'Hi'),
+      );
+
+      await client.messages.create(
+        MessageCreateRequest(
+          model: 'claude-sonnet-4-6',
+          maxTokens: 256,
+          messages: [InputMessage.user('Hello!')],
+        ),
+      );
+
+      final request = mockHttpClient.lastRequest!;
+      expect(request.headers.containsKey('anthropic-user-profile-id'), isFalse);
+    });
+
+    test('createStream sends anthropic-user-profile-id header', () async {
+      mockHttpClient.queueStreamingResponse(
+        MockResponses.streamingEvents(text: 'Hi!'),
+      );
+
+      final stream = client.messages.createStream(
+        MessageCreateRequest(
+          model: 'claude-sonnet-4-6',
+          maxTokens: 256,
+          messages: [InputMessage.user('Hello!')],
+        ),
+        userProfileId: 'uprof_abc123',
+      );
+      await stream.toList();
+
+      final request = mockHttpClient.lastRequest!;
+      expect(request.headers['anthropic-user-profile-id'], 'uprof_abc123');
+    });
+
+    test('countTokens sends anthropic-user-profile-id header', () async {
+      mockHttpClient.queueJsonResponse(
+        MockResponses.tokenCount(inputTokens: 42),
+      );
+
+      await client.messages.countTokens(
+        TokenCountRequest(
+          model: 'claude-sonnet-4-6',
+          messages: [InputMessage.user('Count my tokens!')],
+        ),
+        userProfileId: 'uprof_abc123',
+      );
+
+      final request = mockHttpClient.lastRequest!;
+      expect(request.headers['anthropic-user-profile-id'], 'uprof_abc123');
+    });
+
     test('create handles tool use response', () async {
       mockHttpClient.queueJsonResponse({
         'id': 'msg_tools',
@@ -280,6 +358,34 @@ void main() {
 
       expect(response.id, 'batch_123');
       expect(response.processingStatus, ProcessingStatus.inProgress);
+    });
+
+    test('create sends anthropic-user-profile-id header', () async {
+      mockHttpClient.queueJsonResponse(
+        MockResponses.messageBatch(
+          id: 'batch_123',
+          processingStatus: 'in_progress',
+        ),
+      );
+
+      await client.messages.batches.create(
+        MessageBatchCreateRequest(
+          requests: [
+            BatchRequestItem(
+              customId: 'req_1',
+              params: MessageCreateRequest(
+                model: 'claude-sonnet-4-6',
+                maxTokens: 100,
+                messages: [InputMessage.user('Hello')],
+              ),
+            ),
+          ],
+        ),
+        userProfileId: 'uprof_abc123',
+      );
+
+      final request = mockHttpClient.lastRequest!;
+      expect(request.headers['anthropic-user-profile-id'], 'uprof_abc123');
     });
 
     test('retrieve returns batch status', () async {


### PR DESCRIPTION
## Summary
- Sync `anthropic_sdk_dart` to Anthropic OpenAPI spec `506a5ad7` (from `2ecf157a`).
- Add **Claude Sonnet 5** (`claude-sonnet-5`) — usable directly as a model string; no API change needed.
- Add the **`web_search_20260318` / `web_fetch_20260318`** built-in tool versions with a new `responseInclusion` field (`ResponseInclusion` enum: `full`/`excluded`, version-gated).
- **Managed Agents parity**: event-delta streaming, credential injection location, per-session agent overrides, backward pagination, and agent/deployment webhook events.
- **BREAKING**: `user_profile_id` is **relocated from the message request body to the `anthropic-user-profile-id` header**, exposed as a `userProfileId` parameter on `messages.create` / `createStream` / `countTokens` / `messageBatches.create`.
- **BREAKING**: type two closed-enum `String` fields — `SpanModelUsage.speed` → `AgentSpeed?`, and `WebSearchResultError.errorCode` → a `WebSearchToolResultErrorCode` getter (raw value on `rawErrorCode`).
- Exclude the new research-preview **Tunnels** management resource (no SDK coverage) via `coverage.excluded_resources` + acknowledged manifest skips.

## Details

**Web tools (`web_search_20260318` / `web_fetch_20260318`)** — both add `responseInclusion` (`ResponseInclusion.full` / `ResponseInclusion.excluded`), controlling how a tool's result blocks appear when consumed by a completed `code_execution` call in the same turn. It is emitted only for the `*_20260318` versions; `WebFetchTool.useCache` gating now also covers `web_fetch_20260318`. Exposed through `BuiltInTool.webSearch(...)` / `BuiltInTool.webFetch(...)` and the raw classes.

```dart
final tool = BuiltInTool.webSearch(
  type: 'web_search_20260318',
  responseInclusion: ResponseInclusion.excluded,
);
```

**End-user attribution (`user_profile_id`)** — the spec moved `user_profile_id` off the message-creation body and onto the `anthropic-user-profile-id` request header (verified against `anthropic-sdk-python@main` on the same spec hash). It is now a `userProfileId` method parameter that sets that header on `messages.create`, `messages.createStream`, `messages.countTokens`, and `messageBatches.create`.

```dart
await client.messages.create(
  MessageCreateRequest(
    model: 'claude-opus-4-8',
    maxTokens: 256,
    messages: [InputMessage.user('Hello!')],
  ),
  userProfileId: profile.id, // sent as the anthropic-user-profile-id header
);
```

**Managed Agents**

- **Event-delta streaming** — `SessionEvent` gains `EventStartEvent` (`event_start`) and `EventDeltaEvent` (`event_delta`), previewing an agent message/thinking event before the complete event arrives. Opt in via a new `eventDeltas` parameter on `sessions.events(id).stream(...)` (serialized as `event_deltas[]`, session stream only — the thread stream does not expose it). The nested preview (`EventStartPreview`) and delta (`EventDelta` -> `ContentDelta`) are modeled as sealed classes with `Unknown*` fallbacks.

  ```dart
  final stream = client.sessions
      .events(sessionId)
      .stream(eventDeltas: ['agent.message', 'agent.thinking']);
  ```

- **Credential injection location** — environment-variable vault credentials gain `injectionLocation` (`InjectionLocation` for create/update params, required `InjectionLocationResponse` on the auth response), controlling whether the secret is substituted into outbound request headers, body, or both.

- **Per-session agent overrides** — `CreateSessionParams.agent` now accepts `AgentParamsWithOverrides` (`type: agent_with_overrides`), overriding an agent's model, system prompt, tools, MCP servers, or skills for a single session. `system` uses a tri-state sentinel: omit to preserve the agent's prompt, pass `null` to clear it for the session.

- **Backward pagination** — `ListSessionsResponse` gains `prevPage`; pass it back as the existing `page` parameter to page backward.

- **Webhook events** — 13 new `WebhookEventData` variants covering the agent (`agent.created/updated/deleted/archived`) and deployment (`deployment.*`, `deployment_run.*`) lifecycles.

**Enum typing sweep** — audited the SDK for `String` fields that are closed spec enums. Almost all were already typed; two remained and are now enums: `SpanModelUsage.speed` -> `AgentSpeed?`, and `WebSearchResultError.errorCode` -> a `WebSearchToolResultErrorCode` getter (with the raw wire value preserved on `rawErrorCode`, mirroring `AdvisorToolResultError`).

All api-toolkit gates pass: `verify --checks all --scope all` (0 errors/warnings), `review` (0 changed / 0 missing manifest / 0 coverage gaps). A Codex correctness review (JSON round-trip, tri-state sentinel, version-gating, discriminator dispatch, equality contracts) found no issues.

## Breaking Changes

- `user_profile_id` is no longer a message-creation **body** field. `MessageCreateRequest.userProfileId` is removed; attribution now travels in the `anthropic-user-profile-id` **header** via a `userProfileId` method parameter. (The API relocated the parameter — it was not removed. The User Profiles resource, `client.userProfiles`, is unchanged.)

  ```dart
  // Before — body field on the request
  await client.messages.create(MessageCreateRequest(
    model: 'claude-opus-4-8',
    maxTokens: 256,
    userProfileId: profile.id,
    messages: [InputMessage.user('Hello!')],
  ));

  // After — header via method parameter
  await client.messages.create(
    MessageCreateRequest(
      model: 'claude-opus-4-8',
      maxTokens: 256,
      messages: [InputMessage.user('Hello!')],
    ),
    userProfileId: profile.id,
  );
  ```

  The User Profiles resource itself (`client.userProfiles`) is unchanged — only the message-create field is gone.

- Two closed-enum `String` fields are now typed enums (the rest of the SDK's closed enums were already typed):
  - `SpanModelUsage.speed`: `String?` -> `AgentSpeed?` (has an `unknown` fallback).
  - `WebSearchResultError.errorCode`: was a plain `String`; now a derived `WebSearchToolResultErrorCode get errorCode`, with the raw wire value on the new `rawErrorCode` field (mirrors `AdvisorToolResultError`).

  ```dart
  // Before
  final code = webSearchError.errorCode; // String

  // After
  final code = webSearchError.errorCode;   // WebSearchToolResultErrorCode
  final raw = webSearchError.rawErrorCode;  // String (round-trip fidelity)
  ```

- `responseInclusion` on `WebSearchTool` / `WebFetchTool` is a `ResponseInclusion` enum (not a `String`).

## References

- [Claude Sonnet 5 announcement](https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5) — new Sonnet generation, 1M context, introductory pricing.
- [Managed Agents: events & streaming](https://platform.claude.com/docs/en/managed-agents/events-and-streaming#event-deltas) — event-delta preview stream.

## Test Plan

- [x] Unit tests pass for affected packages (`dart test test/unit/`, 1301 pass)
- [x] New tests added for new functionality (web tools 20260318 + `ResponseInclusion`, event deltas, injection location, agent overrides, prev_page, 13 webhook variants, stream `event_deltas[]`, `anthropic-user-profile-id` header, `SpanModelUsage.speed` + `WebSearchToolResultErrorCode`)
- [x] Sealed class/enum changes include variant, round-trip, and error tests
- [x] `fromJson`/`toJson` round-trip serialization verified
- [x] `==`/`hashCode` contract verified (same fields in both)
- [x] `dart analyze --fatal-infos` clean; `dart format` clean
- [x] api-toolkit `verify` / `review` green; Codex correctness review clean
