### PR TITLE
feat(mistralai_dart)!: OCR-4 block extraction & pages union

### DIFF
--- a/packages/mistralai_dart/.agents/skills/openapi-mistral/config/manifest.json
+++ b/packages/mistralai_dart/.agents/skills/openapi-mistral/config/manifest.json
@@ -1604,6 +1604,30 @@
       "schema": "OAuth2TokenAuth",
       "parent": "ConnectorAuth"
     },
+    "OCRAsideTextBlock": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "OcrAsideTextBlock",
+      "file": "lib/src/models/ocr/ocr_block.dart",
+      "schema": "OCRAsideTextBlock",
+      "parent": "OcrBlock"
+    },
+    "OCRCaptionBlock": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "OcrCaptionBlock",
+      "file": "lib/src/models/ocr/ocr_block.dart",
+      "schema": "OCRCaptionBlock",
+      "parent": "OcrBlock"
+    },
+    "OCRCodeBlock": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "OcrCodeBlock",
+      "file": "lib/src/models/ocr/ocr_block.dart",
+      "schema": "OCRCodeBlock",
+      "parent": "OcrBlock"
+    },
     "OCRConfidenceScore": {
       "spec": "main",
       "kind": "object",
@@ -1611,12 +1635,52 @@
       "file": "lib/src/models/ocr/ocr_confidence_score.dart",
       "schema": "OCRConfidenceScore"
     },
+    "OCREquationBlock": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "OcrEquationBlock",
+      "file": "lib/src/models/ocr/ocr_block.dart",
+      "schema": "OCREquationBlock",
+      "parent": "OcrBlock"
+    },
+    "OCRFooterBlock": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "OcrFooterBlock",
+      "file": "lib/src/models/ocr/ocr_block.dart",
+      "schema": "OCRFooterBlock",
+      "parent": "OcrBlock"
+    },
+    "OCRHeaderBlock": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "OcrHeaderBlock",
+      "file": "lib/src/models/ocr/ocr_block.dart",
+      "schema": "OCRHeaderBlock",
+      "parent": "OcrBlock"
+    },
+    "OCRImageBlock": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "OcrImageBlock",
+      "file": "lib/src/models/ocr/ocr_block.dart",
+      "schema": "OCRImageBlock",
+      "parent": "OcrBlock"
+    },
     "OCRImageObject": {
       "spec": "main",
       "kind": "object",
       "dart_class": "OcrImage",
       "file": "lib/src/models/ocr/ocr_image.dart",
       "schema": "OCRImageObject"
+    },
+    "OCRListBlock": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "OcrListBlock",
+      "file": "lib/src/models/ocr/ocr_block.dart",
+      "schema": "OCRListBlock",
+      "parent": "OcrBlock"
     },
     "OCRPageConfidenceScores": {
       "spec": "main",
@@ -1639,12 +1703,36 @@
       "file": "lib/src/models/ocr/ocr_page.dart",
       "schema": "OCRPageObject"
     },
+    "OCRReferencesBlock": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "OcrReferencesBlock",
+      "file": "lib/src/models/ocr/ocr_block.dart",
+      "schema": "OCRReferencesBlock",
+      "parent": "OcrBlock"
+    },
     "OCRRequest": {
       "spec": "main",
       "kind": "object",
       "dart_class": "OcrRequest",
       "file": "lib/src/models/ocr/ocr_request.dart",
       "schema": "OCRRequest"
+    },
+    "OCRSignatureBlock": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "OcrSignatureBlock",
+      "file": "lib/src/models/ocr/ocr_block.dart",
+      "schema": "OCRSignatureBlock",
+      "parent": "OcrBlock"
+    },
+    "OCRTableBlock": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "OcrTableBlock",
+      "file": "lib/src/models/ocr/ocr_block.dart",
+      "schema": "OCRTableBlock",
+      "parent": "OcrBlock"
     },
     "OCRTableObject": {
       "spec": "main",
@@ -1653,12 +1741,54 @@
       "file": "lib/src/models/ocr/ocr_table.dart",
       "schema": "OCRTableObject"
     },
+    "OCRTextBlock": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "OcrTextBlock",
+      "file": "lib/src/models/ocr/ocr_block.dart",
+      "schema": "OCRTextBlock",
+      "parent": "OcrBlock"
+    },
+    "OCRTitleBlock": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "OcrTitleBlock",
+      "file": "lib/src/models/ocr/ocr_block.dart",
+      "schema": "OCRTitleBlock",
+      "parent": "OcrBlock"
+    },
     "OCRUsageInfo": {
       "spec": "main",
       "kind": "object",
       "dart_class": "OcrUsageInfo",
       "file": "lib/src/models/ocr/ocr_usage_info.dart",
       "schema": "OCRUsageInfo"
+    },
+    "OcrBlock": {
+      "spec": "main",
+      "kind": "sealed_parent",
+      "dart_class": "OcrBlock",
+      "file": "lib/src/models/ocr/ocr_block.dart",
+      "schema": null,
+      "discriminator": {
+        "field": "type",
+        "mapping": {
+          "OCRTextBlock": "text",
+          "OCRTitleBlock": "title",
+          "OCRListBlock": "list",
+          "OCRTableBlock": "table",
+          "OCRImageBlock": "image",
+          "OCREquationBlock": "equation",
+          "OCRCaptionBlock": "caption",
+          "OCRCodeBlock": "code",
+          "OCRReferencesBlock": "references",
+          "OCRAsideTextBlock": "aside_text",
+          "OCRHeaderBlock": "header",
+          "OCRFooterBlock": "footer",
+          "OCRSignatureBlock": "signature"
+        }
+      },
+      "note": null
     },
     "ObservabilityError": {
       "spec": "main",

--- a/packages/mistralai_dart/example/mistralai_dart_example.dart
+++ b/packages/mistralai_dart/example/mistralai_dart_example.dart
@@ -1,0 +1,75 @@
+// ignore_for_file: avoid_print
+import 'dart:io';
+
+import 'package:mistralai_dart/mistralai_dart.dart';
+
+/// Example demonstrating basic usage of the Mistral AI Dart client.
+///
+/// Covers chat completions, embeddings, and OCR document processing with
+/// paragraph-level block extraction. See the other files in this directory
+/// for per-feature examples (streaming, tool calling, agents, files, etc.).
+void main() async {
+  // Get the API key from the environment.
+  final apiKey = Platform.environment['MISTRAL_API_KEY'];
+  if (apiKey == null) {
+    print('Please set the MISTRAL_API_KEY environment variable');
+    exit(1);
+  }
+
+  final client = MistralClient.withApiKey(apiKey);
+
+  try {
+    // --- Chat completion ---
+    print('=== Chat ===');
+    final chat = await client.chat.create(
+      request: ChatCompletionRequest(
+        model: 'mistral-small-latest',
+        messages: [
+          ChatMessage.system('You are a helpful assistant.'),
+          ChatMessage.user('What is the capital of France?'),
+        ],
+      ),
+    );
+    print('Assistant: ${chat.text}');
+    print('Tokens used: ${chat.usage?.totalTokens}');
+
+    // --- Embeddings ---
+    print('\n=== Embeddings ===');
+    final embeddings = await client.embeddings.create(
+      request: EmbeddingRequest.single(
+        model: 'mistral-embed',
+        input: 'Hello, world!',
+      ),
+    );
+    final vector = embeddings.data.first.embedding;
+    print('Embedding dimension: ${vector.length}');
+
+    // --- OCR with block extraction ---
+    print('\n=== OCR ===');
+    final ocr = await client.ocr.process(
+      request: OcrRequest.fromUrl(
+        url: 'https://arxiv.org/pdf/2201.04234',
+        // `pages` accepts a list of 0-indexed numbers or a comma-separated
+        // string of numbers and ranges (e.g. '0,2-4').
+        pages: const OcrPages.string('0'),
+        // Return paragraph-level bounding boxes for each content block.
+        includeBlocks: true,
+      ),
+    );
+    for (final page in ocr.pages) {
+      print('Page ${page.index}: ${page.markdown.length} chars of markdown');
+      for (final block in page.blocks ?? const <OcrBlock>[]) {
+        // Blocks are a sealed union — switch over the concrete subtypes.
+        final detail = switch (block) {
+          OcrImageBlock(:final imageId) => ' (image id: $imageId)',
+          OcrTableBlock(:final tableId) => ' (table id: $tableId)',
+          UnknownOcrBlock() => ' (unrecognized)',
+          _ => '',
+        };
+        print('  [${block.type}]$detail');
+      }
+    }
+  } finally {
+    client.close();
+  }
+}

--- a/packages/mistralai_dart/example/ocr_example.dart
+++ b/packages/mistralai_dart/example/ocr_example.dart
@@ -76,7 +76,7 @@ print('Pages processed: ${response.pages.length}');
 final response = await client.ocr.process(
   request: OcrRequest.fromUrl(
     url: 'https://example.com/long-document.pdf',
-    pages: [0, 1, 4], // Only process pages 1, 2, and 5 (0-indexed)
+    pages: OcrPages.list([0, 1, 4]), // Only pages 1, 2, and 5 (0-indexed)
   ),
 );
 

--- a/packages/mistralai_dart/lib/mistralai_dart.dart
+++ b/packages/mistralai_dart/lib/mistralai_dart.dart
@@ -298,6 +298,7 @@ export 'src/models/observability/span_evaluations_request.dart';
 export 'src/models/observability/spans_request.dart';
 export 'src/models/observability/traces_request.dart';
 // --- Models: OCR ---
+export 'src/models/ocr/ocr_block.dart';
 export 'src/models/ocr/ocr_confidence_score.dart';
 export 'src/models/ocr/ocr_confidence_scores_granularity.dart';
 export 'src/models/ocr/ocr_document.dart';
@@ -305,6 +306,7 @@ export 'src/models/ocr/ocr_image.dart';
 export 'src/models/ocr/ocr_page.dart';
 export 'src/models/ocr/ocr_page_confidence_scores.dart';
 export 'src/models/ocr/ocr_page_dimensions.dart';
+export 'src/models/ocr/ocr_pages.dart';
 export 'src/models/ocr/ocr_request.dart';
 export 'src/models/ocr/ocr_response.dart';
 export 'src/models/ocr/ocr_table.dart';

--- a/packages/mistralai_dart/lib/src/models/ocr/ocr_block.dart
+++ b/packages/mistralai_dart/lib/src/models/ocr/ocr_block.dart
@@ -1,0 +1,1853 @@
+import 'package:meta/meta.dart';
+
+import '../common/copy_with_sentinel.dart';
+import '../common/equality_helpers.dart';
+
+/// A content block extracted from a document page (block extraction).
+///
+/// Populated on [OcrPage.blocks] when `includeBlocks` is enabled on the
+/// request. Each block carries a paragraph-level bounding box, its extracted
+/// `content`, and a structural [type] label. Blocks are returned in reading
+/// order.
+///
+/// This is a sealed union; switch over the concrete subtypes:
+/// [OcrTextBlock], [OcrTitleBlock], [OcrListBlock], [OcrTableBlock],
+/// [OcrImageBlock], [OcrEquationBlock], [OcrCaptionBlock], [OcrCodeBlock],
+/// [OcrReferencesBlock], [OcrAsideTextBlock], [OcrHeaderBlock],
+/// [OcrFooterBlock], [OcrSignatureBlock], and [UnknownOcrBlock] (forward
+/// compatibility).
+@immutable
+sealed class OcrBlock {
+  /// Creates an [OcrBlock].
+  const OcrBlock();
+
+  /// The structural label of the block (the `type` discriminator).
+  String get type;
+
+  /// Creates an [OcrBlock] from JSON, dispatching on the `type` discriminator.
+  ///
+  /// Unrecognized types are preserved as [UnknownOcrBlock] for forward
+  /// compatibility; this never throws on an unknown discriminator.
+  factory OcrBlock.fromJson(Map<String, dynamic> json) =>
+      switch (json['type']) {
+        'text' => OcrTextBlock.fromJson(json),
+        'title' => OcrTitleBlock.fromJson(json),
+        'list' => OcrListBlock.fromJson(json),
+        'table' => OcrTableBlock.fromJson(json),
+        'image' => OcrImageBlock.fromJson(json),
+        'equation' => OcrEquationBlock.fromJson(json),
+        'caption' => OcrCaptionBlock.fromJson(json),
+        'code' => OcrCodeBlock.fromJson(json),
+        'references' => OcrReferencesBlock.fromJson(json),
+        'aside_text' => OcrAsideTextBlock.fromJson(json),
+        'header' => OcrHeaderBlock.fromJson(json),
+        'footer' => OcrFooterBlock.fromJson(json),
+        'signature' => OcrSignatureBlock.fromJson(json),
+        _ => UnknownOcrBlock(json),
+      };
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson();
+}
+
+/// Text paragraph block extracted from a document page.
+@immutable
+class OcrTextBlock extends OcrBlock {
+  /// The structural label of the block (`text`).
+  @override
+  String get type => 'text';
+
+  /// X coordinate of the top-left corner of the bounding box.
+  final int topLeftX;
+
+  /// Y coordinate of the top-left corner of the bounding box.
+  final int topLeftY;
+
+  /// X coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightX;
+
+  /// Y coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightY;
+
+  /// The extracted content of the block.
+  final String content;
+
+  /// Creates an [OcrTextBlock].
+  const OcrTextBlock({
+    required this.topLeftX,
+    required this.topLeftY,
+    required this.bottomRightX,
+    required this.bottomRightY,
+    required this.content,
+  });
+
+  /// Creates an [OcrTextBlock] from JSON.
+  ///
+  /// Throws a [FormatException] if the `type` discriminator is not `text`,
+  /// or if any required field is missing or null.
+  factory OcrTextBlock.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'text') {
+      throw FormatException('OcrTextBlock: expected type "text", got "$type"');
+    }
+    final topLeftX = json['top_left_x'];
+    if (topLeftX is! int) {
+      throw const FormatException(
+        'OcrTextBlock: missing required field "top_left_x"',
+      );
+    }
+    final topLeftY = json['top_left_y'];
+    if (topLeftY is! int) {
+      throw const FormatException(
+        'OcrTextBlock: missing required field "top_left_y"',
+      );
+    }
+    final bottomRightX = json['bottom_right_x'];
+    if (bottomRightX is! int) {
+      throw const FormatException(
+        'OcrTextBlock: missing required field "bottom_right_x"',
+      );
+    }
+    final bottomRightY = json['bottom_right_y'];
+    if (bottomRightY is! int) {
+      throw const FormatException(
+        'OcrTextBlock: missing required field "bottom_right_y"',
+      );
+    }
+    final content = json['content'];
+    if (content is! String) {
+      throw const FormatException(
+        'OcrTextBlock: missing required field "content"',
+      );
+    }
+    return OcrTextBlock(
+      topLeftX: topLeftX,
+      topLeftY: topLeftY,
+      bottomRightX: bottomRightX,
+      bottomRightY: bottomRightY,
+      content: content,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'top_left_x': topLeftX,
+    'top_left_y': topLeftY,
+    'bottom_right_x': bottomRightX,
+    'bottom_right_y': bottomRightY,
+    'content': content,
+  };
+
+  /// Creates a copy with the specified fields replaced.
+  OcrTextBlock copyWith({
+    int? topLeftX,
+    int? topLeftY,
+    int? bottomRightX,
+    int? bottomRightY,
+    String? content,
+  }) => OcrTextBlock(
+    topLeftX: topLeftX ?? this.topLeftX,
+    topLeftY: topLeftY ?? this.topLeftY,
+    bottomRightX: bottomRightX ?? this.bottomRightX,
+    bottomRightY: bottomRightY ?? this.bottomRightY,
+    content: content ?? this.content,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OcrTextBlock &&
+          runtimeType == other.runtimeType &&
+          topLeftX == other.topLeftX &&
+          topLeftY == other.topLeftY &&
+          bottomRightX == other.bottomRightX &&
+          bottomRightY == other.bottomRightY &&
+          content == other.content;
+
+  @override
+  int get hashCode => Object.hash(
+    type,
+    topLeftX,
+    topLeftY,
+    bottomRightX,
+    bottomRightY,
+    content,
+  );
+
+  @override
+  String toString() =>
+      'OcrTextBlock(topLeft: ($topLeftX, $topLeftY), '
+      'bottomRight: ($bottomRightX, $bottomRightY), '
+      'content: ${content.length} chars)';
+}
+
+/// Title / heading block extracted from a document page.
+@immutable
+class OcrTitleBlock extends OcrBlock {
+  /// The structural label of the block (`title`).
+  @override
+  String get type => 'title';
+
+  /// X coordinate of the top-left corner of the bounding box.
+  final int topLeftX;
+
+  /// Y coordinate of the top-left corner of the bounding box.
+  final int topLeftY;
+
+  /// X coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightX;
+
+  /// Y coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightY;
+
+  /// The extracted content of the block.
+  final String content;
+
+  /// Creates an [OcrTitleBlock].
+  const OcrTitleBlock({
+    required this.topLeftX,
+    required this.topLeftY,
+    required this.bottomRightX,
+    required this.bottomRightY,
+    required this.content,
+  });
+
+  /// Creates an [OcrTitleBlock] from JSON.
+  ///
+  /// Throws a [FormatException] if the `type` discriminator is not `title`,
+  /// or if any required field is missing or null.
+  factory OcrTitleBlock.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'title') {
+      throw FormatException(
+        'OcrTitleBlock: expected type "title", got "$type"',
+      );
+    }
+    final topLeftX = json['top_left_x'];
+    if (topLeftX is! int) {
+      throw const FormatException(
+        'OcrTitleBlock: missing required field "top_left_x"',
+      );
+    }
+    final topLeftY = json['top_left_y'];
+    if (topLeftY is! int) {
+      throw const FormatException(
+        'OcrTitleBlock: missing required field "top_left_y"',
+      );
+    }
+    final bottomRightX = json['bottom_right_x'];
+    if (bottomRightX is! int) {
+      throw const FormatException(
+        'OcrTitleBlock: missing required field "bottom_right_x"',
+      );
+    }
+    final bottomRightY = json['bottom_right_y'];
+    if (bottomRightY is! int) {
+      throw const FormatException(
+        'OcrTitleBlock: missing required field "bottom_right_y"',
+      );
+    }
+    final content = json['content'];
+    if (content is! String) {
+      throw const FormatException(
+        'OcrTitleBlock: missing required field "content"',
+      );
+    }
+    return OcrTitleBlock(
+      topLeftX: topLeftX,
+      topLeftY: topLeftY,
+      bottomRightX: bottomRightX,
+      bottomRightY: bottomRightY,
+      content: content,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'top_left_x': topLeftX,
+    'top_left_y': topLeftY,
+    'bottom_right_x': bottomRightX,
+    'bottom_right_y': bottomRightY,
+    'content': content,
+  };
+
+  /// Creates a copy with the specified fields replaced.
+  OcrTitleBlock copyWith({
+    int? topLeftX,
+    int? topLeftY,
+    int? bottomRightX,
+    int? bottomRightY,
+    String? content,
+  }) => OcrTitleBlock(
+    topLeftX: topLeftX ?? this.topLeftX,
+    topLeftY: topLeftY ?? this.topLeftY,
+    bottomRightX: bottomRightX ?? this.bottomRightX,
+    bottomRightY: bottomRightY ?? this.bottomRightY,
+    content: content ?? this.content,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OcrTitleBlock &&
+          runtimeType == other.runtimeType &&
+          topLeftX == other.topLeftX &&
+          topLeftY == other.topLeftY &&
+          bottomRightX == other.bottomRightX &&
+          bottomRightY == other.bottomRightY &&
+          content == other.content;
+
+  @override
+  int get hashCode => Object.hash(
+    type,
+    topLeftX,
+    topLeftY,
+    bottomRightX,
+    bottomRightY,
+    content,
+  );
+
+  @override
+  String toString() =>
+      'OcrTitleBlock(topLeft: ($topLeftX, $topLeftY), '
+      'bottomRight: ($bottomRightX, $bottomRightY), '
+      'content: ${content.length} chars)';
+}
+
+/// List block extracted from a document page.
+@immutable
+class OcrListBlock extends OcrBlock {
+  /// The structural label of the block (`list`).
+  @override
+  String get type => 'list';
+
+  /// X coordinate of the top-left corner of the bounding box.
+  final int topLeftX;
+
+  /// Y coordinate of the top-left corner of the bounding box.
+  final int topLeftY;
+
+  /// X coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightX;
+
+  /// Y coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightY;
+
+  /// The extracted content of the block.
+  final String content;
+
+  /// Creates an [OcrListBlock].
+  const OcrListBlock({
+    required this.topLeftX,
+    required this.topLeftY,
+    required this.bottomRightX,
+    required this.bottomRightY,
+    required this.content,
+  });
+
+  /// Creates an [OcrListBlock] from JSON.
+  ///
+  /// Throws a [FormatException] if the `type` discriminator is not `list`,
+  /// or if any required field is missing or null.
+  factory OcrListBlock.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'list') {
+      throw FormatException('OcrListBlock: expected type "list", got "$type"');
+    }
+    final topLeftX = json['top_left_x'];
+    if (topLeftX is! int) {
+      throw const FormatException(
+        'OcrListBlock: missing required field "top_left_x"',
+      );
+    }
+    final topLeftY = json['top_left_y'];
+    if (topLeftY is! int) {
+      throw const FormatException(
+        'OcrListBlock: missing required field "top_left_y"',
+      );
+    }
+    final bottomRightX = json['bottom_right_x'];
+    if (bottomRightX is! int) {
+      throw const FormatException(
+        'OcrListBlock: missing required field "bottom_right_x"',
+      );
+    }
+    final bottomRightY = json['bottom_right_y'];
+    if (bottomRightY is! int) {
+      throw const FormatException(
+        'OcrListBlock: missing required field "bottom_right_y"',
+      );
+    }
+    final content = json['content'];
+    if (content is! String) {
+      throw const FormatException(
+        'OcrListBlock: missing required field "content"',
+      );
+    }
+    return OcrListBlock(
+      topLeftX: topLeftX,
+      topLeftY: topLeftY,
+      bottomRightX: bottomRightX,
+      bottomRightY: bottomRightY,
+      content: content,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'top_left_x': topLeftX,
+    'top_left_y': topLeftY,
+    'bottom_right_x': bottomRightX,
+    'bottom_right_y': bottomRightY,
+    'content': content,
+  };
+
+  /// Creates a copy with the specified fields replaced.
+  OcrListBlock copyWith({
+    int? topLeftX,
+    int? topLeftY,
+    int? bottomRightX,
+    int? bottomRightY,
+    String? content,
+  }) => OcrListBlock(
+    topLeftX: topLeftX ?? this.topLeftX,
+    topLeftY: topLeftY ?? this.topLeftY,
+    bottomRightX: bottomRightX ?? this.bottomRightX,
+    bottomRightY: bottomRightY ?? this.bottomRightY,
+    content: content ?? this.content,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OcrListBlock &&
+          runtimeType == other.runtimeType &&
+          topLeftX == other.topLeftX &&
+          topLeftY == other.topLeftY &&
+          bottomRightX == other.bottomRightX &&
+          bottomRightY == other.bottomRightY &&
+          content == other.content;
+
+  @override
+  int get hashCode => Object.hash(
+    type,
+    topLeftX,
+    topLeftY,
+    bottomRightX,
+    bottomRightY,
+    content,
+  );
+
+  @override
+  String toString() =>
+      'OcrListBlock(topLeft: ($topLeftX, $topLeftY), '
+      'bottomRight: ($bottomRightX, $bottomRightY), '
+      'content: ${content.length} chars)';
+}
+
+/// Table block extracted from a document page.
+@immutable
+class OcrTableBlock extends OcrBlock {
+  /// The structural label of the block (`table`).
+  @override
+  String get type => 'table';
+
+  /// X coordinate of the top-left corner of the bounding box.
+  final int topLeftX;
+
+  /// Y coordinate of the top-left corner of the bounding box.
+  final int topLeftY;
+
+  /// X coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightX;
+
+  /// Y coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightY;
+
+  /// The extracted content of the block.
+  final String content;
+
+  /// Identifier of the corresponding table in [OcrPage.tables],
+  /// when tables are extracted; `null` otherwise.
+  final String? tableId;
+
+  /// Creates an [OcrTableBlock].
+  const OcrTableBlock({
+    required this.topLeftX,
+    required this.topLeftY,
+    required this.bottomRightX,
+    required this.bottomRightY,
+    required this.content,
+    this.tableId,
+  });
+
+  /// Creates an [OcrTableBlock] from JSON.
+  ///
+  /// Throws a [FormatException] if the `type` discriminator is not `table`,
+  /// or if any required field is missing or null.
+  factory OcrTableBlock.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'table') {
+      throw FormatException(
+        'OcrTableBlock: expected type "table", got "$type"',
+      );
+    }
+    final topLeftX = json['top_left_x'];
+    if (topLeftX is! int) {
+      throw const FormatException(
+        'OcrTableBlock: missing required field "top_left_x"',
+      );
+    }
+    final topLeftY = json['top_left_y'];
+    if (topLeftY is! int) {
+      throw const FormatException(
+        'OcrTableBlock: missing required field "top_left_y"',
+      );
+    }
+    final bottomRightX = json['bottom_right_x'];
+    if (bottomRightX is! int) {
+      throw const FormatException(
+        'OcrTableBlock: missing required field "bottom_right_x"',
+      );
+    }
+    final bottomRightY = json['bottom_right_y'];
+    if (bottomRightY is! int) {
+      throw const FormatException(
+        'OcrTableBlock: missing required field "bottom_right_y"',
+      );
+    }
+    final content = json['content'];
+    if (content is! String) {
+      throw const FormatException(
+        'OcrTableBlock: missing required field "content"',
+      );
+    }
+    return OcrTableBlock(
+      topLeftX: topLeftX,
+      topLeftY: topLeftY,
+      bottomRightX: bottomRightX,
+      bottomRightY: bottomRightY,
+      content: content,
+      tableId: json['table_id'] as String?,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'top_left_x': topLeftX,
+    'top_left_y': topLeftY,
+    'bottom_right_x': bottomRightX,
+    'bottom_right_y': bottomRightY,
+    'content': content,
+    if (tableId != null) 'table_id': tableId,
+  };
+
+  /// Creates a copy with the specified fields replaced.
+  ///
+  /// Pass `null` explicitly to clear nullable fields.
+  OcrTableBlock copyWith({
+    int? topLeftX,
+    int? topLeftY,
+    int? bottomRightX,
+    int? bottomRightY,
+    String? content,
+    Object? tableId = unsetCopyWithValue,
+  }) => OcrTableBlock(
+    topLeftX: topLeftX ?? this.topLeftX,
+    topLeftY: topLeftY ?? this.topLeftY,
+    bottomRightX: bottomRightX ?? this.bottomRightX,
+    bottomRightY: bottomRightY ?? this.bottomRightY,
+    content: content ?? this.content,
+    tableId: tableId == unsetCopyWithValue ? this.tableId : tableId as String?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OcrTableBlock &&
+          runtimeType == other.runtimeType &&
+          topLeftX == other.topLeftX &&
+          topLeftY == other.topLeftY &&
+          bottomRightX == other.bottomRightX &&
+          bottomRightY == other.bottomRightY &&
+          content == other.content &&
+          tableId == other.tableId;
+
+  @override
+  int get hashCode => Object.hash(
+    type,
+    topLeftX,
+    topLeftY,
+    bottomRightX,
+    bottomRightY,
+    content,
+    tableId,
+  );
+
+  @override
+  String toString() =>
+      'OcrTableBlock(topLeft: ($topLeftX, $topLeftY), '
+      'bottomRight: ($bottomRightX, $bottomRightY), '
+      'content: ${content.length} chars, tableId: $tableId)';
+}
+
+/// Image block extracted from a document page.
+@immutable
+class OcrImageBlock extends OcrBlock {
+  /// The structural label of the block (`image`).
+  @override
+  String get type => 'image';
+
+  /// X coordinate of the top-left corner of the bounding box.
+  final int topLeftX;
+
+  /// Y coordinate of the top-left corner of the bounding box.
+  final int topLeftY;
+
+  /// X coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightX;
+
+  /// Y coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightY;
+
+  /// The extracted content of the block.
+  final String content;
+
+  /// Identifier of the corresponding image in [OcrPage.images].
+  final String imageId;
+
+  /// Creates an [OcrImageBlock].
+  const OcrImageBlock({
+    required this.topLeftX,
+    required this.topLeftY,
+    required this.bottomRightX,
+    required this.bottomRightY,
+    required this.content,
+    required this.imageId,
+  });
+
+  /// Creates an [OcrImageBlock] from JSON.
+  ///
+  /// Throws a [FormatException] if the `type` discriminator is not `image`,
+  /// or if any required field is missing or null.
+  factory OcrImageBlock.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'image') {
+      throw FormatException(
+        'OcrImageBlock: expected type "image", got "$type"',
+      );
+    }
+    final topLeftX = json['top_left_x'];
+    if (topLeftX is! int) {
+      throw const FormatException(
+        'OcrImageBlock: missing required field "top_left_x"',
+      );
+    }
+    final topLeftY = json['top_left_y'];
+    if (topLeftY is! int) {
+      throw const FormatException(
+        'OcrImageBlock: missing required field "top_left_y"',
+      );
+    }
+    final bottomRightX = json['bottom_right_x'];
+    if (bottomRightX is! int) {
+      throw const FormatException(
+        'OcrImageBlock: missing required field "bottom_right_x"',
+      );
+    }
+    final bottomRightY = json['bottom_right_y'];
+    if (bottomRightY is! int) {
+      throw const FormatException(
+        'OcrImageBlock: missing required field "bottom_right_y"',
+      );
+    }
+    final content = json['content'];
+    if (content is! String) {
+      throw const FormatException(
+        'OcrImageBlock: missing required field "content"',
+      );
+    }
+    final imageId = json['image_id'];
+    if (imageId is! String) {
+      throw const FormatException(
+        'OcrImageBlock: missing required field "image_id"',
+      );
+    }
+    return OcrImageBlock(
+      topLeftX: topLeftX,
+      topLeftY: topLeftY,
+      bottomRightX: bottomRightX,
+      bottomRightY: bottomRightY,
+      content: content,
+      imageId: imageId,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'top_left_x': topLeftX,
+    'top_left_y': topLeftY,
+    'bottom_right_x': bottomRightX,
+    'bottom_right_y': bottomRightY,
+    'content': content,
+    'image_id': imageId,
+  };
+
+  /// Creates a copy with the specified fields replaced.
+  OcrImageBlock copyWith({
+    int? topLeftX,
+    int? topLeftY,
+    int? bottomRightX,
+    int? bottomRightY,
+    String? content,
+    String? imageId,
+  }) => OcrImageBlock(
+    topLeftX: topLeftX ?? this.topLeftX,
+    topLeftY: topLeftY ?? this.topLeftY,
+    bottomRightX: bottomRightX ?? this.bottomRightX,
+    bottomRightY: bottomRightY ?? this.bottomRightY,
+    content: content ?? this.content,
+    imageId: imageId ?? this.imageId,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OcrImageBlock &&
+          runtimeType == other.runtimeType &&
+          topLeftX == other.topLeftX &&
+          topLeftY == other.topLeftY &&
+          bottomRightX == other.bottomRightX &&
+          bottomRightY == other.bottomRightY &&
+          content == other.content &&
+          imageId == other.imageId;
+
+  @override
+  int get hashCode => Object.hash(
+    type,
+    topLeftX,
+    topLeftY,
+    bottomRightX,
+    bottomRightY,
+    content,
+    imageId,
+  );
+
+  @override
+  String toString() =>
+      'OcrImageBlock(topLeft: ($topLeftX, $topLeftY), '
+      'bottomRight: ($bottomRightX, $bottomRightY), '
+      'content: ${content.length} chars, imageId: $imageId)';
+}
+
+/// Equation block extracted from a document page.
+@immutable
+class OcrEquationBlock extends OcrBlock {
+  /// The structural label of the block (`equation`).
+  @override
+  String get type => 'equation';
+
+  /// X coordinate of the top-left corner of the bounding box.
+  final int topLeftX;
+
+  /// Y coordinate of the top-left corner of the bounding box.
+  final int topLeftY;
+
+  /// X coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightX;
+
+  /// Y coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightY;
+
+  /// The extracted content of the block.
+  final String content;
+
+  /// Creates an [OcrEquationBlock].
+  const OcrEquationBlock({
+    required this.topLeftX,
+    required this.topLeftY,
+    required this.bottomRightX,
+    required this.bottomRightY,
+    required this.content,
+  });
+
+  /// Creates an [OcrEquationBlock] from JSON.
+  ///
+  /// Throws a [FormatException] if the `type` discriminator is not `equation`,
+  /// or if any required field is missing or null.
+  factory OcrEquationBlock.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'equation') {
+      throw FormatException(
+        'OcrEquationBlock: expected type "equation", got "$type"',
+      );
+    }
+    final topLeftX = json['top_left_x'];
+    if (topLeftX is! int) {
+      throw const FormatException(
+        'OcrEquationBlock: missing required field "top_left_x"',
+      );
+    }
+    final topLeftY = json['top_left_y'];
+    if (topLeftY is! int) {
+      throw const FormatException(
+        'OcrEquationBlock: missing required field "top_left_y"',
+      );
+    }
+    final bottomRightX = json['bottom_right_x'];
+    if (bottomRightX is! int) {
+      throw const FormatException(
+        'OcrEquationBlock: missing required field "bottom_right_x"',
+      );
+    }
+    final bottomRightY = json['bottom_right_y'];
+    if (bottomRightY is! int) {
+      throw const FormatException(
+        'OcrEquationBlock: missing required field "bottom_right_y"',
+      );
+    }
+    final content = json['content'];
+    if (content is! String) {
+      throw const FormatException(
+        'OcrEquationBlock: missing required field "content"',
+      );
+    }
+    return OcrEquationBlock(
+      topLeftX: topLeftX,
+      topLeftY: topLeftY,
+      bottomRightX: bottomRightX,
+      bottomRightY: bottomRightY,
+      content: content,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'top_left_x': topLeftX,
+    'top_left_y': topLeftY,
+    'bottom_right_x': bottomRightX,
+    'bottom_right_y': bottomRightY,
+    'content': content,
+  };
+
+  /// Creates a copy with the specified fields replaced.
+  OcrEquationBlock copyWith({
+    int? topLeftX,
+    int? topLeftY,
+    int? bottomRightX,
+    int? bottomRightY,
+    String? content,
+  }) => OcrEquationBlock(
+    topLeftX: topLeftX ?? this.topLeftX,
+    topLeftY: topLeftY ?? this.topLeftY,
+    bottomRightX: bottomRightX ?? this.bottomRightX,
+    bottomRightY: bottomRightY ?? this.bottomRightY,
+    content: content ?? this.content,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OcrEquationBlock &&
+          runtimeType == other.runtimeType &&
+          topLeftX == other.topLeftX &&
+          topLeftY == other.topLeftY &&
+          bottomRightX == other.bottomRightX &&
+          bottomRightY == other.bottomRightY &&
+          content == other.content;
+
+  @override
+  int get hashCode => Object.hash(
+    type,
+    topLeftX,
+    topLeftY,
+    bottomRightX,
+    bottomRightY,
+    content,
+  );
+
+  @override
+  String toString() =>
+      'OcrEquationBlock(topLeft: ($topLeftX, $topLeftY), '
+      'bottomRight: ($bottomRightX, $bottomRightY), '
+      'content: ${content.length} chars)';
+}
+
+/// Caption block extracted from a document page.
+@immutable
+class OcrCaptionBlock extends OcrBlock {
+  /// The structural label of the block (`caption`).
+  @override
+  String get type => 'caption';
+
+  /// X coordinate of the top-left corner of the bounding box.
+  final int topLeftX;
+
+  /// Y coordinate of the top-left corner of the bounding box.
+  final int topLeftY;
+
+  /// X coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightX;
+
+  /// Y coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightY;
+
+  /// The extracted content of the block.
+  final String content;
+
+  /// Creates an [OcrCaptionBlock].
+  const OcrCaptionBlock({
+    required this.topLeftX,
+    required this.topLeftY,
+    required this.bottomRightX,
+    required this.bottomRightY,
+    required this.content,
+  });
+
+  /// Creates an [OcrCaptionBlock] from JSON.
+  ///
+  /// Throws a [FormatException] if the `type` discriminator is not `caption`,
+  /// or if any required field is missing or null.
+  factory OcrCaptionBlock.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'caption') {
+      throw FormatException(
+        'OcrCaptionBlock: expected type "caption", got "$type"',
+      );
+    }
+    final topLeftX = json['top_left_x'];
+    if (topLeftX is! int) {
+      throw const FormatException(
+        'OcrCaptionBlock: missing required field "top_left_x"',
+      );
+    }
+    final topLeftY = json['top_left_y'];
+    if (topLeftY is! int) {
+      throw const FormatException(
+        'OcrCaptionBlock: missing required field "top_left_y"',
+      );
+    }
+    final bottomRightX = json['bottom_right_x'];
+    if (bottomRightX is! int) {
+      throw const FormatException(
+        'OcrCaptionBlock: missing required field "bottom_right_x"',
+      );
+    }
+    final bottomRightY = json['bottom_right_y'];
+    if (bottomRightY is! int) {
+      throw const FormatException(
+        'OcrCaptionBlock: missing required field "bottom_right_y"',
+      );
+    }
+    final content = json['content'];
+    if (content is! String) {
+      throw const FormatException(
+        'OcrCaptionBlock: missing required field "content"',
+      );
+    }
+    return OcrCaptionBlock(
+      topLeftX: topLeftX,
+      topLeftY: topLeftY,
+      bottomRightX: bottomRightX,
+      bottomRightY: bottomRightY,
+      content: content,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'top_left_x': topLeftX,
+    'top_left_y': topLeftY,
+    'bottom_right_x': bottomRightX,
+    'bottom_right_y': bottomRightY,
+    'content': content,
+  };
+
+  /// Creates a copy with the specified fields replaced.
+  OcrCaptionBlock copyWith({
+    int? topLeftX,
+    int? topLeftY,
+    int? bottomRightX,
+    int? bottomRightY,
+    String? content,
+  }) => OcrCaptionBlock(
+    topLeftX: topLeftX ?? this.topLeftX,
+    topLeftY: topLeftY ?? this.topLeftY,
+    bottomRightX: bottomRightX ?? this.bottomRightX,
+    bottomRightY: bottomRightY ?? this.bottomRightY,
+    content: content ?? this.content,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OcrCaptionBlock &&
+          runtimeType == other.runtimeType &&
+          topLeftX == other.topLeftX &&
+          topLeftY == other.topLeftY &&
+          bottomRightX == other.bottomRightX &&
+          bottomRightY == other.bottomRightY &&
+          content == other.content;
+
+  @override
+  int get hashCode => Object.hash(
+    type,
+    topLeftX,
+    topLeftY,
+    bottomRightX,
+    bottomRightY,
+    content,
+  );
+
+  @override
+  String toString() =>
+      'OcrCaptionBlock(topLeft: ($topLeftX, $topLeftY), '
+      'bottomRight: ($bottomRightX, $bottomRightY), '
+      'content: ${content.length} chars)';
+}
+
+/// Code block extracted from a document page.
+@immutable
+class OcrCodeBlock extends OcrBlock {
+  /// The structural label of the block (`code`).
+  @override
+  String get type => 'code';
+
+  /// X coordinate of the top-left corner of the bounding box.
+  final int topLeftX;
+
+  /// Y coordinate of the top-left corner of the bounding box.
+  final int topLeftY;
+
+  /// X coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightX;
+
+  /// Y coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightY;
+
+  /// The extracted content of the block.
+  final String content;
+
+  /// Creates an [OcrCodeBlock].
+  const OcrCodeBlock({
+    required this.topLeftX,
+    required this.topLeftY,
+    required this.bottomRightX,
+    required this.bottomRightY,
+    required this.content,
+  });
+
+  /// Creates an [OcrCodeBlock] from JSON.
+  ///
+  /// Throws a [FormatException] if the `type` discriminator is not `code`,
+  /// or if any required field is missing or null.
+  factory OcrCodeBlock.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'code') {
+      throw FormatException('OcrCodeBlock: expected type "code", got "$type"');
+    }
+    final topLeftX = json['top_left_x'];
+    if (topLeftX is! int) {
+      throw const FormatException(
+        'OcrCodeBlock: missing required field "top_left_x"',
+      );
+    }
+    final topLeftY = json['top_left_y'];
+    if (topLeftY is! int) {
+      throw const FormatException(
+        'OcrCodeBlock: missing required field "top_left_y"',
+      );
+    }
+    final bottomRightX = json['bottom_right_x'];
+    if (bottomRightX is! int) {
+      throw const FormatException(
+        'OcrCodeBlock: missing required field "bottom_right_x"',
+      );
+    }
+    final bottomRightY = json['bottom_right_y'];
+    if (bottomRightY is! int) {
+      throw const FormatException(
+        'OcrCodeBlock: missing required field "bottom_right_y"',
+      );
+    }
+    final content = json['content'];
+    if (content is! String) {
+      throw const FormatException(
+        'OcrCodeBlock: missing required field "content"',
+      );
+    }
+    return OcrCodeBlock(
+      topLeftX: topLeftX,
+      topLeftY: topLeftY,
+      bottomRightX: bottomRightX,
+      bottomRightY: bottomRightY,
+      content: content,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'top_left_x': topLeftX,
+    'top_left_y': topLeftY,
+    'bottom_right_x': bottomRightX,
+    'bottom_right_y': bottomRightY,
+    'content': content,
+  };
+
+  /// Creates a copy with the specified fields replaced.
+  OcrCodeBlock copyWith({
+    int? topLeftX,
+    int? topLeftY,
+    int? bottomRightX,
+    int? bottomRightY,
+    String? content,
+  }) => OcrCodeBlock(
+    topLeftX: topLeftX ?? this.topLeftX,
+    topLeftY: topLeftY ?? this.topLeftY,
+    bottomRightX: bottomRightX ?? this.bottomRightX,
+    bottomRightY: bottomRightY ?? this.bottomRightY,
+    content: content ?? this.content,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OcrCodeBlock &&
+          runtimeType == other.runtimeType &&
+          topLeftX == other.topLeftX &&
+          topLeftY == other.topLeftY &&
+          bottomRightX == other.bottomRightX &&
+          bottomRightY == other.bottomRightY &&
+          content == other.content;
+
+  @override
+  int get hashCode => Object.hash(
+    type,
+    topLeftX,
+    topLeftY,
+    bottomRightX,
+    bottomRightY,
+    content,
+  );
+
+  @override
+  String toString() =>
+      'OcrCodeBlock(topLeft: ($topLeftX, $topLeftY), '
+      'bottomRight: ($bottomRightX, $bottomRightY), '
+      'content: ${content.length} chars)';
+}
+
+/// References block extracted from a document page.
+@immutable
+class OcrReferencesBlock extends OcrBlock {
+  /// The structural label of the block (`references`).
+  @override
+  String get type => 'references';
+
+  /// X coordinate of the top-left corner of the bounding box.
+  final int topLeftX;
+
+  /// Y coordinate of the top-left corner of the bounding box.
+  final int topLeftY;
+
+  /// X coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightX;
+
+  /// Y coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightY;
+
+  /// The extracted content of the block.
+  final String content;
+
+  /// Creates an [OcrReferencesBlock].
+  const OcrReferencesBlock({
+    required this.topLeftX,
+    required this.topLeftY,
+    required this.bottomRightX,
+    required this.bottomRightY,
+    required this.content,
+  });
+
+  /// Creates an [OcrReferencesBlock] from JSON.
+  ///
+  /// Throws a [FormatException] if the `type` discriminator is not `references`,
+  /// or if any required field is missing or null.
+  factory OcrReferencesBlock.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'references') {
+      throw FormatException(
+        'OcrReferencesBlock: expected type "references", got "$type"',
+      );
+    }
+    final topLeftX = json['top_left_x'];
+    if (topLeftX is! int) {
+      throw const FormatException(
+        'OcrReferencesBlock: missing required field "top_left_x"',
+      );
+    }
+    final topLeftY = json['top_left_y'];
+    if (topLeftY is! int) {
+      throw const FormatException(
+        'OcrReferencesBlock: missing required field "top_left_y"',
+      );
+    }
+    final bottomRightX = json['bottom_right_x'];
+    if (bottomRightX is! int) {
+      throw const FormatException(
+        'OcrReferencesBlock: missing required field "bottom_right_x"',
+      );
+    }
+    final bottomRightY = json['bottom_right_y'];
+    if (bottomRightY is! int) {
+      throw const FormatException(
+        'OcrReferencesBlock: missing required field "bottom_right_y"',
+      );
+    }
+    final content = json['content'];
+    if (content is! String) {
+      throw const FormatException(
+        'OcrReferencesBlock: missing required field "content"',
+      );
+    }
+    return OcrReferencesBlock(
+      topLeftX: topLeftX,
+      topLeftY: topLeftY,
+      bottomRightX: bottomRightX,
+      bottomRightY: bottomRightY,
+      content: content,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'top_left_x': topLeftX,
+    'top_left_y': topLeftY,
+    'bottom_right_x': bottomRightX,
+    'bottom_right_y': bottomRightY,
+    'content': content,
+  };
+
+  /// Creates a copy with the specified fields replaced.
+  OcrReferencesBlock copyWith({
+    int? topLeftX,
+    int? topLeftY,
+    int? bottomRightX,
+    int? bottomRightY,
+    String? content,
+  }) => OcrReferencesBlock(
+    topLeftX: topLeftX ?? this.topLeftX,
+    topLeftY: topLeftY ?? this.topLeftY,
+    bottomRightX: bottomRightX ?? this.bottomRightX,
+    bottomRightY: bottomRightY ?? this.bottomRightY,
+    content: content ?? this.content,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OcrReferencesBlock &&
+          runtimeType == other.runtimeType &&
+          topLeftX == other.topLeftX &&
+          topLeftY == other.topLeftY &&
+          bottomRightX == other.bottomRightX &&
+          bottomRightY == other.bottomRightY &&
+          content == other.content;
+
+  @override
+  int get hashCode => Object.hash(
+    type,
+    topLeftX,
+    topLeftY,
+    bottomRightX,
+    bottomRightY,
+    content,
+  );
+
+  @override
+  String toString() =>
+      'OcrReferencesBlock(topLeft: ($topLeftX, $topLeftY), '
+      'bottomRight: ($bottomRightX, $bottomRightY), '
+      'content: ${content.length} chars)';
+}
+
+/// Aside text block extracted from a document page.
+@immutable
+class OcrAsideTextBlock extends OcrBlock {
+  /// The structural label of the block (`aside_text`).
+  @override
+  String get type => 'aside_text';
+
+  /// X coordinate of the top-left corner of the bounding box.
+  final int topLeftX;
+
+  /// Y coordinate of the top-left corner of the bounding box.
+  final int topLeftY;
+
+  /// X coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightX;
+
+  /// Y coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightY;
+
+  /// The extracted content of the block.
+  final String content;
+
+  /// Creates an [OcrAsideTextBlock].
+  const OcrAsideTextBlock({
+    required this.topLeftX,
+    required this.topLeftY,
+    required this.bottomRightX,
+    required this.bottomRightY,
+    required this.content,
+  });
+
+  /// Creates an [OcrAsideTextBlock] from JSON.
+  ///
+  /// Throws a [FormatException] if the `type` discriminator is not `aside_text`,
+  /// or if any required field is missing or null.
+  factory OcrAsideTextBlock.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'aside_text') {
+      throw FormatException(
+        'OcrAsideTextBlock: expected type "aside_text", got "$type"',
+      );
+    }
+    final topLeftX = json['top_left_x'];
+    if (topLeftX is! int) {
+      throw const FormatException(
+        'OcrAsideTextBlock: missing required field "top_left_x"',
+      );
+    }
+    final topLeftY = json['top_left_y'];
+    if (topLeftY is! int) {
+      throw const FormatException(
+        'OcrAsideTextBlock: missing required field "top_left_y"',
+      );
+    }
+    final bottomRightX = json['bottom_right_x'];
+    if (bottomRightX is! int) {
+      throw const FormatException(
+        'OcrAsideTextBlock: missing required field "bottom_right_x"',
+      );
+    }
+    final bottomRightY = json['bottom_right_y'];
+    if (bottomRightY is! int) {
+      throw const FormatException(
+        'OcrAsideTextBlock: missing required field "bottom_right_y"',
+      );
+    }
+    final content = json['content'];
+    if (content is! String) {
+      throw const FormatException(
+        'OcrAsideTextBlock: missing required field "content"',
+      );
+    }
+    return OcrAsideTextBlock(
+      topLeftX: topLeftX,
+      topLeftY: topLeftY,
+      bottomRightX: bottomRightX,
+      bottomRightY: bottomRightY,
+      content: content,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'top_left_x': topLeftX,
+    'top_left_y': topLeftY,
+    'bottom_right_x': bottomRightX,
+    'bottom_right_y': bottomRightY,
+    'content': content,
+  };
+
+  /// Creates a copy with the specified fields replaced.
+  OcrAsideTextBlock copyWith({
+    int? topLeftX,
+    int? topLeftY,
+    int? bottomRightX,
+    int? bottomRightY,
+    String? content,
+  }) => OcrAsideTextBlock(
+    topLeftX: topLeftX ?? this.topLeftX,
+    topLeftY: topLeftY ?? this.topLeftY,
+    bottomRightX: bottomRightX ?? this.bottomRightX,
+    bottomRightY: bottomRightY ?? this.bottomRightY,
+    content: content ?? this.content,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OcrAsideTextBlock &&
+          runtimeType == other.runtimeType &&
+          topLeftX == other.topLeftX &&
+          topLeftY == other.topLeftY &&
+          bottomRightX == other.bottomRightX &&
+          bottomRightY == other.bottomRightY &&
+          content == other.content;
+
+  @override
+  int get hashCode => Object.hash(
+    type,
+    topLeftX,
+    topLeftY,
+    bottomRightX,
+    bottomRightY,
+    content,
+  );
+
+  @override
+  String toString() =>
+      'OcrAsideTextBlock(topLeft: ($topLeftX, $topLeftY), '
+      'bottomRight: ($bottomRightX, $bottomRightY), '
+      'content: ${content.length} chars)';
+}
+
+/// Header block extracted from a document page.
+@immutable
+class OcrHeaderBlock extends OcrBlock {
+  /// The structural label of the block (`header`).
+  @override
+  String get type => 'header';
+
+  /// X coordinate of the top-left corner of the bounding box.
+  final int topLeftX;
+
+  /// Y coordinate of the top-left corner of the bounding box.
+  final int topLeftY;
+
+  /// X coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightX;
+
+  /// Y coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightY;
+
+  /// The extracted content of the block.
+  final String content;
+
+  /// Creates an [OcrHeaderBlock].
+  const OcrHeaderBlock({
+    required this.topLeftX,
+    required this.topLeftY,
+    required this.bottomRightX,
+    required this.bottomRightY,
+    required this.content,
+  });
+
+  /// Creates an [OcrHeaderBlock] from JSON.
+  ///
+  /// Throws a [FormatException] if the `type` discriminator is not `header`,
+  /// or if any required field is missing or null.
+  factory OcrHeaderBlock.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'header') {
+      throw FormatException(
+        'OcrHeaderBlock: expected type "header", got "$type"',
+      );
+    }
+    final topLeftX = json['top_left_x'];
+    if (topLeftX is! int) {
+      throw const FormatException(
+        'OcrHeaderBlock: missing required field "top_left_x"',
+      );
+    }
+    final topLeftY = json['top_left_y'];
+    if (topLeftY is! int) {
+      throw const FormatException(
+        'OcrHeaderBlock: missing required field "top_left_y"',
+      );
+    }
+    final bottomRightX = json['bottom_right_x'];
+    if (bottomRightX is! int) {
+      throw const FormatException(
+        'OcrHeaderBlock: missing required field "bottom_right_x"',
+      );
+    }
+    final bottomRightY = json['bottom_right_y'];
+    if (bottomRightY is! int) {
+      throw const FormatException(
+        'OcrHeaderBlock: missing required field "bottom_right_y"',
+      );
+    }
+    final content = json['content'];
+    if (content is! String) {
+      throw const FormatException(
+        'OcrHeaderBlock: missing required field "content"',
+      );
+    }
+    return OcrHeaderBlock(
+      topLeftX: topLeftX,
+      topLeftY: topLeftY,
+      bottomRightX: bottomRightX,
+      bottomRightY: bottomRightY,
+      content: content,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'top_left_x': topLeftX,
+    'top_left_y': topLeftY,
+    'bottom_right_x': bottomRightX,
+    'bottom_right_y': bottomRightY,
+    'content': content,
+  };
+
+  /// Creates a copy with the specified fields replaced.
+  OcrHeaderBlock copyWith({
+    int? topLeftX,
+    int? topLeftY,
+    int? bottomRightX,
+    int? bottomRightY,
+    String? content,
+  }) => OcrHeaderBlock(
+    topLeftX: topLeftX ?? this.topLeftX,
+    topLeftY: topLeftY ?? this.topLeftY,
+    bottomRightX: bottomRightX ?? this.bottomRightX,
+    bottomRightY: bottomRightY ?? this.bottomRightY,
+    content: content ?? this.content,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OcrHeaderBlock &&
+          runtimeType == other.runtimeType &&
+          topLeftX == other.topLeftX &&
+          topLeftY == other.topLeftY &&
+          bottomRightX == other.bottomRightX &&
+          bottomRightY == other.bottomRightY &&
+          content == other.content;
+
+  @override
+  int get hashCode => Object.hash(
+    type,
+    topLeftX,
+    topLeftY,
+    bottomRightX,
+    bottomRightY,
+    content,
+  );
+
+  @override
+  String toString() =>
+      'OcrHeaderBlock(topLeft: ($topLeftX, $topLeftY), '
+      'bottomRight: ($bottomRightX, $bottomRightY), '
+      'content: ${content.length} chars)';
+}
+
+/// Footer block extracted from a document page.
+@immutable
+class OcrFooterBlock extends OcrBlock {
+  /// The structural label of the block (`footer`).
+  @override
+  String get type => 'footer';
+
+  /// X coordinate of the top-left corner of the bounding box.
+  final int topLeftX;
+
+  /// Y coordinate of the top-left corner of the bounding box.
+  final int topLeftY;
+
+  /// X coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightX;
+
+  /// Y coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightY;
+
+  /// The extracted content of the block.
+  final String content;
+
+  /// Creates an [OcrFooterBlock].
+  const OcrFooterBlock({
+    required this.topLeftX,
+    required this.topLeftY,
+    required this.bottomRightX,
+    required this.bottomRightY,
+    required this.content,
+  });
+
+  /// Creates an [OcrFooterBlock] from JSON.
+  ///
+  /// Throws a [FormatException] if the `type` discriminator is not `footer`,
+  /// or if any required field is missing or null.
+  factory OcrFooterBlock.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'footer') {
+      throw FormatException(
+        'OcrFooterBlock: expected type "footer", got "$type"',
+      );
+    }
+    final topLeftX = json['top_left_x'];
+    if (topLeftX is! int) {
+      throw const FormatException(
+        'OcrFooterBlock: missing required field "top_left_x"',
+      );
+    }
+    final topLeftY = json['top_left_y'];
+    if (topLeftY is! int) {
+      throw const FormatException(
+        'OcrFooterBlock: missing required field "top_left_y"',
+      );
+    }
+    final bottomRightX = json['bottom_right_x'];
+    if (bottomRightX is! int) {
+      throw const FormatException(
+        'OcrFooterBlock: missing required field "bottom_right_x"',
+      );
+    }
+    final bottomRightY = json['bottom_right_y'];
+    if (bottomRightY is! int) {
+      throw const FormatException(
+        'OcrFooterBlock: missing required field "bottom_right_y"',
+      );
+    }
+    final content = json['content'];
+    if (content is! String) {
+      throw const FormatException(
+        'OcrFooterBlock: missing required field "content"',
+      );
+    }
+    return OcrFooterBlock(
+      topLeftX: topLeftX,
+      topLeftY: topLeftY,
+      bottomRightX: bottomRightX,
+      bottomRightY: bottomRightY,
+      content: content,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'top_left_x': topLeftX,
+    'top_left_y': topLeftY,
+    'bottom_right_x': bottomRightX,
+    'bottom_right_y': bottomRightY,
+    'content': content,
+  };
+
+  /// Creates a copy with the specified fields replaced.
+  OcrFooterBlock copyWith({
+    int? topLeftX,
+    int? topLeftY,
+    int? bottomRightX,
+    int? bottomRightY,
+    String? content,
+  }) => OcrFooterBlock(
+    topLeftX: topLeftX ?? this.topLeftX,
+    topLeftY: topLeftY ?? this.topLeftY,
+    bottomRightX: bottomRightX ?? this.bottomRightX,
+    bottomRightY: bottomRightY ?? this.bottomRightY,
+    content: content ?? this.content,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OcrFooterBlock &&
+          runtimeType == other.runtimeType &&
+          topLeftX == other.topLeftX &&
+          topLeftY == other.topLeftY &&
+          bottomRightX == other.bottomRightX &&
+          bottomRightY == other.bottomRightY &&
+          content == other.content;
+
+  @override
+  int get hashCode => Object.hash(
+    type,
+    topLeftX,
+    topLeftY,
+    bottomRightX,
+    bottomRightY,
+    content,
+  );
+
+  @override
+  String toString() =>
+      'OcrFooterBlock(topLeft: ($topLeftX, $topLeftY), '
+      'bottomRight: ($bottomRightX, $bottomRightY), '
+      'content: ${content.length} chars)';
+}
+
+/// Signature block extracted from a document page.
+@immutable
+class OcrSignatureBlock extends OcrBlock {
+  /// The structural label of the block (`signature`).
+  @override
+  String get type => 'signature';
+
+  /// X coordinate of the top-left corner of the bounding box.
+  final int topLeftX;
+
+  /// Y coordinate of the top-left corner of the bounding box.
+  final int topLeftY;
+
+  /// X coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightX;
+
+  /// Y coordinate of the bottom-right corner of the bounding box.
+  final int bottomRightY;
+
+  /// The extracted content of the block.
+  final String content;
+
+  /// Creates an [OcrSignatureBlock].
+  const OcrSignatureBlock({
+    required this.topLeftX,
+    required this.topLeftY,
+    required this.bottomRightX,
+    required this.bottomRightY,
+    required this.content,
+  });
+
+  /// Creates an [OcrSignatureBlock] from JSON.
+  ///
+  /// Throws a [FormatException] if the `type` discriminator is not `signature`,
+  /// or if any required field is missing or null.
+  factory OcrSignatureBlock.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'signature') {
+      throw FormatException(
+        'OcrSignatureBlock: expected type "signature", got "$type"',
+      );
+    }
+    final topLeftX = json['top_left_x'];
+    if (topLeftX is! int) {
+      throw const FormatException(
+        'OcrSignatureBlock: missing required field "top_left_x"',
+      );
+    }
+    final topLeftY = json['top_left_y'];
+    if (topLeftY is! int) {
+      throw const FormatException(
+        'OcrSignatureBlock: missing required field "top_left_y"',
+      );
+    }
+    final bottomRightX = json['bottom_right_x'];
+    if (bottomRightX is! int) {
+      throw const FormatException(
+        'OcrSignatureBlock: missing required field "bottom_right_x"',
+      );
+    }
+    final bottomRightY = json['bottom_right_y'];
+    if (bottomRightY is! int) {
+      throw const FormatException(
+        'OcrSignatureBlock: missing required field "bottom_right_y"',
+      );
+    }
+    final content = json['content'];
+    if (content is! String) {
+      throw const FormatException(
+        'OcrSignatureBlock: missing required field "content"',
+      );
+    }
+    return OcrSignatureBlock(
+      topLeftX: topLeftX,
+      topLeftY: topLeftY,
+      bottomRightX: bottomRightX,
+      bottomRightY: bottomRightY,
+      content: content,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'top_left_x': topLeftX,
+    'top_left_y': topLeftY,
+    'bottom_right_x': bottomRightX,
+    'bottom_right_y': bottomRightY,
+    'content': content,
+  };
+
+  /// Creates a copy with the specified fields replaced.
+  OcrSignatureBlock copyWith({
+    int? topLeftX,
+    int? topLeftY,
+    int? bottomRightX,
+    int? bottomRightY,
+    String? content,
+  }) => OcrSignatureBlock(
+    topLeftX: topLeftX ?? this.topLeftX,
+    topLeftY: topLeftY ?? this.topLeftY,
+    bottomRightX: bottomRightX ?? this.bottomRightX,
+    bottomRightY: bottomRightY ?? this.bottomRightY,
+    content: content ?? this.content,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OcrSignatureBlock &&
+          runtimeType == other.runtimeType &&
+          topLeftX == other.topLeftX &&
+          topLeftY == other.topLeftY &&
+          bottomRightX == other.bottomRightX &&
+          bottomRightY == other.bottomRightY &&
+          content == other.content;
+
+  @override
+  int get hashCode => Object.hash(
+    type,
+    topLeftX,
+    topLeftY,
+    bottomRightX,
+    bottomRightY,
+    content,
+  );
+
+  @override
+  String toString() =>
+      'OcrSignatureBlock(topLeft: ($topLeftX, $topLeftY), '
+      'bottomRight: ($bottomRightX, $bottomRightY), '
+      'content: ${content.length} chars)';
+}
+
+/// Fallback block for an unrecognized `type`, preserving the raw JSON.
+///
+/// Ensures forward compatibility when the API introduces new block types.
+@immutable
+class UnknownOcrBlock extends OcrBlock {
+  /// Creates an [UnknownOcrBlock] wrapping the raw JSON map.
+  UnknownOcrBlock(Map<String, dynamic> raw)
+    : _raw = Map<String, dynamic>.unmodifiable(raw);
+
+  final Map<String, dynamic> _raw;
+
+  /// The raw JSON data for the unrecognized block.
+  Map<String, dynamic> get raw => _raw;
+
+  @override
+  String get type {
+    final rawType = _raw['type'];
+    return rawType is String ? rawType : 'unknown';
+  }
+
+  @override
+  Map<String, dynamic> toJson() => Map<String, dynamic>.of(_raw);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnknownOcrBlock &&
+          runtimeType == other.runtimeType &&
+          mapsDeepEqual(_raw, other._raw);
+
+  @override
+  int get hashCode => mapDeepHashCode(_raw);
+
+  @override
+  String toString() => 'UnknownOcrBlock(type: $type)';
+}

--- a/packages/mistralai_dart/lib/src/models/ocr/ocr_page.dart
+++ b/packages/mistralai_dart/lib/src/models/ocr/ocr_page.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../common/copy_with_sentinel.dart';
 import '../common/equality_helpers.dart';
+import 'ocr_block.dart';
 import 'ocr_image.dart';
 import 'ocr_page_confidence_scores.dart';
 import 'ocr_page_dimensions.dart';
@@ -45,6 +46,12 @@ class OcrPage {
   /// [OcrConfidenceScoresGranularity.page]); `null` otherwise.
   final OcrPageConfidenceScores? confidenceScores;
 
+  /// Paragraph-level content blocks with bounding boxes, in reading order.
+  ///
+  /// Populated when [OcrRequest.includeBlocks] is set to `true` in the request;
+  /// `null` otherwise.
+  final List<OcrBlock>? blocks;
+
   /// Creates an [OcrPage].
   const OcrPage({
     required this.index,
@@ -56,6 +63,7 @@ class OcrPage {
     this.footer,
     this.hyperlinks = const [],
     this.confidenceScores,
+    this.blocks,
   });
 
   /// Creates an [OcrPage] from JSON.
@@ -83,6 +91,9 @@ class OcrPage {
             json['confidence_scores'] as Map<String, dynamic>,
           )
         : null,
+    blocks: (json['blocks'] as List?)
+        ?.map((e) => OcrBlock.fromJson(e as Map<String, dynamic>))
+        .toList(),
   );
 
   /// Converts to JSON.
@@ -97,6 +108,7 @@ class OcrPage {
     if (hyperlinks.isNotEmpty) 'hyperlinks': hyperlinks,
     if (confidenceScores != null)
       'confidence_scores': confidenceScores!.toJson(),
+    if (blocks != null) 'blocks': blocks!.map((e) => e.toJson()).toList(),
   };
 
   /// Creates a copy with the specified fields replaced.
@@ -112,6 +124,7 @@ class OcrPage {
     Object? footer = unsetCopyWithValue,
     List<String>? hyperlinks,
     Object? confidenceScores = unsetCopyWithValue,
+    Object? blocks = unsetCopyWithValue,
   }) => OcrPage(
     index: index ?? this.index,
     markdown: markdown ?? this.markdown,
@@ -126,6 +139,9 @@ class OcrPage {
     confidenceScores: confidenceScores == unsetCopyWithValue
         ? this.confidenceScores
         : confidenceScores as OcrPageConfidenceScores?,
+    blocks: blocks == unsetCopyWithValue
+        ? this.blocks
+        : blocks as List<OcrBlock>?,
   );
 
   @override
@@ -141,7 +157,8 @@ class OcrPage {
           header == other.header &&
           footer == other.footer &&
           listsEqual(hyperlinks, other.hyperlinks) &&
-          confidenceScores == other.confidenceScores;
+          confidenceScores == other.confidenceScores &&
+          listsEqual(blocks, other.blocks);
 
   @override
   int get hashCode => Object.hash(
@@ -154,6 +171,7 @@ class OcrPage {
     footer,
     listHash(hyperlinks),
     confidenceScores,
+    listHash(blocks),
   );
 
   @override

--- a/packages/mistralai_dart/lib/src/models/ocr/ocr_pages.dart
+++ b/packages/mistralai_dart/lib/src/models/ocr/ocr_pages.dart
@@ -1,0 +1,110 @@
+import 'package:meta/meta.dart';
+
+/// Selection of pages to process in an OCR request.
+///
+/// The OCR API accepts pages either as:
+/// - [OcrPagesList]: an explicit list of 0-indexed page numbers, or
+/// - [OcrPagesString]: a string of comma-separated numbers and ranges
+///   (e.g. `'0,1,2'`, `'0-5'`, or `'0,2-4'`).
+///
+/// ## Example
+///
+/// ```dart
+/// // Explicit page numbers
+/// final list = OcrPages.list([0, 1, 2]);
+///
+/// // Comma-separated numbers and ranges
+/// final range = OcrPages.string('0,2-4');
+/// ```
+@immutable
+sealed class OcrPages {
+  const OcrPages();
+
+  /// Creates [OcrPages] from JSON.
+  ///
+  /// Accepts either a [String] or a [List] of integers.
+  ///
+  /// Throws a [FormatException] if the value is neither, or if a list element
+  /// is not an integer.
+  factory OcrPages.fromJson(Object json) {
+    if (json is String) return OcrPagesString(json);
+    if (json is List) {
+      return OcrPagesList(
+        json.map((e) {
+          if (e is int) return e;
+          throw FormatException(
+            'Expected int in pages list, got ${e.runtimeType}',
+          );
+        }).toList(),
+      );
+    }
+    throw FormatException(
+      'Expected String or List<int> for OcrPages, got ${json.runtimeType}',
+    );
+  }
+
+  /// Creates pages from a comma-separated string of numbers and ranges.
+  const factory OcrPages.string(String value) = OcrPagesString;
+
+  /// Creates pages from an explicit list of 0-indexed page numbers.
+  const factory OcrPages.list(List<int> values) = OcrPagesList;
+
+  /// Converts to the JSON format expected by the API.
+  Object toJson();
+}
+
+/// A comma-separated string of page numbers and ranges (e.g. `'0,2-4'`).
+@immutable
+class OcrPagesString extends OcrPages {
+  /// Creates an [OcrPagesString].
+  const OcrPagesString(this.value);
+
+  /// The comma-separated page selection (numbers and ranges).
+  final String value;
+
+  @override
+  Object toJson() => value;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is OcrPagesString &&
+          runtimeType == other.runtimeType &&
+          value == other.value;
+
+  @override
+  int get hashCode => value.hashCode;
+
+  @override
+  String toString() => 'OcrPagesString($value)';
+}
+
+/// An explicit list of 0-indexed page numbers.
+@immutable
+class OcrPagesList extends OcrPages {
+  /// Creates an [OcrPagesList].
+  const OcrPagesList(this.values);
+
+  /// The 0-indexed page numbers to process.
+  final List<int> values;
+
+  @override
+  Object toJson() => values;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other is! OcrPagesList) return false;
+    if (values.length != other.values.length) return false;
+    for (var i = 0; i < values.length; i++) {
+      if (values[i] != other.values[i]) return false;
+    }
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hashAll(values);
+
+  @override
+  String toString() => 'OcrPagesList(${values.length} pages)';
+}

--- a/packages/mistralai_dart/lib/src/models/ocr/ocr_request.dart
+++ b/packages/mistralai_dart/lib/src/models/ocr/ocr_request.dart
@@ -1,10 +1,10 @@
 import 'package:meta/meta.dart';
 
 import '../common/copy_with_sentinel.dart';
-import '../common/equality_helpers.dart';
 import '../metadata/response_format.dart';
 import 'ocr_confidence_scores_granularity.dart';
 import 'ocr_document.dart';
+import 'ocr_pages.dart';
 import 'ocr_table_format.dart';
 
 /// Request to process a document with OCR.
@@ -18,15 +18,23 @@ class OcrRequest {
   /// The document to process.
   final OcrDocument document;
 
-  /// Specific pages to process (0-indexed).
+  /// Specific pages to process.
   ///
-  /// If null, all pages are processed.
-  final List<int>? pages;
+  /// Accepts an explicit list of 0-indexed page numbers ([OcrPages.list]) or a
+  /// comma-separated string of numbers and ranges ([OcrPages.string], e.g.
+  /// `'0,2-4'`). If null, all pages are processed.
+  final OcrPages? pages;
 
   /// Whether to include image base64 data in the response.
   ///
   /// Defaults to false.
   final bool? includeImageBase64;
+
+  /// Whether to return paragraph-level bounding boxes for all content blocks.
+  ///
+  /// When `true`, each processed [OcrPage] includes a `blocks` list of
+  /// [OcrBlock]s in reading order. Defaults to false.
+  final bool? includeBlocks;
 
   /// Image limits for processing.
   final int? imageLimit;
@@ -67,6 +75,7 @@ class OcrRequest {
     required this.document,
     this.pages,
     this.includeImageBase64,
+    this.includeBlocks,
     this.imageLimit,
     this.imageMinSize,
     this.documentAnnotationPrompt,
@@ -82,26 +91,30 @@ class OcrRequest {
   factory OcrRequest.fromUrl({
     String model = 'mistral-ocr-latest',
     required String url,
-    List<int>? pages,
+    OcrPages? pages,
     bool? includeImageBase64,
+    bool? includeBlocks,
   }) => OcrRequest(
     model: model,
     document: OcrDocument.url(url),
     pages: pages,
     includeImageBase64: includeImageBase64,
+    includeBlocks: includeBlocks,
   );
 
   /// Creates an [OcrRequest] from a file ID.
   factory OcrRequest.fromFile({
     String model = 'mistral-ocr-latest',
     required String fileId,
-    List<int>? pages,
+    OcrPages? pages,
     bool? includeImageBase64,
+    bool? includeBlocks,
   }) => OcrRequest(
     model: model,
     document: OcrDocument.file(fileId),
     pages: pages,
     includeImageBase64: includeImageBase64,
+    includeBlocks: includeBlocks,
   );
 
   /// Creates an [OcrRequest] from base64-encoded data.
@@ -109,21 +122,26 @@ class OcrRequest {
     String model = 'mistral-ocr-latest',
     required String data,
     required String mimeType,
-    List<int>? pages,
+    OcrPages? pages,
     bool? includeImageBase64,
+    bool? includeBlocks,
   }) => OcrRequest(
     model: model,
     document: OcrDocument.base64(data: data, mimeType: mimeType),
     pages: pages,
     includeImageBase64: includeImageBase64,
+    includeBlocks: includeBlocks,
   );
 
   /// Creates an [OcrRequest] from JSON.
   factory OcrRequest.fromJson(Map<String, dynamic> json) => OcrRequest(
     model: json['model'] as String? ?? 'mistral-ocr-latest',
     document: OcrDocument.fromJson(json['document'] as Map<String, dynamic>),
-    pages: (json['pages'] as List?)?.cast<int>(),
+    pages: json['pages'] != null
+        ? OcrPages.fromJson(json['pages'] as Object)
+        : null,
     includeImageBase64: json['include_image_base64'] as bool?,
+    includeBlocks: json['include_blocks'] as bool?,
     imageLimit: json['image_limit'] as int?,
     imageMinSize: json['image_min_size'] as int?,
     documentAnnotationPrompt: json['document_annotation_prompt'] as String?,
@@ -149,8 +167,9 @@ class OcrRequest {
   Map<String, dynamic> toJson() => {
     'model': model,
     'document': document.toJson(),
-    if (pages != null) 'pages': pages,
+    if (pages != null) 'pages': pages!.toJson(),
     if (includeImageBase64 != null) 'include_image_base64': includeImageBase64,
+    if (includeBlocks != null) 'include_blocks': includeBlocks,
     if (imageLimit != null) 'image_limit': imageLimit,
     if (imageMinSize != null) 'image_min_size': imageMinSize,
     if (documentAnnotationPrompt != null)
@@ -174,6 +193,7 @@ class OcrRequest {
     OcrDocument? document,
     Object? pages = unsetCopyWithValue,
     Object? includeImageBase64 = unsetCopyWithValue,
+    Object? includeBlocks = unsetCopyWithValue,
     Object? imageLimit = unsetCopyWithValue,
     Object? imageMinSize = unsetCopyWithValue,
     Object? documentAnnotationPrompt = unsetCopyWithValue,
@@ -186,10 +206,13 @@ class OcrRequest {
   }) => OcrRequest(
     model: model ?? this.model,
     document: document ?? this.document,
-    pages: pages == unsetCopyWithValue ? this.pages : pages as List<int>?,
+    pages: pages == unsetCopyWithValue ? this.pages : pages as OcrPages?,
     includeImageBase64: includeImageBase64 == unsetCopyWithValue
         ? this.includeImageBase64
         : includeImageBase64 as bool?,
+    includeBlocks: includeBlocks == unsetCopyWithValue
+        ? this.includeBlocks
+        : includeBlocks as bool?,
     imageLimit: imageLimit == unsetCopyWithValue
         ? this.imageLimit
         : imageLimit as int?,
@@ -227,8 +250,9 @@ class OcrRequest {
           runtimeType == other.runtimeType &&
           model == other.model &&
           document == other.document &&
-          listsEqual(pages, other.pages) &&
+          pages == other.pages &&
           includeImageBase64 == other.includeImageBase64 &&
+          includeBlocks == other.includeBlocks &&
           imageLimit == other.imageLimit &&
           imageMinSize == other.imageMinSize &&
           documentAnnotationPrompt == other.documentAnnotationPrompt &&
@@ -243,8 +267,9 @@ class OcrRequest {
   int get hashCode => Object.hash(
     model,
     document,
-    listHash(pages),
+    pages,
     includeImageBase64,
+    includeBlocks,
     imageLimit,
     imageMinSize,
     documentAnnotationPrompt,

--- a/packages/mistralai_dart/specs/openapi.json
+++ b/packages/mistralai_dart/specs/openapi.json
@@ -16051,6 +16051,141 @@
         "title": "OAuth2TokenAuth",
         "type": "object"
       },
+      "OCRAsideTextBlock": {
+        "type": "object",
+        "properties": {
+          "top_left_x": {
+            "type": "integer",
+            "title": "Top Left X",
+            "minimum": 0
+          },
+          "top_left_y": {
+            "type": "integer",
+            "title": "Top Left Y",
+            "minimum": 0
+          },
+          "bottom_right_x": {
+            "type": "integer",
+            "title": "Bottom Right X",
+            "minimum": 0
+          },
+          "bottom_right_y": {
+            "type": "integer",
+            "title": "Bottom Right Y",
+            "minimum": 0
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "description": "Text/markdown/html content of this block"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "default": "aside_text",
+            "const": "aside_text"
+          }
+        },
+        "title": "OCRAsideTextBlock",
+        "required": [
+          "top_left_x",
+          "top_left_y",
+          "bottom_right_x",
+          "bottom_right_y",
+          "content"
+        ],
+        "additionalProperties": false
+      },
+      "OCRCaptionBlock": {
+        "type": "object",
+        "properties": {
+          "top_left_x": {
+            "type": "integer",
+            "title": "Top Left X",
+            "minimum": 0
+          },
+          "top_left_y": {
+            "type": "integer",
+            "title": "Top Left Y",
+            "minimum": 0
+          },
+          "bottom_right_x": {
+            "type": "integer",
+            "title": "Bottom Right X",
+            "minimum": 0
+          },
+          "bottom_right_y": {
+            "type": "integer",
+            "title": "Bottom Right Y",
+            "minimum": 0
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "description": "Text/markdown/html content of this block"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "default": "caption",
+            "const": "caption"
+          }
+        },
+        "title": "OCRCaptionBlock",
+        "required": [
+          "top_left_x",
+          "top_left_y",
+          "bottom_right_x",
+          "bottom_right_y",
+          "content"
+        ],
+        "additionalProperties": false
+      },
+      "OCRCodeBlock": {
+        "type": "object",
+        "properties": {
+          "top_left_x": {
+            "type": "integer",
+            "title": "Top Left X",
+            "minimum": 0
+          },
+          "top_left_y": {
+            "type": "integer",
+            "title": "Top Left Y",
+            "minimum": 0
+          },
+          "bottom_right_x": {
+            "type": "integer",
+            "title": "Bottom Right X",
+            "minimum": 0
+          },
+          "bottom_right_y": {
+            "type": "integer",
+            "title": "Bottom Right Y",
+            "minimum": 0
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "description": "Text/markdown/html content of this block"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "default": "code",
+            "const": "code"
+          }
+        },
+        "title": "OCRCodeBlock",
+        "required": [
+          "top_left_x",
+          "top_left_y",
+          "bottom_right_x",
+          "bottom_right_y",
+          "content"
+        ],
+        "additionalProperties": false
+      },
       "OCRConfidenceScore": {
         "additionalProperties": false,
         "description": "Confidence score for a token or word in OCR output.",
@@ -16081,6 +16216,192 @@
         ],
         "title": "OCRConfidenceScore",
         "type": "object"
+      },
+      "OCREquationBlock": {
+        "type": "object",
+        "properties": {
+          "top_left_x": {
+            "type": "integer",
+            "title": "Top Left X",
+            "minimum": 0
+          },
+          "top_left_y": {
+            "type": "integer",
+            "title": "Top Left Y",
+            "minimum": 0
+          },
+          "bottom_right_x": {
+            "type": "integer",
+            "title": "Bottom Right X",
+            "minimum": 0
+          },
+          "bottom_right_y": {
+            "type": "integer",
+            "title": "Bottom Right Y",
+            "minimum": 0
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "description": "Text/markdown/html content of this block"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "default": "equation",
+            "const": "equation"
+          }
+        },
+        "title": "OCREquationBlock",
+        "required": [
+          "top_left_x",
+          "top_left_y",
+          "bottom_right_x",
+          "bottom_right_y",
+          "content"
+        ],
+        "additionalProperties": false
+      },
+      "OCRFooterBlock": {
+        "type": "object",
+        "properties": {
+          "top_left_x": {
+            "type": "integer",
+            "title": "Top Left X",
+            "minimum": 0
+          },
+          "top_left_y": {
+            "type": "integer",
+            "title": "Top Left Y",
+            "minimum": 0
+          },
+          "bottom_right_x": {
+            "type": "integer",
+            "title": "Bottom Right X",
+            "minimum": 0
+          },
+          "bottom_right_y": {
+            "type": "integer",
+            "title": "Bottom Right Y",
+            "minimum": 0
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "description": "Text/markdown/html content of this block"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "default": "footer",
+            "const": "footer"
+          }
+        },
+        "title": "OCRFooterBlock",
+        "required": [
+          "top_left_x",
+          "top_left_y",
+          "bottom_right_x",
+          "bottom_right_y",
+          "content"
+        ],
+        "additionalProperties": false
+      },
+      "OCRHeaderBlock": {
+        "type": "object",
+        "properties": {
+          "top_left_x": {
+            "type": "integer",
+            "title": "Top Left X",
+            "minimum": 0
+          },
+          "top_left_y": {
+            "type": "integer",
+            "title": "Top Left Y",
+            "minimum": 0
+          },
+          "bottom_right_x": {
+            "type": "integer",
+            "title": "Bottom Right X",
+            "minimum": 0
+          },
+          "bottom_right_y": {
+            "type": "integer",
+            "title": "Bottom Right Y",
+            "minimum": 0
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "description": "Text/markdown/html content of this block"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "default": "header",
+            "const": "header"
+          }
+        },
+        "title": "OCRHeaderBlock",
+        "required": [
+          "top_left_x",
+          "top_left_y",
+          "bottom_right_x",
+          "bottom_right_y",
+          "content"
+        ],
+        "additionalProperties": false
+      },
+      "OCRImageBlock": {
+        "type": "object",
+        "properties": {
+          "top_left_x": {
+            "type": "integer",
+            "title": "Top Left X",
+            "minimum": 0
+          },
+          "top_left_y": {
+            "type": "integer",
+            "title": "Top Left Y",
+            "minimum": 0
+          },
+          "bottom_right_x": {
+            "type": "integer",
+            "title": "Bottom Right X",
+            "minimum": 0
+          },
+          "bottom_right_y": {
+            "type": "integer",
+            "title": "Bottom Right Y",
+            "minimum": 0
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "description": "Text/markdown/html content of this block"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "default": "image",
+            "const": "image"
+          },
+          "image_id": {
+            "type": "string",
+            "title": "Image Id",
+            "description": "References the corresponding entry in OCRPageObject.images"
+          }
+        },
+        "title": "OCRImageBlock",
+        "required": [
+          "top_left_x",
+          "top_left_y",
+          "bottom_right_x",
+          "bottom_right_y",
+          "content",
+          "image_id"
+        ],
+        "additionalProperties": false
       },
       "OCRImageObject": {
         "additionalProperties": false,
@@ -16177,6 +16498,51 @@
         "title": "OCRImageObject",
         "type": "object"
       },
+      "OCRListBlock": {
+        "type": "object",
+        "properties": {
+          "top_left_x": {
+            "type": "integer",
+            "title": "Top Left X",
+            "minimum": 0
+          },
+          "top_left_y": {
+            "type": "integer",
+            "title": "Top Left Y",
+            "minimum": 0
+          },
+          "bottom_right_x": {
+            "type": "integer",
+            "title": "Bottom Right X",
+            "minimum": 0
+          },
+          "bottom_right_y": {
+            "type": "integer",
+            "title": "Bottom Right Y",
+            "minimum": 0
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "description": "Text/markdown/html content of this block"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "default": "list",
+            "const": "list"
+          }
+        },
+        "title": "OCRListBlock",
+        "required": [
+          "top_left_x",
+          "top_left_y",
+          "bottom_right_x",
+          "bottom_right_y",
+          "content"
+        ],
+        "additionalProperties": false
+      },
       "OCRPageConfidenceScores": {
         "additionalProperties": false,
         "description": "Confidence scores for an OCR page at various granularities.\n\nNote on page-level stats:\n- For 'page' granularity: average/minimum are computed from per-token exp(logprob).\n- For 'word' granularity: average/minimum are computed from per-word confidence,\n  where each word's confidence is exp(mean(token_logprobs)) \u2014 a geometric mean\n  over the word's subword tokens.",
@@ -16244,6 +16610,79 @@
       "OCRPageObject": {
         "additionalProperties": false,
         "properties": {
+          "blocks": {
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/OCRTextBlock"
+                    },
+                    {
+                      "$ref": "#/components/schemas/OCRListBlock"
+                    },
+                    {
+                      "$ref": "#/components/schemas/OCRImageBlock"
+                    },
+                    {
+                      "$ref": "#/components/schemas/OCRTableBlock"
+                    },
+                    {
+                      "$ref": "#/components/schemas/OCRTitleBlock"
+                    },
+                    {
+                      "$ref": "#/components/schemas/OCREquationBlock"
+                    },
+                    {
+                      "$ref": "#/components/schemas/OCRCaptionBlock"
+                    },
+                    {
+                      "$ref": "#/components/schemas/OCRCodeBlock"
+                    },
+                    {
+                      "$ref": "#/components/schemas/OCRReferencesBlock"
+                    },
+                    {
+                      "$ref": "#/components/schemas/OCRAsideTextBlock"
+                    },
+                    {
+                      "$ref": "#/components/schemas/OCRHeaderBlock"
+                    },
+                    {
+                      "$ref": "#/components/schemas/OCRFooterBlock"
+                    },
+                    {
+                      "$ref": "#/components/schemas/OCRSignatureBlock"
+                    }
+                  ],
+                  "discriminator": {
+                    "propertyName": "type",
+                    "mapping": {
+                      "aside_text": "#/components/schemas/OCRAsideTextBlock",
+                      "caption": "#/components/schemas/OCRCaptionBlock",
+                      "code": "#/components/schemas/OCRCodeBlock",
+                      "equation": "#/components/schemas/OCREquationBlock",
+                      "footer": "#/components/schemas/OCRFooterBlock",
+                      "header": "#/components/schemas/OCRHeaderBlock",
+                      "image": "#/components/schemas/OCRImageBlock",
+                      "list": "#/components/schemas/OCRListBlock",
+                      "references": "#/components/schemas/OCRReferencesBlock",
+                      "signature": "#/components/schemas/OCRSignatureBlock",
+                      "table": "#/components/schemas/OCRTableBlock",
+                      "text": "#/components/schemas/OCRTextBlock",
+                      "title": "#/components/schemas/OCRTitleBlock"
+                    }
+                  }
+                }
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Blocks",
+            "description": "Paragraph-level bounding boxes for all content blocks in reading order (populated when include_blocks is True)"
+          },
           "confidence_scores": {
             "anyOf": [
               {
@@ -16334,6 +16773,51 @@
         ],
         "title": "OCRPageObject",
         "type": "object"
+      },
+      "OCRReferencesBlock": {
+        "type": "object",
+        "properties": {
+          "top_left_x": {
+            "type": "integer",
+            "title": "Top Left X",
+            "minimum": 0
+          },
+          "top_left_y": {
+            "type": "integer",
+            "title": "Top Left Y",
+            "minimum": 0
+          },
+          "bottom_right_x": {
+            "type": "integer",
+            "title": "Bottom Right X",
+            "minimum": 0
+          },
+          "bottom_right_y": {
+            "type": "integer",
+            "title": "Bottom Right Y",
+            "minimum": 0
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "description": "Text/markdown/html content of this block"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "default": "references",
+            "const": "references"
+          }
+        },
+        "title": "OCRReferencesBlock",
+        "required": [
+          "top_left_x",
+          "top_left_y",
+          "bottom_right_x",
+          "bottom_right_y",
+          "content"
+        ],
+        "additionalProperties": false
       },
       "OCRRequest": {
         "additionalProperties": false,
@@ -16435,6 +16919,12 @@
             ],
             "description": "Minimum height and width of image to extract",
             "title": "Image Min Size"
+          },
+          "include_blocks": {
+            "type": "boolean",
+            "title": "Include Blocks",
+            "description": "Return paragraph-level bounding boxes for all content blocks in the response",
+            "default": false
           },
           "include_image_base64": {
             "anyOf": [
@@ -16541,6 +17031,109 @@
         "title": "OCRResponse",
         "type": "object"
       },
+      "OCRSignatureBlock": {
+        "type": "object",
+        "properties": {
+          "top_left_x": {
+            "type": "integer",
+            "title": "Top Left X",
+            "minimum": 0
+          },
+          "top_left_y": {
+            "type": "integer",
+            "title": "Top Left Y",
+            "minimum": 0
+          },
+          "bottom_right_x": {
+            "type": "integer",
+            "title": "Bottom Right X",
+            "minimum": 0
+          },
+          "bottom_right_y": {
+            "type": "integer",
+            "title": "Bottom Right Y",
+            "minimum": 0
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "description": "Text/markdown/html content of this block"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "default": "signature",
+            "const": "signature"
+          }
+        },
+        "title": "OCRSignatureBlock",
+        "required": [
+          "top_left_x",
+          "top_left_y",
+          "bottom_right_x",
+          "bottom_right_y",
+          "content"
+        ],
+        "additionalProperties": false,
+        "description": "Signature region. ``content`` is the transcribed name when legible, else ``\"\"``."
+      },
+      "OCRTableBlock": {
+        "type": "object",
+        "properties": {
+          "top_left_x": {
+            "type": "integer",
+            "title": "Top Left X",
+            "minimum": 0
+          },
+          "top_left_y": {
+            "type": "integer",
+            "title": "Top Left Y",
+            "minimum": 0
+          },
+          "bottom_right_x": {
+            "type": "integer",
+            "title": "Bottom Right X",
+            "minimum": 0
+          },
+          "bottom_right_y": {
+            "type": "integer",
+            "title": "Bottom Right Y",
+            "minimum": 0
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "description": "Text/markdown/html content of this block"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "default": "table",
+            "const": "table"
+          },
+          "table_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Table Id",
+            "description": "References the corresponding entry in OCRPageObject.tables, when tables are extracted"
+          }
+        },
+        "title": "OCRTableBlock",
+        "required": [
+          "top_left_x",
+          "top_left_y",
+          "bottom_right_x",
+          "bottom_right_y",
+          "content"
+        ],
+        "additionalProperties": false
+      },
       "OCRTableObject": {
         "additionalProperties": false,
         "properties": {
@@ -16586,6 +17179,96 @@
         ],
         "title": "OCRTableObject",
         "type": "object"
+      },
+      "OCRTextBlock": {
+        "type": "object",
+        "properties": {
+          "top_left_x": {
+            "type": "integer",
+            "title": "Top Left X",
+            "minimum": 0
+          },
+          "top_left_y": {
+            "type": "integer",
+            "title": "Top Left Y",
+            "minimum": 0
+          },
+          "bottom_right_x": {
+            "type": "integer",
+            "title": "Bottom Right X",
+            "minimum": 0
+          },
+          "bottom_right_y": {
+            "type": "integer",
+            "title": "Bottom Right Y",
+            "minimum": 0
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "description": "Text/markdown/html content of this block"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "default": "text",
+            "const": "text"
+          }
+        },
+        "title": "OCRTextBlock",
+        "required": [
+          "top_left_x",
+          "top_left_y",
+          "bottom_right_x",
+          "bottom_right_y",
+          "content"
+        ],
+        "additionalProperties": false
+      },
+      "OCRTitleBlock": {
+        "type": "object",
+        "properties": {
+          "top_left_x": {
+            "type": "integer",
+            "title": "Top Left X",
+            "minimum": 0
+          },
+          "top_left_y": {
+            "type": "integer",
+            "title": "Top Left Y",
+            "minimum": 0
+          },
+          "bottom_right_x": {
+            "type": "integer",
+            "title": "Bottom Right X",
+            "minimum": 0
+          },
+          "bottom_right_y": {
+            "type": "integer",
+            "title": "Bottom Right Y",
+            "minimum": 0
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "description": "Text/markdown/html content of this block"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "default": "title",
+            "const": "title"
+          }
+        },
+        "title": "OCRTitleBlock",
+        "required": [
+          "top_left_x",
+          "top_left_y",
+          "bottom_right_x",
+          "bottom_right_y",
+          "content"
+        ],
+        "additionalProperties": false
       },
       "OCRUsageInfo": {
         "additionalProperties": false,

--- a/packages/mistralai_dart/test/unit/models/ocr/ocr_block_test.dart
+++ b/packages/mistralai_dart/test/unit/models/ocr/ocr_block_test.dart
@@ -1,0 +1,183 @@
+import 'package:mistralai_dart/mistralai_dart.dart';
+import 'package:test/test.dart';
+
+Map<String, dynamic> _block(
+  String type, {
+  Map<String, dynamic> extra = const {},
+}) => {
+  'type': type,
+  'top_left_x': 10,
+  'top_left_y': 20,
+  'bottom_right_x': 100,
+  'bottom_right_y': 150,
+  'content': 'hello',
+  ...extra,
+};
+
+void main() {
+  group('OcrBlock', () {
+    group('fromJson dispatch', () {
+      const cases = <String, Type>{
+        'text': OcrTextBlock,
+        'title': OcrTitleBlock,
+        'list': OcrListBlock,
+        'table': OcrTableBlock,
+        'image': OcrImageBlock,
+        'equation': OcrEquationBlock,
+        'caption': OcrCaptionBlock,
+        'code': OcrCodeBlock,
+        'references': OcrReferencesBlock,
+        'aside_text': OcrAsideTextBlock,
+        'header': OcrHeaderBlock,
+        'footer': OcrFooterBlock,
+        'signature': OcrSignatureBlock,
+      };
+
+      for (final entry in cases.entries) {
+        final wire = entry.key;
+        final type = entry.value;
+        test('parses "$wire" into $type', () {
+          final extra = wire == 'image'
+              ? <String, dynamic>{'image_id': 'img-1'}
+              : <String, dynamic>{};
+          final block = OcrBlock.fromJson(_block(wire, extra: extra));
+
+          expect(block.runtimeType, type);
+          expect(block.type, wire);
+        });
+      }
+    });
+
+    test('parses common bounding box and content fields', () {
+      final block = OcrBlock.fromJson(_block('text')) as OcrTextBlock;
+
+      expect(block.topLeftX, 10);
+      expect(block.topLeftY, 20);
+      expect(block.bottomRightX, 100);
+      expect(block.bottomRightY, 150);
+      expect(block.content, 'hello');
+    });
+
+    test('image block parses required image_id', () {
+      final block =
+          OcrBlock.fromJson(_block('image', extra: {'image_id': 'img-9'}))
+              as OcrImageBlock;
+
+      expect(block.imageId, 'img-9');
+    });
+
+    test('table block parses optional table_id', () {
+      final withId =
+          OcrBlock.fromJson(_block('table', extra: {'table_id': 'tbl-1'}))
+              as OcrTableBlock;
+      expect(withId.tableId, 'tbl-1');
+
+      final withoutId = OcrBlock.fromJson(_block('table')) as OcrTableBlock;
+      expect(withoutId.tableId, isNull);
+    });
+
+    group('round-trip', () {
+      test('text block', () {
+        final json = _block('text');
+        expect(OcrBlock.fromJson(json).toJson(), json);
+      });
+
+      test('image block includes image_id', () {
+        final json = _block('image', extra: {'image_id': 'img-1'});
+        expect(OcrBlock.fromJson(json).toJson(), json);
+      });
+
+      test('table block omits table_id when absent', () {
+        final block = OcrBlock.fromJson(_block('table'));
+        expect(block.toJson().containsKey('table_id'), isFalse);
+      });
+    });
+
+    group('unknown fallback', () {
+      test('unrecognized type is preserved as UnknownOcrBlock', () {
+        final block = OcrBlock.fromJson(const {
+          'type': 'diagram',
+          'foo': 'bar',
+        });
+
+        expect(block, isA<UnknownOcrBlock>());
+        expect(block.type, 'diagram');
+      });
+
+      test('preserves the raw JSON through toJson', () {
+        final json = {'type': 'diagram', 'foo': 'bar', 'n': 1};
+        final block = OcrBlock.fromJson(json);
+
+        expect(block.toJson(), json);
+      });
+
+      test('missing type falls back to "unknown"', () {
+        final block = OcrBlock.fromJson(const {'foo': 'bar'});
+
+        expect(block, isA<UnknownOcrBlock>());
+        expect(block.type, 'unknown');
+      });
+
+      test('non-string type falls back to "unknown" without throwing', () {
+        final block = OcrBlock.fromJson(const {'type': 123, 'foo': 'bar'});
+
+        expect(block, isA<UnknownOcrBlock>());
+        expect(block.type, 'unknown');
+        expect(block.toJson(), const {'type': 123, 'foo': 'bar'});
+      });
+    });
+
+    group('discriminator validation', () {
+      test('variant fromJson rejects a mismatched type', () {
+        expect(
+          () => OcrTextBlock.fromJson(_block('list')),
+          throwsFormatException,
+        );
+      });
+    });
+
+    group('required fields fail fast', () {
+      test('throws when a bounding box coordinate is missing', () {
+        final json = _block('text')..remove('top_left_x');
+        expect(() => OcrTextBlock.fromJson(json), throwsFormatException);
+      });
+
+      test('throws when content is missing', () {
+        final json = _block('text')..remove('content');
+        expect(() => OcrTextBlock.fromJson(json), throwsFormatException);
+      });
+
+      test('image block throws when image_id is missing', () {
+        expect(
+          () => OcrImageBlock.fromJson(_block('image')),
+          throwsFormatException,
+        );
+      });
+    });
+
+    group('equality and copyWith', () {
+      test('equal blocks compare equal', () {
+        expect(
+          OcrBlock.fromJson(_block('text')),
+          OcrBlock.fromJson(_block('text')),
+        );
+      });
+
+      test('copyWith replaces a field and preserves the rest', () {
+        final block = OcrBlock.fromJson(_block('text')) as OcrTextBlock;
+        final copy = block.copyWith(content: 'world');
+
+        expect(copy.content, 'world');
+        expect(copy.topLeftX, 10);
+      });
+
+      test('table copyWith clears tableId with explicit null', () {
+        final block = OcrTableBlock.fromJson(
+          _block('table', extra: {'table_id': 't1'}),
+        );
+
+        expect(block.copyWith(tableId: null).tableId, isNull);
+      });
+    });
+  });
+}

--- a/packages/mistralai_dart/test/unit/models/ocr/ocr_page_test.dart
+++ b/packages/mistralai_dart/test/unit/models/ocr/ocr_page_test.dart
@@ -17,6 +17,7 @@ void main() {
         expect(page.header, isNull);
         expect(page.footer, isNull);
         expect(page.hyperlinks, isEmpty);
+        expect(page.blocks, isNull);
       });
 
       test('parses page with images', () {
@@ -307,6 +308,89 @@ void main() {
 
         expect(cleared.confidenceScores, isNull);
         expect(cleared.markdown, 'text');
+      });
+    });
+
+    group('blocks', () {
+      test('is null when absent', () {
+        final page = OcrPage.fromJson(const {'index': 0, 'markdown': 'text'});
+
+        expect(page.blocks, isNull);
+      });
+
+      test('parses blocks when present', () {
+        final page = OcrPage.fromJson(const {
+          'index': 0,
+          'markdown': 'text',
+          'blocks': [
+            {
+              'type': 'title',
+              'top_left_x': 0,
+              'top_left_y': 0,
+              'bottom_right_x': 100,
+              'bottom_right_y': 30,
+              'content': 'Heading',
+            },
+            {
+              'type': 'text',
+              'top_left_x': 0,
+              'top_left_y': 40,
+              'bottom_right_x': 100,
+              'bottom_right_y': 80,
+              'content': 'Body',
+            },
+          ],
+        });
+
+        expect(page.blocks, hasLength(2));
+        expect(page.blocks!.first, isA<OcrTitleBlock>());
+        expect(page.blocks![1], isA<OcrTextBlock>());
+      });
+
+      test('omits blocks from JSON when null', () {
+        const page = OcrPage(index: 0, markdown: 'text');
+
+        expect(page.toJson().containsKey('blocks'), isFalse);
+      });
+
+      test('round-trips a populated blocks list', () {
+        const original = OcrPage(
+          index: 1,
+          markdown: 'text',
+          blocks: [
+            OcrTitleBlock(
+              topLeftX: 0,
+              topLeftY: 0,
+              bottomRightX: 100,
+              bottomRightY: 30,
+              content: 'Heading',
+            ),
+          ],
+        );
+
+        final roundTripped = OcrPage.fromJson(original.toJson());
+
+        expect(roundTripped, equals(original));
+      });
+
+      test('copyWith clears blocks with explicit null', () {
+        const original = OcrPage(
+          index: 0,
+          markdown: 'text',
+          blocks: [
+            OcrTextBlock(
+              topLeftX: 0,
+              topLeftY: 0,
+              bottomRightX: 10,
+              bottomRightY: 10,
+              content: 'c',
+            ),
+          ],
+        );
+
+        final cleared = original.copyWith(blocks: null);
+
+        expect(cleared.blocks, isNull);
       });
     });
   });

--- a/packages/mistralai_dart/test/unit/models/ocr/ocr_pages_test.dart
+++ b/packages/mistralai_dart/test/unit/models/ocr/ocr_pages_test.dart
@@ -1,0 +1,65 @@
+import 'package:mistralai_dart/mistralai_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OcrPages', () {
+    group('fromJson', () {
+      test('parses a list of integers', () {
+        final pages = OcrPages.fromJson(const [0, 1, 2]);
+
+        expect(pages, isA<OcrPagesList>());
+        expect((pages as OcrPagesList).values, [0, 1, 2]);
+      });
+
+      test('parses a comma-separated string', () {
+        final pages = OcrPages.fromJson('0,2-4');
+
+        expect(pages, isA<OcrPagesString>());
+        expect((pages as OcrPagesString).value, '0,2-4');
+      });
+
+      test('throws FormatException for an unsupported type', () {
+        expect(() => OcrPages.fromJson(42), throwsFormatException);
+      });
+
+      test('throws FormatException for a non-int list element', () {
+        expect(
+          () => OcrPages.fromJson(const [0, 'x', 2]),
+          throwsFormatException,
+        );
+      });
+    });
+
+    group('toJson', () {
+      test('list variant returns the raw list', () {
+        expect(const OcrPages.list([0, 1]).toJson(), [0, 1]);
+      });
+
+      test('string variant returns the raw string', () {
+        expect(const OcrPages.string('0-5').toJson(), '0-5');
+      });
+    });
+
+    group('equality', () {
+      test('list variants with the same values are equal', () {
+        expect(const OcrPages.list([0, 1]), const OcrPages.list([0, 1]));
+        expect(
+          const OcrPages.list([0, 1]).hashCode,
+          const OcrPages.list([0, 1]).hashCode,
+        );
+      });
+
+      test('list variants with different values are not equal', () {
+        expect(const OcrPages.list([0, 1]), isNot(const OcrPages.list([0, 2])));
+      });
+
+      test('string variants with the same value are equal', () {
+        expect(const OcrPages.string('0-5'), const OcrPages.string('0-5'));
+      });
+
+      test('list and string variants are not equal', () {
+        expect(const OcrPages.list([0]), isNot(const OcrPages.string('0')));
+      });
+    });
+  });
+}

--- a/packages/mistralai_dart/test/unit/models/ocr/ocr_request_test.dart
+++ b/packages/mistralai_dart/test/unit/models/ocr/ocr_request_test.dart
@@ -24,8 +24,9 @@ void main() {
         final request = OcrRequest(
           model: 'custom-ocr-model',
           document: const FileDocument('file-123'),
-          pages: const [0, 1, 2],
+          pages: const OcrPages.list([0, 1, 2]),
           includeImageBase64: true,
+          includeBlocks: true,
           imageLimit: 10,
           imageMinSize: 100,
           documentAnnotationPrompt: 'Annotate tables and charts',
@@ -44,8 +45,9 @@ void main() {
 
         expect(request.model, 'custom-ocr-model');
         expect(request.document, isA<FileDocument>());
-        expect(request.pages, [0, 1, 2]);
+        expect(request.pages, const OcrPages.list([0, 1, 2]));
         expect(request.includeImageBase64, isTrue);
+        expect(request.includeBlocks, isTrue);
         expect(request.imageLimit, 10);
         expect(request.imageMinSize, 100);
         expect(request.documentAnnotationPrompt, 'Annotate tables and charts');
@@ -74,12 +76,12 @@ void main() {
       test('fromFile creates file document', () {
         final request = OcrRequest.fromFile(
           fileId: 'file-456',
-          pages: const [0],
+          pages: const OcrPages.list([0]),
         );
 
         expect(request.document, isA<FileDocument>());
         expect((request.document as FileDocument).fileId, 'file-456');
-        expect(request.pages, [0]);
+        expect(request.pages, const OcrPages.list([0]));
       });
 
       test('fromBase64 creates base64 document', () {
@@ -122,7 +124,7 @@ void main() {
         const request = OcrRequest(
           model: 'custom-model',
           document: FileDocument('file-123'),
-          pages: [1, 2, 3],
+          pages: OcrPages.list([1, 2, 3]),
           includeImageBase64: true,
           imageLimit: 5,
           imageMinSize: 50,
@@ -186,7 +188,7 @@ void main() {
 
         expect(request.model, 'mistral-ocr-latest');
         expect(request.document, isA<UrlDocument>());
-        expect(request.pages, [0, 1]);
+        expect(request.pages, const OcrPages.list([0, 1]));
         expect(request.includeImageBase64, isTrue);
         expect(request.documentAnnotationPrompt, isNull);
         expect(request.tableFormat, isNull);
@@ -267,13 +269,13 @@ void main() {
 
         final copy = original.copyWith(
           model: 'new-model',
-          pages: [1, 2],
+          pages: const OcrPages.list([1, 2]),
           tableFormat: OcrTableFormat.html,
         );
 
         expect(copy.model, 'new-model');
         expect(copy.document, equals(original.document));
-        expect(copy.pages, [1, 2]);
+        expect(copy.pages, const OcrPages.list([1, 2]));
         expect(copy.tableFormat, OcrTableFormat.html);
       });
 
@@ -281,7 +283,7 @@ void main() {
         const original = OcrRequest(
           model: 'custom-model',
           document: FileDocument('file-123'),
-          pages: [0],
+          pages: OcrPages.list([0]),
           includeImageBase64: true,
           documentAnnotationPrompt: 'Annotate all',
           tableFormat: OcrTableFormat.markdown,
@@ -292,7 +294,7 @@ void main() {
         final copy = original.copyWith();
 
         expect(copy.model, 'custom-model');
-        expect(copy.pages, [0]);
+        expect(copy.pages, const OcrPages.list([0]));
         expect(copy.includeImageBase64, isTrue);
         expect(copy.documentAnnotationPrompt, 'Annotate all');
         expect(copy.tableFormat, OcrTableFormat.markdown);
@@ -318,11 +320,11 @@ void main() {
       test('requests with same fields are equal', () {
         const request1 = OcrRequest(
           document: UrlDocument('https://example.com/doc.pdf'),
-          pages: [0, 1],
+          pages: OcrPages.list([0, 1]),
         );
         const request2 = OcrRequest(
           document: UrlDocument('https://example.com/doc.pdf'),
-          pages: [0, 1],
+          pages: OcrPages.list([0, 1]),
         );
 
         expect(request1, equals(request2));
@@ -446,6 +448,101 @@ void main() {
           OcrConfidenceScoresGranularity.fromString('character'),
           OcrConfidenceScoresGranularity.unknown,
         );
+      });
+    });
+
+    group('pages', () {
+      test('serializes a list of page numbers', () {
+        const request = OcrRequest(
+          document: UrlDocument('https://example.com/doc.pdf'),
+          pages: OcrPages.list([0, 2, 4]),
+        );
+
+        expect(request.toJson()['pages'], [0, 2, 4]);
+      });
+
+      test('serializes a comma-separated range string', () {
+        const request = OcrRequest(
+          document: UrlDocument('https://example.com/doc.pdf'),
+          pages: OcrPages.string('0,2-4'),
+        );
+
+        expect(request.toJson()['pages'], '0,2-4');
+      });
+
+      test('round-trips the list variant', () {
+        const original = OcrRequest(
+          document: UrlDocument('https://example.com/doc.pdf'),
+          pages: OcrPages.list([0, 1, 2]),
+        );
+
+        final roundTripped = OcrRequest.fromJson(original.toJson());
+
+        expect(roundTripped.pages, const OcrPages.list([0, 1, 2]));
+      });
+
+      test('round-trips the string variant', () {
+        const original = OcrRequest(
+          document: UrlDocument('https://example.com/doc.pdf'),
+          pages: OcrPages.string('0-5'),
+        );
+
+        final roundTripped = OcrRequest.fromJson(original.toJson());
+
+        expect(roundTripped.pages, const OcrPages.string('0-5'));
+      });
+
+      test('copyWith clears with explicit null', () {
+        const original = OcrRequest(
+          document: UrlDocument('https://example.com/doc.pdf'),
+          pages: OcrPages.list([0]),
+        );
+
+        final cleared = original.copyWith(pages: null);
+
+        expect(cleared.pages, isNull);
+      });
+    });
+
+    group('includeBlocks', () {
+      test('serializes when set', () {
+        const request = OcrRequest(
+          document: UrlDocument('https://example.com/doc.pdf'),
+          includeBlocks: true,
+        );
+
+        expect(request.toJson()['include_blocks'], true);
+      });
+
+      test('omitted from JSON when null', () {
+        const request = OcrRequest(
+          document: UrlDocument('https://example.com/doc.pdf'),
+        );
+
+        expect(request.toJson().containsKey('include_blocks'), isFalse);
+      });
+
+      test('parses from JSON', () {
+        final request = OcrRequest.fromJson(const {
+          'document': {
+            'type': 'document_url',
+            'document_url': 'https://example.com/doc.pdf',
+          },
+          'include_blocks': true,
+        });
+
+        expect(request.includeBlocks, isTrue);
+      });
+
+      test('copyWith clears with explicit null', () {
+        const original = OcrRequest(
+          document: UrlDocument('https://example.com/doc.pdf'),
+          includeBlocks: true,
+        );
+
+        final cleared = original.copyWith(includeBlocks: null);
+
+        expect(cleared.includeBlocks, isNull);
       });
     });
   });


### PR DESCRIPTION
## Summary
- Add OCR-4 **paragraph-level block extraction**: set `OcrRequest.includeBlocks: true` to receive `OcrPage.blocks` — a sealed 13-variant `OcrBlock` union (text, title, list, table, image, equation, caption, code, references, aside_text, header, footer, signature), each with a bounding box + `content`, in reading order.
- Support the new **comma-separated `pages` string/range form** (e.g. `'0,2-4'`) alongside explicit page lists, via a sealed `OcrPages` union. **Breaking** (see below).
- Add a canonical `example/mistralai_dart_example.dart`, fixing the pub.dev **"Package has an example" 0/10** check (the package had 29 topic examples but none matched pana's canonical entry-point names).

## Details

Scope decision (confirmed with the maintainer): the published `openapi.yaml` has drifted far beyond OCR (+140 admin/workspace/billing/search-index schemas). This PR is deliberately **OCR-only** — the OCR schemas were surgically merged into the vendored `specs/openapi.json` (683 insertions, **0 deletions**) so `verify --scope all` stays green; the unrelated platform surface is out of scope.

**Blocks** are modeled as a discriminated `oneOf` over 13 named schemas, so `OcrBlock` is a sealed hierarchy (mirroring `ContentPart`/`Tool`) with per-variant fail-fast `fromJson` (throws `FormatException` on a mismatched `type` or a missing required field) and a non-throwing dispatch that preserves unrecognized types as `UnknownOcrBlock` (raw JSON round-trips intact — including non-string discriminators).

```dart
final res = await client.ocr.process(
  request: OcrRequest.fromUrl(
    url: 'https://example.com/doc.pdf',
    pages: const OcrPages.string('0,2-4'), // or OcrPages.list([0, 1, 2])
    includeBlocks: true,
  ),
);
for (final block in res.pages.first.blocks ?? const <OcrBlock>[]) {
  final detail = switch (block) {
    OcrImageBlock(:final imageId) => ' image=$imageId',
    OcrTableBlock(:final tableId) => ' table=$tableId',
    UnknownOcrBlock() => ' (unrecognized)',
    _ => '',
  };
  print('[${block.type}]$detail');
}
```

`OcrPage.blocks` is nullable (`List<OcrBlock>?`) to preserve the spec's `array | null` semantics (absent/`null` "not requested" vs. an empty list), following the repo's omit-null convention. Manifest updated with a `sealed_parent` `OcrBlock` (discriminator mapping) + 13 `sealed_variant` entries (130 insertions, 0 deletions).

`spec_metadata.json` was intentionally left untouched — this is a surgical OCR merge, not a full re-fetch, so bumping the fetch timestamp would misrepresent it. Per repo convention, no manual CHANGELOG/version bump — `/release` generates those.

New models `mistral-ocr-4-0` and `labs-leanstral-1-5` need no code changes (model IDs are free-form strings; `mistral-ocr-latest` still resolves).

## Breaking Changes

`OcrRequest.pages` and the `fromUrl`/`fromFile`/`fromBase64` factory `pages` parameters change from `List<int>?` to the sealed `OcrPages` union (this also corrects a pre-existing drift — the vendored spec already typed `pages` as `string | array<int> | null`).

```dart
// Before
OcrRequest.fromUrl(url: url, pages: [0, 1, 2]);

// After — list of page numbers
OcrRequest.fromUrl(url: url, pages: OcrPages.list([0, 1, 2]));
// After — comma-separated numbers and ranges
OcrRequest.fromUrl(url: url, pages: OcrPages.string('0,2-4'));
```

## References

- [Mistral changelog — OCR 4 & block extraction (June 23, 2026)](https://docs.mistral.ai/getting-started/changelog/) — `include_blocks`, page `blocks`, and `pages` string/range support.
- [OCR block extraction docs](https://docs.mistral.ai/studio-api/document-processing/basic_ocr#block-extraction)

## Test Plan

- [x] Unit tests pass for affected package (`dart test test/unit/` — 1760 pass, 3 skipped)
- [x] New tests added (`ocr_pages_test.dart`, `ocr_block_test.dart`; updated `ocr_request_test.dart`, `ocr_page_test.dart`)
- [x] Sealed class/enum changes include variant, round-trip, and error tests (13 variants, unknown fallback, discriminator mismatch, missing-required-field, non-string discriminator)
- [x] `fromJson`/`toJson` round-trip serialization verified (incl. `UnknownOcrBlock` raw preservation)
- [x] `==`/`hashCode` contract verified (same fields in both)
- [x] `dart analyze --fatal-infos` clean, `dart format` clean
- [x] api-toolkit `verify --checks all --scope all` — errors 0, `failing_checks: []`
- [x] Codex review completed; both low-severity findings fixed (non-string discriminator hardening + stale `ocr_example.dart` snippet)