### PR TITLE
fix(anthropic_sdk_dart): avoid double slash when base URL has a trailing slash

### DIFF
--- a/packages/anthropic_sdk_dart/lib/src/client/request_builder.dart
+++ b/packages/anthropic_sdk_dart/lib/src/client/request_builder.dart
@@ -14,20 +14,36 @@ class RequestBuilder {
 
   /// Builds a URL for an API endpoint.
   ///
+  /// The [path] is a URL path (e.g. `/v1/messages`); pass query parameters via
+  /// [queryParams] rather than embedding them in [path].
+  ///
   /// Merges query parameters in order: Global → Request.
   /// Later values override earlier ones (last-write-wins).
   Uri buildUrl(String path, {Map<String, dynamic>? queryParams}) {
-    final uri = Uri.parse('${config.baseUrl}$path');
+    // Parse the base URL so any existing path/query components are handled
+    // correctly. Mirrors openai_dart's builder.
+    final baseUri = Uri.parse(config.baseUrl);
+
+    // Normalize the base path and requested path to avoid a double slash when
+    // the configured base URL ends with a slash (e.g. a custom proxy or an
+    // `ANTHROPIC_BASE_URL` with a trailing `/`).
+    final basePath = baseUri.path.endsWith('/')
+        ? baseUri.path.substring(0, baseUri.path.length - 1)
+        : baseUri.path;
+    final normalizedPath = path.startsWith('/') ? path : '/$path';
+
+    // Merge query params (last-write-wins), preserving any carried by the base
+    // URL: base URL → configured defaults → per-request.
     final mergedParams = <String, dynamic>{
+      ...baseUri.queryParameters,
       ...config.defaultQueryParams,
       ...?queryParams,
     };
 
-    if (mergedParams.isEmpty) {
-      return uri;
-    }
-
-    return uri.replace(queryParameters: mergedParams);
+    return baseUri.replace(
+      path: '$basePath$normalizedPath',
+      queryParameters: mergedParams.isEmpty ? null : mergedParams,
+    );
   }
 
   /// Builds headers for a request.

--- a/packages/anthropic_sdk_dart/test/unit/client/url_builder_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/client/url_builder_test.dart
@@ -1,0 +1,114 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:anthropic_sdk_dart/src/client/request_builder.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RequestBuilder.buildUrl', () {
+    test('builds URL with the default base URL', () {
+      const builder = RequestBuilder(
+        config: AnthropicConfig(authProvider: ApiKeyProvider('sk-test')),
+      );
+
+      final url = builder.buildUrl('/v1/messages');
+
+      expect(url.scheme, equals('https'));
+      expect(url.host, equals('api.anthropic.com'));
+      expect(url.path, equals('/v1/messages'));
+      expect(url.query, isEmpty);
+    });
+
+    test('normalizes a trailing slash in the base URL (no double slash)', () {
+      const builder = RequestBuilder(
+        config: AnthropicConfig(
+          authProvider: ApiKeyProvider('sk-test'),
+          baseUrl: 'https://api.anthropic.com/',
+        ),
+      );
+
+      final url = builder.buildUrl('/v1/messages');
+
+      // Should be /v1/messages, not //v1/messages.
+      expect(url.path, equals('/v1/messages'));
+      expect(url.toString(), equals('https://api.anthropic.com/v1/messages'));
+    });
+
+    test('preserves a base URL sub-path and avoids a double slash', () {
+      const builder = RequestBuilder(
+        config: AnthropicConfig(
+          authProvider: ApiKeyProvider('sk-test'),
+          baseUrl: 'https://proxy.example.com/anthropic/',
+        ),
+      );
+
+      final url = builder.buildUrl('/v1/messages');
+
+      expect(url.path, equals('/anthropic/v1/messages'));
+    });
+
+    test('handles an endpoint path without a leading slash', () {
+      const builder = RequestBuilder(
+        config: AnthropicConfig(
+          authProvider: ApiKeyProvider('sk-test'),
+          baseUrl: 'https://api.anthropic.com/',
+        ),
+      );
+
+      final url = builder.buildUrl('v1/messages');
+
+      expect(url.path, equals('/v1/messages'));
+    });
+
+    test('merges default and per-request query params', () {
+      const builder = RequestBuilder(
+        config: AnthropicConfig(
+          authProvider: ApiKeyProvider('sk-test'),
+          baseUrl: 'https://api.anthropic.com/',
+          defaultQueryParams: {'beta': 'true'},
+        ),
+      );
+
+      final url = builder.buildUrl(
+        '/v1/messages/batches',
+        queryParams: {'limit': '20'},
+      );
+
+      expect(url.path, equals('/v1/messages/batches'));
+      expect(url.queryParameters['beta'], equals('true'));
+      expect(url.queryParameters['limit'], equals('20'));
+    });
+
+    test('preserves query params carried by the base URL', () {
+      const builder = RequestBuilder(
+        config: AnthropicConfig(
+          authProvider: ApiKeyProvider('sk-test'),
+          baseUrl: 'https://proxy.example.com/?api-version=2024',
+        ),
+      );
+
+      final url = builder.buildUrl(
+        '/v1/messages',
+        queryParams: {'beta': 'true'},
+      );
+
+      expect(url.path, equals('/v1/messages'));
+      expect(url.queryParameters['api-version'], equals('2024'));
+      expect(url.queryParameters['beta'], equals('true'));
+    });
+
+    test('per-request params override base-URL params on conflict', () {
+      const builder = RequestBuilder(
+        config: AnthropicConfig(
+          authProvider: ApiKeyProvider('sk-test'),
+          baseUrl: 'https://proxy.example.com/?api-version=2024',
+        ),
+      );
+
+      final url = builder.buildUrl(
+        '/v1/messages',
+        queryParams: {'api-version': '2025'},
+      );
+
+      expect(url.queryParameters['api-version'], equals('2025'));
+    });
+  });
+}


### PR DESCRIPTION
## Problem

`RequestBuilder.buildUrl` joins the configured base URL and the endpoint path with plain string concatenation:

```dart
final uri = Uri.parse('${config.baseUrl}$path');
```

Every caller passes a leading-slash path (`/v1/messages`, `/v1/messages/batches`, …). The default `baseUrl` has no trailing slash, so the default case is fine — but `AnthropicConfig.baseUrl` is user-configurable (and settable via `ANTHROPIC_BASE_URL`). A base URL with a **trailing slash** produces a double slash in the path:

| `baseUrl` | `path` | Produced (buggy) |
|---|---|---|
| `https://api.anthropic.com/` | `/v1/messages` | `https://api.anthropic.com//v1/messages` |
| `https://proxy.example.com/anthropic/` | `/v1/messages` | `.../anthropic//v1/messages` |

The empty middle segment is preserved in `Uri.path` (not collapsed), so the request targets a wrong path and many gateways/proxies `404` on it.

## Fix

Normalize the base and requested paths and rebuild the URI from the parsed base — the same approach the sibling `openai_dart` `RequestBuilder.buildUrl` already uses (strip a trailing `/` from the base path, ensure a leading `/` on the endpoint path). While aligning with that builder, this also preserves any query string carried by the base URL (e.g. a proxy `?api-version=…`), which the previous code dropped, matching `openai_dart`'s merge order: base URL → configured defaults → per-request (last-write-wins).

## Tests

New `test/unit/client/url_builder_test.dart` (mirrors `openai_dart`'s `url_builder_test.dart`) — 7 cases: default base URL, trailing-slash normalization, base sub-path, path without a leading slash, default + per-request query merge, base-URL query-param preservation, and per-request override on conflict. The trailing-slash cases fail on the old code and pass with the fix.

## Verification

- `dart analyze packages/anthropic_sdk_dart` → No issues found.
- `dart format` → clean.
- `dart test --exclude-tags integration packages/anthropic_sdk_dart/test/unit/` → 1308 pass, 3 skipped (env-var tests), no regressions.
