### PR TITLE
fix(mistralai_dart): avoid double slash and preserve base URL query params in buildUrl

### DIFF
--- a/packages/mistralai_dart/lib/src/client/request_builder.dart
+++ b/packages/mistralai_dart/lib/src/client/request_builder.dart
@@ -14,20 +14,42 @@ class RequestBuilder {
 
   /// Builds a URL for an API endpoint.
   ///
-  /// Merges query parameters in order: Global → Request.
-  /// Later values override earlier ones (last-write-wins).
+  /// The [path] is a URL path (e.g. `/v1/chat/completions`); pass query
+  /// parameters via [queryParams] rather than embedding them in [path].
+  /// Values may be a `String` or an `Iterable<String>` (rendered as repeated
+  /// keys, e.g. `?status=a&status=b`).
+  ///
+  /// Merges query parameters in order: base URL → config defaults → request.
+  /// Later sources override earlier ones by key (last-write-wins; the whole
+  /// value list for that key is replaced). Repeated keys carried by the base
+  /// URL (e.g. `?k=a&k=b`) are preserved.
   Uri buildUrl(String path, {Map<String, dynamic>? queryParams}) {
-    final uri = Uri.parse('${config.baseUrl}$path');
+    // Parse the base URL so existing path/query components are handled
+    // correctly (e.g. a proxy sub-path or an `?api-version=` param).
+    final baseUri = Uri.parse(config.baseUrl);
+
+    // Normalize the base path and endpoint path to avoid a double slash when
+    // the configured base URL ends with a trailing slash.
+    final basePath = baseUri.path.endsWith('/')
+        ? baseUri.path.substring(0, baseUri.path.length - 1)
+        : baseUri.path;
+    final normalizedPath = path.startsWith('/') ? path : '/$path';
+
+    // Merge query params (last-write-wins by key). `queryParametersAll`
+    // preserves repeated base-URL keys; `Uri.replace` accepts both `String`
+    // and `Iterable<String>` values.
     final mergedParams = <String, dynamic>{
+      ...baseUri.queryParametersAll,
       ...config.defaultQueryParams,
       ...?queryParams,
     };
 
-    if (mergedParams.isEmpty) {
-      return uri;
-    }
-
-    return uri.replace(queryParameters: mergedParams);
+    // `replace` keeps scheme, userInfo, host, port, and fragment from the
+    // base URL; only path and query are rebuilt.
+    return baseUri.replace(
+      path: '$basePath$normalizedPath',
+      queryParameters: mergedParams.isEmpty ? null : mergedParams,
+    );
   }
 
   /// Builds headers for a request.

--- a/packages/mistralai_dart/test/unit/client/url_builder_test.dart
+++ b/packages/mistralai_dart/test/unit/client/url_builder_test.dart
@@ -1,0 +1,214 @@
+import 'package:mistralai_dart/mistralai_dart.dart';
+import 'package:mistralai_dart/src/client/request_builder.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RequestBuilder.buildUrl', () {
+    test('builds URL with the default base URL', () {
+      const builder = RequestBuilder(config: MistralConfig());
+
+      final url = builder.buildUrl('/v1/chat/completions');
+
+      expect(url.scheme, equals('https'));
+      expect(url.host, equals('api.mistral.ai'));
+      expect(url.path, equals('/v1/chat/completions'));
+      expect(url.query, isEmpty);
+    });
+
+    test('normalizes a trailing slash in the base URL (no double slash)', () {
+      const builder = RequestBuilder(
+        config: MistralConfig(baseUrl: 'https://api.mistral.ai/'),
+      );
+
+      final url = builder.buildUrl('/v1/chat/completions');
+
+      // Should be /v1/chat/completions, not //v1/chat/completions.
+      expect(url.path, equals('/v1/chat/completions'));
+      expect(
+        url.toString(),
+        equals('https://api.mistral.ai/v1/chat/completions'),
+      );
+    });
+
+    test('preserves a base URL sub-path with a trailing slash', () {
+      const builder = RequestBuilder(
+        config: MistralConfig(baseUrl: 'https://proxy.example.com/mistral/'),
+      );
+
+      final url = builder.buildUrl('/v1/chat/completions');
+
+      expect(url.path, equals('/mistral/v1/chat/completions'));
+    });
+
+    test('handles an endpoint path without a leading slash', () {
+      const builder = RequestBuilder(
+        config: MistralConfig(baseUrl: 'https://api.mistral.ai/'),
+      );
+
+      final url = builder.buildUrl('v1/chat/completions');
+
+      expect(url.path, equals('/v1/chat/completions'));
+    });
+
+    test('handles a base URL with no path', () {
+      const builder = RequestBuilder(
+        config: MistralConfig(baseUrl: 'https://api.example.com'),
+      );
+
+      final url = builder.buildUrl('/v1/chat/completions');
+
+      expect(url.path, equals('/v1/chat/completions'));
+    });
+
+    test('handles a base URL with multiple path segments', () {
+      const builder = RequestBuilder(
+        config: MistralConfig(baseUrl: 'https://proxy.example.com/api/v1/x'),
+      );
+
+      final url = builder.buildUrl('/v1/chat/completions');
+
+      expect(url.path, equals('/api/v1/x/v1/chat/completions'));
+    });
+
+    test('preserves query params carried by the base URL', () {
+      const builder = RequestBuilder(
+        config: MistralConfig(
+          baseUrl: 'https://proxy.example.com/?api-version=2024',
+        ),
+      );
+
+      final url = builder.buildUrl('/v1/chat/completions');
+
+      expect(url.path, equals('/v1/chat/completions'));
+      expect(url.queryParameters['api-version'], equals('2024'));
+    });
+
+    test('merges default and per-request query params', () {
+      const builder = RequestBuilder(
+        config: MistralConfig(
+          baseUrl: 'https://api.mistral.ai/',
+          defaultQueryParams: {'beta': 'true'},
+        ),
+      );
+
+      final url = builder.buildUrl('/v1/models', queryParams: {'limit': '20'});
+
+      expect(url.path, equals('/v1/models'));
+      expect(url.queryParameters['beta'], equals('true'));
+      expect(url.queryParameters['limit'], equals('20'));
+    });
+
+    test('per-request params override defaults on conflict', () {
+      const builder = RequestBuilder(
+        config: MistralConfig(defaultQueryParams: {'limit': '10'}),
+      );
+
+      final url = builder.buildUrl('/v1/models', queryParams: {'limit': '20'});
+
+      expect(url.queryParameters['limit'], equals('20'));
+    });
+
+    test('per-request params override base-URL params on conflict', () {
+      const builder = RequestBuilder(
+        config: MistralConfig(
+          baseUrl: 'https://proxy.example.com/?api-version=2024',
+        ),
+      );
+
+      final url = builder.buildUrl(
+        '/v1/models',
+        queryParams: {'api-version': '2025'},
+      );
+
+      expect(url.queryParameters['api-version'], equals('2025'));
+    });
+
+    test('default params override base-URL params on conflict', () {
+      const builder = RequestBuilder(
+        config: MistralConfig(
+          baseUrl: 'https://proxy.example.com/?api-version=2024',
+          defaultQueryParams: {'api-version': '2025'},
+        ),
+      );
+
+      final url = builder.buildUrl('/v1/models');
+
+      expect(url.queryParameters['api-version'], equals('2025'));
+    });
+
+    test('preserves repeated query keys carried by the base URL', () {
+      const builder = RequestBuilder(
+        config: MistralConfig(baseUrl: 'https://proxy.example.com/?k=a&k=b'),
+      );
+
+      final url = builder.buildUrl('/v1/models');
+
+      expect(url.queryParametersAll['k'], equals(['a', 'b']));
+      expect(url.toString(), contains('k=a&k=b'));
+    });
+
+    test('per-request params replace the whole repeated-key list', () {
+      const builder = RequestBuilder(
+        config: MistralConfig(baseUrl: 'https://proxy.example.com/?k=a&k=b'),
+      );
+
+      final url = builder.buildUrl('/v1/models', queryParams: {'k': 'c'});
+
+      expect(url.queryParametersAll['k'], equals(['c']));
+    });
+
+    test('default params replace repeated base-URL keys', () {
+      const builder = RequestBuilder(
+        config: MistralConfig(
+          baseUrl: 'https://proxy.example.com/?k=a&k=b',
+          defaultQueryParams: {'k': 'c'},
+        ),
+      );
+
+      final url = builder.buildUrl('/v1/models');
+
+      expect(url.queryParametersAll['k'], equals(['c']));
+    });
+
+    test('renders Iterable query param values as repeated keys', () {
+      // Mirrors WorkflowCoreResource.listWorkflows, which passes List<String>
+      // values for form/explode array params (status=a&status=b).
+      const builder = RequestBuilder(config: MistralConfig());
+
+      final url = builder.buildUrl(
+        '/v1/workflows',
+        queryParams: {
+          'status': ['queued', 'running'],
+        },
+      );
+
+      expect(url.queryParametersAll['status'], equals(['queued', 'running']));
+      expect(url.toString(), contains('status=queued&status=running'));
+    });
+
+    test('preserves a non-standard port in the base URL', () {
+      const builder = RequestBuilder(
+        config: MistralConfig(baseUrl: 'https://api.example.com:8443'),
+      );
+
+      final url = builder.buildUrl('/v1/models');
+
+      expect(url.port, equals(8443));
+      expect(url.path, equals('/v1/models'));
+    });
+
+    test('preserves userInfo and fragment from the base URL', () {
+      const builder = RequestBuilder(
+        config: MistralConfig(
+          baseUrl: 'https://user:pass@api.example.com/base#frag',
+        ),
+      );
+
+      final url = builder.buildUrl('/v1/models');
+
+      expect(url.userInfo, equals('user:pass'));
+      expect(url.path, equals('/base/v1/models'));
+      expect(url.fragment, equals('frag'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Fixes `RequestBuilder.buildUrl` producing a double slash (`//v1/...`) when `MistralConfig.baseUrl` (or `MISTRAL_BASE_URL`) has a trailing slash — many gateways/proxies 404 on the empty path segment.
- Preserves query parameters carried by the base URL (e.g. a proxy `?api-version=...`), which were previously dropped or mangled into the path.
- Preserves repeated base-URL query keys (`?k=a&k=b`) via `queryParametersAll` instead of collapsing to the last value.

## Details

Port of the fix applied to `anthropic_sdk_dart` in #271, with multi-value query preservation. The base URL is parsed once, its path is normalized (trailing slash stripped, leading slash ensured on the endpoint path), and query params merge in order: **base URL → `defaultQueryParams` → per-request** (last-write-wins by key; a later source replaces the whole value list for that key). The URI is rebuilt with `Uri.replace`, which keeps scheme, userInfo, host, port, and fragment from the base URL.

`Iterable<String>` values in `queryParams` still render as repeated keys (`status=queued&status=running`) — the contract `WorkflowCoreResource.listWorkflows` relies on; a regression test covers it.

No signature changes; no caller changes needed.

## References

- #271 — the equivalent fix for `anthropic_sdk_dart` this PR mirrors.

## Test Plan

- [x] New `test/unit/client/url_builder_test.dart` (17 cases): trailing slash, base sub-path, base-URL query preservation, 3-layer merge precedence, repeated-key preservation/replacement, Iterable rendering, port/userInfo/fragment preservation. Written first (TDD): 6 cases fail on the old code.
- [x] Full unit suite passes: `dart test --reporter=failures-only packages/mistralai_dart/test/unit/` (1777 passed).
- [x] `dart format` / `dart fix` / `dart analyze` clean.