### PR TITLE
fix(ollama_dart): avoid double slash and preserve base URL query params in buildUrl

### DIFF
--- a/packages/ollama_dart/lib/src/client/request_builder.dart
+++ b/packages/ollama_dart/lib/src/client/request_builder.dart
@@ -14,20 +14,42 @@ class RequestBuilder {
 
   /// Builds a URL for an API endpoint.
   ///
-  /// Merges query parameters in order: Global → Request.
-  /// Later values override earlier ones (last-write-wins).
+  /// The [path] is a URL path (e.g. `/api/chat`); pass query parameters via
+  /// [queryParams] rather than embedding them in [path]. Values may be a
+  /// `String` or an `Iterable<String>` (rendered as repeated keys, e.g.
+  /// `?status=a&status=b`).
+  ///
+  /// Merges query parameters in order: base URL → config defaults → request.
+  /// Later sources override earlier ones by key (last-write-wins; the whole
+  /// value list for that key is replaced). Repeated keys carried by the base
+  /// URL (e.g. `?k=a&k=b`) are preserved.
   Uri buildUrl(String path, {Map<String, dynamic>? queryParams}) {
-    final uri = Uri.parse('${config.baseUrl}$path');
+    // Parse the base URL so existing path/query components are handled
+    // correctly (e.g. a proxy sub-path or an `?token=` param).
+    final baseUri = Uri.parse(config.baseUrl);
+
+    // Normalize the base path and endpoint path to avoid a double slash when
+    // the configured base URL ends with a trailing slash.
+    final basePath = baseUri.path.endsWith('/')
+        ? baseUri.path.substring(0, baseUri.path.length - 1)
+        : baseUri.path;
+    final normalizedPath = path.startsWith('/') ? path : '/$path';
+
+    // Merge query params (last-write-wins by key). `queryParametersAll`
+    // preserves repeated base-URL keys; `Uri.replace` accepts both `String`
+    // and `Iterable<String>` values.
     final mergedParams = <String, dynamic>{
+      ...baseUri.queryParametersAll,
       ...config.defaultQueryParams,
       ...?queryParams,
     };
 
-    if (mergedParams.isEmpty) {
-      return uri;
-    }
-
-    return uri.replace(queryParameters: mergedParams);
+    // `replace` keeps scheme, userInfo, host, port, and fragment from the
+    // base URL; only path and query are rebuilt.
+    return baseUri.replace(
+      path: '$basePath$normalizedPath',
+      queryParameters: mergedParams.isEmpty ? null : mergedParams,
+    );
   }
 
   /// Builds headers for a request.

--- a/packages/ollama_dart/test/unit/client/url_builder_test.dart
+++ b/packages/ollama_dart/test/unit/client/url_builder_test.dart
@@ -1,0 +1,203 @@
+import 'package:ollama_dart/ollama_dart.dart';
+import 'package:ollama_dart/src/client/request_builder.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RequestBuilder.buildUrl', () {
+    test('builds URL with the default base URL', () {
+      const builder = RequestBuilder(config: OllamaConfig());
+
+      final url = builder.buildUrl('/api/chat');
+
+      expect(url.scheme, equals('http'));
+      expect(url.host, equals('localhost'));
+      expect(url.port, equals(11434));
+      expect(url.path, equals('/api/chat'));
+      expect(url.query, isEmpty);
+    });
+
+    test('normalizes a trailing slash in the base URL (no double slash)', () {
+      const builder = RequestBuilder(
+        config: OllamaConfig(baseUrl: 'http://localhost:11434/'),
+      );
+
+      final url = builder.buildUrl('/api/chat');
+
+      // Should be /api/chat, not //api/chat.
+      expect(url.path, equals('/api/chat'));
+      expect(url.toString(), equals('http://localhost:11434/api/chat'));
+    });
+
+    test('preserves a base URL sub-path with a trailing slash', () {
+      const builder = RequestBuilder(
+        config: OllamaConfig(baseUrl: 'https://proxy.example.com/ollama/'),
+      );
+
+      final url = builder.buildUrl('/api/chat');
+
+      expect(url.path, equals('/ollama/api/chat'));
+    });
+
+    test('handles an endpoint path without a leading slash', () {
+      const builder = RequestBuilder(
+        config: OllamaConfig(baseUrl: 'http://localhost:11434/'),
+      );
+
+      final url = builder.buildUrl('api/chat');
+
+      expect(url.path, equals('/api/chat'));
+    });
+
+    test('handles a base URL with no path', () {
+      const builder = RequestBuilder(
+        config: OllamaConfig(baseUrl: 'https://ollama.example.com'),
+      );
+
+      final url = builder.buildUrl('/api/chat');
+
+      expect(url.path, equals('/api/chat'));
+    });
+
+    test('handles a base URL with multiple path segments', () {
+      const builder = RequestBuilder(
+        config: OllamaConfig(baseUrl: 'https://proxy.example.com/api/v1/x'),
+      );
+
+      final url = builder.buildUrl('/api/chat');
+
+      expect(url.path, equals('/api/v1/x/api/chat'));
+    });
+
+    test('preserves query params carried by the base URL', () {
+      const builder = RequestBuilder(
+        config: OllamaConfig(baseUrl: 'https://proxy.example.com/?token=abc'),
+      );
+
+      final url = builder.buildUrl('/api/chat');
+
+      expect(url.path, equals('/api/chat'));
+      expect(url.queryParameters['token'], equals('abc'));
+    });
+
+    test('merges default and per-request query params', () {
+      const builder = RequestBuilder(
+        config: OllamaConfig(
+          baseUrl: 'http://localhost:11434/',
+          defaultQueryParams: {'beta': 'true'},
+        ),
+      );
+
+      final url = builder.buildUrl('/api/tags', queryParams: {'limit': '20'});
+
+      expect(url.path, equals('/api/tags'));
+      expect(url.queryParameters['beta'], equals('true'));
+      expect(url.queryParameters['limit'], equals('20'));
+    });
+
+    test('per-request params override defaults on conflict', () {
+      const builder = RequestBuilder(
+        config: OllamaConfig(defaultQueryParams: {'limit': '10'}),
+      );
+
+      final url = builder.buildUrl('/api/tags', queryParams: {'limit': '20'});
+
+      expect(url.queryParameters['limit'], equals('20'));
+    });
+
+    test('per-request params override base-URL params on conflict', () {
+      const builder = RequestBuilder(
+        config: OllamaConfig(baseUrl: 'https://proxy.example.com/?token=old'),
+      );
+
+      final url = builder.buildUrl('/api/tags', queryParams: {'token': 'new'});
+
+      expect(url.queryParameters['token'], equals('new'));
+    });
+
+    test('default params override base-URL params on conflict', () {
+      const builder = RequestBuilder(
+        config: OllamaConfig(
+          baseUrl: 'https://proxy.example.com/?token=old',
+          defaultQueryParams: {'token': 'new'},
+        ),
+      );
+
+      final url = builder.buildUrl('/api/tags');
+
+      expect(url.queryParameters['token'], equals('new'));
+    });
+
+    test('preserves repeated query keys carried by the base URL', () {
+      const builder = RequestBuilder(
+        config: OllamaConfig(baseUrl: 'https://proxy.example.com/?k=a&k=b'),
+      );
+
+      final url = builder.buildUrl('/api/tags');
+
+      expect(url.queryParametersAll['k'], equals(['a', 'b']));
+      expect(url.toString(), contains('k=a&k=b'));
+    });
+
+    test('per-request params replace the whole repeated-key list', () {
+      const builder = RequestBuilder(
+        config: OllamaConfig(baseUrl: 'https://proxy.example.com/?k=a&k=b'),
+      );
+
+      final url = builder.buildUrl('/api/tags', queryParams: {'k': 'c'});
+
+      expect(url.queryParametersAll['k'], equals(['c']));
+    });
+
+    test('default params replace repeated base-URL keys', () {
+      const builder = RequestBuilder(
+        config: OllamaConfig(
+          baseUrl: 'https://proxy.example.com/?k=a&k=b',
+          defaultQueryParams: {'k': 'c'},
+        ),
+      );
+
+      final url = builder.buildUrl('/api/tags');
+
+      expect(url.queryParametersAll['k'], equals(['c']));
+    });
+
+    test('renders Iterable query param values as repeated keys', () {
+      const builder = RequestBuilder(config: OllamaConfig());
+
+      final url = builder.buildUrl(
+        '/api/tags',
+        queryParams: {
+          'status': ['queued', 'running'],
+        },
+      );
+
+      expect(url.queryParametersAll['status'], equals(['queued', 'running']));
+      expect(url.toString(), contains('status=queued&status=running'));
+    });
+
+    test('preserves a non-standard port in the base URL', () {
+      const builder = RequestBuilder(
+        config: OllamaConfig(baseUrl: 'https://ollama.example.com:8443'),
+      );
+
+      final url = builder.buildUrl('/api/tags');
+
+      expect(url.port, equals(8443));
+      expect(url.path, equals('/api/tags'));
+    });
+
+    test('preserves userInfo and fragment from the base URL', () {
+      const builder = RequestBuilder(
+        config: OllamaConfig(
+          baseUrl: 'https://user:pass@ollama.example.com/base#frag',
+        ),
+      );
+
+      final url = builder.buildUrl('/api/tags');
+
+      expect(url.userInfo, equals('user:pass'));
+      expect(url.path, equals('/base/api/tags'));
+      expect(url.fragment, equals('frag'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Fixes `RequestBuilder.buildUrl` producing a double slash (`//api/...`) when `OllamaConfig.baseUrl` (or `OLLAMA_HOST`) has a trailing slash — proxies and some Ollama setups 404/misroute on the empty path segment.
- Preserves query parameters carried by the base URL (e.g. a proxy `?token=...`), which were previously dropped or mangled into the path.
- Preserves repeated base-URL query keys (`?k=a&k=b`) via `queryParametersAll` instead of collapsing to the last value.

## Details

Port of the fix applied to `anthropic_sdk_dart` in #271 (see also #272 for `mistralai_dart`), with multi-value query preservation. The base URL is parsed once, its path normalized (trailing slash stripped, leading slash ensured on the endpoint path), and query params merge in order: **base URL → `defaultQueryParams` → per-request** (last-write-wins by key; a later source replaces the whole value list). The URI is rebuilt with `Uri.replace`, keeping scheme, userInfo, host, port, and fragment from the base URL.

No signature changes; no caller changes needed.

## References

- #271 — the equivalent fix for `anthropic_sdk_dart` this PR mirrors.

## Test Plan

- [x] New `test/unit/client/url_builder_test.dart` (17 cases): trailing slash, base sub-path, base-URL query preservation, 3-layer merge precedence, repeated-key preservation/replacement, Iterable rendering, port/userInfo/fragment preservation. Written first (TDD): 6 cases fail on the old code.
- [x] Full unit suite passes: `dart test --reporter=failures-only packages/ollama_dart/test/unit/` (255 passed).
- [x] `dart format` / `dart fix` / `dart analyze` clean.