### PR TITLE
fix(googleai_dart): normalize base URL handling across request, upload, and live URLs

### DIFF
--- a/packages/googleai_dart/lib/src/client/request_builder.dart
+++ b/packages/googleai_dart/lib/src/client/request_builder.dart
@@ -19,8 +19,10 @@ class RequestBuilder {
 
   /// Builds a URL for an API endpoint.
   ///
-  /// Merges query parameters in order: Global → Endpoint → Request.
-  /// Later values override earlier ones (last-write-wins).
+  /// Merges query parameters in order: base URL → Global → Endpoint → Request.
+  /// Later sources override earlier ones by key (last-write-wins; the whole
+  /// value list for that key is replaced). Repeated keys carried by the base
+  /// URL (e.g. `?k=a&k=b`) are preserved.
   ///
   /// Transforms the path based on the API mode and version.
   /// Use `{version}` placeholder in paths, which gets replaced with the configured version.
@@ -31,15 +33,58 @@ class RequestBuilder {
     EndpointConfig? endpointConfig,
     Map<String, dynamic>? queryParams,
   }) {
-    final transformedPath = _transformPath(path);
-    final uri = Uri.parse('${config.baseUrl}$transformedPath');
+    final baseUri = Uri.parse(config.baseUrl);
+    final combinedPath = _joinPaths(baseUri.path, _transformPath(path));
     final mergedParams = <String, dynamic>{
+      ...baseUri.queryParametersAll,
       ...config.defaultQueryParams,
       ...?endpointConfig?.queryParams,
       ...?queryParams,
     };
 
-    return uri.replace(queryParameters: mergedParams);
+    // `replace` keeps scheme, userInfo, host, port, and fragment from the
+    // base URL; only path and query are rebuilt.
+    return baseUri.replace(
+      path: combinedPath,
+      queryParameters: mergedParams.isEmpty ? null : mergedParams,
+    );
+  }
+
+  /// Builds a URL for resumable-upload endpoints (`/upload/{version}/...`).
+  ///
+  /// Upload endpoints sit outside the standard versioned API surface and are
+  /// Google-AI-only, so Vertex path injection does not apply. Replaces the
+  /// `{version}` placeholder and merges query params in order:
+  /// base URL → Global → [queryParams] (last-write-wins by key).
+  Uri buildUploadUrl(String path, {Map<String, String>? queryParams}) {
+    final baseUri = Uri.parse(config.baseUrl);
+    final transformedPath = path.replaceFirst(
+      '{version}',
+      config.apiVersion.value,
+    );
+    final combinedPath = _joinPaths(baseUri.path, transformedPath);
+    final mergedParams = <String, dynamic>{
+      ...baseUri.queryParametersAll,
+      ...config.defaultQueryParams,
+      ...?queryParams,
+    };
+
+    return baseUri.replace(
+      path: combinedPath,
+      queryParameters: mergedParams.isEmpty ? null : mergedParams,
+    );
+  }
+
+  /// Joins the base URL path and an endpoint path, avoiding a double slash
+  /// when the base URL has a trailing slash and preserving any base sub-path.
+  static String _joinPaths(String basePath, String endpointPath) {
+    final trimmedBase = basePath.endsWith('/')
+        ? basePath.substring(0, basePath.length - 1)
+        : basePath;
+    final normalized = endpointPath.startsWith('/')
+        ? endpointPath
+        : '/$endpointPath';
+    return '$trimmedBase$normalized';
   }
 
   /// Transforms the path based on API mode and version.

--- a/packages/googleai_dart/lib/src/interceptors/auth_interceptor.dart
+++ b/packages/googleai_dart/lib/src/interceptors/auth_interceptor.dart
@@ -81,7 +81,7 @@ class AuthInterceptor implements Interceptor {
     } else {
       // Add as query parameter (default)
       final uri = request.url;
-      final queryParams = Map<String, dynamic>.from(uri.queryParameters);
+      final queryParams = Map<String, dynamic>.from(uri.queryParametersAll);
 
       // Don't overwrite existing 'key' query parameter
       if (queryParams.containsKey('key')) {
@@ -144,7 +144,7 @@ class AuthInterceptor implements Interceptor {
     } else {
       // Add as query parameter (default)
       final uri = request.url;
-      final queryParams = Map<String, dynamic>.from(uri.queryParameters);
+      final queryParams = Map<String, dynamic>.from(uri.queryParametersAll);
 
       // Don't overwrite existing 'access_token' query parameter
       if (queryParams.containsKey('access_token')) {

--- a/packages/googleai_dart/lib/src/live/live_client.dart
+++ b/packages/googleai_dart/lib/src/live/live_client.dart
@@ -1,6 +1,7 @@
 import 'dart:async' show Completer, StreamSubscription, unawaited;
 
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 
 import '../auth/auth_provider.dart';
 import '../client/config.dart';
@@ -176,35 +177,63 @@ class LiveClient {
 
   Future<Uri> _buildWebSocketUri(String model, {String? accessToken}) async {
     // Get auth credentials for query params
-    final queryParams = await _getAuthQueryParams(accessToken: accessToken);
+    final authQueryParams = await _getAuthQueryParams(accessToken: accessToken);
+    return buildWebSocketUri(_config, authQueryParams);
+  }
 
-    switch (_config.apiMode) {
+  /// Builds the WebSocket URI for a Live API connection.
+  ///
+  /// For Google AI mode, the configured base URL is parsed so a trailing
+  /// slash, sub-path (proxy), explicit port, or query params carried by the
+  /// base URL are handled correctly. An `http`/`ws` base URL maps to `ws`;
+  /// anything else (including scheme-less values) maps to `wss`.
+  ///
+  /// Merges query parameters in order: base URL → auth → config defaults
+  /// (last-write-wins by key).
+  @visibleForTesting
+  static Uri buildWebSocketUri(
+    GoogleAIConfig config,
+    Map<String, String> authQueryParams,
+  ) {
+    switch (config.apiMode) {
       case ApiMode.googleAI:
         // Google AI endpoint
         // wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent
-        final baseUrl = _config.baseUrl.isNotEmpty
-            ? _config.baseUrl
-            : 'generativelanguage.googleapis.com';
+        var raw = config.baseUrl.isNotEmpty
+            ? config.baseUrl
+            : 'https://generativelanguage.googleapis.com';
+        // Back-compat: scheme-less host strings were previously accepted.
+        if (!raw.contains('://')) {
+          raw = 'https://$raw';
+        }
+        final baseUri = Uri.parse(raw);
+        final basePath = baseUri.path.endsWith('/')
+            ? baseUri.path.substring(0, baseUri.path.length - 1)
+            : baseUri.path;
+        final secure = baseUri.scheme != 'http' && baseUri.scheme != 'ws';
 
-        queryParams.addAll(_config.defaultQueryParams);
+        final queryParams = <String, dynamic>{
+          ...baseUri.queryParametersAll,
+          ...authQueryParams,
+          ...config.defaultQueryParams,
+        };
 
         return Uri(
-          scheme: 'wss',
-          host: baseUrl
-              .replaceFirst('https://', '')
-              .replaceFirst('http://', ''),
-          port: 443, // Explicit port to avoid :0 issue
+          scheme: secure ? 'wss' : 'ws',
+          host: baseUri.host,
+          // Explicit port to avoid :0 issue.
+          port: baseUri.hasPort ? baseUri.port : (secure ? 443 : 80),
           path:
-              '/ws/google.ai.generativelanguage.${_config.apiVersion.value}.GenerativeService.BidiGenerateContent',
-          queryParameters: queryParams,
+              '$basePath/ws/google.ai.generativelanguage.${config.apiVersion.value}.GenerativeService.BidiGenerateContent',
+          queryParameters: queryParams.isEmpty ? null : queryParams,
         );
 
       case ApiMode.vertexAI:
         // Vertex AI endpoint
         // wss://{location}-aiplatform.googleapis.com/ws/...
         // ('global' uses aiplatform.googleapis.com without location prefix)
-        final location = _config.location ?? 'us-central1';
-        final projectId = _config.projectId;
+        final location = config.location ?? 'us-central1';
+        final projectId = config.projectId;
 
         if (projectId == null) {
           throw const LiveSessionSetupException(
@@ -213,11 +242,14 @@ class LiveClient {
         }
 
         final host = GoogleAIConfig.vertexAIHost(location);
-        final version = _config.apiVersion == ApiVersion.v1 ? 'v1' : 'v1beta1';
+        final version = config.apiVersion == ApiVersion.v1 ? 'v1' : 'v1beta1';
 
-        queryParams['project'] = projectId;
-        queryParams['location'] = location;
-        queryParams.addAll(_config.defaultQueryParams);
+        final queryParams = <String, String>{
+          ...authQueryParams,
+          'project': projectId,
+          'location': location,
+          ...config.defaultQueryParams,
+        };
 
         // Note: Vertex AI requires OAuth Bearer token in headers.
         // On native platforms, the websocket_connector passes headers to dart:io.

--- a/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_io.dart
+++ b/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_io.dart
@@ -278,10 +278,6 @@ class FileSearchStoresResource extends ResourceBase {
 
     // FileSearchStores uses resumable upload protocol
     // Step 1: Initiate the upload and get upload URL
-    final uploadUrl = Uri.parse(
-      '${config.baseUrl}/upload/${config.apiVersion.value}/$parent:uploadToFileSearchStore',
-    );
-
     final initiationHeaders = <String, String>{
       'X-Goog-Upload-Protocol': 'resumable',
       'X-Goog-Upload-Command': 'start',
@@ -290,47 +286,36 @@ class FileSearchStoresResource extends ResourceBase {
       'Content-Type': 'application/json',
     };
 
-    // Apply authentication to initiation request
+    // Apply authentication to the initiation request. Query-placement
+    // credentials are collected and merged into the upload URL below.
+    final authQueryParams = <String, String>{};
     if (config.authProvider != null) {
       final credentials = await config.authProvider!.getCredentials();
       switch (credentials) {
         case ApiKeyCredentials(:final apiKey, :final placement):
           if (placement == AuthPlacement.header) {
             initiationHeaders['X-Goog-Api-Key'] = apiKey;
+          } else {
+            authQueryParams['key'] = apiKey;
           }
         case BearerTokenCredentials(:final token):
           initiationHeaders['Authorization'] = 'Bearer $token';
         case EphemeralTokenCredentials(:final token, :final placement):
           if (placement == EphemeralTokenPlacement.header) {
             initiationHeaders['Authorization'] = 'Token $token';
+          } else {
+            authQueryParams['access_token'] = token;
           }
-        // Query param handled below
         case NoAuthCredentials():
           // No auth needed
           break;
       }
     }
 
-    // Add API key or ephemeral token as query param if needed
-    final Uri uploadUrlWithAuth;
-    if (config.authProvider != null) {
-      final credentials = await config.authProvider!.getCredentials();
-      if (credentials is ApiKeyCredentials &&
-          credentials.placement == AuthPlacement.queryParam) {
-        uploadUrlWithAuth = uploadUrl.replace(
-          queryParameters: {'key': credentials.apiKey},
-        );
-      } else if (credentials is EphemeralTokenCredentials &&
-          credentials.placement == EphemeralTokenPlacement.queryParam) {
-        uploadUrlWithAuth = uploadUrl.replace(
-          queryParameters: {'access_token': credentials.token},
-        );
-      } else {
-        uploadUrlWithAuth = uploadUrl;
-      }
-    } else {
-      uploadUrlWithAuth = uploadUrl;
-    }
+    final uploadUrlWithAuth = requestBuilder.buildUploadUrl(
+      '/upload/{version}/$parent:uploadToFileSearchStore',
+      queryParams: authQueryParams,
+    );
 
     // Build request body with metadata
     final requestBody = <String, dynamic>{

--- a/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_web.dart
+++ b/packages/googleai_dart/lib/src/resources/file_search_stores/file_search_stores_resource_web.dart
@@ -227,10 +227,6 @@ class FileSearchStoresResource extends ResourceBase {
 
     // FileSearchStores uses resumable upload protocol
     // Step 1: Initiate the upload and get upload URL
-    final uploadUrl = Uri.parse(
-      '${config.baseUrl}/upload/${config.apiVersion.value}/$parent:uploadToFileSearchStore',
-    );
-
     final initiationHeaders = <String, String>{
       'X-Goog-Upload-Protocol': 'resumable',
       'X-Goog-Upload-Command': 'start',
@@ -239,47 +235,36 @@ class FileSearchStoresResource extends ResourceBase {
       'Content-Type': 'application/json',
     };
 
-    // Apply authentication to initiation request
+    // Apply authentication to the initiation request. Query-placement
+    // credentials are collected and merged into the upload URL below.
+    final authQueryParams = <String, String>{};
     if (config.authProvider != null) {
       final credentials = await config.authProvider!.getCredentials();
       switch (credentials) {
         case ApiKeyCredentials(:final apiKey, :final placement):
           if (placement == AuthPlacement.header) {
             initiationHeaders['X-Goog-Api-Key'] = apiKey;
+          } else {
+            authQueryParams['key'] = apiKey;
           }
         case BearerTokenCredentials(:final token):
           initiationHeaders['Authorization'] = 'Bearer $token';
         case EphemeralTokenCredentials(:final token, :final placement):
           if (placement == EphemeralTokenPlacement.header) {
             initiationHeaders['Authorization'] = 'Token $token';
+          } else {
+            authQueryParams['access_token'] = token;
           }
-        // Query param handled below
         case NoAuthCredentials():
           // No auth needed
           break;
       }
     }
 
-    // Add API key or ephemeral token as query param if needed
-    final Uri uploadUrlWithAuth;
-    if (config.authProvider != null) {
-      final credentials = await config.authProvider!.getCredentials();
-      if (credentials is ApiKeyCredentials &&
-          credentials.placement == AuthPlacement.queryParam) {
-        uploadUrlWithAuth = uploadUrl.replace(
-          queryParameters: {'key': credentials.apiKey},
-        );
-      } else if (credentials is EphemeralTokenCredentials &&
-          credentials.placement == EphemeralTokenPlacement.queryParam) {
-        uploadUrlWithAuth = uploadUrl.replace(
-          queryParameters: {'access_token': credentials.token},
-        );
-      } else {
-        uploadUrlWithAuth = uploadUrl;
-      }
-    } else {
-      uploadUrlWithAuth = uploadUrl;
-    }
+    final uploadUrlWithAuth = requestBuilder.buildUploadUrl(
+      '/upload/{version}/$parent:uploadToFileSearchStore',
+      queryParams: authQueryParams,
+    );
 
     // Build request body with metadata
     final requestBody = <String, dynamic>{

--- a/packages/googleai_dart/lib/src/resources/files/files_resource_io.dart
+++ b/packages/googleai_dart/lib/src/resources/files/files_resource_io.dart
@@ -174,10 +174,6 @@ class FilesResource extends ResourceBase {
 
     // Google AI Files API uses resumable upload protocol
     // Step 1: Initiate the upload and get upload URL
-    final uploadUrl = Uri.parse(
-      '${config.baseUrl}/upload/${config.apiVersion.value}/files',
-    );
-
     final initiationHeaders = <String, String>{
       'X-Goog-Upload-Protocol': 'resumable',
       'X-Goog-Upload-Command': 'start',
@@ -186,47 +182,36 @@ class FilesResource extends ResourceBase {
       'Content-Type': 'application/json',
     };
 
-    // Apply authentication to initiation request
+    // Apply authentication to the initiation request. Query-placement
+    // credentials are collected and merged into the upload URL below.
+    final authQueryParams = <String, String>{};
     if (config.authProvider != null) {
       final credentials = await config.authProvider!.getCredentials();
       switch (credentials) {
         case ApiKeyCredentials(:final apiKey, :final placement):
           if (placement == AuthPlacement.header) {
             initiationHeaders['X-Goog-Api-Key'] = apiKey;
+          } else {
+            authQueryParams['key'] = apiKey;
           }
         case BearerTokenCredentials(:final token):
           initiationHeaders['Authorization'] = 'Bearer $token';
         case EphemeralTokenCredentials(:final token, :final placement):
           if (placement == EphemeralTokenPlacement.header) {
             initiationHeaders['Authorization'] = 'Token $token';
+          } else {
+            authQueryParams['access_token'] = token;
           }
-        // Query param handled below
         case NoAuthCredentials():
           // No auth needed
           break;
       }
     }
 
-    // Add API key or ephemeral token as query param if needed
-    final Uri uploadUrlWithAuth;
-    if (config.authProvider != null) {
-      final credentials = await config.authProvider!.getCredentials();
-      if (credentials is ApiKeyCredentials &&
-          credentials.placement == AuthPlacement.queryParam) {
-        uploadUrlWithAuth = uploadUrl.replace(
-          queryParameters: {'key': credentials.apiKey},
-        );
-      } else if (credentials is EphemeralTokenCredentials &&
-          credentials.placement == EphemeralTokenPlacement.queryParam) {
-        uploadUrlWithAuth = uploadUrl.replace(
-          queryParameters: {'access_token': credentials.token},
-        );
-      } else {
-        uploadUrlWithAuth = uploadUrl;
-      }
-    } else {
-      uploadUrlWithAuth = uploadUrl;
-    }
+    final uploadUrlWithAuth = requestBuilder.buildUploadUrl(
+      '/upload/{version}/files',
+      queryParams: authQueryParams,
+    );
 
     final initiationBody = jsonEncode({
       'file': {'displayName': displayFileName},

--- a/packages/googleai_dart/lib/src/resources/files/files_resource_web.dart
+++ b/packages/googleai_dart/lib/src/resources/files/files_resource_web.dart
@@ -105,10 +105,6 @@ class FilesResource extends ResourceBase {
 
     // Google AI Files API uses resumable upload protocol
     // Step 1: Initiate the upload and get upload URL
-    final uploadUrl = Uri.parse(
-      '${config.baseUrl}/upload/${config.apiVersion.value}/files',
-    );
-
     final initiationHeaders = <String, String>{
       'X-Goog-Upload-Protocol': 'resumable',
       'X-Goog-Upload-Command': 'start',
@@ -117,47 +113,36 @@ class FilesResource extends ResourceBase {
       'Content-Type': 'application/json',
     };
 
-    // Apply authentication to initiation request
+    // Apply authentication to the initiation request. Query-placement
+    // credentials are collected and merged into the upload URL below.
+    final authQueryParams = <String, String>{};
     if (config.authProvider != null) {
       final credentials = await config.authProvider!.getCredentials();
       switch (credentials) {
         case ApiKeyCredentials(:final apiKey, :final placement):
           if (placement == AuthPlacement.header) {
             initiationHeaders['X-Goog-Api-Key'] = apiKey;
+          } else {
+            authQueryParams['key'] = apiKey;
           }
         case BearerTokenCredentials(:final token):
           initiationHeaders['Authorization'] = 'Bearer $token';
         case EphemeralTokenCredentials(:final token, :final placement):
           if (placement == EphemeralTokenPlacement.header) {
             initiationHeaders['Authorization'] = 'Token $token';
+          } else {
+            authQueryParams['access_token'] = token;
           }
-        // Query param handled below
         case NoAuthCredentials():
           // No auth needed
           break;
       }
     }
 
-    // Add API key or ephemeral token as query param if needed
-    final Uri uploadUrlWithAuth;
-    if (config.authProvider != null) {
-      final credentials = await config.authProvider!.getCredentials();
-      if (credentials is ApiKeyCredentials &&
-          credentials.placement == AuthPlacement.queryParam) {
-        uploadUrlWithAuth = uploadUrl.replace(
-          queryParameters: {'key': credentials.apiKey},
-        );
-      } else if (credentials is EphemeralTokenCredentials &&
-          credentials.placement == EphemeralTokenPlacement.queryParam) {
-        uploadUrlWithAuth = uploadUrl.replace(
-          queryParameters: {'access_token': credentials.token},
-        );
-      } else {
-        uploadUrlWithAuth = uploadUrl;
-      }
-    } else {
-      uploadUrlWithAuth = uploadUrl;
-    }
+    final uploadUrlWithAuth = requestBuilder.buildUploadUrl(
+      '/upload/{version}/files',
+      queryParams: authQueryParams,
+    );
 
     final initiationBody = jsonEncode({
       'file': {'displayName': finalFileName},

--- a/packages/googleai_dart/lib/src/resources/streaming_resource.dart
+++ b/packages/googleai_dart/lib/src/resources/streaming_resource.dart
@@ -222,7 +222,7 @@ mixin StreamingResource on ResourceBase {
     } else {
       final uri = request.url;
       if (!uri.queryParameters.containsKey('key')) {
-        final queryParams = Map<String, dynamic>.from(uri.queryParameters);
+        final queryParams = Map<String, dynamic>.from(uri.queryParametersAll);
         queryParams['key'] = apiKey;
         final newUri = uri.replace(queryParameters: queryParams);
 
@@ -255,7 +255,7 @@ mixin StreamingResource on ResourceBase {
     if (uri.queryParameters.containsKey('access_token')) {
       return request;
     }
-    final queryParams = Map<String, dynamic>.from(uri.queryParameters);
+    final queryParams = Map<String, dynamic>.from(uri.queryParametersAll);
     queryParams['access_token'] = token;
     final newUri = uri.replace(queryParameters: queryParams);
 

--- a/packages/googleai_dart/test/unit/client/request_builder_precedence_test.dart
+++ b/packages/googleai_dart/test/unit/client/request_builder_precedence_test.dart
@@ -188,7 +188,8 @@ void main() {
         final url = builder.buildUrl('/endpoint');
 
         expect(url.toString(), startsWith('https://api.example.com'));
-        expect(url.path, contains('endpoint'));
+        // No double slash: /endpoint, not //endpoint.
+        expect(url.path, equals('/endpoint'));
       });
     });
 

--- a/packages/googleai_dart/test/unit/client/request_builder_url_join_test.dart
+++ b/packages/googleai_dart/test/unit/client/request_builder_url_join_test.dart
@@ -1,0 +1,238 @@
+import 'package:googleai_dart/src/client/config.dart';
+import 'package:googleai_dart/src/client/endpoint_config.dart';
+import 'package:googleai_dart/src/client/request_builder.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RequestBuilder.buildUrl - URL joining', () {
+    test('normalizes a trailing slash in the base URL (no double slash)', () {
+      const builder = RequestBuilder(
+        config: GoogleAIConfig(baseUrl: 'https://api.example.com/'),
+      );
+
+      final url = builder.buildUrl('/{version}/models/m:generateContent');
+
+      expect(url.path, equals('/v1beta/models/m:generateContent'));
+      expect(
+        url.toString(),
+        equals('https://api.example.com/v1beta/models/m:generateContent'),
+      );
+    });
+
+    test('preserves a base URL sub-path (proxy)', () {
+      const builder = RequestBuilder(
+        config: GoogleAIConfig(baseUrl: 'https://proxy.example.com/gemini'),
+      );
+
+      final url = builder.buildUrl('/{version}/models/m:generateContent');
+
+      expect(url.path, equals('/gemini/v1beta/models/m:generateContent'));
+    });
+
+    test('preserves a base URL sub-path with a trailing slash', () {
+      const builder = RequestBuilder(
+        config: GoogleAIConfig(baseUrl: 'https://proxy.example.com/gemini/'),
+      );
+
+      final url = builder.buildUrl('/{version}/models/m:generateContent');
+
+      expect(url.path, equals('/gemini/v1beta/models/m:generateContent'));
+    });
+
+    test('preserves query params carried by the base URL', () {
+      const builder = RequestBuilder(
+        config: GoogleAIConfig(baseUrl: 'https://api.example.com?token=abc'),
+      );
+
+      final url = builder.buildUrl('/{version}/files');
+
+      expect(url.path, equals('/v1beta/files'));
+      expect(url.queryParameters['token'], equals('abc'));
+    });
+
+    test('preserves repeated query keys carried by the base URL', () {
+      const builder = RequestBuilder(
+        config: GoogleAIConfig(baseUrl: 'https://api.example.com?a=1&a=2'),
+      );
+
+      final url = builder.buildUrl('/{version}/files');
+
+      expect(url.queryParametersAll['a'], equals(['1', '2']));
+      expect(url.toString(), contains('a=1&a=2'));
+    });
+
+    test('merges all four query param layers with correct precedence', () {
+      const builder = RequestBuilder(
+        config: GoogleAIConfig(
+          baseUrl: 'https://api.example.com?p=base&b=b',
+          defaultQueryParams: {'p': 'default', 'd': 'd'},
+        ),
+      );
+
+      final url = builder.buildUrl(
+        '/{version}/files',
+        endpointConfig: const EndpointConfig(
+          queryParams: {'p': 'endpoint', 'e': 'e'},
+        ),
+        queryParams: {'p': 'request'},
+      );
+
+      expect(url.queryParameters['p'], equals('request'));
+      expect(url.queryParameters['b'], equals('b'));
+      expect(url.queryParameters['d'], equals('d'));
+      expect(url.queryParameters['e'], equals('e'));
+    });
+
+    test('vertex mode injects project path with a trailing-slash base', () {
+      const builder = RequestBuilder(
+        config: GoogleAIConfig(
+          baseUrl: 'https://us-central1-aiplatform.googleapis.com/',
+          apiMode: ApiMode.vertexAI,
+          projectId: 'P',
+          location: 'L',
+        ),
+      );
+
+      final url = builder.buildUrl('/{version}/models/m:generateContent');
+
+      expect(
+        url.path,
+        equals(
+          '/v1beta/projects/P/locations/L/publishers/google/models/m:generateContent',
+        ),
+      );
+    });
+
+    test('vertex mode composes with a base URL sub-path', () {
+      const builder = RequestBuilder(
+        config: GoogleAIConfig(
+          baseUrl: 'https://proxy.example.com/vtx',
+          apiMode: ApiMode.vertexAI,
+          projectId: 'P',
+          location: 'L',
+        ),
+      );
+
+      final url = builder.buildUrl('/{version}/models/m:generateContent');
+
+      expect(
+        url.path,
+        equals(
+          '/vtx/v1beta/projects/P/locations/L/publishers/google/models/m:generateContent',
+        ),
+      );
+    });
+
+    test('preserves scheme and port for a local base URL', () {
+      const builder = RequestBuilder(
+        config: GoogleAIConfig(baseUrl: 'http://localhost:8080'),
+      );
+
+      final url = builder.buildUrl('/{version}/files');
+
+      expect(url.scheme, equals('http'));
+      expect(url.port, equals(8080));
+      expect(url.path, equals('/v1beta/files'));
+    });
+
+    test('emits no stray ? when there are no query params', () {
+      const builder = RequestBuilder(
+        config: GoogleAIConfig(baseUrl: 'https://api.example.com'),
+      );
+
+      final url = builder.buildUrl('/{version}/files');
+
+      expect(url.hasQuery, isFalse);
+      expect(url.toString(), isNot(endsWith('?')));
+    });
+  });
+
+  group('RequestBuilder.buildUploadUrl', () {
+    test(
+      'builds an upload URL without a double slash on trailing-slash base',
+      () {
+        const builder = RequestBuilder(
+          config: GoogleAIConfig(
+            baseUrl: 'https://generativelanguage.googleapis.com/',
+          ),
+        );
+
+        final url = builder.buildUploadUrl('/upload/{version}/files');
+
+        expect(url.path, equals('/upload/v1beta/files'));
+        expect(
+          url.toString(),
+          equals(
+            'https://generativelanguage.googleapis.com/upload/v1beta/files',
+          ),
+        );
+      },
+    );
+
+    test('prefixes a base URL sub-path', () {
+      const builder = RequestBuilder(
+        config: GoogleAIConfig(baseUrl: 'https://proxy.example.com/gemini'),
+      );
+
+      final url = builder.buildUploadUrl('/upload/{version}/files');
+
+      expect(url.path, equals('/gemini/upload/v1beta/files'));
+    });
+
+    test('respects the configured API version', () {
+      const builder = RequestBuilder(
+        config: GoogleAIConfig(apiVersion: ApiVersion.v1),
+      );
+
+      final url = builder.buildUploadUrl('/upload/{version}/files');
+
+      expect(url.path, equals('/upload/v1/files'));
+    });
+
+    test('merges defaultQueryParams and base-URL params', () {
+      const builder = RequestBuilder(
+        config: GoogleAIConfig(
+          baseUrl: 'https://api.example.com?token=abc',
+          defaultQueryParams: {'proxy': 'p'},
+        ),
+      );
+
+      final url = builder.buildUploadUrl('/upload/{version}/files');
+
+      expect(url.queryParameters['token'], equals('abc'));
+      expect(url.queryParameters['proxy'], equals('p'));
+    });
+
+    test('per-request params win over same-named defaults', () {
+      const builder = RequestBuilder(
+        config: GoogleAIConfig(defaultQueryParams: {'key': 'default-key'}),
+      );
+
+      final url = builder.buildUploadUrl(
+        '/upload/{version}/files',
+        queryParams: {'key': 'request-key'},
+      );
+
+      expect(url.queryParameters['key'], equals('request-key'));
+    });
+
+    test('does not apply Vertex path injection', () {
+      const builder = RequestBuilder(
+        config: GoogleAIConfig(
+          apiMode: ApiMode.vertexAI,
+          projectId: 'P',
+          location: 'L',
+        ),
+      );
+
+      final url = builder.buildUploadUrl(
+        '/upload/{version}/fileSearchStores/s:uploadToFileSearchStore',
+      );
+
+      expect(
+        url.path,
+        equals('/upload/v1beta/fileSearchStores/s:uploadToFileSearchStore'),
+      );
+    });
+  });
+}

--- a/packages/googleai_dart/test/unit/interceptors/auth_repeated_query_params_test.dart
+++ b/packages/googleai_dart/test/unit/interceptors/auth_repeated_query_params_test.dart
@@ -1,0 +1,113 @@
+import 'package:googleai_dart/src/auth/auth_provider.dart';
+import 'package:googleai_dart/src/client/config.dart';
+import 'package:googleai_dart/src/client/interceptor_chain.dart';
+import 'package:googleai_dart/src/client/request_builder.dart';
+import 'package:googleai_dart/src/interceptors/auth_interceptor.dart';
+import 'package:googleai_dart/src/interceptors/interceptor.dart';
+import 'package:googleai_dart/src/resources/base_resource.dart';
+import 'package:googleai_dart/src/resources/streaming_resource.dart';
+import 'package:http/http.dart' as http;
+import 'package:test/test.dart';
+
+/// Minimal resource to exercise [StreamingResource.prepareStreamingRequest].
+class _TestStreamingResource extends ResourceBase with StreamingResource {
+  _TestStreamingResource({
+    required super.config,
+    required super.httpClient,
+    required super.interceptorChain,
+    required super.requestBuilder,
+  });
+}
+
+_TestStreamingResource _buildStreamingResource(GoogleAIConfig config) {
+  final httpClient = http.Client();
+  addTearDown(httpClient.close);
+  return _TestStreamingResource(
+    config: config,
+    httpClient: httpClient,
+    interceptorChain: InterceptorChain(
+      interceptors: const [],
+      httpClient: httpClient,
+    ),
+    requestBuilder: RequestBuilder(config: config),
+  );
+}
+
+void main() {
+  // Repeated query keys (e.g. carried by a proxy base URL) must survive the
+  // auth param being appended - regression tests for the four sites that
+  // used to rebuild the query from the collapsing `uri.queryParameters`.
+  final requestUrl = Uri.parse('https://example.com/api?k=a&k=b');
+
+  group('AuthInterceptor preserves repeated query keys', () {
+    Future<http.BaseRequest> intercept(GoogleAIConfig config) async {
+      final interceptor = AuthInterceptor(config: config);
+      http.BaseRequest? captured;
+      Future<http.Response> mockNext(RequestContext context) async {
+        captured = context.request;
+        return http.Response('{}', 200);
+      }
+
+      final context = RequestContext(
+        request: http.Request('POST', requestUrl),
+        metadata: {},
+      );
+      await interceptor.intercept(context, mockNext);
+      return captured!;
+    }
+
+    test('when adding the key query param', () async {
+      const config = GoogleAIConfig(authProvider: ApiKeyProvider('test-key'));
+
+      final request = await intercept(config);
+
+      expect(request.url.queryParameters['key'], equals('test-key'));
+      expect(request.url.queryParametersAll['k'], equals(['a', 'b']));
+    });
+
+    test('when adding the access_token query param', () async {
+      const config = GoogleAIConfig(
+        authProvider: EphemeralTokenProvider('test-token'),
+      );
+
+      final request = await intercept(config);
+
+      expect(request.url.queryParameters['access_token'], equals('test-token'));
+      expect(request.url.queryParametersAll['k'], equals(['a', 'b']));
+    });
+  });
+
+  group(
+    'StreamingResource.prepareStreamingRequest preserves repeated keys',
+    () {
+      test('when adding the key query param', () async {
+        const config = GoogleAIConfig(authProvider: ApiKeyProvider('test-key'));
+        final resource = _buildStreamingResource(config);
+
+        final prepared = await resource.prepareStreamingRequest(
+          http.Request('POST', requestUrl),
+        );
+
+        expect(prepared.url.queryParameters['key'], equals('test-key'));
+        expect(prepared.url.queryParametersAll['k'], equals(['a', 'b']));
+      });
+
+      test('when adding the access_token query param', () async {
+        const config = GoogleAIConfig(
+          authProvider: EphemeralTokenProvider('test-token'),
+        );
+        final resource = _buildStreamingResource(config);
+
+        final prepared = await resource.prepareStreamingRequest(
+          http.Request('POST', requestUrl),
+        );
+
+        expect(
+          prepared.url.queryParameters['access_token'],
+          equals('test-token'),
+        );
+        expect(prepared.url.queryParametersAll['k'], equals(['a', 'b']));
+      });
+    },
+  );
+}

--- a/packages/googleai_dart/test/unit/live/live_client_uri_test.dart
+++ b/packages/googleai_dart/test/unit/live/live_client_uri_test.dart
@@ -1,0 +1,160 @@
+import 'package:googleai_dart/src/client/config.dart';
+import 'package:googleai_dart/src/errors/exceptions.dart';
+import 'package:googleai_dart/src/live/live_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LiveClient.buildWebSocketUri - Google AI mode', () {
+    test('builds the default wss URI', () {
+      const config = GoogleAIConfig();
+
+      final uri = LiveClient.buildWebSocketUri(config, {'key': 'k'});
+
+      expect(uri.scheme, equals('wss'));
+      expect(uri.host, equals('generativelanguage.googleapis.com'));
+      expect(uri.port, equals(443));
+      expect(
+        uri.path,
+        equals(
+          '/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent',
+        ),
+      );
+      expect(uri.queryParameters['key'], equals('k'));
+    });
+
+    test('a trailing slash in the base URL does not corrupt the host', () {
+      const config = GoogleAIConfig(
+        baseUrl: 'https://generativelanguage.googleapis.com/',
+      );
+
+      final uri = LiveClient.buildWebSocketUri(config, {});
+
+      expect(uri.host, equals('generativelanguage.googleapis.com'));
+      expect(
+        uri.path,
+        equals(
+          '/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent',
+        ),
+      );
+    });
+
+    test('a base URL sub-path is prepended to the ws path', () {
+      const config = GoogleAIConfig(
+        baseUrl: 'https://proxy.example.com/gemini',
+      );
+
+      final uri = LiveClient.buildWebSocketUri(config, {});
+
+      expect(uri.host, equals('proxy.example.com'));
+      expect(
+        uri.path,
+        equals(
+          '/gemini/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent',
+        ),
+      );
+    });
+
+    test('a scheme-less base URL is treated as https/wss', () {
+      const config = GoogleAIConfig(
+        baseUrl: 'generativelanguage.googleapis.com',
+      );
+
+      final uri = LiveClient.buildWebSocketUri(config, {});
+
+      expect(uri.scheme, equals('wss'));
+      expect(uri.host, equals('generativelanguage.googleapis.com'));
+      expect(uri.port, equals(443));
+    });
+
+    test('an http base URL maps to ws and preserves the port', () {
+      const config = GoogleAIConfig(baseUrl: 'http://localhost:8765');
+
+      final uri = LiveClient.buildWebSocketUri(config, {});
+
+      expect(uri.scheme, equals('ws'));
+      expect(uri.host, equals('localhost'));
+      expect(uri.port, equals(8765));
+    });
+
+    test('preserves query params carried by the base URL', () {
+      const config = GoogleAIConfig(
+        baseUrl: 'https://proxy.example.com?token=abc',
+      );
+
+      final uri = LiveClient.buildWebSocketUri(config, {});
+
+      expect(uri.queryParameters['token'], equals('abc'));
+    });
+
+    test('defaultQueryParams override auth params (existing order)', () {
+      const config = GoogleAIConfig(defaultQueryParams: {'key': 'default'});
+
+      final uri = LiveClient.buildWebSocketUri(config, {'key': 'auth'});
+
+      expect(uri.queryParameters['key'], equals('default'));
+    });
+
+    test('uses the configured API version in the path', () {
+      const config = GoogleAIConfig(apiVersion: ApiVersion.v1);
+
+      final uri = LiveClient.buildWebSocketUri(config, {});
+
+      expect(
+        uri.path,
+        equals(
+          '/ws/google.ai.generativelanguage.v1.GenerativeService.BidiGenerateContent',
+        ),
+      );
+    });
+  });
+
+  group('LiveClient.buildWebSocketUri - Vertex AI mode', () {
+    test('builds the vertex wss URI with project/location params', () {
+      const config = GoogleAIConfig(
+        apiMode: ApiMode.vertexAI,
+        projectId: 'P',
+        location: 'us-central1',
+      );
+
+      final uri = LiveClient.buildWebSocketUri(config, {});
+
+      expect(uri.scheme, equals('wss'));
+      expect(uri.host, equals('us-central1-aiplatform.googleapis.com'));
+      expect(
+        uri.path,
+        equals(
+          '/ws/google.cloud.aiplatform.v1beta1.PredictionService.BidiGenerateContent',
+        ),
+      );
+      expect(uri.queryParameters['project'], equals('P'));
+      expect(uri.queryParameters['location'], equals('us-central1'));
+    });
+
+    test('maps ApiVersion.v1 to the v1 prediction service', () {
+      const config = GoogleAIConfig(
+        apiMode: ApiMode.vertexAI,
+        apiVersion: ApiVersion.v1,
+        projectId: 'P',
+        location: 'us-central1',
+      );
+
+      final uri = LiveClient.buildWebSocketUri(config, {});
+
+      expect(
+        uri.path,
+        equals(
+          '/ws/google.cloud.aiplatform.v1.PredictionService.BidiGenerateContent',
+        ),
+      );
+    });
+
+    test('throws LiveSessionSetupException when projectId is missing', () {
+      const config = GoogleAIConfig(apiMode: ApiMode.vertexAI);
+
+      expect(
+        () => LiveClient.buildWebSocketUri(config, {}),
+        throwsA(isA<LiveSessionSetupException>()),
+      );
+    });
+  });
+}

--- a/packages/googleai_dart/test/unit/resources/file_search_stores/file_search_stores_upload_url_test.dart
+++ b/packages/googleai_dart/test/unit/resources/file_search_stores/file_search_stores_upload_url_test.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+
+import 'package:googleai_dart/src/auth/auth_provider.dart';
+import 'package:googleai_dart/src/client/config.dart';
+import 'package:googleai_dart/src/client/interceptor_chain.dart';
+import 'package:googleai_dart/src/client/request_builder.dart';
+import 'package:googleai_dart/src/resources/file_search_stores/file_search_stores_resource.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class _MockHttpClient extends Mock implements http.Client {}
+
+http.StreamedResponse _jsonResponse(
+  Map<String, dynamic> body, {
+  int status = 200,
+  Map<String, String> headers = const {},
+}) {
+  return http.StreamedResponse(
+    Stream.value(utf8.encode(jsonEncode(body))),
+    status,
+    headers: {'content-type': 'application/json', ...headers},
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      http.Request('GET', Uri.parse('https://example.com')),
+    );
+  });
+
+  group('FileSearchStoresResource.upload URL construction', () {
+    late _MockHttpClient mockHttpClient;
+    final capturedRequests = <http.BaseRequest>[];
+
+    FileSearchStoresResource buildResource(GoogleAIConfig config) {
+      mockHttpClient = _MockHttpClient();
+      capturedRequests.clear();
+
+      when(() => mockHttpClient.send(any())).thenAnswer((invocation) async {
+        final request =
+            invocation.positionalArguments.first as http.BaseRequest;
+        capturedRequests.add(request);
+        if (capturedRequests.length == 1) {
+          return _jsonResponse(
+            {},
+            headers: {'x-goog-upload-url': 'https://upload.example.com/next'},
+          );
+        }
+        return _jsonResponse({});
+      });
+
+      return FileSearchStoresResource(
+        config: config,
+        httpClient: mockHttpClient,
+        interceptorChain: InterceptorChain(
+          interceptors: const [],
+          httpClient: mockHttpClient,
+        ),
+        requestBuilder: RequestBuilder(config: config),
+      );
+    }
+
+    test('trailing-slash base URL yields no double slash and merges '
+        'defaultQueryParams and query-placement auth', () async {
+      const config = GoogleAIConfig(
+        baseUrl: 'https://generativelanguage.googleapis.com/',
+        authProvider: ApiKeyProvider('test-key'),
+        defaultQueryParams: {'proxy': 'p'},
+      );
+      final resource = buildResource(config);
+
+      await resource.upload(
+        parent: 'fileSearchStores/my-store',
+        bytes: [1, 2, 3],
+        fileName: 'test.txt',
+        mimeType: 'text/plain',
+      );
+
+      expect(capturedRequests.length, greaterThanOrEqualTo(1));
+      final initiation = capturedRequests.first;
+      expect(initiation.url.host, 'generativelanguage.googleapis.com');
+      expect(
+        initiation.url.path,
+        '/upload/v1beta/fileSearchStores/my-store:uploadToFileSearchStore',
+      );
+      expect(initiation.url.queryParameters['key'], 'test-key');
+      expect(initiation.url.queryParameters['proxy'], 'p');
+    });
+
+    test(
+      'header-placement auth sets X-Goog-Api-Key and no key param',
+      () async {
+        const config = GoogleAIConfig(
+          baseUrl: 'https://generativelanguage.googleapis.com/',
+          authProvider: ApiKeyProvider(
+            'test-key',
+            placement: AuthPlacement.header,
+          ),
+        );
+        final resource = buildResource(config);
+
+        await resource.upload(
+          parent: 'fileSearchStores/my-store',
+          bytes: [1, 2, 3],
+          fileName: 'test.txt',
+          mimeType: 'text/plain',
+        );
+
+        final initiation = capturedRequests.first;
+        expect(
+          initiation.url.path,
+          '/upload/v1beta/fileSearchStores/my-store:uploadToFileSearchStore',
+        );
+        expect(initiation.headers['X-Goog-Api-Key'], 'test-key');
+        expect(initiation.url.queryParameters.containsKey('key'), isFalse);
+      },
+    );
+  });
+}

--- a/packages/googleai_dart/test/unit/resources/files/files_resource_upload_url_test.dart
+++ b/packages/googleai_dart/test/unit/resources/files/files_resource_upload_url_test.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+
+import 'package:googleai_dart/src/auth/auth_provider.dart';
+import 'package:googleai_dart/src/client/config.dart';
+import 'package:googleai_dart/src/client/interceptor_chain.dart';
+import 'package:googleai_dart/src/client/request_builder.dart';
+import 'package:googleai_dart/src/resources/files/files_resource.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class _MockHttpClient extends Mock implements http.Client {}
+
+http.StreamedResponse _jsonResponse(
+  Map<String, dynamic> body, {
+  int status = 200,
+  Map<String, String> headers = const {},
+}) {
+  return http.StreamedResponse(
+    Stream.value(utf8.encode(jsonEncode(body))),
+    status,
+    headers: {'content-type': 'application/json', ...headers},
+  );
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      http.Request('GET', Uri.parse('https://example.com')),
+    );
+  });
+
+  group('FilesResource.upload URL construction', () {
+    late _MockHttpClient mockHttpClient;
+    final capturedRequests = <http.BaseRequest>[];
+
+    FilesResource buildResource(GoogleAIConfig config) {
+      mockHttpClient = _MockHttpClient();
+      capturedRequests.clear();
+
+      when(() => mockHttpClient.send(any())).thenAnswer((invocation) async {
+        final request =
+            invocation.positionalArguments.first as http.BaseRequest;
+        capturedRequests.add(request);
+        if (capturedRequests.length == 1) {
+          // Initiation response carries the resumable upload URL.
+          return _jsonResponse(
+            {},
+            headers: {'x-goog-upload-url': 'https://upload.example.com/next'},
+          );
+        }
+        return _jsonResponse({
+          'file': {
+            'name': 'files/abc123',
+            'mimeType': 'text/plain',
+            'createTime': '2026-01-01T00:00:00Z',
+            'updateTime': '2026-01-01T00:00:00Z',
+            'expirationTime': '2026-01-03T00:00:00Z',
+            'uri': 'https://generativelanguage.googleapis.com/files/abc123',
+          },
+        });
+      });
+
+      return FilesResource(
+        config: config,
+        httpClient: mockHttpClient,
+        interceptorChain: InterceptorChain(
+          interceptors: const [],
+          httpClient: mockHttpClient,
+        ),
+        requestBuilder: RequestBuilder(config: config),
+      );
+    }
+
+    test('trailing-slash base URL yields no double slash and merges '
+        'defaultQueryParams and query-placement auth', () async {
+      const config = GoogleAIConfig(
+        baseUrl: 'https://generativelanguage.googleapis.com/',
+        authProvider: ApiKeyProvider('test-key'),
+        defaultQueryParams: {'proxy': 'p'},
+      );
+      final resource = buildResource(config);
+
+      await resource.upload(
+        bytes: [1, 2, 3],
+        fileName: 'test.txt',
+        mimeType: 'text/plain',
+      );
+
+      expect(capturedRequests.length, greaterThanOrEqualTo(1));
+      final initiation = capturedRequests.first;
+      expect(initiation.url.host, 'generativelanguage.googleapis.com');
+      expect(initiation.url.path, '/upload/v1beta/files');
+      expect(initiation.url.queryParameters['key'], 'test-key');
+      expect(initiation.url.queryParameters['proxy'], 'p');
+    });
+
+    test(
+      'header-placement auth sets X-Goog-Api-Key and no key param',
+      () async {
+        const config = GoogleAIConfig(
+          baseUrl: 'https://generativelanguage.googleapis.com/',
+          authProvider: ApiKeyProvider(
+            'test-key',
+            placement: AuthPlacement.header,
+          ),
+        );
+        final resource = buildResource(config);
+
+        await resource.upload(
+          bytes: [1, 2, 3],
+          fileName: 'test.txt',
+          mimeType: 'text/plain',
+        );
+
+        final initiation = capturedRequests.first;
+        expect(initiation.url.path, '/upload/v1beta/files');
+        expect(initiation.headers['X-Goog-Api-Key'], 'test-key');
+        expect(initiation.url.queryParameters.containsKey('key'), isFalse);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- Fixes the double slash (`//v1beta/...`) produced by `RequestBuilder.buildUrl` when `GoogleAIConfig.baseUrl` has a trailing slash, and makes it preserve base-URL sub-paths (proxies) and query params — including repeated keys (`?k=a&k=b`) via `queryParametersAll`.
- Fixes the four file/file-search-store upload sites that concatenated `baseUrl` directly (bypassing the builder): they now build URLs through a new `RequestBuilder.buildUploadUrl`, so trailing slashes, proxy sub-paths, base-URL query params, and `defaultQueryParams` are handled consistently.
- Fixes the Live (WebSocket) client corrupting the host when `baseUrl` had a trailing slash or sub-path (`host: 'host/'`). The wss URI is now derived by parsing the base URL: sub-paths are prepended to the `/ws/...` path, explicit ports and base query params are preserved.
- Fixes four downstream auth URL rebuilds (`key`/`access_token` in `AuthInterceptor` and `StreamingResource`) that collapsed repeated query keys after the builder fix preserved them.

## Details

Port of the base-URL normalization applied to `anthropic_sdk_dart` in #271 (see also #272-#274), generalized to googleai_dart's six URL-construction sites plus the four downstream query rebuilds. All URL joining now flows through one mechanism (`RequestBuilder._joinPaths` + rebuild from the parsed base URL via `Uri.replace`). Query params merge base URL → `defaultQueryParams` → `EndpointConfig` → per-request (last-write-wins by key).

`buildUploadUrl` replaces `{version}` and deliberately skips Vertex path injection (uploads are Google-AI-only, enforced by `_validateGoogleAIOnly`). The upload refactor also removes a redundant second `getCredentials()` call per upload. `LiveClient.buildWebSocketUri` is extracted as a `@visibleForTesting` static so the wss derivation is unit-testable; the vertex branch is unchanged (it never used `baseUrl`).

### Intentional behavior changes
- No more trailing `?` on URLs with no query params (previously `uri.replace(queryParameters: {})` always emitted one).
- Upload URLs now honor `defaultQueryParams` and base-URL query params (previously dropped); the auth `key`/`access_token` is passed as the request-layer param and wins over a same-named default. Upload protocol headers (`X-Goog-Upload-*`) remain hand-built; `defaultHeaders` merging for uploads stays out of scope.
- An `http://`/`ws://` base URL now maps to `ws` for Live connections (previously always `wss`), enabling plaintext local proxies; scheme-less values still map to `wss`.

## References

- #271 — the equivalent `anthropic_sdk_dart` fix this PR generalizes.

## Test Plan

- [x] New `test/unit/client/request_builder_url_join_test.dart` (16 cases): trailing slash, proxy sub-paths, 4-layer precedence, repeated-key preservation, vertex injection with sub-path bases, `buildUploadUrl` matrix. Written first (TDD) — file fails to load pre-fix (`buildUploadUrl` missing) and double-slash cases fail.
- [x] Strengthened the existing trailing-slash assertion in `request_builder_precedence_test.dart` (previously passed against the bug).
- [x] New upload-URL capture tests for both resources (mocktail, captured initiation request): no double slash, `key` + `defaultQueryParams` merged, header-placement variant. Red pre-fix (`//upload/...`).
- [x] New `test/unit/live/live_client_uri_test.dart` (11 cases): default/trailing-slash/sub-path/scheme-less/http-port bases, base query preservation, defaults-over-auth order, both vertex branches, missing projectId throws. Red pre-fix.
- [x] New `test/unit/interceptors/auth_repeated_query_params_test.dart`: 4 repeated-key tests (one per fixed site), all red pre-fix (`['a','b']` collapsed to `['b']`).
- [x] Full unit suite passes: `dart test --reporter=failures-only packages/googleai_dart/test/unit/` (1530 passed).
- [x] `dart format` / `dart fix` / `dart analyze` clean.