### PR TITLE
fix(chromadb): preserve base URL query params and normalize path joining in buildUrl

### DIFF
--- a/packages/chromadb/lib/src/client/request_builder.dart
+++ b/packages/chromadb/lib/src/client/request_builder.dart
@@ -36,28 +36,34 @@ class RequestBuilder {
   /// Builds a complete URL from a path and optional query parameters.
   ///
   /// The [path] should start with a `/` and will be appended to the base URL.
-  /// Query parameters are merged with defaults using last-write-wins.
+  ///
+  /// Merges query parameters in order: base URL → defaults → request.
+  /// Later sources override earlier ones by key (last-write-wins; the whole
+  /// value list for that key is replaced). Repeated keys carried by the base
+  /// URL (e.g. `?k=a&k=b`) are preserved.
   Uri buildUrl(String path, {Map<String, String>? queryParameters}) {
     final baseUri = Uri.parse(baseUrl);
 
-    // Merge query parameters (request params override defaults)
-    final mergedParams = <String, String>{
+    // Normalize the base path and endpoint path to avoid a double slash when
+    // the configured base URL ends with a trailing slash.
+    final basePath = baseUri.path.endsWith('/')
+        ? baseUri.path.substring(0, baseUri.path.length - 1)
+        : baseUri.path;
+    final normalizedPath = path.startsWith('/') ? path : '/$path';
+
+    // Merge query params (last-write-wins by key). `queryParametersAll`
+    // preserves repeated base-URL keys; `Uri.replace` accepts both `String`
+    // and `Iterable<String>` values.
+    final mergedParams = <String, dynamic>{
+      ...baseUri.queryParametersAll,
       ...defaultQueryParameters,
       ...?queryParameters,
     };
 
-    // Handle path properly - avoid double slashes
-    String fullPath;
-    if (baseUri.path.isEmpty || baseUri.path == '/') {
-      fullPath = path;
-    } else if (path.startsWith('/')) {
-      fullPath = '${baseUri.path}$path';
-    } else {
-      fullPath = '${baseUri.path}/$path';
-    }
-
+    // `replace` keeps scheme, userInfo, host, port, and fragment from the
+    // base URL; only path and query are rebuilt.
     return baseUri.replace(
-      path: fullPath,
+      path: '$basePath$normalizedPath',
       queryParameters: mergedParams.isEmpty ? null : mergedParams,
     );
   }

--- a/packages/chromadb/test/unit/client/url_builder_test.dart
+++ b/packages/chromadb/test/unit/client/url_builder_test.dart
@@ -1,0 +1,207 @@
+import 'package:chromadb/src/client/request_builder.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RequestBuilder.buildUrl', () {
+    test('builds URL with a plain base URL', () {
+      final builder = RequestBuilder(baseUrl: 'http://localhost:8000');
+
+      final url = builder.buildUrl('/api/v2/healthcheck');
+
+      expect(url.scheme, equals('http'));
+      expect(url.host, equals('localhost'));
+      expect(url.port, equals(8000));
+      expect(url.path, equals('/api/v2/healthcheck'));
+      expect(url.query, isEmpty);
+    });
+
+    test('normalizes a trailing slash in the base URL (no double slash)', () {
+      final builder = RequestBuilder(baseUrl: 'http://localhost:8000/');
+
+      final url = builder.buildUrl('/api/v2/healthcheck');
+
+      expect(url.path, equals('/api/v2/healthcheck'));
+      expect(
+        url.toString(),
+        equals('http://localhost:8000/api/v2/healthcheck'),
+      );
+    });
+
+    test('preserves a base URL sub-path with a trailing slash', () {
+      final builder = RequestBuilder(
+        baseUrl: 'https://proxy.example.com/chroma/',
+      );
+
+      final url = builder.buildUrl('/api/v2/healthcheck');
+
+      // Previously produced /chroma//api/v2/healthcheck.
+      expect(url.path, equals('/chroma/api/v2/healthcheck'));
+    });
+
+    test('handles an endpoint path without a leading slash', () {
+      final builder = RequestBuilder(baseUrl: 'http://localhost:8000/');
+
+      final url = builder.buildUrl('api/v2/healthcheck');
+
+      expect(url.path, equals('/api/v2/healthcheck'));
+    });
+
+    test('handles a base URL with multiple path segments', () {
+      final builder = RequestBuilder(
+        baseUrl: 'https://proxy.example.com/team/chroma',
+      );
+
+      final url = builder.buildUrl('/api/v2/healthcheck');
+
+      expect(url.path, equals('/team/chroma/api/v2/healthcheck'));
+    });
+
+    test('preserves query params carried by the base URL', () {
+      final builder = RequestBuilder(
+        baseUrl: 'https://api.trychroma.com/?tenant=default',
+      );
+
+      final url = builder.buildUrl('/api/v2/healthcheck');
+
+      expect(url.path, equals('/api/v2/healthcheck'));
+      expect(url.queryParameters['tenant'], equals('default'));
+    });
+
+    test('preserves base-URL params when merging default params', () {
+      // Regression: merging defaults/request params used to wipe the whole
+      // base-URL query instead of merging into it.
+      final builder = RequestBuilder(
+        baseUrl: 'https://api.trychroma.com/?tenant=default',
+        defaultQueryParameters: {'beta': 'true'},
+      );
+
+      final url = builder.buildUrl('/api/v2/healthcheck');
+
+      expect(url.queryParameters['tenant'], equals('default'));
+      expect(url.queryParameters['beta'], equals('true'));
+    });
+
+    test('preserves repeated base-URL keys when merging other params', () {
+      final builder = RequestBuilder(
+        baseUrl: 'https://proxy.example.com/?k=a&k=b',
+        defaultQueryParameters: {'x': '1'},
+      );
+
+      final url = builder.buildUrl('/api/v2/collections');
+
+      expect(url.queryParametersAll['k'], equals(['a', 'b']));
+      expect(url.queryParameters['x'], equals('1'));
+    });
+
+    test('merges default and per-request query params', () {
+      final builder = RequestBuilder(
+        baseUrl: 'http://localhost:8000',
+        defaultQueryParameters: {'beta': 'true'},
+      );
+
+      final url = builder.buildUrl(
+        '/api/v2/collections',
+        queryParameters: {'limit': '20'},
+      );
+
+      expect(url.queryParameters['beta'], equals('true'));
+      expect(url.queryParameters['limit'], equals('20'));
+    });
+
+    test('per-request params override defaults on conflict', () {
+      final builder = RequestBuilder(
+        baseUrl: 'http://localhost:8000',
+        defaultQueryParameters: {'limit': '10'},
+      );
+
+      final url = builder.buildUrl(
+        '/api/v2/collections',
+        queryParameters: {'limit': '20'},
+      );
+
+      expect(url.queryParameters['limit'], equals('20'));
+    });
+
+    test('per-request params override base-URL params on conflict', () {
+      final builder = RequestBuilder(
+        baseUrl: 'https://api.trychroma.com/?tenant=old',
+      );
+
+      final url = builder.buildUrl(
+        '/api/v2/collections',
+        queryParameters: {'tenant': 'new'},
+      );
+
+      expect(url.queryParameters['tenant'], equals('new'));
+    });
+
+    test('default params override base-URL params on conflict', () {
+      final builder = RequestBuilder(
+        baseUrl: 'https://api.trychroma.com/?tenant=old',
+        defaultQueryParameters: {'tenant': 'new'},
+      );
+
+      final url = builder.buildUrl('/api/v2/collections');
+
+      expect(url.queryParameters['tenant'], equals('new'));
+    });
+
+    test('preserves repeated query keys carried by the base URL', () {
+      final builder = RequestBuilder(
+        baseUrl: 'https://proxy.example.com/?k=a&k=b',
+      );
+
+      final url = builder.buildUrl('/api/v2/collections');
+
+      expect(url.queryParametersAll['k'], equals(['a', 'b']));
+      expect(url.toString(), contains('k=a&k=b'));
+    });
+
+    test('per-request params replace the whole repeated-key list', () {
+      final builder = RequestBuilder(
+        baseUrl: 'https://proxy.example.com/?k=a&k=b',
+      );
+
+      final url = builder.buildUrl(
+        '/api/v2/collections',
+        queryParameters: {'k': 'c'},
+      );
+
+      expect(url.queryParametersAll['k'], equals(['c']));
+    });
+
+    test('default params replace repeated base-URL keys', () {
+      final builder = RequestBuilder(
+        baseUrl: 'https://proxy.example.com/?k=a&k=b',
+        defaultQueryParameters: {'k': 'c'},
+      );
+
+      final url = builder.buildUrl('/api/v2/collections');
+
+      expect(url.queryParametersAll['k'], equals(['c']));
+    });
+
+    test('preserves a non-standard port in the base URL', () {
+      final builder = RequestBuilder(
+        baseUrl: 'https://chroma.example.com:8443',
+      );
+
+      final url = builder.buildUrl('/api/v2/collections');
+
+      expect(url.port, equals(8443));
+      expect(url.path, equals('/api/v2/collections'));
+    });
+
+    test('preserves userInfo and fragment from the base URL', () {
+      final builder = RequestBuilder(
+        baseUrl: 'https://user:pass@chroma.example.com/base#frag',
+      );
+
+      final url = builder.buildUrl('/api/v2/collections');
+
+      expect(url.userInfo, equals('user:pass'));
+      expect(url.path, equals('/base/api/v2/collections'));
+      expect(url.fragment, equals('frag'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Fixes `RequestBuilder.buildUrl` wiping query parameters carried by the base URL (e.g. `?tenant=...` on a proxy/gateway URL) whenever default or per-request query params were merged — previously the merge replaced the whole query string.
- Fixes a double slash for base URLs with a sub-path and a trailing slash (`https://proxy/chroma/` + `/api/v2/...` → `/chroma//api/v2/...`).
- Preserves repeated base-URL query keys (`?k=a&k=b`) via `queryParametersAll` instead of dropping or collapsing them when merging.

## Details

Aligns chromadb's URL building with the normalization applied across the monorepo (#271-#275): strip a trailing slash from the base path, ensure a leading slash on the endpoint path, and merge query params **base URL → `defaultQueryParameters` → per-request** (last-write-wins by key). The URI is rebuilt with `Uri.replace`, keeping scheme, userInfo, host, port, and fragment from the base URL. The old root-path special case is subsumed by the normalization.

Constructor shape and the `Map<String, String>? queryParameters` signature are unchanged; no caller changes needed. Note: preserving base-URL query params during merges is a behavior change for users who embed params in `baseUrl` — previously those params were silently lost on any request that carried other query params, which is the bug being fixed.

## References

- #271 — the `anthropic_sdk_dart` fix this aligns with.

## Test Plan

- [x] New `test/unit/client/url_builder_test.dart` (17 cases, the package's first URL-builder tests): trailing slash, sub-path joins, base-URL query preservation standalone and under merges, 3-layer precedence, repeated-key preservation/replacement, port/userInfo/fragment preservation. Written first (TDD): 3 cases fail on the old code (sub-path double slash, base-query wipe on merge, repeated-key drop on merge).
- [x] Full unit suite passes: `dart test --reporter=failures-only packages/chromadb/test/unit/` (321 passed).
- [x] `dart format` / `dart fix` / `dart analyze` clean.