### PR TITLE
fix(openai_dart): preserve repeated base URL query params in buildUrl

### DIFF
--- a/packages/openai_dart/lib/src/client/request_builder.dart
+++ b/packages/openai_dart/lib/src/client/request_builder.dart
@@ -36,7 +36,9 @@ class RequestBuilder {
   ///
   /// The [path] should start with a `/`, e.g., `/chat/completions`.
   /// Optional [queryParams] are merged with any query parameters in the
-  /// base URL (request-level params override base-level on key conflicts).
+  /// base URL (request-level params override base-level on key conflicts;
+  /// the whole value list for that key is replaced). Repeated keys carried
+  /// by the base URL (e.g. `?k=a&k=b`) are preserved.
   ///
   /// This correctly handles base URLs with existing query parameters,
   /// such as Azure OpenAI endpoints with `api-version`.
@@ -51,9 +53,10 @@ class RequestBuilder {
     final normalizedPath = path.startsWith('/') ? path : '/$path';
     final combinedPath = '$basePath$normalizedPath';
 
-    // Merge query params: base URL params + request params (request wins on conflict)
-    final mergedQueryParams = <String, String>{
-      ...baseUri.queryParameters,
+    // Merge query params: base URL params + request params (request wins on
+    // conflict). `queryParametersAll` preserves repeated base-URL keys.
+    final mergedQueryParams = <String, dynamic>{
+      ...baseUri.queryParametersAll,
       ...?queryParams,
     };
 

--- a/packages/openai_dart/test/unit/client/url_builder_test.dart
+++ b/packages/openai_dart/test/unit/client/url_builder_test.dart
@@ -162,6 +162,47 @@ void main() {
       );
       expect(url.queryParameters['api-version'], equals('2024-08-01-preview'));
     });
+
+    test('preserves repeated query keys carried by the base URL', () {
+      const builder = RequestBuilder(
+        config: OpenAIConfig(
+          authProvider: ApiKeyProvider('sk-test'),
+          baseUrl: 'https://proxy.example.com/v1?k=a&k=b',
+        ),
+      );
+
+      final url = builder.buildUrl('/models');
+
+      expect(url.queryParametersAll['k'], equals(['a', 'b']));
+      expect(url.toString(), contains('k=a&k=b'));
+    });
+
+    test('request params replace the whole repeated-key list', () {
+      const builder = RequestBuilder(
+        config: OpenAIConfig(
+          authProvider: ApiKeyProvider('sk-test'),
+          baseUrl: 'https://proxy.example.com/v1?k=a&k=b',
+        ),
+      );
+
+      final url = builder.buildUrl('/models', queryParams: {'k': 'c'});
+
+      expect(url.queryParametersAll['k'], equals(['c']));
+    });
+
+    test('preserves repeated base-URL keys when merging other params', () {
+      const builder = RequestBuilder(
+        config: OpenAIConfig(
+          authProvider: ApiKeyProvider('sk-test'),
+          baseUrl: 'https://proxy.example.com/v1?k=a&k=b',
+        ),
+      );
+
+      final url = builder.buildUrl('/models', queryParams: {'x': '1'});
+
+      expect(url.queryParametersAll['k'], equals(['a', 'b']));
+      expect(url.queryParameters['x'], equals('1'));
+    });
   });
 
   group('buildUrlWithQueryAll', () {


### PR DESCRIPTION
## Summary
- `RequestBuilder.buildUrl` now preserves repeated query keys carried by the base URL (`?k=a&k=b`) instead of collapsing them to the last value, by merging from `baseUri.queryParametersAll`.

## Details

One-line semantic fix aligning `buildUrl` with the multi-value-preserving merge now used across the monorepo's request builders (#271-#276). Previously `...baseUri.queryParameters` kept only the last value of a repeated base-URL key; a proxy/gateway base URL carrying duplicate keys silently lost all but the last on every request. Single-value behavior (including Azure `api-version` handling) is unchanged: a request-level param still replaces the whole value list for its key. `buildUrlWithQueryAll` already had these semantics and is untouched.

## Test Plan

- [x] 3 new cases in the existing `test/unit/client/url_builder_test.dart` `URL Builder` group: repeated base keys preserved, request param replaces the whole list, repeated keys survive merging unrelated params. Written first (TDD): 2 fail on the old code.
- [x] Full unit suite passes: `dart test --reporter=failures-only packages/openai_dart/test/unit/` (1326 passed).
- [x] `dart format` / `dart fix` / `dart analyze` clean.