### PR TITLE
fix(anthropic_sdk_dart): preserve repeated base URL query params in buildUrl

### DIFF
--- a/packages/anthropic_sdk_dart/lib/src/client/request_builder.dart
+++ b/packages/anthropic_sdk_dart/lib/src/client/request_builder.dart
@@ -15,10 +15,14 @@ class RequestBuilder {
   /// Builds a URL for an API endpoint.
   ///
   /// The [path] is a URL path (e.g. `/v1/messages`); pass query parameters via
-  /// [queryParams] rather than embedding them in [path].
+  /// [queryParams] rather than embedding them in [path]. Values may be a
+  /// `String` or an `Iterable<String>` (rendered as repeated keys, e.g.
+  /// `?types[]=a&types[]=b`).
   ///
-  /// Merges query parameters in order: Global → Request.
-  /// Later values override earlier ones (last-write-wins).
+  /// Merges query parameters in order: base URL → config defaults → request.
+  /// Later sources override earlier ones by key (last-write-wins; the whole
+  /// value list for that key is replaced). Repeated keys carried by the base
+  /// URL (e.g. `?k=a&k=b`) are preserved.
   Uri buildUrl(String path, {Map<String, dynamic>? queryParams}) {
     // Parse the base URL so any existing path/query components are handled
     // correctly. Mirrors openai_dart's builder.
@@ -32,10 +36,11 @@ class RequestBuilder {
         : baseUri.path;
     final normalizedPath = path.startsWith('/') ? path : '/$path';
 
-    // Merge query params (last-write-wins), preserving any carried by the base
-    // URL: base URL → configured defaults → per-request.
+    // Merge query params (last-write-wins by key), preserving any carried by
+    // the base URL: base URL → configured defaults → per-request.
+    // `queryParametersAll` preserves repeated base-URL keys.
     final mergedParams = <String, dynamic>{
-      ...baseUri.queryParameters,
+      ...baseUri.queryParametersAll,
       ...config.defaultQueryParams,
       ...?queryParams,
     };

--- a/packages/anthropic_sdk_dart/test/unit/client/url_builder_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/client/url_builder_test.dart
@@ -110,5 +110,122 @@ void main() {
 
       expect(url.queryParameters['api-version'], equals('2025'));
     });
+
+    test('handles a base URL with multiple path segments', () {
+      const builder = RequestBuilder(
+        config: AnthropicConfig(
+          authProvider: ApiKeyProvider('sk-test'),
+          baseUrl: 'https://proxy.example.com/api/anthropic',
+        ),
+      );
+
+      final url = builder.buildUrl('/v1/messages');
+
+      expect(url.path, equals('/api/anthropic/v1/messages'));
+    });
+
+    test('default params override base-URL params on conflict', () {
+      const builder = RequestBuilder(
+        config: AnthropicConfig(
+          authProvider: ApiKeyProvider('sk-test'),
+          baseUrl: 'https://proxy.example.com/?api-version=2024',
+          defaultQueryParams: {'api-version': '2025'},
+        ),
+      );
+
+      final url = builder.buildUrl('/v1/messages');
+
+      expect(url.queryParameters['api-version'], equals('2025'));
+    });
+
+    test('preserves repeated query keys carried by the base URL', () {
+      const builder = RequestBuilder(
+        config: AnthropicConfig(
+          authProvider: ApiKeyProvider('sk-test'),
+          baseUrl: 'https://proxy.example.com/?k=a&k=b',
+        ),
+      );
+
+      final url = builder.buildUrl('/v1/messages');
+
+      expect(url.queryParametersAll['k'], equals(['a', 'b']));
+      expect(url.toString(), contains('k=a&k=b'));
+    });
+
+    test('per-request params replace the whole repeated-key list', () {
+      const builder = RequestBuilder(
+        config: AnthropicConfig(
+          authProvider: ApiKeyProvider('sk-test'),
+          baseUrl: 'https://proxy.example.com/?k=a&k=b',
+        ),
+      );
+
+      final url = builder.buildUrl('/v1/messages', queryParams: {'k': 'c'});
+
+      expect(url.queryParametersAll['k'], equals(['c']));
+    });
+
+    test('default params replace repeated base-URL keys', () {
+      const builder = RequestBuilder(
+        config: AnthropicConfig(
+          authProvider: ApiKeyProvider('sk-test'),
+          baseUrl: 'https://proxy.example.com/?k=a&k=b',
+          defaultQueryParams: {'k': 'c'},
+        ),
+      );
+
+      final url = builder.buildUrl('/v1/messages');
+
+      expect(url.queryParametersAll['k'], equals(['c']));
+    });
+
+    test('renders Iterable query param values as repeated keys', () {
+      // Mirrors SessionEventsResource, which passes List<String> values for
+      // `types[]` / `event_deltas[]` array params.
+      const builder = RequestBuilder(
+        config: AnthropicConfig(authProvider: ApiKeyProvider('sk-test')),
+      );
+
+      final url = builder.buildUrl(
+        '/v1/sessions/s_123/events',
+        queryParams: {
+          'types[]': ['message', 'tool_use'],
+        },
+      );
+
+      expect(
+        url.queryParametersAll['types[]'],
+        equals(['message', 'tool_use']),
+      );
+    });
+
+    test('preserves a non-standard port in the base URL', () {
+      const builder = RequestBuilder(
+        config: AnthropicConfig(
+          authProvider: ApiKeyProvider('sk-test'),
+          baseUrl: 'https://api.example.com:8443',
+        ),
+      );
+
+      final url = builder.buildUrl('/v1/messages');
+
+      expect(url.port, equals(8443));
+      expect(url.path, equals('/v1/messages'));
+    });
+
+    test('preserves userInfo and fragment from the base URL', () {
+      const builder = RequestBuilder(
+        config: AnthropicConfig(
+          authProvider: ApiKeyProvider('sk-test'),
+          baseUrl: 'https://user:pass@api.example.com/base#frag',
+        ),
+      );
+
+      final url = builder.buildUrl('/v1/messages');
+
+      expect(url.userInfo, equals('user:pass'));
+      expect(url.path, equals('/base/v1/messages'));
+      expect(url.fragment, equals('frag'));
+    });
   });
 }


### PR DESCRIPTION
## Summary
- `RequestBuilder.buildUrl` now preserves repeated query keys carried by the base URL (`?k=a&k=b`) instead of collapsing them to the last value, by merging from `baseUri.queryParametersAll`.
- Fixes the stale `buildUrl` doc comment left by #271: it still described the old two-source "Global → Request" merge; it now documents the actual three-source order (base URL → config defaults → per-request) and the `String | Iterable<String>` value contract.

## Details

Follow-up to #271 (review findings), aligning anthropic with the multi-value-preserving merge now used across the monorepo's request builders (#272-#277). Single-value behavior is unchanged: a later source still replaces the whole value list for its key. `Iterable<String>` request values (used by `SessionEventsResource` for `types[]`/`event_deltas[]`) continue to render as repeated keys; a regression test now covers that contract.

## References

- #271 — the base fix this follows up on.

## Test Plan

- [x] 8 new cases in `test/unit/client/url_builder_test.dart` (extends the #271 suite to 15): multi-segment base path, defaults-override-base precedence, repeated-key preservation/replacement, Iterable rendering (`types[]`), port and userInfo/fragment preservation. Written first (TDD): the repeated-key preservation case fails on the #271 code.
- [x] Full unit suite passes: `dart test --reporter=failures-only packages/anthropic_sdk_dart/test/unit/` (1315 passed).
- [x] `dart format` / `dart fix` / `dart analyze` clean.