### PR TITLE
fix(anthropic_sdk_dart): adopt agent-memory-2026-07-22 beta header

### DIFF
--- a/packages/anthropic_sdk_dart/example/memory_stores_example.dart
+++ b/packages/anthropic_sdk_dart/example/memory_stores_example.dart
@@ -15,7 +15,7 @@ import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
 /// 7. Archive and delete the store
 ///
 /// Note: Memory Stores are a beta feature and require the
-/// `anthropic-beta: managed-agents-2026-04-01` header (sent automatically by
+/// `anthropic-beta: agent-memory-2026-07-22` header (sent automatically by
 /// the SDK).
 void main() async {
   final client = AnthropicClient(

--- a/packages/anthropic_sdk_dart/lib/src/resources/memories_resource.dart
+++ b/packages/anthropic_sdk_dart/lib/src/resources/memories_resource.dart
@@ -10,8 +10,8 @@ import '../models/managed_agents/memory_stores/memory_view.dart';
 import '../models/managed_agents/memory_stores/update_memory_params.dart';
 import 'base_resource.dart';
 
-/// Beta header for the Managed Agents API.
-const _betaHeader = 'managed-agents-2026-04-01';
+/// Beta header for the Agent Memory API.
+const _betaHeader = 'agent-memory-2026-07-22';
 
 /// Resource for memories within a single [MemoryStore] (Beta).
 ///
@@ -67,12 +67,18 @@ class MemoriesResource extends ResourceBase {
   ///
   /// Parameters:
   /// - [pathPrefix]: Restrict results to memories whose path starts with this
-  ///   prefix.
+  ///   prefix. Must end with `/` and matches whole path segments.
   /// - [depth]: Roll up entries deeper than this into [MemoryPrefix] items.
-  /// - [orderBy]: Field to sort by (e.g., `path`, `updated_at`).
-  /// - [order]: Sort order.
+  ///   Only `0`, `1`, or omitted are accepted; other values return a `400`
+  ///   error.
+  /// - [orderBy]: Field to sort by (e.g., `path`, `updated_at`). Ignored by
+  ///   the server — results are returned in a stable, server-defined order.
+  /// - [order]: Sort order. Ignored by the server — results are returned in
+  ///   a stable, server-defined order.
   /// - [limit]: Maximum number of items to return.
-  /// - [page]: Pagination token from a previous response.
+  /// - [page]: Pagination token from a previous response. Cursors issued
+  ///   under the `managed-agents-2026-04-01` header are not valid — restart
+  ///   from the first page.
   /// - [view]: How much of each memory's content to return.
   /// - [abortTrigger]: Allows canceling the request.
   Future<MemoryListResponse> list({

--- a/packages/anthropic_sdk_dart/lib/src/resources/memory_stores_resource.dart
+++ b/packages/anthropic_sdk_dart/lib/src/resources/memory_stores_resource.dart
@@ -10,8 +10,8 @@ import 'base_resource.dart';
 import 'memories_resource.dart';
 import 'memory_versions_resource.dart';
 
-/// Beta header for the Managed Agents API.
-const _betaHeader = 'managed-agents-2026-04-01';
+/// Beta header for the Agent Memory API.
+const _betaHeader = 'agent-memory-2026-07-22';
 
 /// Resource for the Memory Stores API (Beta).
 ///

--- a/packages/anthropic_sdk_dart/lib/src/resources/memory_versions_resource.dart
+++ b/packages/anthropic_sdk_dart/lib/src/resources/memory_versions_resource.dart
@@ -7,8 +7,8 @@ import '../models/managed_agents/memory_stores/memory_version_list_response.dart
 import '../models/managed_agents/memory_stores/memory_view.dart';
 import 'base_resource.dart';
 
-/// Beta header for the Managed Agents API.
-const _betaHeader = 'managed-agents-2026-04-01';
+/// Beta header for the Agent Memory API.
+const _betaHeader = 'agent-memory-2026-07-22';
 
 /// Resource for memory versions within a single [MemoryStore] (Beta).
 ///

--- a/packages/anthropic_sdk_dart/llms.txt
+++ b/packages/anthropic_sdk_dart/llms.txt
@@ -5,8 +5,8 @@
 ## Docs
 
 - [README](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/README.md) (~5.3k tokens): Primary package documentation with installation, configuration, and usage examples.
-- [CHANGELOG](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/CHANGELOG.md) (~10.4k tokens): Release history and version-by-version changes.
-- [MIGRATION](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/MIGRATION.md) (~6.7k tokens): Upgrade notes and breaking-change guidance.
+- [CHANGELOG](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/CHANGELOG.md) (~11k tokens): Release history and version-by-version changes.
+- [MIGRATION](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/MIGRATION.md) (~7.2k tokens): Upgrade notes and breaking-change guidance.
 
 ## Examples
 
@@ -21,7 +21,7 @@
 - [files_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/files_example.dart) (~842 tokens): File management (beta).
 - [skills_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/skills_example.dart) (~1.1k tokens): Skills management (beta).
 - [managed_agents_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/managed_agents_example.dart) (~1.6k tokens): Managed agents: agents, sessions, vaults, multiagent rosters, outcomes, webhooks, credential validation (beta).
-- [memory_stores_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/memory_stores_example.dart) (~903 tokens): Managed agents memory stores, memories, and versions (beta).
+- [memory_stores_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/memory_stores_example.dart) (~902 tokens): Managed agents memory stores, memories, and versions (beta).
 - [error_handling_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/error_handling_example.dart) (~632 tokens): Exception handling patterns.
 - [mid_conversation_system_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/mid_conversation_system_example.dart) (~458 tokens): Mid-conversation system messages (Opus 4.8).
 - [web_search_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/web_search_example.dart) (~793 tokens): Web search tool.
@@ -41,4 +41,4 @@
 
 - [Package directory](https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/anthropic_sdk_dart): Source tree, pubspec, and package-local files.
 
-**Total: ~44.7k tokens**
+**Total: ~45.8k tokens**

--- a/packages/anthropic_sdk_dart/specs/spec_metadata.json
+++ b/packages/anthropic_sdk_dart/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "unknown",
-      "last_fetched": "2026-07-04T11:25:40.494739Z",
+      "last_fetched": "2026-07-11T06:54:31.075636Z",
       "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-506a5ad71d522b4ae56ac3429380486647af1f92eddde80603480fb592d62b54.yml",
       "title": "Anthropic API",
       "version_history": [

--- a/packages/anthropic_sdk_dart/test/unit/resources/memory_stores_resource_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/resources/memory_stores_resource_test.dart
@@ -109,7 +109,7 @@ void main() {
       final request = mockHttpClient.lastRequest!;
       expect(request.url.path, '/v1/memory_stores');
       expect(request.method, 'POST');
-      expect(request.headers['anthropic-beta'], 'managed-agents-2026-04-01');
+      expect(request.headers['anthropic-beta'], 'agent-memory-2026-07-22');
       expect(request.headers['x-api-key'], 'test-api-key');
 
       final body =
@@ -151,7 +151,7 @@ void main() {
         request.url.queryParameters['created_at[lte]'],
         '2026-04-30T00:00:00Z',
       );
-      expect(request.headers['anthropic-beta'], 'managed-agents-2026-04-01');
+      expect(request.headers['anthropic-beta'], 'agent-memory-2026-07-22');
     });
 
     test('retrieve sends correct request and parses response', () async {
@@ -164,7 +164,7 @@ void main() {
       final request = mockHttpClient.lastRequest!;
       expect(request.url.path, '/v1/memory_stores/memstore_test123');
       expect(request.method, 'GET');
-      expect(request.headers['anthropic-beta'], 'managed-agents-2026-04-01');
+      expect(request.headers['anthropic-beta'], 'agent-memory-2026-07-22');
     });
 
     test('update sends patch body and parses response', () async {
@@ -185,7 +185,7 @@ void main() {
       final request = mockHttpClient.lastRequest!;
       expect(request.url.path, '/v1/memory_stores/memstore_test123');
       expect(request.method, 'POST');
-      expect(request.headers['anthropic-beta'], 'managed-agents-2026-04-01');
+      expect(request.headers['anthropic-beta'], 'agent-memory-2026-07-22');
 
       final body =
           jsonDecode((request as dynamic).body) as Map<String, dynamic>;
@@ -210,7 +210,7 @@ void main() {
       final request = mockHttpClient.lastRequest!;
       expect(request.url.path, '/v1/memory_stores/memstore_test123');
       expect(request.method, 'DELETE');
-      expect(request.headers['anthropic-beta'], 'managed-agents-2026-04-01');
+      expect(request.headers['anthropic-beta'], 'agent-memory-2026-07-22');
     });
 
     test('archive sends empty-body POST and parses response', () async {
@@ -225,7 +225,7 @@ void main() {
       final request = mockHttpClient.lastRequest!;
       expect(request.url.path, '/v1/memory_stores/memstore_test123/archive');
       expect(request.method, 'POST');
-      expect(request.headers['anthropic-beta'], 'managed-agents-2026-04-01');
+      expect(request.headers['anthropic-beta'], 'agent-memory-2026-07-22');
 
       final body =
           jsonDecode((request as dynamic).body) as Map<String, dynamic>;
@@ -251,7 +251,7 @@ void main() {
       expect(request.url.path, '/v1/memory_stores/memstore_test123/memories');
       expect(request.method, 'POST');
       expect(request.url.queryParameters['view'], 'full');
-      expect(request.headers['anthropic-beta'], 'managed-agents-2026-04-01');
+      expect(request.headers['anthropic-beta'], 'agent-memory-2026-07-22');
 
       final body =
           jsonDecode((request as dynamic).body) as Map<String, dynamic>;
@@ -297,7 +297,7 @@ void main() {
       expect(request.url.queryParameters['limit'], '50');
       expect(request.url.queryParameters['page'], 'pg');
       expect(request.url.queryParameters['view'], 'basic');
-      expect(request.headers['anthropic-beta'], 'managed-agents-2026-04-01');
+      expect(request.headers['anthropic-beta'], 'agent-memory-2026-07-22');
     });
 
     test('retrieve sends correct request with view', () async {
@@ -316,7 +316,7 @@ void main() {
       );
       expect(request.method, 'GET');
       expect(request.url.queryParameters['view'], 'full');
-      expect(request.headers['anthropic-beta'], 'managed-agents-2026-04-01');
+      expect(request.headers['anthropic-beta'], 'agent-memory-2026-07-22');
     });
 
     test('update sends body with sealed precondition', () async {
@@ -338,7 +338,7 @@ void main() {
         '/v1/memory_stores/memstore_test123/memories/mem_test123',
       );
       expect(request.method, 'POST');
-      expect(request.headers['anthropic-beta'], 'managed-agents-2026-04-01');
+      expect(request.headers['anthropic-beta'], 'agent-memory-2026-07-22');
 
       final body =
           jsonDecode((request as dynamic).body) as Map<String, dynamic>;
@@ -371,7 +371,7 @@ void main() {
       );
       expect(request.method, 'DELETE');
       expect(request.url.queryParameters['expected_content_sha256'], 'sha-abc');
-      expect(request.headers['anthropic-beta'], 'managed-agents-2026-04-01');
+      expect(request.headers['anthropic-beta'], 'agent-memory-2026-07-22');
     });
   });
 
@@ -424,7 +424,7 @@ void main() {
       expect(request.url.queryParameters['limit'], '5');
       expect(request.url.queryParameters['page'], 'pg');
       expect(request.url.queryParameters['view'], 'full');
-      expect(request.headers['anthropic-beta'], 'managed-agents-2026-04-01');
+      expect(request.headers['anthropic-beta'], 'agent-memory-2026-07-22');
     });
 
     test('retrieve sends correct request', () async {
@@ -443,7 +443,7 @@ void main() {
       );
       expect(request.method, 'GET');
       expect(request.url.queryParameters['view'], 'basic');
-      expect(request.headers['anthropic-beta'], 'managed-agents-2026-04-01');
+      expect(request.headers['anthropic-beta'], 'agent-memory-2026-07-22');
     });
 
     test('redact sends empty-body POST to /redact', () async {
@@ -467,7 +467,7 @@ void main() {
         '/v1/memory_stores/memstore_test123/memory_versions/memver_test123/redact',
       );
       expect(request.method, 'POST');
-      expect(request.headers['anthropic-beta'], 'managed-agents-2026-04-01');
+      expect(request.headers['anthropic-beta'], 'agent-memory-2026-07-22');
 
       final body =
           jsonDecode((request as dynamic).body) as Map<String, dynamic>;


### PR DESCRIPTION
## Summary
- Memory store endpoints (`/v1/memory_stores/**` — memory stores, memories, and memory versions) now send the `anthropic-beta: agent-memory-2026-07-22` header instead of `managed-agents-2026-04-01`, matching the July 8, 2026 releases of the official Anthropic SDKs (Python 0.116.0, TypeScript 0.110.0, etc.).
- Updated `MemoriesResource.list()` documentation for the new header's semantics: results come back in a stable, server-defined order (`orderBy`/`order` are ignored), `depth` accepts only `0`, `1`, or omitted, and `pathPrefix` must end with `/` and matches whole path segments.
- All other Managed Agents resources (agents, sessions, deployments, vaults, etc.) continue to send `managed-agents-2026-04-01`, which remains the correct header for those endpoints.

## Details

Per the [July 2, 2026 API changelog](https://platform.claude.com/docs/en/api/beta-headers#endpoint-specific-headers), `agent-memory-2026-07-22` replaces `managed-agents-2026-04-01` on memory store endpoints — sending both returns a `400` error, and on July 22, 2026 the old header adopts the same list behavior anyway.

Behavioral notes for consumers:
- Page cursors issued under the old header are not valid with the new one. If you persist `page` tokens across upgrades, restart pagination from the first page.
- `list()` keeps its `orderBy`/`order` parameters (they remain in the API spec and official SDKs), but the server now ignores them on this endpoint.

No spec promotion was needed: the pinned OpenAPI spec already matches the latest upstream hash, and the `agent-memory-2026-07-22` value was already present in the spec's `AnthropicBeta` enum. `llms.txt` was regenerated and `spec_metadata.json` records the refreshed fetch timestamp.

## References

- [Anthropic API changelog — July 2, 2026](https://platform.claude.com/docs/en/api/beta-headers#endpoint-specific-headers) — introduction of `agent-memory-2026-07-22` and its list-memories behavior changes
- [Memory docs — list memories](https://platform.claude.com/docs/en/managed-agents/memory#list-memories) — endpoint behavior under the new header

## Test Plan

- [x] Unit tests pass for `anthropic_sdk_dart` (1315 passed; 14 header assertions updated across memory stores/memories/memory versions groups)
- [x] `dart analyze --fatal-infos` clean; `dart format` unchanged
- [x] api-toolkit `verify --checks all --scope all` passes with no warnings
- [x] Grep-verified: no memory-store resource references the old header; non-memory Managed Agents resources still send `managed-agents-2026-04-01`