### PR TITLE
feat(googleai_dart)!: sync clients to latest Gemini API specs

### DIFF
--- a/packages/googleai_dart/.agents/skills/openapi-googleai/config/manifest.json
+++ b/packages/googleai_dart/.agents/skills/openapi-googleai/config/manifest.json
@@ -784,6 +784,13 @@
       "dart_class": "GroundingToolCount",
       "file": "lib/src/models/interactions/grounding_tool_count.dart"
     },
+    "HarmCategory": {
+      "spec": "main",
+      "schema": "HarmCategory",
+      "kind": "enum",
+      "dart_class": "HarmCategory",
+      "file": "lib/src/models/safety/harm_category.dart"
+    },
     "Image": {
       "spec": "main",
       "kind": "object",
@@ -1078,7 +1085,16 @@
       "schema": "ResponseFormat",
       "kind": "sealed_parent",
       "dart_class": "InteractionResponseFormat",
-      "file": "lib/src/models/interactions/response_formats/response_formats.dart"
+      "file": "lib/src/models/interactions/response_formats/response_formats.dart",
+      "discriminator": {
+        "field": "type",
+        "mapping": {
+          "audio": "#/components/schemas/AudioResponseFormat",
+          "text": "#/components/schemas/TextResponseFormat",
+          "image": "#/components/schemas/ImageResponseFormat",
+          "video": "#/components/schemas/VideoResponseFormat"
+        }
+      }
     },
     "ResponseFormatList": {
       "spec": "interactions",
@@ -1214,7 +1230,9 @@
           "google_maps_result": "#/components/schemas/GoogleMapsResultDelta",
           "mcp_server_tool_result": "#/components/schemas/McpServerToolResultDelta",
           "file_search_result": "#/components/schemas/FileSearchResultDelta",
-          "function_result": "#/components/schemas/FunctionResultDelta"
+          "function_result": "#/components/schemas/FunctionResultDelta",
+          "retrieval_call": "#/components/schemas/RetrievalCallDelta",
+          "retrieval_result": "#/components/schemas/RetrievalResultDelta"
         }
       }
     },
@@ -1724,12 +1742,26 @@
         "acknowledged"
       ]
     },
+    "interactions:HarmCategory": {
+      "spec": "interactions",
+      "schema": "HarmCategory",
+      "kind": "enum",
+      "dart_class": "InteractionHarmCategory",
+      "file": "lib/src/models/interactions/safety_setting.dart"
+    },
     "interactions:ImageConfig": {
       "spec": "interactions",
       "schema": "ImageConfig",
       "dart_class": "InteractionImageConfig",
       "file": "lib/src/models/interactions/image_config.dart",
       "kind": "object"
+    },
+    "interactions:VideoConfig": {
+      "spec": "interactions",
+      "schema": "VideoConfig",
+      "kind": "object",
+      "dart_class": "InteractionVideoConfig",
+      "file": "lib/src/models/interactions/video_config.dart"
     },
     "interactions:McpServer": {
       "spec": "interactions",
@@ -1761,6 +1793,13 @@
       "file": "lib/src/models/interactions/tools/retrieval_tool.dart",
       "kind": "sealed_variant",
       "parent": "InteractionTool"
+    },
+    "interactions:SafetySetting": {
+      "spec": "interactions",
+      "schema": "SafetySetting",
+      "kind": "object",
+      "dart_class": "InteractionSafetySetting",
+      "file": "lib/src/models/interactions/safety_setting.dart"
     },
     "interactions:SpeechConfig": {
       "spec": "interactions",
@@ -1912,6 +1951,14 @@
       "tags": [
         "acknowledged"
       ]
+    },
+    "interactions:VideoResponseFormat": {
+      "spec": "interactions",
+      "schema": "VideoResponseFormat",
+      "parent": "ResponseFormat",
+      "kind": "sealed_variant",
+      "dart_class": "InteractionVideoResponseFormat",
+      "file": "lib/src/models/interactions/response_formats/video_response_format.dart"
     },
     "AudioResponseFormat": {
       "spec": "main",
@@ -2096,6 +2143,65 @@
         "acknowledged"
       ],
       "note": "SSE/delta event DTOs follow the existing googleai_dart convention of omitting copyWith on small immutable events."
+    },
+    "RetrievalCallDelta": {
+      "spec": "interactions",
+      "schema": "RetrievalCallDelta",
+      "parent": "StepDeltaData",
+      "kind": "sealed_variant",
+      "dart_class": "RetrievalCallDelta",
+      "file": "lib/src/models/interactions/deltas/retrieval_call_delta.dart"
+    },
+    "RetrievalResultDelta": {
+      "spec": "interactions",
+      "schema": "RetrievalResultDelta",
+      "parent": "StepDeltaData",
+      "kind": "sealed_variant",
+      "dart_class": "RetrievalResultDelta",
+      "file": "lib/src/models/interactions/deltas/retrieval_result_delta.dart"
+    },
+    "RetrievalStepArguments": {
+      "spec": "interactions",
+      "schema": "RetrievalStepArguments",
+      "kind": "object",
+      "dart_class": "RetrievalCallArguments",
+      "file": "lib/src/models/interactions/deltas/retrieval_call_delta.dart",
+      "note": "Spec applies a speakeasy name-override renaming this schema's generated type to RetrievalCallArguments; Dart follows the override name."
+    },
+    "interactions:Status": {
+      "spec": "interactions",
+      "schema": "Status",
+      "kind": "object",
+      "dart_class": "Status",
+      "file": "lib/src/models/batch/status.dart",
+      "note": "Reuses the existing batch Status model; the interactions google.rpc.Status shape is identical (code/message/details)."
+    },
+    "RetrievalCallStep": {
+      "spec": "interactions",
+      "schema": "RetrievalCallStep",
+      "kind": "skip",
+      "note": "Orphan schema: not referenced by any spec union/property; python-genai omits it. Review when a spec union gains it.",
+      "tags": [
+        "acknowledged"
+      ]
+    },
+    "RetrievalResultStep": {
+      "spec": "interactions",
+      "schema": "RetrievalResultStep",
+      "kind": "skip",
+      "note": "Orphan schema: not referenced by any spec union/property; python-genai omits it. Review when a spec union gains it.",
+      "tags": [
+        "acknowledged"
+      ]
+    },
+    "LocalEnvironmentConfig": {
+      "spec": "interactions",
+      "schema": "LocalEnvironmentConfig",
+      "kind": "skip",
+      "note": "Orphan schema: not referenced by any spec union/property; python-genai omits it. Review when a spec union gains it.",
+      "tags": [
+        "acknowledged"
+      ]
     },
     "interactions:ServiceTier": {
       "spec": "interactions",

--- a/packages/googleai_dart/lib/googleai_dart.dart
+++ b/packages/googleai_dart/lib/googleai_dart.dart
@@ -158,6 +158,7 @@ export 'src/models/interactions/media_resolution.dart';
 export 'src/models/interactions/modality_tokens.dart';
 export 'src/models/interactions/response_formats/response_formats.dart';
 export 'src/models/interactions/response_modality.dart';
+export 'src/models/interactions/safety_setting.dart';
 export 'src/models/interactions/speech_config.dart';
 export 'src/models/interactions/steps/steps.dart';
 export 'src/models/interactions/stream_metadata.dart';
@@ -173,6 +174,7 @@ export 'src/models/interactions/tools/rag_store_config.dart';
 export 'src/models/interactions/tools/tools.dart';
 export 'src/models/interactions/tools/vertex_ai_search_config.dart';
 export 'src/models/interactions/usage.dart';
+export 'src/models/interactions/video_config.dart';
 export 'src/models/interactions/webhook_config.dart';
 // Models - Live API
 export 'src/models/live/config/audio_transcription_config.dart';

--- a/packages/googleai_dart/lib/src/models/interactions/deltas/deltas.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/deltas/deltas.dart
@@ -20,6 +20,8 @@ part 'google_search_result_delta.dart';
 part 'image_delta.dart';
 part 'mcp_server_tool_call_delta.dart';
 part 'mcp_server_tool_result_delta.dart';
+part 'retrieval_call_delta.dart';
+part 'retrieval_result_delta.dart';
 part 'text_annotation_delta.dart';
 part 'text_delta.dart';
 part 'thought_signature_delta.dart';
@@ -38,10 +40,11 @@ part 'video_delta.dart';
 ///   [TextAnnotationDelta], [ArgumentsDelta].
 /// - Tool-call deltas: [CodeExecutionCallDelta], [UrlContextCallDelta],
 ///   [GoogleSearchCallDelta], [GoogleMapsCallDelta], [McpServerToolCallDelta],
-///   [FileSearchCallDelta].
+///   [FileSearchCallDelta], [RetrievalCallDelta].
 /// - Tool-result deltas: [CodeExecutionResultDelta], [UrlContextResultDelta],
 ///   [GoogleSearchResultDelta], [GoogleMapsResultDelta],
-///   [McpServerToolResultDelta], [FileSearchResultDelta], [FunctionResultDelta].
+///   [McpServerToolResultDelta], [FileSearchResultDelta], [FunctionResultDelta],
+///   [RetrievalResultDelta].
 ///
 /// Plus an [UnknownStepDelta] fallback for any `type` this client does not yet
 /// model, keeping streams forward-compatible.
@@ -81,6 +84,8 @@ sealed class StepDeltaData {
       'mcp_server_tool_result' => McpServerToolResultDelta.fromJson(json),
       'file_search_result' => FileSearchResultDelta.fromJson(json),
       'function_result' => FunctionResultDelta.fromJson(json),
+      'retrieval_call' => RetrievalCallDelta.fromJson(json),
+      'retrieval_result' => RetrievalResultDelta.fromJson(json),
       _ => UnknownStepDelta.fromJson(json),
     };
   }

--- a/packages/googleai_dart/lib/src/models/interactions/deltas/retrieval_call_delta.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/deltas/retrieval_call_delta.dart
@@ -1,0 +1,130 @@
+part of 'deltas.dart';
+
+/// The type of retrieval tools used by a [RetrievalCallDelta].
+enum RetrievalType {
+  /// Vertex AI Search.
+  vertexAiSearch,
+
+  /// RAG store.
+  ragStore,
+
+  /// Exa AI Search.
+  exaAiSearch,
+
+  /// Parallel AI Search.
+  parallelAiSearch,
+}
+
+/// Converts a JSON string to a [RetrievalType], or `null` if unrecognized
+/// (forward-compatible).
+RetrievalType? retrievalTypeFromString(String? value) {
+  return switch (value) {
+    'vertex_ai_search' => RetrievalType.vertexAiSearch,
+    'rag_store' => RetrievalType.ragStore,
+    'exa_ai_search' => RetrievalType.exaAiSearch,
+    'parallel_ai_search' => RetrievalType.parallelAiSearch,
+    _ => null,
+  };
+}
+
+/// Converts a [RetrievalType] to its JSON string.
+String retrievalTypeToString(RetrievalType value) {
+  return switch (value) {
+    RetrievalType.vertexAiSearch => 'vertex_ai_search',
+    RetrievalType.ragStore => 'rag_store',
+    RetrievalType.exaAiSearch => 'exa_ai_search',
+    RetrievalType.parallelAiSearch => 'parallel_ai_search',
+  };
+}
+
+/// The arguments to pass to a Retrieval tool.
+class RetrievalCallArguments {
+  /// Queries for Retrieval information.
+  final List<String>? queries;
+
+  /// Creates a [RetrievalCallArguments] instance.
+  const RetrievalCallArguments({this.queries});
+
+  /// Creates a [RetrievalCallArguments] from JSON.
+  factory RetrievalCallArguments.fromJson(Map<String, dynamic> json) =>
+      RetrievalCallArguments(
+        queries: (json['queries'] as List<dynamic>?)?.cast<String>(),
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {if (queries != null) 'queries': queries};
+
+  /// Creates a copy with replaced values.
+  RetrievalCallArguments copyWith({Object? queries = unsetCopyWithValue}) {
+    return RetrievalCallArguments(
+      queries: queries == unsetCopyWithValue
+          ? this.queries
+          : queries as List<String>?,
+    );
+  }
+}
+
+/// A streamed delta for a Retrieval tool call.
+///
+/// Used by Vertex Retrieval tools such as Parallel AI, Exa AI, Vertex AI
+/// Search, etc. [retrievalType] decides which tool is used.
+class RetrievalCallDelta extends StepDeltaData {
+  @override
+  String get type => 'retrieval_call';
+
+  /// Required. The arguments to pass to the Retrieval tool.
+  final RetrievalCallArguments arguments;
+
+  /// The type of retrieval tools.
+  final RetrievalType? retrievalType;
+
+  /// A signature hash for backend validation.
+  final String? signature;
+
+  /// Creates a [RetrievalCallDelta] instance.
+  const RetrievalCallDelta({
+    required this.arguments,
+    this.retrievalType,
+    this.signature,
+  });
+
+  /// Creates a [RetrievalCallDelta] from JSON.
+  factory RetrievalCallDelta.fromJson(Map<String, dynamic> json) =>
+      RetrievalCallDelta(
+        arguments: RetrievalCallArguments.fromJson(
+          json['arguments'] as Map<String, dynamic>,
+        ),
+        retrievalType: retrievalTypeFromString(
+          json['retrieval_type'] as String?,
+        ),
+        signature: json['signature'] as String?,
+      );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'arguments': arguments.toJson(),
+    if (retrievalType != null)
+      'retrieval_type': retrievalTypeToString(retrievalType!),
+    if (signature != null) 'signature': signature,
+  };
+
+  /// Creates a copy with replaced values.
+  RetrievalCallDelta copyWith({
+    Object? arguments = unsetCopyWithValue,
+    Object? retrievalType = unsetCopyWithValue,
+    Object? signature = unsetCopyWithValue,
+  }) {
+    return RetrievalCallDelta(
+      arguments: arguments == unsetCopyWithValue
+          ? this.arguments
+          : arguments! as RetrievalCallArguments,
+      retrievalType: retrievalType == unsetCopyWithValue
+          ? this.retrievalType
+          : retrievalType as RetrievalType?,
+      signature: signature == unsetCopyWithValue
+          ? this.signature
+          : signature as String?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/deltas/retrieval_result_delta.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/deltas/retrieval_result_delta.dart
@@ -1,0 +1,46 @@
+part of 'deltas.dart';
+
+/// A streamed delta for a Retrieval tool result.
+///
+/// Used by Vertex Retrieval tools such as Parallel AI, Exa AI, Vertex AI
+/// Search, etc.
+class RetrievalResultDelta extends StepDeltaData {
+  @override
+  String get type => 'retrieval_result';
+
+  /// Whether the retrieval resulted in an error.
+  final bool? isError;
+
+  /// A signature hash for backend validation.
+  final String? signature;
+
+  /// Creates a [RetrievalResultDelta] instance.
+  const RetrievalResultDelta({this.isError, this.signature});
+
+  /// Creates a [RetrievalResultDelta] from JSON.
+  factory RetrievalResultDelta.fromJson(Map<String, dynamic> json) =>
+      RetrievalResultDelta(
+        isError: json['is_error'] as bool?,
+        signature: json['signature'] as String?,
+      );
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (isError != null) 'is_error': isError,
+    if (signature != null) 'signature': signature,
+  };
+
+  /// Creates a copy with replaced values.
+  RetrievalResultDelta copyWith({
+    Object? isError = unsetCopyWithValue,
+    Object? signature = unsetCopyWithValue,
+  }) {
+    return RetrievalResultDelta(
+      isError: isError == unsetCopyWithValue ? this.isError : isError as bool?,
+      signature: signature == unsetCopyWithValue
+          ? this.signature
+          : signature as String?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/environments/allowlist_entry.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/environments/allowlist_entry.dart
@@ -10,18 +10,28 @@ class AllowlistEntry {
   /// Headers to inject on all outbound requests matching this [domain].
   ///
   /// Each entry is a flat `{header_name: header_value}` object; the egress
-  /// proxy injects these automatically.
+  /// proxy injects these automatically. The spec accepts a single dict or a
+  /// list of dicts; a single dict is normalized to a one-element list.
   final List<Map<String, String>>? transform;
 
   /// Creates an [AllowlistEntry].
   const AllowlistEntry({required this.domain, this.transform});
 
   /// Creates an [AllowlistEntry] from JSON.
+  ///
+  /// `transform` accepts either a single `{header_name: header_value}` object
+  /// or a list of such objects; a single object is normalized to a
+  /// one-element list.
   factory AllowlistEntry.fromJson(Map<String, dynamic> json) => AllowlistEntry(
     domain: json['domain'] as String,
-    transform: (json['transform'] as List<dynamic>?)
-        ?.map((e) => (e as Map<String, dynamic>).cast<String, String>())
-        .toList(),
+    transform: switch (json['transform']) {
+      final List<dynamic> list =>
+        list
+            .map((e) => (e as Map<String, dynamic>).cast<String, String>())
+            .toList(),
+      final Map<String, dynamic> map => [map.cast<String, String>()],
+      _ => null,
+    },
   );
 
   /// Converts to JSON.

--- a/packages/googleai_dart/lib/src/models/interactions/environments/environment_config.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/environments/environment_config.dart
@@ -17,8 +17,13 @@ class EnvironmentConfig {
   /// Sources mounted into the environment's sandbox.
   final List<Source>? sources;
 
+  /// Optional. The environment ID for the interaction. If specified, the
+  /// request will update the existing environment instead of creating a new
+  /// one.
+  final String? environmentId;
+
   /// Creates an [EnvironmentConfig].
-  const EnvironmentConfig({this.network, this.sources});
+  const EnvironmentConfig({this.network, this.sources, this.environmentId});
 
   /// Creates an [EnvironmentConfig] from JSON.
   ///
@@ -40,6 +45,7 @@ class EnvironmentConfig {
       sources: (json['sources'] as List<dynamic>?)
           ?.map((e) => Source.fromJson(e as Map<String, dynamic>))
           .toList(),
+      environmentId: json['environment_id'] as String?,
     );
   }
 
@@ -48,12 +54,14 @@ class EnvironmentConfig {
     'type': type,
     if (network != null) 'network': network!.toJson(),
     if (sources != null) 'sources': sources!.map((e) => e.toJson()).toList(),
+    if (environmentId != null) 'environment_id': environmentId,
   };
 
   /// Creates a copy with replaced values.
   EnvironmentConfig copyWith({
     Object? network = unsetCopyWithValue,
     Object? sources = unsetCopyWithValue,
+    Object? environmentId = unsetCopyWithValue,
   }) {
     return EnvironmentConfig(
       network: network == unsetCopyWithValue
@@ -62,6 +70,9 @@ class EnvironmentConfig {
       sources: sources == unsetCopyWithValue
           ? this.sources
           : sources as List<Source>?,
+      environmentId: environmentId == unsetCopyWithValue
+          ? this.environmentId
+          : environmentId as String?,
     );
   }
 }

--- a/packages/googleai_dart/lib/src/models/interactions/events/events.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/events/events.dart
@@ -3,6 +3,7 @@ import '../interaction.dart';
 import '../interaction_status.dart';
 import '../steps/steps.dart';
 import '../stream_metadata.dart';
+import '../usage.dart';
 
 part 'error_event.dart';
 part 'interaction_completed_event.dart';

--- a/packages/googleai_dart/lib/src/models/interactions/events/step_stop_event.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/events/step_stop_event.dart
@@ -11,8 +11,20 @@ class StepStopEvent extends InteractionEvent {
   /// Optional metadata accompanying this streamed event.
   final StreamMetadata? metadata;
 
+  /// Cumulative model usage stats from the start of the session.
+  final InteractionUsage? usage;
+
+  /// Model usage stats for this specific step.
+  final InteractionUsage? stepUsage;
+
   /// Creates a [StepStopEvent] instance.
-  const StepStopEvent({required this.index, this.metadata, super.eventId});
+  const StepStopEvent({
+    required this.index,
+    this.metadata,
+    this.usage,
+    this.stepUsage,
+    super.eventId,
+  });
 
   /// Creates a [StepStopEvent] from JSON.
   factory StepStopEvent.fromJson(Map<String, dynamic> json) {
@@ -25,6 +37,14 @@ class StepStopEvent extends InteractionEvent {
       metadata: json['metadata'] != null
           ? StreamMetadata.fromJson(json['metadata'] as Map<String, dynamic>)
           : null,
+      usage: json['usage'] != null
+          ? InteractionUsage.fromJson(json['usage'] as Map<String, dynamic>)
+          : null,
+      stepUsage: json['step_usage'] != null
+          ? InteractionUsage.fromJson(
+              json['step_usage'] as Map<String, dynamic>,
+            )
+          : null,
       eventId: json['event_id'] as String?,
     );
   }
@@ -34,6 +54,8 @@ class StepStopEvent extends InteractionEvent {
     'event_type': eventType,
     'index': index,
     if (metadata != null) 'metadata': metadata!.toJson(),
+    if (usage != null) 'usage': usage!.toJson(),
+    if (stepUsage != null) 'step_usage': stepUsage!.toJson(),
     if (eventId != null) 'event_id': eventId,
   };
 }

--- a/packages/googleai_dart/lib/src/models/interactions/generation_config.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/generation_config.dart
@@ -4,6 +4,7 @@ import 'speech_config.dart';
 import 'thinking_level.dart';
 import 'thinking_summaries.dart';
 import 'tool_choice.dart';
+import 'video_config.dart';
 
 /// Configuration parameters for model interactions.
 class InteractionGenerationConfig {
@@ -12,18 +13,6 @@ class InteractionGenerationConfig {
 
   /// The maximum cumulative probability of tokens to consider when sampling.
   final double? topP;
-
-  /// Penalizes tokens based on their frequency in the generated text.
-  ///
-  /// A positive value helps to reduce the repetition of words and phrases.
-  /// Valid values range from [-2.0, 2.0].
-  final double? frequencyPenalty;
-
-  /// Penalizes tokens that have already appeared in the generated text.
-  ///
-  /// A positive value encourages the model to generate more diverse and less
-  /// repetitive text. Valid values range from [-2.0, 2.0].
-  final double? presencePenalty;
 
   /// Seed used in decoding for reproducibility.
   final int? seed;
@@ -49,12 +38,13 @@ class InteractionGenerationConfig {
   /// Configuration for image interaction.
   final InteractionImageConfig? imageConfig;
 
+  /// Configuration for video generation.
+  final InteractionVideoConfig? videoConfig;
+
   /// Creates an [InteractionGenerationConfig] instance.
   const InteractionGenerationConfig({
     this.temperature,
     this.topP,
-    this.frequencyPenalty,
-    this.presencePenalty,
     this.seed,
     this.stopSequences,
     this.toolChoice,
@@ -63,6 +53,7 @@ class InteractionGenerationConfig {
     this.maxOutputTokens,
     this.speechConfig,
     this.imageConfig,
+    this.videoConfig,
   });
 
   /// Creates an [InteractionGenerationConfig] from JSON.
@@ -71,8 +62,6 @@ class InteractionGenerationConfig {
   ) => InteractionGenerationConfig(
     temperature: (json['temperature'] as num?)?.toDouble(),
     topP: (json['top_p'] as num?)?.toDouble(),
-    frequencyPenalty: (json['frequency_penalty'] as num?)?.toDouble(),
-    presencePenalty: (json['presence_penalty'] as num?)?.toDouble(),
     seed: json['seed'] as int?,
     stopSequences: (json['stop_sequences'] as List<dynamic>?)?.cast<String>(),
     toolChoice: json['tool_choice'] != null
@@ -97,14 +86,17 @@ class InteractionGenerationConfig {
             json['image_config'] as Map<String, dynamic>,
           )
         : null,
+    videoConfig: json['video_config'] != null
+        ? InteractionVideoConfig.fromJson(
+            json['video_config'] as Map<String, dynamic>,
+          )
+        : null,
   );
 
   /// Converts to JSON.
   Map<String, dynamic> toJson() => {
     if (temperature != null) 'temperature': temperature,
     if (topP != null) 'top_p': topP,
-    if (frequencyPenalty != null) 'frequency_penalty': frequencyPenalty,
-    if (presencePenalty != null) 'presence_penalty': presencePenalty,
     if (seed != null) 'seed': seed,
     if (stopSequences != null) 'stop_sequences': stopSequences,
     if (toolChoice != null) 'tool_choice': toolChoice!.toJson(),
@@ -118,14 +110,13 @@ class InteractionGenerationConfig {
     if (speechConfig != null)
       'speech_config': speechConfig!.map((e) => e.toJson()).toList(),
     if (imageConfig != null) 'image_config': imageConfig!.toJson(),
+    if (videoConfig != null) 'video_config': videoConfig!.toJson(),
   };
 
   /// Creates a copy with replaced values.
   InteractionGenerationConfig copyWith({
     Object? temperature = unsetCopyWithValue,
     Object? topP = unsetCopyWithValue,
-    Object? frequencyPenalty = unsetCopyWithValue,
-    Object? presencePenalty = unsetCopyWithValue,
     Object? seed = unsetCopyWithValue,
     Object? stopSequences = unsetCopyWithValue,
     Object? toolChoice = unsetCopyWithValue,
@@ -134,18 +125,13 @@ class InteractionGenerationConfig {
     Object? maxOutputTokens = unsetCopyWithValue,
     Object? speechConfig = unsetCopyWithValue,
     Object? imageConfig = unsetCopyWithValue,
+    Object? videoConfig = unsetCopyWithValue,
   }) {
     return InteractionGenerationConfig(
       temperature: temperature == unsetCopyWithValue
           ? this.temperature
           : temperature as double?,
       topP: topP == unsetCopyWithValue ? this.topP : topP as double?,
-      frequencyPenalty: frequencyPenalty == unsetCopyWithValue
-          ? this.frequencyPenalty
-          : frequencyPenalty as double?,
-      presencePenalty: presencePenalty == unsetCopyWithValue
-          ? this.presencePenalty
-          : presencePenalty as double?,
       seed: seed == unsetCopyWithValue ? this.seed : seed as int?,
       stopSequences: stopSequences == unsetCopyWithValue
           ? this.stopSequences
@@ -168,6 +154,9 @@ class InteractionGenerationConfig {
       imageConfig: imageConfig == unsetCopyWithValue
           ? this.imageConfig
           : imageConfig as InteractionImageConfig?,
+      videoConfig: videoConfig == unsetCopyWithValue
+          ? this.videoConfig
+          : videoConfig as InteractionVideoConfig?,
     );
   }
 }

--- a/packages/googleai_dart/lib/src/models/interactions/interaction.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/interaction.dart
@@ -7,6 +7,7 @@ import 'interaction_input.dart';
 import 'interaction_status.dart';
 import 'response_formats/response_formats.dart';
 import 'response_modality.dart';
+import 'safety_setting.dart';
 import 'steps/steps.dart';
 import 'tools/tools.dart';
 import 'usage.dart';
@@ -97,6 +98,12 @@ class Interaction {
   /// completes.
   final WebhookConfig? webhookConfig;
 
+  /// The labels with user-defined metadata for the request.
+  final Map<String, String>? labels;
+
+  /// Safety settings for the interaction.
+  final List<InteractionSafetySetting>? safetySettings;
+
   /// Creates an [Interaction] instance.
   const Interaction({
     required this.id,
@@ -122,6 +129,8 @@ class Interaction {
     this.environment,
     this.environmentId,
     this.webhookConfig,
+    this.labels,
+    this.safetySettings,
   });
 
   /// Creates an [Interaction] from JSON.
@@ -179,6 +188,12 @@ class Interaction {
     webhookConfig: json['webhook_config'] != null
         ? WebhookConfig.fromJson(json['webhook_config'] as Map<String, dynamic>)
         : null,
+    labels: (json['labels'] as Map<String, dynamic>?)?.cast<String, String>(),
+    safetySettings: (json['safety_settings'] as List<dynamic>?)
+        ?.map(
+          (e) => InteractionSafetySetting.fromJson(e as Map<String, dynamic>),
+        )
+        .toList(),
   );
 
   /// Converts to JSON.
@@ -212,6 +227,9 @@ class Interaction {
     if (environment != null) 'environment': environment!.toJson(),
     if (environmentId != null) 'environment_id': environmentId,
     if (webhookConfig != null) 'webhook_config': webhookConfig!.toJson(),
+    if (labels != null) 'labels': labels,
+    if (safetySettings != null)
+      'safety_settings': safetySettings!.map((e) => e.toJson()).toList(),
   };
 
   /// Creates a copy with replaced values.
@@ -239,6 +257,8 @@ class Interaction {
     Object? environment = unsetCopyWithValue,
     Object? environmentId = unsetCopyWithValue,
     Object? webhookConfig = unsetCopyWithValue,
+    Object? labels = unsetCopyWithValue,
+    Object? safetySettings = unsetCopyWithValue,
   }) {
     return Interaction(
       id: id == unsetCopyWithValue ? this.id : id! as String,
@@ -302,6 +322,12 @@ class Interaction {
       webhookConfig: webhookConfig == unsetCopyWithValue
           ? this.webhookConfig
           : webhookConfig as WebhookConfig?,
+      labels: labels == unsetCopyWithValue
+          ? this.labels
+          : labels as Map<String, String>?,
+      safetySettings: safetySettings == unsetCopyWithValue
+          ? this.safetySettings
+          : safetySettings as List<InteractionSafetySetting>?,
     );
   }
 }
@@ -359,6 +385,12 @@ class CreateModelInteractionParams {
   /// completes.
   final WebhookConfig? webhookConfig;
 
+  /// The labels with user-defined metadata for the request.
+  final Map<String, String>? labels;
+
+  /// Safety settings for the interaction.
+  final List<InteractionSafetySetting>? safetySettings;
+
   /// Creates a [CreateModelInteractionParams] instance.
   const CreateModelInteractionParams({
     required this.model,
@@ -375,48 +407,55 @@ class CreateModelInteractionParams {
     this.serviceTier,
     this.environment,
     this.webhookConfig,
+    this.labels,
+    this.safetySettings,
   });
 
   /// Creates from JSON.
-  factory CreateModelInteractionParams.fromJson(Map<String, dynamic> json) =>
-      CreateModelInteractionParams(
-        model: json['model'] as String,
-        cachedContent: json['cached_content'] as String?,
-        input: json['input'] != null
-            ? InteractionInput.fromJson(json['input'] as Object)
-            : null,
-        systemInstruction: json['system_instruction'] as String?,
-        tools: (json['tools'] as List<dynamic>?)
-            ?.map((e) => InteractionTool.fromJson(e as Map<String, dynamic>))
-            .toList(),
-        generationConfig: json['generation_config'] != null
-            ? InteractionGenerationConfig.fromJson(
-                json['generation_config'] as Map<String, dynamic>,
-              )
-            : null,
-        responseModalities: (json['response_modalities'] as List<dynamic>?)
-            ?.map((e) => interactionResponseModalityFromString(e as String))
-            .toList(),
-        responseMimeType: json['response_mime_type'] as String?,
-        responseFormat: json['response_format'] != null
-            ? InteractionResponseFormatConfig.fromJson(
-                json['response_format'] as Object,
-              )
-            : null,
-        previousInteractionId: json['previous_interaction_id'] as String?,
-        background: json['background'] as bool?,
-        serviceTier: json['service_tier'] != null
-            ? serviceTierFromString(json['service_tier'] as String?)
-            : null,
-        environment: json['environment'] != null
-            ? EnvironmentConfigOrId.fromJson(json['environment'] as Object)
-            : null,
-        webhookConfig: json['webhook_config'] != null
-            ? WebhookConfig.fromJson(
-                json['webhook_config'] as Map<String, dynamic>,
-              )
-            : null,
-      );
+  factory CreateModelInteractionParams.fromJson(
+    Map<String, dynamic> json,
+  ) => CreateModelInteractionParams(
+    model: json['model'] as String,
+    cachedContent: json['cached_content'] as String?,
+    input: json['input'] != null
+        ? InteractionInput.fromJson(json['input'] as Object)
+        : null,
+    systemInstruction: json['system_instruction'] as String?,
+    tools: (json['tools'] as List<dynamic>?)
+        ?.map((e) => InteractionTool.fromJson(e as Map<String, dynamic>))
+        .toList(),
+    generationConfig: json['generation_config'] != null
+        ? InteractionGenerationConfig.fromJson(
+            json['generation_config'] as Map<String, dynamic>,
+          )
+        : null,
+    responseModalities: (json['response_modalities'] as List<dynamic>?)
+        ?.map((e) => interactionResponseModalityFromString(e as String))
+        .toList(),
+    responseMimeType: json['response_mime_type'] as String?,
+    responseFormat: json['response_format'] != null
+        ? InteractionResponseFormatConfig.fromJson(
+            json['response_format'] as Object,
+          )
+        : null,
+    previousInteractionId: json['previous_interaction_id'] as String?,
+    background: json['background'] as bool?,
+    serviceTier: json['service_tier'] != null
+        ? serviceTierFromString(json['service_tier'] as String?)
+        : null,
+    environment: json['environment'] != null
+        ? EnvironmentConfigOrId.fromJson(json['environment'] as Object)
+        : null,
+    webhookConfig: json['webhook_config'] != null
+        ? WebhookConfig.fromJson(json['webhook_config'] as Map<String, dynamic>)
+        : null,
+    labels: (json['labels'] as Map<String, dynamic>?)?.cast<String, String>(),
+    safetySettings: (json['safety_settings'] as List<dynamic>?)
+        ?.map(
+          (e) => InteractionSafetySetting.fromJson(e as Map<String, dynamic>),
+        )
+        .toList(),
+  );
 
   /// Converts to JSON.
   Map<String, dynamic> toJson() => {
@@ -440,6 +479,9 @@ class CreateModelInteractionParams {
       'service_tier': serviceTierToString(serviceTier!),
     if (environment != null) 'environment': environment!.toJson(),
     if (webhookConfig != null) 'webhook_config': webhookConfig!.toJson(),
+    if (labels != null) 'labels': labels,
+    if (safetySettings != null)
+      'safety_settings': safetySettings!.map((e) => e.toJson()).toList(),
   };
 }
 
@@ -478,6 +520,12 @@ class CreateAgentInteractionParams {
   /// completes.
   final WebhookConfig? webhookConfig;
 
+  /// The labels with user-defined metadata for the request.
+  final Map<String, String>? labels;
+
+  /// Safety settings for the interaction.
+  final List<InteractionSafetySetting>? safetySettings;
+
   /// Creates a [CreateAgentInteractionParams] instance.
   const CreateAgentInteractionParams({
     required this.agent,
@@ -489,37 +537,44 @@ class CreateAgentInteractionParams {
     this.serviceTier,
     this.environment,
     this.webhookConfig,
+    this.labels,
+    this.safetySettings,
   });
 
   /// Creates from JSON.
-  factory CreateAgentInteractionParams.fromJson(Map<String, dynamic> json) =>
-      CreateAgentInteractionParams(
-        agent: json['agent'] as String,
-        input: json['input'] != null
-            ? InteractionInput.fromJson(json['input'] as Object)
-            : null,
-        agentConfig: json['agent_config'] != null
-            ? AgentConfig.fromJson(json['agent_config'] as Map<String, dynamic>)
-            : null,
-        responseFormat: json['response_format'] != null
-            ? InteractionResponseFormatConfig.fromJson(
-                json['response_format'] as Object,
-              )
-            : null,
-        previousInteractionId: json['previous_interaction_id'] as String?,
-        background: json['background'] as bool?,
-        serviceTier: json['service_tier'] != null
-            ? serviceTierFromString(json['service_tier'] as String?)
-            : null,
-        environment: json['environment'] != null
-            ? EnvironmentConfigOrId.fromJson(json['environment'] as Object)
-            : null,
-        webhookConfig: json['webhook_config'] != null
-            ? WebhookConfig.fromJson(
-                json['webhook_config'] as Map<String, dynamic>,
-              )
-            : null,
-      );
+  factory CreateAgentInteractionParams.fromJson(
+    Map<String, dynamic> json,
+  ) => CreateAgentInteractionParams(
+    agent: json['agent'] as String,
+    input: json['input'] != null
+        ? InteractionInput.fromJson(json['input'] as Object)
+        : null,
+    agentConfig: json['agent_config'] != null
+        ? AgentConfig.fromJson(json['agent_config'] as Map<String, dynamic>)
+        : null,
+    responseFormat: json['response_format'] != null
+        ? InteractionResponseFormatConfig.fromJson(
+            json['response_format'] as Object,
+          )
+        : null,
+    previousInteractionId: json['previous_interaction_id'] as String?,
+    background: json['background'] as bool?,
+    serviceTier: json['service_tier'] != null
+        ? serviceTierFromString(json['service_tier'] as String?)
+        : null,
+    environment: json['environment'] != null
+        ? EnvironmentConfigOrId.fromJson(json['environment'] as Object)
+        : null,
+    webhookConfig: json['webhook_config'] != null
+        ? WebhookConfig.fromJson(json['webhook_config'] as Map<String, dynamic>)
+        : null,
+    labels: (json['labels'] as Map<String, dynamic>?)?.cast<String, String>(),
+    safetySettings: (json['safety_settings'] as List<dynamic>?)
+        ?.map(
+          (e) => InteractionSafetySetting.fromJson(e as Map<String, dynamic>),
+        )
+        .toList(),
+  );
 
   /// Converts to JSON.
   Map<String, dynamic> toJson() => {
@@ -534,5 +589,8 @@ class CreateAgentInteractionParams {
       'service_tier': serviceTierToString(serviceTier!),
     if (environment != null) 'environment': environment!.toJson(),
     if (webhookConfig != null) 'webhook_config': webhookConfig!.toJson(),
+    if (labels != null) 'labels': labels,
+    if (safetySettings != null)
+      'safety_settings': safetySettings!.map((e) => e.toJson()).toList(),
   };
 }

--- a/packages/googleai_dart/lib/src/models/interactions/response_formats/response_formats.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/response_formats/response_formats.dart
@@ -5,11 +5,13 @@ part 'image_response_format.dart';
 part 'response_format_config.dart';
 part 'text_response_format.dart';
 part 'unknown_response_format.dart';
+part 'video_response_format.dart';
 
 /// A single response format for an interaction.
 ///
 /// This is a sealed class with subtypes [InteractionAudioResponseFormat],
-/// [InteractionTextResponseFormat], [InteractionImageResponseFormat], and
+/// [InteractionTextResponseFormat], [InteractionImageResponseFormat],
+/// [InteractionVideoResponseFormat], and
 /// [UnknownInteractionResponseFormat] for the spec's open `{ "type": object }`
 /// member.
 ///
@@ -31,6 +33,7 @@ sealed class InteractionResponseFormat {
       'audio' => InteractionAudioResponseFormat.fromJson(json),
       'text' => InteractionTextResponseFormat.fromJson(json),
       'image' => InteractionImageResponseFormat.fromJson(json),
+      'video' => InteractionVideoResponseFormat.fromJson(json),
       _ => UnknownInteractionResponseFormat.fromJson(json),
     };
   }

--- a/packages/googleai_dart/lib/src/models/interactions/response_formats/video_response_format.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/response_formats/video_response_format.dart
@@ -1,0 +1,140 @@
+part of 'response_formats.dart';
+
+/// Aspect ratio for a video response.
+enum InteractionVideoResponseFormatAspectRatio {
+  /// 16:9 aspect ratio.
+  ratio16x9,
+
+  /// 9:16 aspect ratio.
+  ratio9x16,
+}
+
+/// Converts a JSON string to an [InteractionVideoResponseFormatAspectRatio],
+/// or `null` if unrecognized (forward-compatible).
+InteractionVideoResponseFormatAspectRatio?
+interactionVideoResponseFormatAspectRatioFromString(String? value) {
+  return switch (value) {
+    '16:9' => InteractionVideoResponseFormatAspectRatio.ratio16x9,
+    '9:16' => InteractionVideoResponseFormatAspectRatio.ratio9x16,
+    _ => null,
+  };
+}
+
+/// Converts an [InteractionVideoResponseFormatAspectRatio] to its JSON
+/// string.
+String interactionVideoResponseFormatAspectRatioToString(
+  InteractionVideoResponseFormatAspectRatio value,
+) {
+  return switch (value) {
+    InteractionVideoResponseFormatAspectRatio.ratio16x9 => '16:9',
+    InteractionVideoResponseFormatAspectRatio.ratio9x16 => '9:16',
+  };
+}
+
+/// Delivery mode for a video response.
+enum InteractionVideoResponseFormatDelivery {
+  /// Video data is returned inline in the response.
+  inline,
+
+  /// Video data is returned as a URI.
+  uri,
+}
+
+/// Converts a JSON string to an [InteractionVideoResponseFormatDelivery], or
+/// `null` if unrecognized (forward-compatible).
+InteractionVideoResponseFormatDelivery?
+interactionVideoResponseFormatDeliveryFromString(String? value) {
+  return switch (value) {
+    'inline' => InteractionVideoResponseFormatDelivery.inline,
+    'uri' => InteractionVideoResponseFormatDelivery.uri,
+    _ => null,
+  };
+}
+
+/// Converts an [InteractionVideoResponseFormatDelivery] to its JSON string.
+String interactionVideoResponseFormatDeliveryToString(
+  InteractionVideoResponseFormatDelivery value,
+) {
+  return switch (value) {
+    InteractionVideoResponseFormatDelivery.inline => 'inline',
+    InteractionVideoResponseFormatDelivery.uri => 'uri',
+  };
+}
+
+/// Configuration for video output format.
+class InteractionVideoResponseFormat extends InteractionResponseFormat {
+  @override
+  String get type => 'video';
+
+  /// The aspect ratio for the video output.
+  final InteractionVideoResponseFormatAspectRatio? aspectRatio;
+
+  /// The delivery mode for the video output.
+  final InteractionVideoResponseFormatDelivery? delivery;
+
+  /// The duration for the video output.
+  final String? duration;
+
+  /// The GCS URI to store the video output. Required for Vertex if delivery
+  /// mode is URI.
+  final String? gcsUri;
+
+  /// Creates an [InteractionVideoResponseFormat] instance.
+  const InteractionVideoResponseFormat({
+    this.aspectRatio,
+    this.delivery,
+    this.duration,
+    this.gcsUri,
+  });
+
+  /// Creates an [InteractionVideoResponseFormat] from JSON.
+  factory InteractionVideoResponseFormat.fromJson(Map<String, dynamic> json) {
+    if (json['type'] != 'video') {
+      throw FormatException('Expected type "video" but got "${json['type']}"');
+    }
+    return InteractionVideoResponseFormat(
+      aspectRatio: interactionVideoResponseFormatAspectRatioFromString(
+        json['aspect_ratio'] as String?,
+      ),
+      delivery: interactionVideoResponseFormatDeliveryFromString(
+        json['delivery'] as String?,
+      ),
+      duration: json['duration'] as String?,
+      gcsUri: json['gcs_uri'] as String?,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    if (aspectRatio != null)
+      'aspect_ratio': interactionVideoResponseFormatAspectRatioToString(
+        aspectRatio!,
+      ),
+    if (delivery != null)
+      'delivery': interactionVideoResponseFormatDeliveryToString(delivery!),
+    if (duration != null) 'duration': duration,
+    if (gcsUri != null) 'gcs_uri': gcsUri,
+  };
+
+  /// Creates a copy with replaced values.
+  InteractionVideoResponseFormat copyWith({
+    Object? aspectRatio = unsetCopyWithValue,
+    Object? delivery = unsetCopyWithValue,
+    Object? duration = unsetCopyWithValue,
+    Object? gcsUri = unsetCopyWithValue,
+  }) {
+    return InteractionVideoResponseFormat(
+      aspectRatio: aspectRatio == unsetCopyWithValue
+          ? this.aspectRatio
+          : aspectRatio as InteractionVideoResponseFormatAspectRatio?,
+      delivery: delivery == unsetCopyWithValue
+          ? this.delivery
+          : delivery as InteractionVideoResponseFormatDelivery?,
+      duration: duration == unsetCopyWithValue
+          ? this.duration
+          : duration as String?,
+      gcsUri: gcsUri == unsetCopyWithValue ? this.gcsUri : gcsUri as String?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/safety_setting.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/safety_setting.dart
@@ -1,0 +1,216 @@
+import '../copy_with_sentinel.dart';
+
+/// Harm categories that can be blocked by an [InteractionSafetySetting].
+enum InteractionHarmCategory {
+  /// Content that promotes violence or incites hatred against individuals or
+  /// groups based on certain attributes.
+  hateSpeech,
+
+  /// Content that promotes, facilitates, or enables dangerous activities.
+  dangerousContent,
+
+  /// Abusive, threatening, or content intended to bully, torment, or ridicule.
+  harassment,
+
+  /// Content that contains sexually explicit material.
+  sexuallyExplicit,
+
+  /// Deprecated: Election filter is not longer supported. The harm category
+  /// is civic integrity.
+  civicIntegrity,
+
+  /// Images that contain hate speech.
+  imageHate,
+
+  /// Images that contain dangerous content.
+  imageDangerousContent,
+
+  /// Images that contain harassment.
+  imageHarassment,
+
+  /// Images that contain sexually explicit content.
+  imageSexuallyExplicit,
+
+  /// Prompts designed to bypass safety filters.
+  jailbreak,
+
+  /// Unknown harm category (for forward compatibility).
+  unknown,
+}
+
+/// Converts a string to [InteractionHarmCategory].
+///
+/// Returns [InteractionHarmCategory.unknown] for unrecognized values.
+InteractionHarmCategory interactionHarmCategoryFromString(String? value) {
+  return switch (value) {
+    'hate_speech' => InteractionHarmCategory.hateSpeech,
+    'dangerous_content' => InteractionHarmCategory.dangerousContent,
+    'harassment' => InteractionHarmCategory.harassment,
+    'sexually_explicit' => InteractionHarmCategory.sexuallyExplicit,
+    'civic_integrity' => InteractionHarmCategory.civicIntegrity,
+    'image_hate' => InteractionHarmCategory.imageHate,
+    'image_dangerous_content' => InteractionHarmCategory.imageDangerousContent,
+    'image_harassment' => InteractionHarmCategory.imageHarassment,
+    'image_sexually_explicit' => InteractionHarmCategory.imageSexuallyExplicit,
+    'jailbreak' => InteractionHarmCategory.jailbreak,
+    _ => InteractionHarmCategory.unknown,
+  };
+}
+
+/// Converts [InteractionHarmCategory] to a string.
+String interactionHarmCategoryToString(InteractionHarmCategory category) {
+  return switch (category) {
+    InteractionHarmCategory.hateSpeech => 'hate_speech',
+    InteractionHarmCategory.dangerousContent => 'dangerous_content',
+    InteractionHarmCategory.harassment => 'harassment',
+    InteractionHarmCategory.sexuallyExplicit => 'sexually_explicit',
+    InteractionHarmCategory.civicIntegrity => 'civic_integrity',
+    InteractionHarmCategory.imageHate => 'image_hate',
+    InteractionHarmCategory.imageDangerousContent => 'image_dangerous_content',
+    InteractionHarmCategory.imageHarassment => 'image_harassment',
+    InteractionHarmCategory.imageSexuallyExplicit => 'image_sexually_explicit',
+    InteractionHarmCategory.jailbreak => 'jailbreak',
+    InteractionHarmCategory.unknown => 'unknown',
+  };
+}
+
+/// The threshold for blocking content in an [InteractionSafetySetting].
+enum InteractionHarmBlockThreshold {
+  /// Block content with a low harm probability or higher.
+  blockLowAndAbove,
+
+  /// Block content with a medium harm probability or higher.
+  blockMediumAndAbove,
+
+  /// Block content with a high harm probability.
+  blockOnlyHigh,
+
+  /// Do not block any content, regardless of its harm probability.
+  blockNone,
+
+  /// Turn off the safety filter entirely.
+  off,
+
+  /// Unknown threshold (for forward compatibility).
+  unknown,
+}
+
+/// Converts a string to [InteractionHarmBlockThreshold].
+///
+/// Returns [InteractionHarmBlockThreshold.unknown] for unrecognized values.
+InteractionHarmBlockThreshold interactionHarmBlockThresholdFromString(
+  String? value,
+) {
+  return switch (value) {
+    'block_low_and_above' => InteractionHarmBlockThreshold.blockLowAndAbove,
+    'block_medium_and_above' =>
+      InteractionHarmBlockThreshold.blockMediumAndAbove,
+    'block_only_high' => InteractionHarmBlockThreshold.blockOnlyHigh,
+    'block_none' => InteractionHarmBlockThreshold.blockNone,
+    'off' => InteractionHarmBlockThreshold.off,
+    _ => InteractionHarmBlockThreshold.unknown,
+  };
+}
+
+/// Converts [InteractionHarmBlockThreshold] to a string.
+String interactionHarmBlockThresholdToString(
+  InteractionHarmBlockThreshold threshold,
+) {
+  return switch (threshold) {
+    InteractionHarmBlockThreshold.blockLowAndAbove => 'block_low_and_above',
+    InteractionHarmBlockThreshold.blockMediumAndAbove =>
+      'block_medium_and_above',
+    InteractionHarmBlockThreshold.blockOnlyHigh => 'block_only_high',
+    InteractionHarmBlockThreshold.blockNone => 'block_none',
+    InteractionHarmBlockThreshold.off => 'off',
+    InteractionHarmBlockThreshold.unknown => 'unknown',
+  };
+}
+
+/// The method for blocking content in an [InteractionSafetySetting].
+enum InteractionSafetyMethod {
+  /// The harm block method uses both probability and severity scores.
+  severity,
+
+  /// The harm block method uses the probability score.
+  probability,
+}
+
+/// Converts a string to an [InteractionSafetyMethod], or `null` if
+/// unrecognized (forward-compatible).
+InteractionSafetyMethod? interactionSafetyMethodFromString(String? value) {
+  return switch (value) {
+    'severity' => InteractionSafetyMethod.severity,
+    'probability' => InteractionSafetyMethod.probability,
+    _ => null,
+  };
+}
+
+/// Converts an [InteractionSafetyMethod] to its JSON string.
+String interactionSafetyMethodToString(InteractionSafetyMethod method) {
+  return switch (method) {
+    InteractionSafetyMethod.severity => 'severity',
+    InteractionSafetyMethod.probability => 'probability',
+  };
+}
+
+/// A safety setting that affects the safety-blocking behavior of an
+/// interaction.
+///
+/// A [InteractionSafetySetting] consists of a harm category and a threshold
+/// for that category.
+class InteractionSafetySetting {
+  /// Required. The type of harm category to be blocked.
+  final InteractionHarmCategory type;
+
+  /// Required. The threshold for blocking content. If the harm probability
+  /// exceeds this threshold, the content will be blocked.
+  final InteractionHarmBlockThreshold threshold;
+
+  /// Optional. The method for blocking content. If not specified, the
+  /// default behavior is to use the probability score.
+  final InteractionSafetyMethod? method;
+
+  /// Creates an [InteractionSafetySetting].
+  const InteractionSafetySetting({
+    required this.type,
+    required this.threshold,
+    this.method,
+  });
+
+  /// Creates an [InteractionSafetySetting] from JSON.
+  factory InteractionSafetySetting.fromJson(Map<String, dynamic> json) =>
+      InteractionSafetySetting(
+        type: interactionHarmCategoryFromString(json['type'] as String?),
+        threshold: interactionHarmBlockThresholdFromString(
+          json['threshold'] as String?,
+        ),
+        method: interactionSafetyMethodFromString(json['method'] as String?),
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'type': interactionHarmCategoryToString(type),
+    'threshold': interactionHarmBlockThresholdToString(threshold),
+    if (method != null) 'method': interactionSafetyMethodToString(method!),
+  };
+
+  /// Creates a copy with replaced values.
+  InteractionSafetySetting copyWith({
+    Object? type = unsetCopyWithValue,
+    Object? threshold = unsetCopyWithValue,
+    Object? method = unsetCopyWithValue,
+  }) {
+    return InteractionSafetySetting(
+      type: type == unsetCopyWithValue
+          ? this.type
+          : type! as InteractionHarmCategory,
+      threshold: threshold == unsetCopyWithValue
+          ? this.threshold
+          : threshold! as InteractionHarmBlockThreshold,
+      method: method == unsetCopyWithValue
+          ? this.method
+          : method as InteractionSafetyMethod?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/interactions/steps/model_output_step.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/steps/model_output_step.dart
@@ -11,8 +11,11 @@ class ModelOutputStep extends InteractionStep {
   /// The content of the model output.
   final List<InteractionContent>? content;
 
+  /// The error result of the operation in case of failure or cancellation.
+  final Status? error;
+
   /// Creates a [ModelOutputStep] instance.
-  const ModelOutputStep({this.content});
+  const ModelOutputStep({this.content, this.error});
 
   /// Creates a [ModelOutputStep] from JSON.
   factory ModelOutputStep.fromJson(Map<String, dynamic> json) {
@@ -25,6 +28,9 @@ class ModelOutputStep extends InteractionStep {
       content: (json['content'] as List<dynamic>?)
           ?.map((e) => InteractionContent.fromJson(e as Map<String, dynamic>))
           .toList(),
+      error: json['error'] != null
+          ? Status.fromJson(json['error'] as Map<String, dynamic>)
+          : null,
     );
   }
 
@@ -32,14 +38,19 @@ class ModelOutputStep extends InteractionStep {
   Map<String, dynamic> toJson() => {
     'type': type,
     if (content != null) 'content': content!.map((e) => e.toJson()).toList(),
+    if (error != null) 'error': error!.toJson(),
   };
 
   /// Creates a copy with replaced values.
-  ModelOutputStep copyWith({Object? content = unsetCopyWithValue}) {
+  ModelOutputStep copyWith({
+    Object? content = unsetCopyWithValue,
+    Object? error = unsetCopyWithValue,
+  }) {
     return ModelOutputStep(
       content: content == unsetCopyWithValue
           ? this.content
           : content as List<InteractionContent>?,
+      error: error == unsetCopyWithValue ? this.error : error as Status?,
     );
   }
 }

--- a/packages/googleai_dart/lib/src/models/interactions/steps/steps.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/steps/steps.dart
@@ -1,3 +1,4 @@
+import '../../batch/status.dart';
 import '../../copy_with_sentinel.dart';
 import '../content/content.dart';
 import '../interaction_review_snippet.dart';

--- a/packages/googleai_dart/lib/src/models/interactions/tools/computer_use_tool.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/tools/computer_use_tool.dart
@@ -1,5 +1,44 @@
 part of 'tools.dart';
 
+/// Converts a string to a [ComputerUseSafetyPolicy] using the interactions
+/// spec's lowercase `snake_case` wire format (as opposed to the main spec's
+/// `UPPER_SNAKE_CASE` format).
+ComputerUseSafetyPolicy interactionComputerUseSafetyPolicyFromString(
+  String? value,
+) {
+  return switch (value) {
+    'financial_transactions' => ComputerUseSafetyPolicy.financialTransactions,
+    'sensitive_data_modification' =>
+      ComputerUseSafetyPolicy.sensitiveDataModification,
+    'communication_tool' => ComputerUseSafetyPolicy.communicationTool,
+    'account_creation' => ComputerUseSafetyPolicy.accountCreation,
+    'data_modification' => ComputerUseSafetyPolicy.dataModification,
+    'user_consent_management' => ComputerUseSafetyPolicy.userConsentManagement,
+    'legal_terms_and_agreements' =>
+      ComputerUseSafetyPolicy.legalTermsAndAgreements,
+    _ => ComputerUseSafetyPolicy.unspecified,
+  };
+}
+
+/// Converts a [ComputerUseSafetyPolicy] to the interactions spec's lowercase
+/// `snake_case` wire format.
+String interactionComputerUseSafetyPolicyToString(
+  ComputerUseSafetyPolicy policy,
+) {
+  return switch (policy) {
+    ComputerUseSafetyPolicy.financialTransactions => 'financial_transactions',
+    ComputerUseSafetyPolicy.sensitiveDataModification =>
+      'sensitive_data_modification',
+    ComputerUseSafetyPolicy.communicationTool => 'communication_tool',
+    ComputerUseSafetyPolicy.accountCreation => 'account_creation',
+    ComputerUseSafetyPolicy.dataModification => 'data_modification',
+    ComputerUseSafetyPolicy.userConsentManagement => 'user_consent_management',
+    ComputerUseSafetyPolicy.legalTermsAndAgreements =>
+      'legal_terms_and_agreements',
+    ComputerUseSafetyPolicy.unspecified => 'unspecified',
+  };
+}
+
 /// A tool that allows the model to interact with the computer.
 class ComputerUseTool extends InteractionTool {
   @override
@@ -17,23 +56,31 @@ class ComputerUseTool extends InteractionTool {
   /// computer-use request.
   final bool? enablePromptInjectionDetection;
 
+  /// Optional. Disabled safety policies for computer use.
+  final List<ComputerUseSafetyPolicy>? disabledSafetyPolicies;
+
   /// Creates a [ComputerUseTool] instance.
   const ComputerUseTool({
     this.environment,
     this.excludedPredefinedFunctions,
     this.enablePromptInjectionDetection,
+    this.disabledSafetyPolicies,
   });
 
   /// Creates a [ComputerUseTool] from JSON.
-  factory ComputerUseTool.fromJson(Map<String, dynamic> json) =>
-      ComputerUseTool(
-        environment: json['environment'] as String?,
-        excludedPredefinedFunctions:
-            (json['excluded_predefined_functions'] as List<dynamic>?)
-                ?.cast<String>(),
-        enablePromptInjectionDetection:
-            json['enable_prompt_injection_detection'] as bool?,
-      );
+  factory ComputerUseTool.fromJson(
+    Map<String, dynamic> json,
+  ) => ComputerUseTool(
+    environment: json['environment'] as String?,
+    excludedPredefinedFunctions:
+        (json['excluded_predefined_functions'] as List<dynamic>?)
+            ?.cast<String>(),
+    enablePromptInjectionDetection:
+        json['enable_prompt_injection_detection'] as bool?,
+    disabledSafetyPolicies: (json['disabled_safety_policies'] as List<dynamic>?)
+        ?.map((e) => interactionComputerUseSafetyPolicyFromString(e as String?))
+        .toList(),
+  );
 
   @override
   Map<String, dynamic> toJson() => {
@@ -43,5 +90,9 @@ class ComputerUseTool extends InteractionTool {
       'excluded_predefined_functions': excludedPredefinedFunctions,
     if (enablePromptInjectionDetection != null)
       'enable_prompt_injection_detection': enablePromptInjectionDetection,
+    if (disabledSafetyPolicies != null)
+      'disabled_safety_policies': disabledSafetyPolicies!
+          .map(interactionComputerUseSafetyPolicyToString)
+          .toList(),
   };
 }

--- a/packages/googleai_dart/lib/src/models/interactions/tools/tools.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/tools/tools.dart
@@ -1,4 +1,5 @@
 import '../../copy_with_sentinel.dart';
+import '../../tools/computer_use_safety_policy.dart';
 import '../allowed_tools.dart';
 import 'exa_ai_search_config.dart';
 import 'parallel_ai_search_config.dart';

--- a/packages/googleai_dart/lib/src/models/interactions/video_config.dart
+++ b/packages/googleai_dart/lib/src/models/interactions/video_config.dart
@@ -1,0 +1,73 @@
+import '../copy_with_sentinel.dart';
+
+/// The task mode for video generation.
+enum InteractionVideoConfigTask {
+  /// Generates video solely from a text prompt.
+  textToVideo,
+
+  /// Generates video from one or two source images. The first image defines
+  /// the starting frame, and the optional second image defines the ending
+  /// frame.
+  imageToVideo,
+
+  /// Generates video using reference media (such as images, audio, or video).
+  referenceToVideo,
+
+  /// Modifies an existing input video.
+  edit,
+}
+
+/// Converts a string to an [InteractionVideoConfigTask], or `null` if
+/// unrecognized (forward-compatible).
+InteractionVideoConfigTask? interactionVideoConfigTaskFromString(
+  String? value,
+) {
+  return switch (value) {
+    'text_to_video' => InteractionVideoConfigTask.textToVideo,
+    'image_to_video' => InteractionVideoConfigTask.imageToVideo,
+    'reference_to_video' => InteractionVideoConfigTask.referenceToVideo,
+    'edit' => InteractionVideoConfigTask.edit,
+    _ => null,
+  };
+}
+
+/// Converts an [InteractionVideoConfigTask] to its JSON string.
+String interactionVideoConfigTaskToString(InteractionVideoConfigTask task) {
+  return switch (task) {
+    InteractionVideoConfigTask.textToVideo => 'text_to_video',
+    InteractionVideoConfigTask.imageToVideo => 'image_to_video',
+    InteractionVideoConfigTask.referenceToVideo => 'reference_to_video',
+    InteractionVideoConfigTask.edit => 'edit',
+  };
+}
+
+/// Configuration options for video generation.
+class InteractionVideoConfig {
+  /// Optional task mode for video generation. If not specified, the model
+  /// automatically determines the appropriate mode based on the provided text
+  /// prompt and input media.
+  final InteractionVideoConfigTask? task;
+
+  /// Creates an [InteractionVideoConfig] instance.
+  const InteractionVideoConfig({this.task});
+
+  /// Creates an [InteractionVideoConfig] from JSON.
+  factory InteractionVideoConfig.fromJson(Map<String, dynamic> json) =>
+      InteractionVideoConfig(
+        task: interactionVideoConfigTaskFromString(json['task'] as String?),
+      );
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    if (task != null) 'task': interactionVideoConfigTaskToString(task!),
+  };
+
+  /// Creates a copy with replaced values.
+  InteractionVideoConfig copyWith({Object? task = unsetCopyWithValue}) {
+    return InteractionVideoConfig(
+      task: task == unsetCopyWithValue
+          ? this.task
+          : task as InteractionVideoConfigTask?,
+    );
+  }
+}

--- a/packages/googleai_dart/lib/src/models/safety/harm_category.dart
+++ b/packages/googleai_dart/lib/src/models/safety/harm_category.dart
@@ -17,6 +17,32 @@ enum HarmCategory {
 
   /// Civic integrity.
   civicIntegrity,
+
+  /// Prompts attempting to bypass or subvert the model's safety guidelines
+  /// (jailbreak attempts).
+  jailbreak,
+
+  /// Legacy PaLM category: negative or harmful comments targeting identity
+  /// and/or protected attribute.
+  derogatory,
+
+  /// Legacy PaLM category: content that is rude, disrespectful, or profane.
+  toxicity,
+
+  /// Legacy PaLM category: describes scenarios depicting violence against an
+  /// individual or group, or general descriptions of gore.
+  violence,
+
+  /// Legacy PaLM category: contains references to sexual acts or other lewd
+  /// content.
+  sexual,
+
+  /// Legacy PaLM category: promotes unchecked medical advice.
+  medical,
+
+  /// Legacy PaLM category: dangerous content that promotes, facilitates, or
+  /// encourages harmful acts.
+  dangerous,
 }
 
 /// Converts string to HarmCategory enum.
@@ -27,6 +53,13 @@ HarmCategory harmCategoryFromString(String? value) {
     'HARM_CATEGORY_HARASSMENT' => HarmCategory.harassment,
     'HARM_CATEGORY_DANGEROUS_CONTENT' => HarmCategory.dangerousContent,
     'HARM_CATEGORY_CIVIC_INTEGRITY' => HarmCategory.civicIntegrity,
+    'HARM_CATEGORY_JAILBREAK' => HarmCategory.jailbreak,
+    'HARM_CATEGORY_DEROGATORY' => HarmCategory.derogatory,
+    'HARM_CATEGORY_TOXICITY' => HarmCategory.toxicity,
+    'HARM_CATEGORY_VIOLENCE' => HarmCategory.violence,
+    'HARM_CATEGORY_SEXUAL' => HarmCategory.sexual,
+    'HARM_CATEGORY_MEDICAL' => HarmCategory.medical,
+    'HARM_CATEGORY_DANGEROUS' => HarmCategory.dangerous,
     _ => HarmCategory.unspecified,
   };
 }
@@ -39,6 +72,13 @@ String harmCategoryToString(HarmCategory category) {
     HarmCategory.harassment => 'HARM_CATEGORY_HARASSMENT',
     HarmCategory.dangerousContent => 'HARM_CATEGORY_DANGEROUS_CONTENT',
     HarmCategory.civicIntegrity => 'HARM_CATEGORY_CIVIC_INTEGRITY',
+    HarmCategory.jailbreak => 'HARM_CATEGORY_JAILBREAK',
+    HarmCategory.derogatory => 'HARM_CATEGORY_DEROGATORY',
+    HarmCategory.toxicity => 'HARM_CATEGORY_TOXICITY',
+    HarmCategory.violence => 'HARM_CATEGORY_VIOLENCE',
+    HarmCategory.sexual => 'HARM_CATEGORY_SEXUAL',
+    HarmCategory.medical => 'HARM_CATEGORY_MEDICAL',
+    HarmCategory.dangerous => 'HARM_CATEGORY_DANGEROUS',
     HarmCategory.unspecified => 'HARM_CATEGORY_UNSPECIFIED',
   };
 }

--- a/packages/googleai_dart/specs/openapi-interactions.json
+++ b/packages/googleai_dart/specs/openapi-interactions.json
@@ -10,15 +10,6 @@
           "type": "string"
         }
       },
-      "google_genai_api_revision": {
-        "description": "API revision header to send with Google GenAI API requests.",
-        "in": "header",
-        "name": "Api-Revision",
-        "schema": {
-          "type": "string"
-        },
-        "x-speakeasy-name-override": "api_revision"
-      },
       "google_genai_user_project": {
         "description": "Quota project header to send with Google GenAI API requests.",
         "in": "header",
@@ -179,15 +170,27 @@
             "type": "string"
           },
           "transform": {
-            "description": "Headers to inject on all outbound requests matching this domain. Each entry is a flat {header_name: header_value} object. The egress proxy injects these automatically.",
-            "items": {
-              "additionalProperties": {
-                "type": "string"
+            "description": "Headers to inject on all outbound requests matching this domain. Accepts a single dict or a list of dicts. The egress proxy injects these automatically.",
+            "oneOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "description": "A single header injection mapping, e.g., {\"Authorization\": \"Bearer token\"}.",
+                "type": "object"
               },
-              "description": "A single header to inject, e.g. {'Authorization': 'Bearer token'} or {'x-goog-api-key': 'key'}.",
-              "type": "object"
-            },
-            "type": "array"
+              {
+                "description": "A list of headers to inject.",
+                "items": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "A single header to inject.",
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            ]
           }
         },
         "required": [
@@ -687,6 +690,31 @@
       "ComputerUse": {
         "description": "A tool that can be used by the model to interact with the computer.",
         "properties": {
+          "disabled_safety_policies": {
+            "description": "Optional. Disabled safety policies for computer use.",
+            "items": {
+              "enum": [
+                "financial_transactions",
+                "sensitive_data_modification",
+                "communication_tool",
+                "account_creation",
+                "data_modification",
+                "user_consent_management",
+                "legal_terms_and_agreements"
+              ],
+              "type": "string",
+              "x-google-enum-descriptions": [
+                "Safety policy for financial transactions.",
+                "Safety policy for sensitive data modification.",
+                "Safety policy for communication tools (e.g. Gmail, Chat, Meet).",
+                "Safety policy for account creation.",
+                "Safety policy for data modification.",
+                "Safety policy for user consent management.",
+                "Safety policy for legal terms and agreements."
+              ]
+            },
+            "type": "array"
+          },
           "enable_prompt_injection_detection": {
             "description": "Whether enable the prompt injection detection check on computer-use\nrequest.",
             "type": "boolean"
@@ -1025,6 +1053,13 @@
           "input": {
             "$ref": "#/components/schemas/InteractionsInput"
           },
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "The labels with user-defined metadata for the request.",
+            "type": "object"
+          },
           "previous_interaction_id": {
             "description": "The ID of the previous interaction, if any.",
             "type": "string"
@@ -1059,6 +1094,13 @@
             "description": "The requested modalities of the response (TEXT, IMAGE, AUDIO).",
             "items": {
               "$ref": "#/components/schemas/ResponseModality"
+            },
+            "type": "array"
+          },
+          "safety_settings": {
+            "description": "Safety settings for the interaction.",
+            "items": {
+              "$ref": "#/components/schemas/SafetySetting"
             },
             "type": "array"
           },
@@ -1187,6 +1229,13 @@
           "input": {
             "$ref": "#/components/schemas/InteractionsInput"
           },
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "The labels with user-defined metadata for the request.",
+            "type": "object"
+          },
           "model": {
             "$ref": "#/components/schemas/ModelOption",
             "description": "The name of the `Model` used for generating the interaction."
@@ -1225,6 +1274,13 @@
             "description": "The requested modalities of the response (TEXT, IMAGE, AUDIO).",
             "items": {
               "$ref": "#/components/schemas/ResponseModality"
+            },
+            "type": "array"
+          },
+          "safety_settings": {
+            "description": "Safety settings for the interaction.",
+            "items": {
+              "$ref": "#/components/schemas/SafetySetting"
             },
             "type": "array"
           },
@@ -1561,6 +1617,10 @@
           }
         ],
         "properties": {
+          "environment_id": {
+            "description": "Optional. The environment ID for the interaction. If specified, the request will\nupdate the existing environment instead of creating a new one.",
+            "type": "string"
+          },
           "network": {
             "description": "Network configuration for the environment.",
             "oneOf": [
@@ -2240,11 +2300,6 @@
       "GenerationConfig": {
         "description": "Configuration parameters for model interactions.",
         "properties": {
-          "frequency_penalty": {
-            "description": "Penalizes tokens based on their frequency in the generated text.\nA positive value helps to reduce the repetition of words and phrases.\nValid values can range from [-2.0, 2.0].",
-            "format": "float",
-            "type": "number"
-          },
           "image_config": {
             "$ref": "#/components/schemas/ImageConfig",
             "deprecated": true,
@@ -2254,11 +2309,6 @@
             "description": "The maximum number of tokens to include in the response.",
             "format": "int32",
             "type": "integer"
-          },
-          "presence_penalty": {
-            "description": "Penalizes tokens that have already appeared in the generated\ntext. A positive value encourages the model to generate more diverse and\nless repetitive text. Valid values can range from [-2.0, 2.0].",
-            "format": "float",
-            "type": "number"
           },
           "seed": {
             "description": "Seed used in decoding for reproducibility.",
@@ -2326,6 +2376,10 @@
             "description": "The maximum cumulative probability of tokens to consider when sampling.",
             "format": "float",
             "type": "number"
+          },
+          "video_config": {
+            "$ref": "#/components/schemas/VideoConfig",
+            "description": "Configuration for video generation."
           }
         },
         "type": "object",
@@ -2939,6 +2993,52 @@
         "type": "object",
         "x-speakeasy-model-namespace": "interactions"
       },
+      "HarmCategory": {
+        "enum": [
+          "hate_speech",
+          "dangerous_content",
+          "harassment",
+          "sexually_explicit",
+          "civic_integrity",
+          "image_hate",
+          "image_dangerous_content",
+          "image_harassment",
+          "image_sexually_explicit",
+          "jailbreak"
+        ],
+        "type": "string",
+        "x-google-enum-deprecated": [
+          false,
+          false,
+          false,
+          false,
+          true,
+          false,
+          false,
+          false,
+          false,
+          false
+        ],
+        "x-google-enum-descriptions": [
+          "Content that promotes violence or incites hatred against individuals or\ngroups based on certain attributes.",
+          "Content that promotes, facilitates, or enables dangerous activities.",
+          "Abusive, threatening, or content intended to bully, torment, or ridicule.",
+          "Content that contains sexually explicit material.",
+          "Deprecated: Election filter is not longer supported.\nThe harm category is civic integrity.",
+          "Images that contain hate speech.",
+          "Images that contain dangerous content.",
+          "Images that contain harassment.",
+          "Images that contain sexually explicit content.",
+          "Prompts designed to bypass safety filters."
+        ],
+        "x-speakeasy-exports": [
+          {
+            "group": "interactions",
+            "name": "HarmCategory"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
       "HybridSearch": {
         "description": "Config for Hybrid Search.",
         "properties": {
@@ -3328,6 +3428,13 @@
           "input": {
             "$ref": "#/components/schemas/InteractionsInput"
           },
+          "labels": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "The labels with user-defined metadata for the request.",
+            "type": "object"
+          },
           "model": {
             "$ref": "#/components/schemas/ModelOption",
             "description": "The name of the `Model` used for generating the interaction."
@@ -3382,6 +3489,13 @@
             "description": "The requested modalities of the response (TEXT, IMAGE, AUDIO).",
             "items": {
               "$ref": "#/components/schemas/ResponseModality"
+            },
+            "type": "array"
+          },
+          "safety_settings": {
+            "description": "Safety settings for the interaction.",
+            "items": {
+              "$ref": "#/components/schemas/SafetySetting"
             },
             "type": "array"
           },
@@ -3858,6 +3972,19 @@
         "x-speakeasy-model-namespace": "webhooks",
         "x-speakeasy-name-override": "WebhookListResponse"
       },
+      "LocalEnvironmentConfig": {
+        "description": "Configuration for an environment that lives on the client connection rather\nthan in a server-managed sandbox.\n\nWhen set (via Interaction.local_environment), the agent's filesystem and\nshell are treated as living on the client: the agent's built-in environment\noperations (e.g. reading/listing/editing files and running commands) are\nsuspended on the server and yielded back to the client to execute, with their\nresults returned on a subsequent turn. This is mutually exclusive with a\nserver-managed `EnvironmentConfig` (remote_environment), since the\nenvironment is either on the client or in a server sandbox, never both.\n\nThis governs only the agent's built-in environment. Client-declared function\ntools are always executed on the client regardless of this field.",
+        "properties": {
+          "type": {
+            "const": "local"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "x-speakeasy-model-namespace": "interactions"
+      },
       "McpServer": {
         "description": "A MCPServer is a server that can be called by the model to perform actions.",
         "properties": {
@@ -4232,6 +4359,10 @@
             },
             "type": "array"
           },
+          "error": {
+            "$ref": "#/components/schemas/Status",
+            "description": "The error result of the operation in case of failure or cancellation."
+          },
           "type": {
             "const": "model_output"
           }
@@ -4457,9 +4588,6 @@
       "Ranking": {
         "$ref": "#/components/schemas/RankService",
         "description": "Config for ranking and reranking.",
-        "discriminator": {
-          "propertyName": "type"
-        },
         "type": "object",
         "x-speakeasy-model-namespace": "interactions"
       },
@@ -4473,6 +4601,9 @@
           },
           {
             "$ref": "#/components/schemas/ImageResponseFormat"
+          },
+          {
+            "$ref": "#/components/schemas/VideoResponseFormat"
           },
           {
             "additionalProperties": true,
@@ -4548,6 +4679,197 @@
         "type": "object",
         "x-speakeasy-model-namespace": "interactions"
       },
+      "RetrievalCallDelta": {
+        "description": "Used by Vertex Retrieval tools such as Parallel AI, Exa AI, Vertex AI Search,\netc. RetrievalType decides which tool is used.",
+        "properties": {
+          "arguments": {
+            "$ref": "#/components/schemas/RetrievalStepArguments",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RetrievalStepArguments"
+              }
+            ],
+            "description": "Required. The arguments to pass to the Retrieval tool."
+          },
+          "retrieval_type": {
+            "description": "The type of retrieval tools.",
+            "enum": [
+              "vertex_ai_search",
+              "rag_store",
+              "exa_ai_search",
+              "parallel_ai_search"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "",
+              "",
+              "",
+              ""
+            ]
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "retrieval_call"
+          }
+        },
+        "required": [
+          "arguments",
+          "type"
+        ],
+        "type": "object",
+        "x-speakeasy-exports": [
+          {
+            "group": "interactions",
+            "name": "RetrievalCallDelta"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "RetrievalCallStep": {
+        "description": "Retrieval call step.\nUsed by Vertex Retrieval tools such as Parallel AI, Exa AI, Vertex AI Search,\netc. RetrievalType decides which tool is used.",
+        "properties": {
+          "arguments": {
+            "$ref": "#/components/schemas/RetrievalStepArguments",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RetrievalStepArguments"
+              }
+            ],
+            "description": "Required. The arguments to pass to the retrieval tool."
+          },
+          "id": {
+            "description": "Required. A unique ID for this specific tool call.",
+            "type": "string"
+          },
+          "retrieval_type": {
+            "description": "The type of retrieval tools.",
+            "enum": [
+              "vertex_ai_search",
+              "rag_store",
+              "exa_ai_search",
+              "parallel_ai_search"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "",
+              "",
+              "",
+              ""
+            ]
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "retrieval_call"
+          }
+        },
+        "required": [
+          "arguments",
+          "id",
+          "type"
+        ],
+        "type": "object",
+        "x-speakeasy-exports": [
+          {
+            "group": "interactions",
+            "name": "RetrievalCallStep"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "RetrievalResultDelta": {
+        "description": "Used by Vertex Retrieval tools such as Parallel AI, Exa AI, Vertex AI Search,\netc.\nToolResultDelta.type",
+        "properties": {
+          "is_error": {
+            "description": "Whether the retrieval resulted in an error.",
+            "type": "boolean"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "retrieval_result"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "x-speakeasy-exports": [
+          {
+            "group": "interactions",
+            "name": "RetrievalResultDelta"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "RetrievalResultStep": {
+        "description": "Vertex Retrieval result step.\nUsed by Vertex Retrieval tools such as Parallel AI, Exa AI, Vertex AI Search,\netc.",
+        "properties": {
+          "call_id": {
+            "description": "Required. ID to match the ID from the function call block.",
+            "type": "string"
+          },
+          "is_error": {
+            "description": "Whether the retrieval resulted in an error.",
+            "type": "boolean"
+          },
+          "signature": {
+            "description": "A signature hash for backend validation.",
+            "format": "byte",
+            "type": "string",
+            "x-speakeasy-base64-input-mode": "file"
+          },
+          "type": {
+            "const": "retrieval_result"
+          }
+        },
+        "required": [
+          "call_id",
+          "type"
+        ],
+        "type": "object",
+        "x-speakeasy-exports": [
+          {
+            "group": "interactions",
+            "name": "RetrievalResultStep"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "RetrievalStepArguments": {
+        "description": "The arguments to pass to Retrieval tools.",
+        "properties": {
+          "queries": {
+            "description": "Queries for Retrieval information.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object",
+        "x-speakeasy-exports": [
+          {
+            "group": "interactions",
+            "name": "RetrievalCallArguments"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions",
+        "x-speakeasy-name-override": "RetrievalCallArguments"
+      },
       "ReviewSnippet": {
         "description": "Encapsulates a snippet of a user review that answers a question about\nthe features of a specific place in Google Maps.",
         "properties": {
@@ -4611,6 +4933,57 @@
         ],
         "x-speakeasy-model-namespace": "webhooks",
         "x-speakeasy-name-override": "WebhookRotateSigningSecretResponse"
+      },
+      "SafetySetting": {
+        "description": "A safety setting that affects the safety-blocking behavior.\n\nA SafetySetting consists of a\nharm category and a\nthreshold for that\ncategory.",
+        "properties": {
+          "method": {
+            "description": "Optional. The method for blocking content. If not specified, the default\nbehavior is to use the probability score.",
+            "enum": [
+              "severity",
+              "probability"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "The harm block method uses both probability and severity scores.",
+              "The harm block method uses the probability score."
+            ]
+          },
+          "threshold": {
+            "description": "Required. The threshold for blocking content. If the harm probability\nexceeds this threshold, the content will be blocked.",
+            "enum": [
+              "block_low_and_above",
+              "block_medium_and_above",
+              "block_only_high",
+              "block_none",
+              "off"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Block content with a low harm probability or higher.",
+              "Block content with a medium harm probability or higher.",
+              "Block content with a high harm probability.",
+              "Do not block any content, regardless of its harm probability.",
+              "Turn off the safety filter entirely."
+            ]
+          },
+          "type": {
+            "$ref": "#/components/schemas/HarmCategory",
+            "description": "Required. The type of harm category to be blocked."
+          }
+        },
+        "required": [
+          "threshold",
+          "type"
+        ],
+        "type": "object",
+        "x-speakeasy-exports": [
+          {
+            "group": "interactions",
+            "name": "SafetySetting"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
       },
       "ServiceTier": {
         "enum": [
@@ -4711,6 +5084,32 @@
             "name": "SpeechConfig"
           }
         ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "Status": {
+        "description": "The `Status` type defines a logical error model that is suitable for\ndifferent programming environments, including REST APIs and RPC APIs. It is\nused by [gRPC](https://github.com/grpc). Each `Status` message contains\nthree pieces of data: error code, error message, and error details.\n\nYou can find out more about this error model and how to work with it in the\n[API Design Guide](https://cloud.google.com/apis/design/errors).",
+        "properties": {
+          "code": {
+            "description": "The status code, which should be an enum value of google.rpc.Code.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "details": {
+            "description": "A list of messages that carry the error details.  There is a common set of\nmessage types for APIs to use.",
+            "items": {
+              "additionalProperties": {
+                "description": "Properties of the object. Contains field @type with type URL."
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "message": {
+            "description": "A developer-facing error message, which should be in English. Any\nuser-facing error message should be localized and sent in the\ngoogle.rpc.Status.details field, or localized by the client.",
+            "type": "string"
+          }
+        },
+        "type": "object",
         "x-speakeasy-model-namespace": "interactions"
       },
       "Step": {
@@ -4881,6 +5280,9 @@
             "$ref": "#/components/schemas/GoogleMapsCallDelta"
           },
           {
+            "$ref": "#/components/schemas/RetrievalCallDelta"
+          },
+          {
             "$ref": "#/components/schemas/CodeExecutionResultDelta"
           },
           {
@@ -4897,6 +5299,9 @@
           },
           {
             "$ref": "#/components/schemas/GoogleMapsResultDelta"
+          },
+          {
+            "$ref": "#/components/schemas/RetrievalResultDelta"
           },
           {
             "$ref": "#/components/schemas/FunctionResultDelta"
@@ -4992,6 +5397,14 @@
           "metadata": {
             "$ref": "#/components/schemas/StreamMetadata",
             "description": "Optional metadata accompanying ANY streamed event."
+          },
+          "step_usage": {
+            "$ref": "#/components/schemas/Usage",
+            "description": "Model usage stats for this specific step."
+          },
+          "usage": {
+            "$ref": "#/components/schemas/Usage",
+            "description": "Cumulative model usage stats from the start of the session."
           }
         },
         "required": [
@@ -5195,6 +5608,7 @@
         "x-speakeasy-model-namespace": "interactions"
       },
       "ThoughtContent": {
+        "deprecated": true,
         "description": "A thought content block.",
         "examples": [
           {
@@ -5561,12 +5975,8 @@
         ],
         "properties": {
           "arguments": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/UrlContextCallArguments"
-              }
-            ],
-            "description": "The arguments to pass to the URL context."
+            "$ref": "#/components/schemas/UrlContextCallArguments",
+            "description": "Required. The arguments to pass to the URL context."
           },
           "id": {
             "description": "Required. A unique ID for this specific tool call.",
@@ -5859,6 +6269,35 @@
         "type": "object",
         "x-speakeasy-model-namespace": "interactions"
       },
+      "VideoConfig": {
+        "description": "Configuration options for video generation.",
+        "properties": {
+          "task": {
+            "description": "Optional task mode for video generation. If not specified, the model\nautomatically determines the appropriate mode based on the provided text\nprompt and input media.",
+            "enum": [
+              "text_to_video",
+              "image_to_video",
+              "reference_to_video",
+              "edit"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Generates video solely from a text prompt.",
+              "Generates video from one or two source images. The first image defines\nthe starting frame, and the optional second image defines the ending\nframe.",
+              "Generates video using reference media (such as images, audio, or video).",
+              "Modifies an existing input video."
+            ]
+          }
+        },
+        "type": "object",
+        "x-speakeasy-exports": [
+          {
+            "group": "interactions",
+            "name": "VideoConfig"
+          }
+        ],
+        "x-speakeasy-model-namespace": "interactions"
+      },
       "VideoContent": {
         "description": "A video content block.",
         "examples": [
@@ -5976,6 +6415,70 @@
           "type"
         ],
         "type": "object",
+        "x-speakeasy-model-namespace": "interactions"
+      },
+      "VideoResponseFormat": {
+        "description": "Configuration for video output format.",
+        "examples": [
+          {
+            "video_response_format": {
+              "summary": "Video Output",
+              "value": {
+                "aspect_ratio": "16:9",
+                "delivery": "inline",
+                "type": "video"
+              }
+            }
+          }
+        ],
+        "properties": {
+          "aspect_ratio": {
+            "description": "The aspect ratio for the video output.",
+            "enum": [
+              "16:9",
+              "9:16"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "16:9 aspect ratio.",
+              "9:16 aspect ratio."
+            ]
+          },
+          "delivery": {
+            "description": "The delivery mode for the video output.",
+            "enum": [
+              "inline",
+              "uri"
+            ],
+            "type": "string",
+            "x-google-enum-descriptions": [
+              "Video data is returned inline in the response.",
+              "Video data is returned as a URI."
+            ]
+          },
+          "duration": {
+            "description": "The duration for the video output.",
+            "format": "google-duration",
+            "type": "string"
+          },
+          "gcs_uri": {
+            "description": "The GCS URI to store the video output. Required for Vertex if delivery mode\nis URI.",
+            "type": "string"
+          },
+          "type": {
+            "const": "video"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "x-speakeasy-exports": [
+          {
+            "group": "interactions",
+            "name": "VideoResponseFormat"
+          }
+        ],
         "x-speakeasy-model-namespace": "interactions"
       },
       "Webhook": {
@@ -6205,7 +6708,7 @@
     }
   },
   "info": {
-    "description": "The Gemini Interactions API that allows developers to build generative AI applications using Gemini models. Gemini is our most capable model, built from the ground up to be multimodal. It can generalize and seamlessly understand, operate across, and combine different types of information including language, images, audio, video, and code. You can use the Gemini API for use cases like reasoning across text and images, content generation, dialogue agents, summarization and classification systems, and more.",
+    "description": "The Gemini Interactions API allows developers to build generative AI applications using Gemini models. Gemini is our most capable model, built from the ground up to be multimodal. It can generalize and seamlessly understand, operate across, and combine different types of information including language, images, audio, video, and code. You can use the Gemini API for use cases like reasoning across text and images, content generation, dialogue agents, summarization and classification systems, and more.",
     "title": "Gemini API",
     "version": "v1beta",
     "x-google-revision": "0"
@@ -7328,11 +7831,21 @@
                     "summary": "Cancel Interaction",
                     "value": {
                       "agent": "deep-research-pro-preview-12-2025",
-                      "created": "2025-11-26T12:25:15Z",
-                      "id": "v1_ChdPU0F4YWFtNkFwS2kxZThQZ05lbXdROBIXT1NBeGFhbTZBcEtpMWU4UGdOZW13UTg",
-                      "object": "interaction",
+                      "created": "2026-06-22T04:55:47Z",
+                      "id": "v1_ChdVc0E0YXJTYk1zYlV6N0lQcXRXVG1BYxIXVXNBNGFyU2JNc2JVejdJUHF0V1RtQWM",
                       "status": "cancelled",
-                      "updated": "2025-11-26T12:25:15Z"
+                      "steps": [
+                        {
+                          "content": [
+                            {
+                              "text": "Research the history of the Google TPUs with a focus on 2025 specs.",
+                              "type": "text"
+                            }
+                          ],
+                          "type": "user_input"
+                        }
+                      ],
+                      "updated": "2026-06-22T04:55:47Z"
                     }
                   }
                 },
@@ -7757,9 +8270,6 @@
     "parameters": [
       {
         "$ref": "#/components/parameters/api_version"
-      },
-      {
-        "$ref": "#/components/parameters/google_genai_api_revision"
       },
       {
         "$ref": "#/components/parameters/google_genai_user_project"

--- a/packages/googleai_dart/specs/openapi.json
+++ b/packages/googleai_dart/specs/openapi.json
@@ -3029,7 +3029,7 @@
             "type": "string"
           },
           "safetySettings": {
-            "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content.\n\nThis will be enforced on the `GenerateContentRequest.contents` and\n`GenerateContentResponse.candidates`. There should not be more than one\nsetting for each `SafetyCategory` type. The API will block any contents and\nresponses that fail to meet the thresholds set by these settings. This list\noverrides the default settings for each `SafetyCategory` specified in the\nsafety_settings. If there is no `SafetySetting` for a given\n`SafetyCategory` provided in the list, the API will use the default safety\nsetting for that category. Harm categories HARM_CATEGORY_HATE_SPEECH,\nHARM_CATEGORY_SEXUALLY_EXPLICIT, HARM_CATEGORY_DANGEROUS_CONTENT,\nHARM_CATEGORY_HARASSMENT, HARM_CATEGORY_CIVIC_INTEGRITY are supported.\nRefer to the [guide](https://ai.google.dev/gemini-api/docs/safety-settings)\nfor detailed information on available safety settings. Also refer to the\n[Safety guidance](https://ai.google.dev/gemini-api/docs/safety-guidance) to\nlearn how to incorporate safety considerations in your AI applications.",
+            "description": "Optional. A list of unique `SafetySetting` instances for blocking unsafe content.\n\nThis will be enforced on the `GenerateContentRequest.contents` and\n`GenerateContentResponse.candidates`. There should not be more than one\nsetting for each `SafetyCategory` type. The API will block any contents and\nresponses that fail to meet the thresholds set by these settings. This list\noverrides the default settings for each `SafetyCategory` specified in the\nsafety_settings. If there is no `SafetySetting` for a given\n`SafetyCategory` provided in the list, the API will use the default safety\nsetting for that category. Harm categories HARM_CATEGORY_HATE_SPEECH,\nHARM_CATEGORY_SEXUALLY_EXPLICIT, HARM_CATEGORY_DANGEROUS_CONTENT,\nHARM_CATEGORY_HARASSMENT, HARM_CATEGORY_CIVIC_INTEGRITY,\nHARM_CATEGORY_JAILBREAK are supported.\nRefer to the [guide](https://ai.google.dev/gemini-api/docs/safety-settings)\nfor detailed information on available safety settings. Also refer to the\n[Safety guidance](https://ai.google.dev/gemini-api/docs/safety-guidance) to\nlearn how to incorporate safety considerations in your AI applications.",
             "items": {
               "$ref": "#/components/schemas/SafetySetting"
             },
@@ -3817,7 +3817,8 @@
           "HARM_CATEGORY_HATE_SPEECH",
           "HARM_CATEGORY_SEXUALLY_EXPLICIT",
           "HARM_CATEGORY_DANGEROUS_CONTENT",
-          "HARM_CATEGORY_CIVIC_INTEGRITY"
+          "HARM_CATEGORY_CIVIC_INTEGRITY",
+          "HARM_CATEGORY_JAILBREAK"
         ],
         "type": "string",
         "x-google-enum-deprecated": [
@@ -3832,7 +3833,8 @@
           false,
           false,
           false,
-          true
+          true,
+          false
         ],
         "x-google-enum-descriptions": [
           "Category is unspecified.",
@@ -3846,7 +3848,8 @@
           "**Gemini** - Hate speech and content.",
           "**Gemini** - Sexually explicit content.",
           "**Gemini** - Dangerous content.",
-          "**Gemini** - Content that may be used to harm civic integrity.\nDEPRECATED: use enable_enhanced_civic_answers instead."
+          "**Gemini** - Content that may be used to harm civic integrity.\nDEPRECATED: use enable_enhanced_civic_answers instead.",
+          "**Gemini** - Prompts attempting to bypass or subvert the model's safety\nguidelines (jailbreak attempts)."
         ]
       },
       "HistoryConfig": {
@@ -6828,7 +6831,7 @@
     "description": "The Gemini API allows developers to build generative AI applications using Gemini models. Gemini is our most capable model, built from the ground up to be multimodal. It can generalize and seamlessly understand, operate across, and combine different types of information including language, images, audio, video, and code. You can use the Gemini API for use cases like reasoning across text and images, content generation, dialogue agents, summarization and classification systems, and more.",
     "title": "Gemini API",
     "version": "v1beta",
-    "x-google-revision": "20260702"
+    "x-google-revision": "20260709"
   },
   "openapi": "3.0.3",
   "paths": {

--- a/packages/googleai_dart/specs/spec_metadata.json
+++ b/packages/googleai_dart/specs/spec_metadata.json
@@ -2,14 +2,14 @@
   "specs": {
     "interactions": {
       "current_version": "v1beta",
-      "last_fetched": "2026-07-04T13:11:12.958395Z",
+      "last_fetched": "2026-07-11T06:56:25.531824Z",
       "source_url": "https://ai.google.dev/static/api/interactions.openapi.json",
       "title": "Gemini API",
       "version_history": []
     },
     "main": {
       "current_version": "v1beta",
-      "last_fetched": "2026-07-04T13:11:11.594445Z",
+      "last_fetched": "2026-07-11T06:56:23.713362Z",
       "source_url": "https://generativelanguage.googleapis.com/$discovery/OPENAPI3_0?version=v1beta",
       "title": "Gemini API",
       "version_history": []

--- a/packages/googleai_dart/test/unit/models/generation/generate_answer_request_test.dart
+++ b/packages/googleai_dart/test/unit/models/generation/generate_answer_request_test.dart
@@ -89,6 +89,65 @@ void main() {
         );
         expect(request.temperature, 0.2);
       });
+
+      test('parses jailbreak harm category', () {
+        final json = {
+          'contents': [
+            {
+              'parts': [
+                {'text': 'Question'},
+              ],
+            },
+          ],
+          'answerStyle': 'ABSTRACTIVE',
+          'safetySettings': [
+            {
+              'category': 'HARM_CATEGORY_JAILBREAK',
+              'threshold': 'BLOCK_ONLY_HIGH',
+            },
+          ],
+        };
+
+        final request = GenerateAnswerRequest.fromJson(json);
+
+        expect(request.safetySettings![0].category, HarmCategory.jailbreak);
+      });
+
+      test('parses legacy PaLM harm categories', () {
+        final cases = {
+          'HARM_CATEGORY_DEROGATORY': HarmCategory.derogatory,
+          'HARM_CATEGORY_TOXICITY': HarmCategory.toxicity,
+          'HARM_CATEGORY_VIOLENCE': HarmCategory.violence,
+          'HARM_CATEGORY_SEXUAL': HarmCategory.sexual,
+          'HARM_CATEGORY_MEDICAL': HarmCategory.medical,
+          'HARM_CATEGORY_DANGEROUS': HarmCategory.dangerous,
+        };
+
+        for (final entry in cases.entries) {
+          expect(harmCategoryFromString(entry.key), entry.value);
+          expect(harmCategoryToString(entry.value), entry.key);
+        }
+      });
+
+      test('falls back to unspecified for unknown harm category', () {
+        final json = {
+          'contents': [
+            {
+              'parts': [
+                {'text': 'Question'},
+              ],
+            },
+          ],
+          'answerStyle': 'ABSTRACTIVE',
+          'safetySettings': [
+            {'category': 'HARM_CATEGORY_UNKNOWN', 'threshold': 'BLOCK_NONE'},
+          ],
+        };
+
+        final request = GenerateAnswerRequest.fromJson(json);
+
+        expect(request.safetySettings![0].category, HarmCategory.unspecified);
+      });
     });
 
     group('toJson', () {

--- a/packages/googleai_dart/test/unit/models/interactions/computer_use_tool_test.dart
+++ b/packages/googleai_dart/test/unit/models/interactions/computer_use_tool_test.dart
@@ -29,5 +29,32 @@ void main() {
         isFalse,
       );
     });
+
+    test('serializes disabledSafetyPolicies and round-trips', () {
+      const tool = ComputerUseTool(
+        environment: 'browser',
+        disabledSafetyPolicies: [
+          ComputerUseSafetyPolicy.financialTransactions,
+          ComputerUseSafetyPolicy.legalTermsAndAgreements,
+        ],
+      );
+
+      final json = tool.toJson();
+      expect(json['disabled_safety_policies'], [
+        'financial_transactions',
+        'legal_terms_and_agreements',
+      ]);
+
+      final restored = InteractionTool.fromJson(json) as ComputerUseTool;
+      expect(restored.disabledSafetyPolicies, [
+        ComputerUseSafetyPolicy.financialTransactions,
+        ComputerUseSafetyPolicy.legalTermsAndAgreements,
+      ]);
+    });
+
+    test('omits disabledSafetyPolicies when null', () {
+      const tool = ComputerUseTool(environment: 'browser');
+      expect(tool.toJson().containsKey('disabled_safety_policies'), isFalse);
+    });
   });
 }

--- a/packages/googleai_dart/test/unit/models/interactions/delta_test.dart
+++ b/packages/googleai_dart/test/unit/models/interactions/delta_test.dart
@@ -25,7 +25,7 @@ void main() {
     });
 
     test(
-      'the 13 tool-call/result delta variants dispatch to typed classes',
+      'the 15 tool-call/result delta variants dispatch to typed classes',
       () {
         final expected = <String, Type>{
           'code_execution_call': CodeExecutionCallDelta,
@@ -34,6 +34,7 @@ void main() {
           'google_maps_call': GoogleMapsCallDelta,
           'mcp_server_tool_call': McpServerToolCallDelta,
           'file_search_call': FileSearchCallDelta,
+          'retrieval_call': RetrievalCallDelta,
           'code_execution_result': CodeExecutionResultDelta,
           'url_context_result': UrlContextResultDelta,
           'google_search_result': GoogleSearchResultDelta,
@@ -41,9 +42,15 @@ void main() {
           'mcp_server_tool_result': McpServerToolResultDelta,
           'file_search_result': FileSearchResultDelta,
           'function_result': FunctionResultDelta,
+          'retrieval_result': RetrievalResultDelta,
         };
         for (final entry in expected.entries) {
-          final delta = StepDeltaData.fromJson({'type': entry.key});
+          final json = <String, dynamic>{'type': entry.key};
+          // RetrievalCallDelta.arguments is required.
+          if (entry.key == 'retrieval_call') {
+            json['arguments'] = <String, dynamic>{};
+          }
+          final delta = StepDeltaData.fromJson(json);
           expect(delta.runtimeType, entry.value, reason: entry.key);
           expect(delta, isNot(isA<UnknownStepDelta>()), reason: entry.key);
           expect(delta.type, entry.key);
@@ -109,6 +116,72 @@ void main() {
                 as CodeExecutionResultDelta;
         expect(delta.result, '42');
         expect(delta.toJson()['result'], '42');
+      });
+
+      test('RetrievalCallDelta round-trips arguments + retrieval_type', () {
+        final delta =
+            StepDeltaData.fromJson({
+                  'type': 'retrieval_call',
+                  'arguments': {
+                    'queries': ['dart', 'flutter'],
+                  },
+                  'retrieval_type': 'vertex_ai_search',
+                  'signature': 'sig',
+                })
+                as RetrievalCallDelta;
+        expect(delta.arguments.queries, ['dart', 'flutter']);
+        expect(delta.retrievalType, RetrievalType.vertexAiSearch);
+        expect(delta.signature, 'sig');
+
+        final json = delta.toJson();
+        expect(json['type'], 'retrieval_call');
+        expect((json['arguments'] as Map)['queries'], ['dart', 'flutter']);
+        expect(json['retrieval_type'], 'vertex_ai_search');
+
+        final restored = StepDeltaData.fromJson(json) as RetrievalCallDelta;
+        expect(restored.retrievalType, RetrievalType.vertexAiSearch);
+      });
+
+      test('RetrievalCallDelta copyWith replaces values', () {
+        const delta = RetrievalCallDelta(
+          arguments: RetrievalCallArguments(queries: ['a']),
+          retrievalType: RetrievalType.ragStore,
+        );
+
+        final copy = delta.copyWith(
+          arguments: const RetrievalCallArguments(queries: ['b']),
+          signature: 'sig',
+        );
+
+        expect(copy.arguments.queries, ['b']);
+        expect(copy.retrievalType, RetrievalType.ragStore);
+        expect(copy.signature, 'sig');
+      });
+
+      test('RetrievalResultDelta round-trips is_error + signature', () {
+        final delta =
+            StepDeltaData.fromJson({
+                  'type': 'retrieval_result',
+                  'is_error': true,
+                  'signature': 'sig',
+                })
+                as RetrievalResultDelta;
+        expect(delta.isError, true);
+        expect(delta.signature, 'sig');
+
+        final json = delta.toJson();
+        expect(json['type'], 'retrieval_result');
+        expect(json['is_error'], true);
+        expect(json['signature'], 'sig');
+      });
+
+      test('RetrievalResultDelta copyWith replaces values', () {
+        const delta = RetrievalResultDelta(isError: false);
+
+        final copy = delta.copyWith(isError: true, signature: 'sig');
+
+        expect(copy.isError, true);
+        expect(copy.signature, 'sig');
       });
 
       test('McpServerToolCallDelta round-trips name + raw arguments', () {

--- a/packages/googleai_dart/test/unit/models/interactions/environment_test.dart
+++ b/packages/googleai_dart/test/unit/models/interactions/environment_test.dart
@@ -39,6 +39,34 @@ void main() {
       expect(restored.domain, 'api.example.com');
       expect(restored.transform!.first['x-goog-api-key'], 'k');
     });
+
+    test('accepts a single dict form for transform', () {
+      final entry = AllowlistEntry.fromJson({
+        'domain': 'api.example.com',
+        'transform': {'x-goog-api-key': 'k'},
+      });
+
+      expect(entry.transform, hasLength(1));
+      expect(entry.transform!.first['x-goog-api-key'], 'k');
+    });
+
+    test('accepts a list of dicts form for transform', () {
+      final entry = AllowlistEntry.fromJson({
+        'domain': 'api.example.com',
+        'transform': [
+          {'x-goog-api-key': 'k1'},
+          {'x-goog-api-key': 'k2'},
+        ],
+      });
+
+      expect(entry.transform, hasLength(2));
+      expect(entry.transform![1]['x-goog-api-key'], 'k2');
+    });
+
+    test('transform is null when absent', () {
+      final entry = AllowlistEntry.fromJson({'domain': 'api.example.com'});
+      expect(entry.transform, isNull);
+    });
   });
 
   group('EnvironmentNetworkEgressAllowlist', () {
@@ -98,6 +126,22 @@ void main() {
       expect(json['network'], 'disabled');
       final restored = EnvironmentConfig.fromJson(json);
       expect(restored.network, isA<EnvironmentNetworkDisabled>());
+    });
+
+    test('round-trips environmentId', () {
+      const config = EnvironmentConfig(environmentId: 'env-123');
+      final json = config.toJson();
+      expect(json['environment_id'], 'env-123');
+
+      final restored = EnvironmentConfig.fromJson(json);
+      expect(restored.environmentId, 'env-123');
+    });
+
+    test('environmentId is omitted from JSON when null', () {
+      expect(
+        const EnvironmentConfig().toJson().containsKey('environment_id'),
+        isFalse,
+      );
     });
 
     test('type is the constant "remote" and is always serialized', () {

--- a/packages/googleai_dart/test/unit/models/interactions/event_test.dart
+++ b/packages/googleai_dart/test/unit/models/interactions/event_test.dart
@@ -111,6 +111,39 @@ void main() {
     });
   });
 
+  group('StepStopEvent usage', () {
+    test('parses usage and stepUsage and round-trips', () {
+      final event =
+          InteractionEvent.fromJson({
+                'event_type': 'step.stop',
+                'index': 2,
+                'usage': {'total_tokens': 100},
+                'step_usage': {'total_tokens': 10},
+              })
+              as StepStopEvent;
+
+      expect(event.usage, isNotNull);
+      expect(event.usage!.totalTokens, 100);
+      expect(event.stepUsage, isNotNull);
+      expect(event.stepUsage!.totalTokens, 10);
+
+      final json = event.toJson();
+      final restored = InteractionEvent.fromJson(json) as StepStopEvent;
+      expect(restored.usage!.totalTokens, 100);
+      expect(restored.stepUsage!.totalTokens, 10);
+    });
+
+    test('usage and stepUsage are absent when not provided', () {
+      final event =
+          InteractionEvent.fromJson({'event_type': 'step.stop', 'index': 0})
+              as StepStopEvent;
+      expect(event.usage, isNull);
+      expect(event.stepUsage, isNull);
+      expect(event.toJson().containsKey('usage'), isFalse);
+      expect(event.toJson().containsKey('step_usage'), isFalse);
+    });
+  });
+
   group('InteractionStatus', () {
     test('round-trips budget_exceeded', () {
       expect(

--- a/packages/googleai_dart/test/unit/models/interactions/interaction_test.dart
+++ b/packages/googleai_dart/test/unit/models/interactions/interaction_test.dart
@@ -508,4 +508,201 @@ void main() {
       expect((restored.tools![1] as FunctionTool).name, 'get_weather');
     });
   });
+
+  group('Interaction labels and safetySettings', () {
+    test('round-trip conversion preserves labels and safetySettings', () {
+      const original = Interaction(
+        id: 'labels-test',
+        status: InteractionStatus.completed,
+        labels: {'env': 'test', 'team': 'growth'},
+        safetySettings: [
+          InteractionSafetySetting(
+            type: InteractionHarmCategory.jailbreak,
+            threshold: InteractionHarmBlockThreshold.blockOnlyHigh,
+            method: InteractionSafetyMethod.probability,
+          ),
+        ],
+      );
+
+      final json = original.toJson();
+      final restored = Interaction.fromJson(json);
+
+      expect(restored.labels, {'env': 'test', 'team': 'growth'});
+      expect(restored.safetySettings, hasLength(1));
+      expect(
+        restored.safetySettings!.first.type,
+        InteractionHarmCategory.jailbreak,
+      );
+      expect(
+        restored.safetySettings!.first.threshold,
+        InteractionHarmBlockThreshold.blockOnlyHigh,
+      );
+      expect(
+        restored.safetySettings!.first.method,
+        InteractionSafetyMethod.probability,
+      );
+    });
+
+    test('CreateModelInteractionParams round-trip preserves labels and '
+        'safetySettings', () {
+      const original = CreateModelInteractionParams(
+        model: 'gemini-3.5-flash',
+        labels: {'env': 'test'},
+        safetySettings: [
+          InteractionSafetySetting(
+            type: InteractionHarmCategory.harassment,
+            threshold: InteractionHarmBlockThreshold.blockNone,
+          ),
+        ],
+      );
+
+      final json = original.toJson();
+      final restored = CreateModelInteractionParams.fromJson(json);
+
+      expect(restored.labels, {'env': 'test'});
+      expect(restored.safetySettings, hasLength(1));
+      expect(
+        restored.safetySettings!.first.type,
+        InteractionHarmCategory.harassment,
+      );
+    });
+
+    test('CreateAgentInteractionParams round-trip preserves labels and '
+        'safetySettings', () {
+      const original = CreateAgentInteractionParams(
+        agent: 'my-agent',
+        labels: {'env': 'test'},
+        safetySettings: [
+          InteractionSafetySetting(
+            type: InteractionHarmCategory.civicIntegrity,
+            threshold: InteractionHarmBlockThreshold.off,
+          ),
+        ],
+      );
+
+      final json = original.toJson();
+      final restored = CreateAgentInteractionParams.fromJson(json);
+
+      expect(restored.labels, {'env': 'test'});
+      expect(restored.safetySettings, hasLength(1));
+      expect(
+        restored.safetySettings!.first.type,
+        InteractionHarmCategory.civicIntegrity,
+      );
+    });
+  });
+
+  group('InteractionHarmCategory', () {
+    test('fromString parses all values', () {
+      final cases = {
+        'hate_speech': InteractionHarmCategory.hateSpeech,
+        'dangerous_content': InteractionHarmCategory.dangerousContent,
+        'harassment': InteractionHarmCategory.harassment,
+        'sexually_explicit': InteractionHarmCategory.sexuallyExplicit,
+        'civic_integrity': InteractionHarmCategory.civicIntegrity,
+        'image_hate': InteractionHarmCategory.imageHate,
+        'image_dangerous_content':
+            InteractionHarmCategory.imageDangerousContent,
+        'image_harassment': InteractionHarmCategory.imageHarassment,
+        'image_sexually_explicit':
+            InteractionHarmCategory.imageSexuallyExplicit,
+        'jailbreak': InteractionHarmCategory.jailbreak,
+      };
+
+      for (final entry in cases.entries) {
+        expect(interactionHarmCategoryFromString(entry.key), entry.value);
+        expect(interactionHarmCategoryToString(entry.value), entry.key);
+      }
+    });
+
+    test('fromString falls back to unknown for unrecognized value', () {
+      expect(
+        interactionHarmCategoryFromString('unknown_category'),
+        InteractionHarmCategory.unknown,
+      );
+      expect(
+        interactionHarmCategoryFromString(null),
+        InteractionHarmCategory.unknown,
+      );
+    });
+
+    test('toString serializes unknown', () {
+      expect(
+        interactionHarmCategoryToString(InteractionHarmCategory.unknown),
+        'unknown',
+      );
+    });
+  });
+
+  group('InteractionHarmBlockThreshold', () {
+    test('fromString parses all values', () {
+      final cases = {
+        'block_low_and_above': InteractionHarmBlockThreshold.blockLowAndAbove,
+        'block_medium_and_above':
+            InteractionHarmBlockThreshold.blockMediumAndAbove,
+        'block_only_high': InteractionHarmBlockThreshold.blockOnlyHigh,
+        'block_none': InteractionHarmBlockThreshold.blockNone,
+        'off': InteractionHarmBlockThreshold.off,
+      };
+
+      for (final entry in cases.entries) {
+        expect(interactionHarmBlockThresholdFromString(entry.key), entry.value);
+        expect(interactionHarmBlockThresholdToString(entry.value), entry.key);
+      }
+    });
+
+    test('fromString falls back to unknown for unrecognized value', () {
+      expect(
+        interactionHarmBlockThresholdFromString('some_future_threshold'),
+        InteractionHarmBlockThreshold.unknown,
+      );
+      expect(
+        interactionHarmBlockThresholdFromString(null),
+        InteractionHarmBlockThreshold.unknown,
+      );
+    });
+
+    test('toString serializes unknown', () {
+      expect(
+        interactionHarmBlockThresholdToString(
+          InteractionHarmBlockThreshold.unknown,
+        ),
+        'unknown',
+      );
+    });
+
+    test('InteractionSafetySetting round-trips an unrecognized threshold as '
+        'unknown', () {
+      final setting = InteractionSafetySetting.fromJson({
+        'type': 'jailbreak',
+        'threshold': 'some_future_threshold',
+      });
+
+      expect(setting.threshold, InteractionHarmBlockThreshold.unknown);
+
+      final json = setting.toJson();
+      expect(json['threshold'], 'unknown');
+    });
+  });
+
+  group('InteractionGenerationConfig', () {
+    test('fromJson and toJson round-trip videoConfig', () {
+      const original = InteractionGenerationConfig(
+        videoConfig: InteractionVideoConfig(
+          task: InteractionVideoConfigTask.imageToVideo,
+        ),
+      );
+
+      final json = original.toJson();
+      final restored = InteractionGenerationConfig.fromJson(json);
+
+      expect(json.containsKey('frequency_penalty'), false);
+      expect(json.containsKey('presence_penalty'), false);
+      expect(restored.videoConfig, isNotNull);
+      expect(
+        restored.videoConfig!.task,
+        InteractionVideoConfigTask.imageToVideo,
+      );
+    });
+  });
 }

--- a/packages/googleai_dart/test/unit/models/interactions/response_format_test.dart
+++ b/packages/googleai_dart/test/unit/models/interactions/response_format_test.dart
@@ -90,7 +90,7 @@ void main() {
   });
 
   group('InteractionResponseFormat dispatch', () {
-    test('dispatches the three typed variants', () {
+    test('dispatches the four typed variants', () {
       expect(
         InteractionResponseFormat.fromJson({'type': 'audio'}),
         isA<InteractionAudioResponseFormat>(),
@@ -103,14 +103,13 @@ void main() {
         InteractionResponseFormat.fromJson({'type': 'image'}),
         isA<InteractionImageResponseFormat>(),
       );
+      expect(
+        InteractionResponseFormat.fromJson({'type': 'video'}),
+        isA<InteractionVideoResponseFormat>(),
+      );
     });
 
-    test('removed/unknown type parses as UnknownInteractionResponseFormat', () {
-      // `video` was removed from the spec union and now falls through to the
-      // forward-compatible fallback (raw JSON preserved).
-      final video = InteractionResponseFormat.fromJson({'type': 'video'});
-      expect(video, isA<UnknownInteractionResponseFormat>());
-
+    test('unknown type parses as UnknownInteractionResponseFormat', () {
       final unknown = InteractionResponseFormat.fromJson({
         'type': 'object',
         'properties': {
@@ -122,6 +121,48 @@ void main() {
       expect(unknown.toJson()['properties'], {
         'x': {'type': 'string'},
       });
+    });
+  });
+
+  group('InteractionVideoResponseFormat', () {
+    test('round-trips aspect_ratio/delivery/duration/gcs_uri', () {
+      final video =
+          InteractionResponseFormat.fromJson({
+                'type': 'video',
+                'aspect_ratio': '16:9',
+                'delivery': 'uri',
+                'duration': '5s',
+                'gcs_uri': 'gs://bucket/video.mp4',
+              })
+              as InteractionVideoResponseFormat;
+
+      expect(
+        video.aspectRatio,
+        InteractionVideoResponseFormatAspectRatio.ratio16x9,
+      );
+      expect(video.delivery, InteractionVideoResponseFormatDelivery.uri);
+      expect(video.duration, '5s');
+      expect(video.gcsUri, 'gs://bucket/video.mp4');
+
+      final json = video.toJson();
+      expect(json['type'], 'video');
+      expect(json['aspect_ratio'], '16:9');
+      expect(json['delivery'], 'uri');
+      expect(json['duration'], '5s');
+      expect(json['gcs_uri'], 'gs://bucket/video.mp4');
+
+      final restored =
+          InteractionResponseFormat.fromJson(json)
+              as InteractionVideoResponseFormat;
+      expect(
+        restored.aspectRatio,
+        InteractionVideoResponseFormatAspectRatio.ratio16x9,
+      );
+    });
+
+    test('omits null fields from JSON', () {
+      const video = InteractionVideoResponseFormat();
+      expect(video.toJson(), {'type': 'video'});
     });
   });
 


### PR DESCRIPTION
## Summary
- Syncs `googleai_dart` to the latest **main** and **interactions** OpenAPI specs (June 2026 Gemini API updates), with all api-toolkit verify/review gates green for both specs.
- **Interactions safety settings**: new `InteractionSafetySetting` (with `InteractionHarmCategory`, `InteractionHarmBlockThreshold`, `InteractionSafetyMethod` enums) and a `safetySettings` + `labels` field on `Interaction`, `CreateModelInteractionParams`, and `CreateAgentInteractionParams`.
- **Video generation**: new `InteractionVideoConfig` (task modes: text-to-video, image-to-video, reference-to-video, edit) wired into `InteractionGenerationConfig.videoConfig`, and a new `InteractionVideoResponseFormat` variant (aspect ratio, delivery mode, duration, GCS URI) in the `InteractionResponseFormat` union.
- **Retrieval tool streaming**: new `RetrievalCallDelta` / `RetrievalResultDelta` variants in the `StepDeltaData` union (with `RetrievalCallArguments` and a `RetrievalType` enum covering Vertex AI Search, RAG store, Exa AI, and Parallel AI).
- **Computer Use safety policies**: `ComputerUseTool.disabledSafetyPolicies` (reuses the existing `ComputerUseSafetyPolicy` enum with interactions-format converters).
- **Step/event enrichment**: `ModelOutputStep.error` (`Status`), `StepStopEvent.usage` / `stepUsage` (`InteractionUsage`), `EnvironmentConfig.environmentId`, and `AllowlistEntry.transform` now accepts both a single header map and a list (spec changed to `oneOf`).
- **Main spec**: `HarmCategory` gains `jailbreak` plus the six legacy PaLM categories (`derogatory`, `toxicity`, `violence`, `sexual`, `medical`, `dangerous`) so the enum now covers the full spec surface.
- **Breaking**: `frequencyPenalty` / `presencePenalty` removed from `InteractionGenerationConfig` (removed from the Interactions API spec and official SDKs).

## Details

New schemas follow the established naming convention for main/interactions collisions (`Interaction` prefix on Dart classes, `interactions:` prefix on manifest keys). All new enums have forward-compatible parsing: optional enums return `null` for unrecognized wire values; required enums (`InteractionHarmCategory`, `InteractionHarmBlockThreshold`) carry an explicit `unknown` member so an unrecognized value from the API is never silently misread as a real category/threshold.

```dart
// Safety settings + labels on an interaction request
final params = CreateModelInteractionParams(
  model: 'gemini-3.1-pro',
  input: InteractionInput.text('...'),
  labels: {'team': 'search'},
  safetySettings: [
    InteractionSafetySetting(
      type: InteractionHarmCategory.jailbreak,
      threshold: InteractionHarmBlockThreshold.blockLowAndAbove,
    ),
  ],
);

// Video generation config
final config = InteractionGenerationConfig(
  videoConfig: InteractionVideoConfig(task: InteractionVideoConfigTask.textToVideo),
);
```

Decisions cross-checked against the official `python-genai` SDK (which mirrors all of them):
- `RetrievalCallStep`, `RetrievalResultStep`, and `LocalEnvironmentConfig` are **orphan schemas** in the new spec (not referenced by any union or property; the deltas *are* wired into `StepDeltaData`, but the spec `Step` union does not include the step variants). They are acknowledged as fileless `kind: skip` manifest entries rather than implemented — python-genai omits them too. They'll be picked up automatically when a future spec wires them in.
- The interactions `Status` schema is the standard `google.rpc.Status`; the existing `Status` class (`lib/src/models/batch/status.dart`) is reused for `ModelOutputStep.error` instead of duplicating it (noted in the manifest).
- Penalty removal matches python-genai's interactions `GenerationConfig`, which no longer has the fields.

Manifest changes: 12 new entries (including the main-spec `HarmCategory` enum, which was previously untracked) and updated discriminator mappings for the `ResponseFormat` and `StepDeltaData` unions.

## Breaking Changes

- `InteractionGenerationConfig.frequencyPenalty` and `InteractionGenerationConfig.presencePenalty` were removed. The Interactions API no longer accepts `frequency_penalty` / `presence_penalty` (removed from the OpenAPI spec and official SDKs), so requests setting them were already ineffective.

  ```dart
  // Before
  final config = InteractionGenerationConfig(
    temperature: 0.7,
    frequencyPenalty: 0.5,
    presencePenalty: 0.5,
  );

  // After — drop the penalty parameters
  final config = InteractionGenerationConfig(
    temperature: 0.7,
  );
  ```

## References

- [Gemini API changelog](https://ai.google.dev/gemini-api/docs/changelog) — June 24, 2026: Computer Use public preview with configurable safety policies; June 30, 2026: video generation via Gemini Omni Flash.

## Test Plan

- [x] `api_toolkit.py verify --checks all --scope all` green for both `main` and `interactions` specs (0 errors)
- [x] `api_toolkit.py review` shows 0 changed-type / 0 missing-manifest for both specs after promotion
- [x] `dart analyze --fatal-infos` — no issues
- [x] `dart format --set-exit-if-changed .` — clean
- [x] `dart test test/unit/` — 1559 passed (7 pre-existing skips for missing `GOOGLE_GENAI_API_KEY`)
- [x] New tests: union dispatch for retrieval deltas + video response format, fromJson/toJson round-trips for all new models, enum FromString/ToString incl. unknown-value fallbacks, AllowlistEntry single-map vs list parsing, legacy PaLM harm-category round-trips
