### PR TITLE
feat(anthropic_sdk_dart)!: Dreams API, tool changes, fallback credits

### DIFF
--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
@@ -1144,6 +1144,8 @@
           "BetaRequestTextBlock": "text",
           "BetaRequestTextEditorCodeExecutionToolResultBlock": "text_editor_code_execution_tool_result",
           "BetaRequestThinkingBlock": "thinking",
+          "BetaRequestToolAdditionBlock": "tool_addition",
+          "BetaRequestToolRemovalBlock": "tool_removal",
           "BetaRequestToolResultBlock": "tool_result",
           "BetaRequestToolSearchToolResultBlock": "tool_search_tool_result",
           "BetaRequestToolUseBlock": "tool_use",
@@ -5451,6 +5453,444 @@
         "acknowledged"
       ],
       "note": "Create-side union; oneOf variants are the already-tracked UserMessage/UserDefineOutcome/SystemMessage EventParams. Modeled as thin Dart wrappers (DeploymentInitialEventParams) delegating to those classes; no new spec schema to verify."
+    },
+    "StopReason": {
+      "spec": "main",
+      "kind": "enum",
+      "dart_class": "StopReason",
+      "file": "lib/src/models/metadata/stop_reason.dart",
+      "schema": "StopReason"
+    },
+    "FallbackCreditUsage": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "FallbackCreditUsage",
+      "file": "lib/src/models/metadata/fallback_credit_usage.dart",
+      "schema": "BetaFallbackCreditUsage"
+    },
+    "FallbackCreditStatus": {
+      "spec": "main",
+      "kind": "sealed_parent",
+      "dart_class": "FallbackCreditStatus",
+      "file": "lib/src/models/metadata/fallback_credit_usage.dart",
+      "schema": null,
+      "discriminator": {
+        "field": "type",
+        "mapping": {
+          "BetaFallbackCreditRedeemed": "redeemed",
+          "BetaFallbackCreditNotApplied": "not_applied"
+        }
+      },
+      "note": "Synthetic parent for the inline status union nested in BetaFallbackCreditUsage.status."
+    },
+    "FallbackCreditRedeemed": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "FallbackCreditRedeemed",
+      "file": "lib/src/models/metadata/fallback_credit_usage.dart",
+      "schema": "BetaFallbackCreditRedeemed",
+      "parent": "FallbackCreditStatus"
+    },
+    "FallbackCreditNotApplied": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "FallbackCreditNotApplied",
+      "file": "lib/src/models/metadata/fallback_credit_usage.dart",
+      "schema": "BetaFallbackCreditNotApplied",
+      "parent": "FallbackCreditStatus"
+    },
+    "UnknownFallbackCreditStatus": {
+      "spec": "main",
+      "kind": "extension",
+      "dart_class": "UnknownFallbackCreditStatus",
+      "file": "lib/src/models/metadata/fallback_credit_usage.dart",
+      "schema": null,
+      "parent": "FallbackCreditStatus",
+      "note": "Forward-compatible fallback for unrecognized fallback-credit status types; preserves raw JSON."
+    },
+    "FallbackCreditTokenParam": {
+      "spec": "main",
+      "kind": "sealed_parent",
+      "dart_class": "FallbackCreditTokenParam",
+      "file": "lib/src/models/messages/fallback_credit_token_param.dart",
+      "schema": null,
+      "discriminator": {
+        "field": "runtime_type",
+        "mapping": {}
+      },
+      "note": "fromJson accepts dynamic: String -> FallbackCreditTokenParamToken, Map -> FallbackCreditTokenParamConfig (anyOf[string, BetaFallbackCreditTokenParam] on BetaCreateMessageParams.fallback_credit_token)."
+    },
+    "FallbackCreditTokenParamToken": {
+      "spec": "main",
+      "kind": "extension",
+      "dart_class": "FallbackCreditTokenParamToken",
+      "file": "lib/src/models/messages/fallback_credit_token_param.dart",
+      "schema": null,
+      "parent": "FallbackCreditTokenParam",
+      "note": "Bare-string wire form of fallback_credit_token; no dedicated spec schema."
+    },
+    "FallbackCreditTokenParamConfig": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "FallbackCreditTokenParamConfig",
+      "file": "lib/src/models/messages/fallback_credit_token_param.dart",
+      "schema": "BetaFallbackCreditTokenParam",
+      "parent": "FallbackCreditTokenParam"
+    },
+    "ToolAdditionInputBlock": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "ToolAdditionInputBlock",
+      "file": "lib/src/models/content/input_content_block.dart",
+      "schema": "BetaRequestToolAdditionBlock",
+      "parent": "InputContentBlock"
+    },
+    "ToolRemovalInputBlock": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "ToolRemovalInputBlock",
+      "file": "lib/src/models/content/input_content_block.dart",
+      "schema": "BetaRequestToolRemovalBlock",
+      "parent": "InputContentBlock"
+    },
+    "ToolChangeReference": {
+      "spec": "main",
+      "kind": "sealed_parent",
+      "dart_class": "ToolChangeReference",
+      "file": "lib/src/models/tools/tool_change_reference.dart",
+      "schema": null,
+      "discriminator": {
+        "field": "type",
+        "mapping": {
+          "BetaToolChangeToolReference": "tool_reference",
+          "BetaToolChangeMCPToolReference": "mcp_tool_reference",
+          "BetaToolChangeMCPToolsetReference": "mcp_toolset_reference"
+        }
+      },
+      "note": "Synthetic parent for the inline tool-reference union in the tool field of tool_addition/tool_removal blocks."
+    },
+    "ToolChangeToolReference": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "ToolChangeToolReference",
+      "file": "lib/src/models/tools/tool_change_reference.dart",
+      "schema": "BetaToolChangeToolReference",
+      "parent": "ToolChangeReference"
+    },
+    "ToolChangeMCPToolReference": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "ToolChangeMCPToolReference",
+      "file": "lib/src/models/tools/tool_change_reference.dart",
+      "schema": "BetaToolChangeMCPToolReference",
+      "parent": "ToolChangeReference"
+    },
+    "ToolChangeMCPToolsetReference": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "ToolChangeMCPToolsetReference",
+      "file": "lib/src/models/tools/tool_change_reference.dart",
+      "schema": "BetaToolChangeMCPToolsetReference",
+      "parent": "ToolChangeReference"
+    },
+    "WebhookEnvironmentArchivedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookEnvironmentArchivedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookEnvironmentArchivedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookEnvironmentCreatedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookEnvironmentCreatedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookEnvironmentCreatedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookEnvironmentDeletedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookEnvironmentDeletedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookEnvironmentDeletedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookEnvironmentUpdatedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookEnvironmentUpdatedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookEnvironmentUpdatedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookMemoryStoreArchivedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookMemoryStoreArchivedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookMemoryStoreArchivedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookMemoryStoreCreatedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookMemoryStoreCreatedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookMemoryStoreCreatedEventData",
+      "parent": "WebhookEventData"
+    },
+    "WebhookMemoryStoreDeletedEventData": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "WebhookMemoryStoreDeletedEventData",
+      "file": "lib/src/models/managed_agents/webhooks/webhook_event.dart",
+      "schema": "BetaWebhookMemoryStoreDeletedEventData",
+      "parent": "WebhookEventData"
+    },
+    "BetaManagedAgentsSessionInitialEventParams": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "SessionInitialEventParams",
+      "file": "lib/src/models/managed_agents/sessions/session_initial_event_params.dart",
+      "schema": "BetaManagedAgentsSessionInitialEventParams",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Create-side union; oneOf variants are the already-tracked UserMessage/UserDefineOutcome EventParams. Modeled as thin Dart wrappers (SessionInitialEventParams) delegating to those classes; no new spec schema to verify."
+    },
+    "EffortParams": {
+      "spec": "main",
+      "kind": "sealed_parent",
+      "dart_class": "EffortParams",
+      "file": "lib/src/models/managed_agents/config/effort_params.dart",
+      "schema": "BetaManagedAgentsEffortParams",
+      "note": "fromJson accepts dynamic: String -> EffortParamsLevel (bare BetaManagedAgentsEffortLevel), Map -> EffortParamsObject ({type: level} BetaManagedAgentsEffort form)."
+    },
+    "EffortParamsLevel": {
+      "spec": "main",
+      "kind": "extension",
+      "dart_class": "EffortParamsLevel",
+      "file": "lib/src/models/managed_agents/config/effort_params.dart",
+      "schema": null,
+      "parent": "EffortParams",
+      "note": "Bare-string wire form (BetaManagedAgentsEffortLevel), collapsed to the shared EffortLevel enum."
+    },
+    "EffortParamsObject": {
+      "spec": "main",
+      "kind": "extension",
+      "dart_class": "EffortParamsObject",
+      "file": "lib/src/models/managed_agents/config/effort_params.dart",
+      "schema": null,
+      "parent": "EffortParams",
+      "note": "Object wire form {type: level}; level collapsed to the shared EffortLevel enum."
+    },
+    "BetaManagedAgentsEffortLevel": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "EffortLevel",
+      "file": "lib/src/models/beta/config/output_config.dart",
+      "schema": "BetaManagedAgentsEffortLevel",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Identical value set (low/medium/high/xhigh/max) to the existing EffortLevel enum; reused rather than duplicated."
+    },
+    "BetaManagedAgentsEffort": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "EffortLevel",
+      "file": "lib/src/models/beta/config/output_config.dart",
+      "schema": "BetaManagedAgentsEffort",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Discriminated {type: level} object union collapsed to the EffortLevel enum: ModelConfig.effort unwraps/rewraps the object form; EffortParamsObject covers the params side."
+    },
+    "BetaManagedAgentsEffortLow": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "EffortLevel",
+      "file": "lib/src/models/beta/config/output_config.dart",
+      "schema": "BetaManagedAgentsEffortLow",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Empty {type} discriminated variant of BetaManagedAgentsEffort, collapsed to EffortLevel.low."
+    },
+    "BetaManagedAgentsEffortMedium": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "EffortLevel",
+      "file": "lib/src/models/beta/config/output_config.dart",
+      "schema": "BetaManagedAgentsEffortMedium",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Empty {type} discriminated variant of BetaManagedAgentsEffort, collapsed to EffortLevel.medium."
+    },
+    "BetaManagedAgentsEffortHigh": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "EffortLevel",
+      "file": "lib/src/models/beta/config/output_config.dart",
+      "schema": "BetaManagedAgentsEffortHigh",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Empty {type} discriminated variant of BetaManagedAgentsEffort, collapsed to EffortLevel.high."
+    },
+    "BetaManagedAgentsEffortXhigh": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "EffortLevel",
+      "file": "lib/src/models/beta/config/output_config.dart",
+      "schema": "BetaManagedAgentsEffortXhigh",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Empty {type} discriminated variant of BetaManagedAgentsEffort, collapsed to EffortLevel.xhigh."
+    },
+    "BetaManagedAgentsEffortMax": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "EffortLevel",
+      "file": "lib/src/models/beta/config/output_config.dart",
+      "schema": "BetaManagedAgentsEffortMax",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Empty {type} discriminated variant of BetaManagedAgentsEffort, collapsed to EffortLevel.max."
+    },
+    "DreamStatus": {
+      "spec": "main",
+      "kind": "enum",
+      "dart_class": "DreamStatus",
+      "file": "lib/src/models/dreams/dream_status.dart",
+      "schema": "BetaDreamStatus"
+    },
+    "DreamInput": {
+      "spec": "main",
+      "kind": "sealed_parent",
+      "dart_class": "DreamInput",
+      "file": "lib/src/models/dreams/dream_input.dart",
+      "schema": "BetaDreamInput"
+    },
+    "DreamMemoryStoreInput": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "DreamMemoryStoreInput",
+      "file": "lib/src/models/dreams/dream_input.dart",
+      "schema": "BetaDreamMemoryStoreInput",
+      "parent": "DreamInput"
+    },
+    "DreamSessionsInput": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "DreamSessionsInput",
+      "file": "lib/src/models/dreams/dream_input.dart",
+      "schema": "BetaDreamSessionsInput",
+      "parent": "DreamInput"
+    },
+    "UnknownDreamInput": {
+      "spec": "main",
+      "kind": "extension",
+      "dart_class": "UnknownDreamInput",
+      "file": "lib/src/models/dreams/dream_input.dart",
+      "schema": null,
+      "parent": "DreamInput",
+      "note": "Forward-compatible fallback for unrecognized DreamInput types; preserves raw JSON."
+    },
+    "DreamOutput": {
+      "spec": "main",
+      "kind": "sealed_parent",
+      "dart_class": "DreamOutput",
+      "file": "lib/src/models/dreams/dream_output.dart",
+      "schema": "BetaDreamOutput"
+    },
+    "DreamMemoryStoreOutput": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "DreamMemoryStoreOutput",
+      "file": "lib/src/models/dreams/dream_output.dart",
+      "schema": "BetaDreamMemoryStoreOutput",
+      "parent": "DreamOutput"
+    },
+    "UnknownDreamOutput": {
+      "spec": "main",
+      "kind": "extension",
+      "dart_class": "UnknownDreamOutput",
+      "file": "lib/src/models/dreams/dream_output.dart",
+      "schema": null,
+      "parent": "DreamOutput",
+      "note": "Forward-compatible fallback for unrecognized DreamOutput types; preserves raw JSON."
+    },
+    "DreamModelConfig": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "DreamModelConfig",
+      "file": "lib/src/models/dreams/dream_model_config.dart",
+      "schema": "BetaDreamModelConfig"
+    },
+    "DreamModelParams": {
+      "spec": "main",
+      "kind": "sealed_parent",
+      "dart_class": "DreamModelParams",
+      "file": "lib/src/models/dreams/dream_model_config.dart",
+      "schema": "BetaDreamModelParams"
+    },
+    "DreamModelParamsId": {
+      "spec": "main",
+      "kind": "extension",
+      "dart_class": "DreamModelParamsId",
+      "file": "lib/src/models/dreams/dream_model_config.dart",
+      "schema": null,
+      "parent": "DreamModelParams",
+      "note": "Bare model-id string variant of BetaDreamModelParams; no dedicated spec schema."
+    },
+    "DreamModelConfigParams": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "DreamModelConfigParams",
+      "file": "lib/src/models/dreams/dream_model_config.dart",
+      "schema": "BetaDreamModelConfigParams",
+      "parent": "DreamModelParams"
+    },
+    "DreamError": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "DreamError",
+      "file": "lib/src/models/dreams/dream_error.dart",
+      "schema": "BetaDreamError"
+    },
+    "DreamUsage": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "DreamUsage",
+      "file": "lib/src/models/dreams/dream_usage.dart",
+      "schema": "BetaDreamUsage"
+    },
+    "Dream": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "Dream",
+      "file": "lib/src/models/dreams/dream.dart",
+      "schema": "BetaDream"
+    },
+    "CreateDreamRequest": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "CreateDreamRequest",
+      "file": "lib/src/models/dreams/create_dream_request.dart",
+      "schema": "BetaCreateDreamRequest"
+    },
+    "ListDreamsResponse": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "ListDreamsResponse",
+      "file": "lib/src/models/dreams/list_dreams_response.dart",
+      "schema": "BetaListDreamsResponse"
     }
   }
 }

--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
@@ -5593,6 +5593,15 @@
       "schema": "BetaToolChangeMCPToolsetReference",
       "parent": "ToolChangeReference"
     },
+    "UnknownToolChangeReference": {
+      "spec": "main",
+      "kind": "extension",
+      "dart_class": "UnknownToolChangeReference",
+      "file": "lib/src/models/tools/tool_change_reference.dart",
+      "schema": null,
+      "parent": "ToolChangeReference",
+      "note": "Forward-compatible fallback for unrecognized tool-change reference types; preserves raw JSON."
+    },
     "WebhookEnvironmentArchivedEventData": {
       "spec": "main",
       "kind": "sealed_variant",

--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/specs.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/specs.json
@@ -31,9 +31,9 @@
       "fetch_mode": "remote",
       "local_file": "openapi.yaml",
       "name": "Anthropic API",
-      "pinned_hash": "506a5ad71d522b4ae56ac3429380486647af1f92eddde80603480fb592d62b54",
+      "pinned_hash": "6d5c96a475b06ff067a4491fc2258181f0426af6c64bcfd4be5d167a8c0d9d16",
       "requires_auth": false,
-      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-506a5ad71d522b4ae56ac3429380486647af1f92eddde80603480fb592d62b54.yml"
+      "url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-6d5c96a475b06ff067a4491fc2258181f0426af6c64bcfd4be5d167a8c0d9d16.yml"
     }
   },
   "specs_dir": "packages/anthropic_sdk_dart/specs"

--- a/packages/anthropic_sdk_dart/README.md
+++ b/packages/anthropic_sdk_dart/README.md
@@ -36,11 +36,12 @@ Dart client for the **[Anthropic API](https://docs.anthropic.com/en/api)** to bu
 - SSE streaming with cancelation and token counting
 - Extended thinking and adaptive thinking controls, with `outputTokensDetails` reasoning-token breakdown
 - Prompt-cache diagnostics: report why the cache prefix diverged between turns (beta)
-- Server-side fallback: automatically re-run refused requests on another model via the `fallbacks` chain, or retry manually with the refusal `fallback_credit_token` (beta)
+- Server-side fallback: automatically re-run refused requests on another model via the `fallbacks` chain, or retry manually with the refusal `fallback_credit_token` — including best-effort redemption mode and per-response `fallback_credit` usage outcomes (beta)
 
 ### Tools and multimodal
 
 - Custom tool calling with strict schemas and tool choice controls
+- Mid-conversation tool changes: add or remove tools between turns with `tool_addition`/`tool_removal` blocks while preserving the prompt cache (beta)
 - Computer use, web search, code execution, advisor, and MCP tool integration
 - Vision and document inputs with citations, plus your own cited `search_result` blocks (RAG)
 
@@ -53,6 +54,7 @@ Dart client for the **[Anthropic API](https://docs.anthropic.com/en/api)** to bu
 - Multiagent coordinator orchestration and outcome evaluations with grading rubrics (beta)
 - Typed webhook event parsing and MCP-OAuth / static-bearer / environment-variable credential validation (beta)
 - Memory stores for persistent agent memories with versioning and redaction (beta)
+- Dreams: asynchronous memory-consolidation jobs over memory stores and session transcripts (beta, research preview)
 - User profiles with relationship classification (`external`/`resold`/`internal`), trust-grant tracking, and enrollment URLs (beta)
 
 ## Why choose this client?
@@ -684,6 +686,7 @@ See the [example/](example/) directory for complete examples:
 | [`session_threads_example.dart`](example/session_threads_example.dart) | Session threads: list, retrieve, stream events, archive (beta) |
 | [`deployments_example.dart`](example/deployments_example.dart) | Scheduled deployments and deployment runs: cron schedule, pause/resume, run-now (beta) |
 | [`memory_stores_example.dart`](example/memory_stores_example.dart) | Managed agents memory stores, memories, and versions (beta) |
+| [`dreams_example.dart`](example/dreams_example.dart) | Dreams: memory-consolidation jobs — create, poll, list, archive (beta, research preview) |
 | [`user_profiles_example.dart`](example/user_profiles_example.dart) | User profiles and enrollment URLs (beta) |
 | [`models_example.dart`](example/models_example.dart) | Model listing |
 | [`error_handling_example.dart`](example/error_handling_example.dart) | Exception handling patterns |
@@ -702,6 +705,7 @@ See the [example/](example/) directory for complete examples:
 | Sessions (Beta) | ✅ Full |
 | Vaults (Beta) | ✅ Full |
 | Memory Stores (Beta) | ✅ Full |
+| Dreams (Beta) | ✅ Full |
 | User Profiles (Beta) | ✅ Full |
 | Webhooks (Beta) | ✅ Full |
 

--- a/packages/anthropic_sdk_dart/example/dreams_example.dart
+++ b/packages/anthropic_sdk_dart/example/dreams_example.dart
@@ -1,0 +1,92 @@
+// ignore_for_file: avoid_print
+import 'dart:async';
+
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+
+/// Dreams API example (Beta, research preview).
+///
+/// A dream is an asynchronous memory-consolidation job that reads a memory
+/// store plus a set of session transcripts and writes consolidated memories
+/// into a new output memory store. This example demonstrates:
+///
+/// 1. Create a dream from a memory store and session transcripts
+/// 2. Poll until the dream finishes
+/// 3. List dreams filtered by status
+/// 4. Cancel a still-running dream, or archive a finished one
+///
+/// Note: the Dreams API is in research preview — request and response shapes
+/// are volatile and may change without the deprecation period that applies
+/// to generally-available endpoints. This is a beta feature and requires the
+/// `anthropic-beta: dreaming-2026-04-21` header (sent automatically by the
+/// SDK).
+void main() async {
+  final client = AnthropicClient(
+    config: const AnthropicConfig(
+      authProvider: ApiKeyProvider(String.fromEnvironment('ANTHROPIC_API_KEY')),
+    ),
+  );
+
+  try {
+    // 1. Create a dream that reads an existing memory store plus a couple of
+    //    session transcripts, and writes consolidated memories into a new
+    //    output memory store.
+    print('=== Create Dream ===');
+    var dream = await client.dreams.create(
+      const CreateDreamRequest(
+        inputs: [
+          DreamMemoryStoreInput(memoryStoreId: 'memstore_source123'),
+          DreamSessionsInput(sessionIds: ['session_a', 'session_b']),
+        ],
+        instructions: 'Consolidate notes about user preferences.',
+        model: DreamModelParamsId(id: 'claude-opus-4-7'),
+      ),
+    );
+    print('Created dream: ${dream.id} (status: ${dream.status})');
+
+    // 2. Poll until the dream finishes.
+    print('\n=== Poll Dream ===');
+    while (dream.status == DreamStatus.pending ||
+        dream.status == DreamStatus.running) {
+      await Future<void>.delayed(const Duration(seconds: 2));
+      dream = await client.dreams.retrieve(dream.id);
+      print('  status: ${dream.status}');
+    }
+
+    switch (dream.status) {
+      case DreamStatus.completed:
+        for (final output in dream.outputs) {
+          if (output is DreamMemoryStoreOutput) {
+            print('Consolidated memories written to: ${output.memoryStoreId}');
+          }
+        }
+      case DreamStatus.failed:
+        print('Dream failed: ${dream.error?.message}');
+      case DreamStatus.canceled:
+      case DreamStatus.pending:
+      case DreamStatus.running:
+      case DreamStatus.unknown:
+        print('Dream ended with status: ${dream.status}');
+    }
+    print(
+      'Usage: ${dream.usage.inputTokens} input, '
+      '${dream.usage.outputTokens} output tokens',
+    );
+
+    // 3. List dreams, filtering by status.
+    print('\n=== List Dreams ===');
+    final dreamList = await client.dreams.list(
+      statuses: [DreamStatus.completed, DreamStatus.failed],
+      limit: 10,
+    );
+    for (final d in dreamList.data) {
+      print('  ${d.id}: ${d.status}');
+    }
+
+    // 4. Archive the finished dream (or cancel it, if it were still running).
+    print('\n=== Archive Dream ===');
+    final archived = await client.dreams.archive(dream.id);
+    print('Archived at: ${archived.archivedAt}');
+  } finally {
+    client.close();
+  }
+}

--- a/packages/anthropic_sdk_dart/example/fallback_example.dart
+++ b/packages/anthropic_sdk_dart/example/fallback_example.dart
@@ -69,15 +69,29 @@ final first = await client.messages.create(
 
 if (first.stopReason == StopReason.refusal) {
   final details = first.stopDetails; // RefusalStopDetails
+  final token = details?.fallbackCreditToken;
   final retry = await client.messages.create(
     request.copyWith(
       model: details?.recommendedModel ?? 'claude-opus-4-8',
-      fallbackCreditToken: details?.fallbackCreditToken,
+      fallbackCreditToken: token != null
+          ? FallbackCreditTokenParam.token(token)
+          : null,
     ),
     betas: const ['fallback-credit-2026-06-01'],
   );
   // ... use `retry`
 }
+
+To opt into a best-effort retry (served even if redemption fails, billed at
+normal price if it does), pass the object form instead — it requires the
+`anthropic-beta: fallback-credit-2026-07-01` header:
+
+fallbackCreditToken: token != null
+    ? FallbackCreditTokenParam.config(
+        token: token,
+        mode: FallbackCreditMode.bestEffort,
+      )
+    : null,
 ''');
   } finally {
     client.close();

--- a/packages/anthropic_sdk_dart/lib/anthropic_sdk_dart.dart
+++ b/packages/anthropic_sdk_dart/lib/anthropic_sdk_dart.dart
@@ -83,6 +83,17 @@ export 'src/models/content/citations_config.dart';
 export 'src/models/content/content_block.dart';
 export 'src/models/content/input_content_block.dart';
 
+// Models - Dreams (Beta, research preview)
+export 'src/models/dreams/create_dream_request.dart';
+export 'src/models/dreams/dream.dart';
+export 'src/models/dreams/dream_error.dart';
+export 'src/models/dreams/dream_input.dart';
+export 'src/models/dreams/dream_model_config.dart';
+export 'src/models/dreams/dream_output.dart';
+export 'src/models/dreams/dream_status.dart';
+export 'src/models/dreams/dream_usage.dart';
+export 'src/models/dreams/list_dreams_response.dart';
+
 // Models - Files (Beta)
 export 'src/models/files/file_delete_response.dart';
 export 'src/models/files/file_list_response.dart';
@@ -100,6 +111,7 @@ export 'src/models/managed_agents/common/list_order.dart';
 export 'src/models/managed_agents/common/managed_agent_actor.dart';
 export 'src/models/managed_agents/config/agent_skill.dart';
 export 'src/models/managed_agents/config/agent_tool.dart';
+export 'src/models/managed_agents/config/effort_params.dart';
 export 'src/models/managed_agents/config/mcp_server.dart';
 export 'src/models/managed_agents/config/model_config.dart';
 export 'src/models/managed_agents/config/permission_policy.dart';
@@ -153,6 +165,7 @@ export 'src/models/managed_agents/resources/session_resource_params.dart';
 export 'src/models/managed_agents/sessions/create_session_params.dart';
 export 'src/models/managed_agents/sessions/session.dart';
 export 'src/models/managed_agents/sessions/session_agent_update.dart';
+export 'src/models/managed_agents/sessions/session_initial_event_params.dart';
 export 'src/models/managed_agents/sessions/session_list_response.dart';
 export 'src/models/managed_agents/sessions/session_thread.dart';
 export 'src/models/managed_agents/sessions/session_thread_list_response.dart';
@@ -168,6 +181,7 @@ export 'src/models/messages/cache_miss_reason.dart';
 export 'src/models/messages/diagnostics.dart';
 export 'src/models/messages/diagnostics_param.dart';
 export 'src/models/messages/fallback_config.dart';
+export 'src/models/messages/fallback_credit_token_param.dart';
 export 'src/models/messages/input_message.dart';
 export 'src/models/messages/message.dart';
 export 'src/models/messages/message_create_request.dart';
@@ -176,6 +190,7 @@ export 'src/models/messages/thinking_config.dart';
 
 // Models - Metadata
 export 'src/models/metadata/cache_control.dart';
+export 'src/models/metadata/fallback_credit_usage.dart';
 export 'src/models/metadata/metadata.dart';
 export 'src/models/metadata/processing_status.dart';
 export 'src/models/metadata/service_tier.dart';
@@ -212,6 +227,7 @@ export 'src/models/tools/input_schema.dart';
 export 'src/models/tools/response_inclusion.dart';
 export 'src/models/tools/tool.dart';
 export 'src/models/tools/tool_caller.dart';
+export 'src/models/tools/tool_change_reference.dart';
 export 'src/models/tools/tool_choice.dart';
 export 'src/models/tools/tool_definition.dart';
 
@@ -229,6 +245,7 @@ export 'src/models/user_profiles/user_profile_trust_grant.dart';
 export 'src/resources/agents_resource.dart';
 export 'src/resources/deployment_runs_resource.dart';
 export 'src/resources/deployments_resource.dart';
+export 'src/resources/dreams_resource.dart';
 export 'src/resources/files_resource.dart';
 export 'src/resources/memories_resource.dart';
 export 'src/resources/memory_stores_resource.dart';

--- a/packages/anthropic_sdk_dart/lib/src/client/anthropic_client.dart
+++ b/packages/anthropic_sdk_dart/lib/src/client/anthropic_client.dart
@@ -8,6 +8,7 @@ import '../interceptors/logging_interceptor.dart';
 import '../resources/agents_resource.dart';
 import '../resources/deployment_runs_resource.dart';
 import '../resources/deployments_resource.dart';
+import '../resources/dreams_resource.dart';
 import '../resources/files_resource.dart';
 import '../resources/memory_stores_resource.dart';
 import '../resources/message_batches_resource.dart';
@@ -98,6 +99,9 @@ class AnthropicClient {
 
   /// Resource for the Vaults API (Beta).
   late final VaultsResource vaults;
+
+  /// Resource for the Dreams API (Beta, research preview).
+  late final DreamsResource dreams;
 
   /// Resource for the Deployments API (Beta).
   late final DeploymentsResource deployments;
@@ -232,6 +236,13 @@ class AnthropicClient {
       ensureNotClosed: _ensureNotClosed,
     );
     vaults = VaultsResource(
+      config: config,
+      httpClient: _httpClient,
+      interceptorChain: _interceptorChain,
+      requestBuilder: _requestBuilder,
+      ensureNotClosed: _ensureNotClosed,
+    );
+    dreams = DreamsResource(
       config: config,
       httpClient: _httpClient,
       interceptorChain: _interceptorChain,

--- a/packages/anthropic_sdk_dart/lib/src/models/content/input_content_block.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/input_content_block.dart
@@ -7,6 +7,7 @@ import '../metadata/cache_control.dart';
 import '../sources/document_source.dart';
 import '../sources/image_source.dart';
 import '../tools/tool_caller.dart';
+import '../tools/tool_change_reference.dart';
 import 'citations_config.dart';
 import 'content_block.dart';
 
@@ -142,6 +143,26 @@ sealed class InputContentBlock {
     CacheControlEphemeral? cacheControl,
   }) = ToolReferenceInputBlock;
 
+  /// Creates a mid-conversation directive to surface a declared tool.
+  ///
+  /// [tool] references a tool (or MCP toolset) by name from the request's
+  /// `tools`; it is offered to the model from this point in the conversation
+  /// onward.
+  factory InputContentBlock.toolAddition({
+    required ToolChangeReference tool,
+    CacheControlEphemeral? cacheControl,
+  }) = ToolAdditionInputBlock;
+
+  /// Creates a mid-conversation directive to withdraw a tool.
+  ///
+  /// [tool] references a tool (or MCP toolset) by name from the request's
+  /// `tools`; it is no longer offered to the model from this point in the
+  /// conversation onward.
+  factory InputContentBlock.toolRemoval({
+    required ToolChangeReference tool,
+    CacheControlEphemeral? cacheControl,
+  }) = ToolRemovalInputBlock;
+
   /// Creates a mid-conversation system block.
   ///
   /// Injects updated system instructions partway through a conversation (e.g.
@@ -187,6 +208,8 @@ sealed class InputContentBlock {
       'container_upload' => ContainerUploadInputBlock.fromJson(json),
       'compaction' => CompactionInputBlock.fromJson(json),
       'tool_reference' => ToolReferenceInputBlock.fromJson(json),
+      'tool_addition' => ToolAdditionInputBlock.fromJson(json),
+      'tool_removal' => ToolRemovalInputBlock.fromJson(json),
       'mcp_tool_use' => MCPToolUseInputBlock.fromJson(json),
       'mcp_tool_result' => MCPToolResultInputBlock.fromJson(json),
       'advisor_tool_result' => AdvisorToolResultInputBlock.fromJson(json),
@@ -1606,6 +1629,134 @@ class ToolReferenceInputBlock extends InputContentBlock {
   String toString() =>
       'ToolReferenceInputBlock(toolName: $toolName, '
       'cacheControl: $cacheControl)';
+}
+
+/// Mid-conversation directive to surface a declared tool.
+///
+/// [tool] references a tool (or MCP toolset) by name from the request's
+/// `tools`; it is offered to the model from this point in the conversation
+/// onward.
+@immutable
+class ToolAdditionInputBlock extends InputContentBlock {
+  /// The tool (or MCP toolset) to surface.
+  final ToolChangeReference tool;
+
+  /// Cache control for this block.
+  final CacheControlEphemeral? cacheControl;
+
+  /// Creates a [ToolAdditionInputBlock].
+  const ToolAdditionInputBlock({required this.tool, this.cacheControl});
+
+  /// Creates a [ToolAdditionInputBlock] from JSON.
+  factory ToolAdditionInputBlock.fromJson(Map<String, dynamic> json) {
+    return ToolAdditionInputBlock(
+      tool: ToolChangeReference.fromJson(json['tool'] as Map<String, dynamic>),
+      cacheControl: json['cache_control'] != null
+          ? CacheControlEphemeral.fromJson(
+              json['cache_control'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'tool_addition',
+    'tool': tool.toJson(),
+    if (cacheControl != null) 'cache_control': cacheControl!.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  ToolAdditionInputBlock copyWith({
+    ToolChangeReference? tool,
+    Object? cacheControl = unsetCopyWithValue,
+  }) {
+    return ToolAdditionInputBlock(
+      tool: tool ?? this.tool,
+      cacheControl: cacheControl == unsetCopyWithValue
+          ? this.cacheControl
+          : cacheControl as CacheControlEphemeral?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ToolAdditionInputBlock &&
+          runtimeType == other.runtimeType &&
+          tool == other.tool &&
+          cacheControl == other.cacheControl;
+
+  @override
+  int get hashCode => Object.hash(tool, cacheControl);
+
+  @override
+  String toString() =>
+      'ToolAdditionInputBlock(tool: $tool, cacheControl: $cacheControl)';
+}
+
+/// Mid-conversation directive to withdraw a tool.
+///
+/// [tool] references a tool (or MCP toolset) by name from the request's
+/// `tools`; it is no longer offered to the model from this point in the
+/// conversation onward.
+@immutable
+class ToolRemovalInputBlock extends InputContentBlock {
+  /// The tool (or MCP toolset) to withdraw.
+  final ToolChangeReference tool;
+
+  /// Cache control for this block.
+  final CacheControlEphemeral? cacheControl;
+
+  /// Creates a [ToolRemovalInputBlock].
+  const ToolRemovalInputBlock({required this.tool, this.cacheControl});
+
+  /// Creates a [ToolRemovalInputBlock] from JSON.
+  factory ToolRemovalInputBlock.fromJson(Map<String, dynamic> json) {
+    return ToolRemovalInputBlock(
+      tool: ToolChangeReference.fromJson(json['tool'] as Map<String, dynamic>),
+      cacheControl: json['cache_control'] != null
+          ? CacheControlEphemeral.fromJson(
+              json['cache_control'] as Map<String, dynamic>,
+            )
+          : null,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'tool_removal',
+    'tool': tool.toJson(),
+    if (cacheControl != null) 'cache_control': cacheControl!.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  ToolRemovalInputBlock copyWith({
+    ToolChangeReference? tool,
+    Object? cacheControl = unsetCopyWithValue,
+  }) {
+    return ToolRemovalInputBlock(
+      tool: tool ?? this.tool,
+      cacheControl: cacheControl == unsetCopyWithValue
+          ? this.cacheControl
+          : cacheControl as CacheControlEphemeral?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ToolRemovalInputBlock &&
+          runtimeType == other.runtimeType &&
+          tool == other.tool &&
+          cacheControl == other.cacheControl;
+
+  @override
+  int get hashCode => Object.hash(tool, cacheControl);
+
+  @override
+  String toString() =>
+      'ToolRemovalInputBlock(tool: $tool, cacheControl: $cacheControl)';
 }
 
 /// A `fallback` block echoed back from a prior response.

--- a/packages/anthropic_sdk_dart/lib/src/models/dreams/create_dream_request.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/dreams/create_dream_request.dart
@@ -1,0 +1,86 @@
+import 'package:meta/meta.dart';
+
+import '../common/copy_with_sentinel.dart';
+import '../common/equality_helpers.dart';
+import 'dream_input.dart';
+import 'dream_model_config.dart';
+
+/// Request parameters for creating a Dream.
+@immutable
+class CreateDreamRequest {
+  /// Input sources the dream should read from.
+  final List<DreamInput> inputs;
+
+  /// Custom instructions for the dream. 1-4096 characters.
+  final String? instructions;
+
+  /// Model identifier and configuration applied to every pipeline stage.
+  final DreamModelParams model;
+
+  /// Creates a [CreateDreamRequest].
+  const CreateDreamRequest({
+    required this.inputs,
+    this.instructions,
+    required this.model,
+  });
+
+  /// Creates a [CreateDreamRequest] from JSON.
+  factory CreateDreamRequest.fromJson(Map<String, dynamic> json) {
+    final rawInputs = json['inputs'] as List? ?? [];
+    final inputs = rawInputs.map((e) {
+      if (e is! Map<String, dynamic>) {
+        throw FormatException(
+          'CreateDreamRequest.inputs: expected Map, got ${e.runtimeType}',
+        );
+      }
+      return DreamInput.fromJson(e);
+    }).toList();
+
+    return CreateDreamRequest(
+      inputs: inputs,
+      instructions: json['instructions'] as String?,
+      model: DreamModelParams.fromJson(json['model'] as Object),
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'inputs': inputs.map((e) => e.toJson()).toList(),
+    if (instructions != null) 'instructions': instructions,
+    'model': model.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  CreateDreamRequest copyWith({
+    List<DreamInput>? inputs,
+    Object? instructions = unsetCopyWithValue,
+    DreamModelParams? model,
+  }) {
+    return CreateDreamRequest(
+      inputs: inputs ?? this.inputs,
+      instructions: instructions == unsetCopyWithValue
+          ? this.instructions
+          : instructions as String?,
+      model: model ?? this.model,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CreateDreamRequest &&
+          runtimeType == other.runtimeType &&
+          listsEqual(inputs, other.inputs) &&
+          instructions == other.instructions &&
+          model == other.model;
+
+  @override
+  int get hashCode => Object.hash(listHash(inputs), instructions, model);
+
+  @override
+  String toString() =>
+      'CreateDreamRequest('
+      'inputs: ${inputs.length} items, '
+      'instructions: $instructions, '
+      'model: $model)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/dreams/dream.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/dreams/dream.dart
@@ -30,8 +30,15 @@ class Dream {
   /// Output destinations the dream writes consolidated memories into.
   final List<DreamOutput> outputs;
 
-  /// Lifecycle status of the dream.
-  final DreamStatus status;
+  /// The raw wire status string, preserved verbatim for round-tripping.
+  ///
+  /// Use [status] for typed access; this field exists so an unrecognized
+  /// status value survives a `fromJson`/`toJson` round-trip instead of being
+  /// collapsed to the literal string `"unknown"`.
+  final String rawStatus;
+
+  /// Lifecycle status of the dream, derived from [rawStatus].
+  DreamStatus get status => DreamStatus.fromJson(rawStatus);
 
   /// When the dream was created.
   final DateTime createdAt;
@@ -64,7 +71,7 @@ class Dream {
     required this.id,
     required this.inputs,
     required this.outputs,
-    required this.status,
+    required this.rawStatus,
     required this.createdAt,
     this.endedAt,
     this.archivedAt,
@@ -102,7 +109,7 @@ class Dream {
       id: json['id'] as String,
       inputs: inputs,
       outputs: outputs,
-      status: DreamStatus.fromJson(json['status'] as String),
+      rawStatus: json['status'] as String,
       createdAt: DateTime.parse(json['created_at'] as String),
       endedAt: json['ended_at'] != null
           ? DateTime.parse(json['ended_at'] as String)
@@ -126,7 +133,7 @@ class Dream {
     'id': id,
     'inputs': inputs.map((e) => e.toJson()).toList(),
     'outputs': outputs.map((e) => e.toJson()).toList(),
-    'status': status.toJson(),
+    'status': rawStatus,
     'created_at': createdAt.toUtc().toIso8601String(),
     'ended_at': endedAt?.toUtc().toIso8601String(),
     'archived_at': archivedAt?.toUtc().toIso8601String(),
@@ -148,7 +155,7 @@ class Dream {
     String? id,
     List<DreamInput>? inputs,
     List<DreamOutput>? outputs,
-    DreamStatus? status,
+    String? rawStatus,
     DateTime? createdAt,
     Object? endedAt = unsetCopyWithValue,
     Object? archivedAt = unsetCopyWithValue,
@@ -163,7 +170,7 @@ class Dream {
       id: id ?? this.id,
       inputs: inputs ?? this.inputs,
       outputs: outputs ?? this.outputs,
-      status: status ?? this.status,
+      rawStatus: rawStatus ?? this.rawStatus,
       createdAt: createdAt ?? this.createdAt,
       endedAt: endedAt == unsetCopyWithValue
           ? this.endedAt
@@ -192,7 +199,7 @@ class Dream {
           id == other.id &&
           listsEqual(inputs, other.inputs) &&
           listsEqual(outputs, other.outputs) &&
-          status == other.status &&
+          rawStatus == other.rawStatus &&
           createdAt == other.createdAt &&
           endedAt == other.endedAt &&
           archivedAt == other.archivedAt &&
@@ -208,7 +215,7 @@ class Dream {
     id,
     listHash(inputs),
     listHash(outputs),
-    status,
+    rawStatus,
     createdAt,
     endedAt,
     archivedAt,

--- a/packages/anthropic_sdk_dart/lib/src/models/dreams/dream.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/dreams/dream.dart
@@ -1,0 +1,238 @@
+import 'package:meta/meta.dart';
+
+import '../common/copy_with_sentinel.dart';
+import '../common/equality_helpers.dart';
+import 'dream_error.dart';
+import 'dream_input.dart';
+import 'dream_model_config.dart';
+import 'dream_output.dart';
+import 'dream_status.dart';
+import 'dream_usage.dart';
+
+/// An asynchronous memory-consolidation job that reads a memory store plus a
+/// set of session transcripts and writes consolidated memories into a new
+/// output memory store.
+///
+/// The Dreams API is in research preview: the request and response shapes
+/// are volatile and may change without the deprecation period that applies
+/// to generally-available endpoints.
+@immutable
+class Dream {
+  /// Object type. Always `dream`.
+  final String type;
+
+  /// Unique identifier for the dream.
+  final String id;
+
+  /// Input sources the dream reads from.
+  final List<DreamInput> inputs;
+
+  /// Output destinations the dream writes consolidated memories into.
+  final List<DreamOutput> outputs;
+
+  /// Lifecycle status of the dream.
+  final DreamStatus status;
+
+  /// When the dream was created.
+  final DateTime createdAt;
+
+  /// When the dream finished processing (successfully, with failure, or by
+  /// cancellation). Null while the dream is still pending or running.
+  final DateTime? endedAt;
+
+  /// When the dream was archived. Null if not archived.
+  final DateTime? archivedAt;
+
+  /// Failure detail when [status] is [DreamStatus.failed]. Null otherwise.
+  final DreamError? error;
+
+  /// Model identifier and configuration applied to every pipeline stage.
+  final DreamModelConfig model;
+
+  /// Custom instructions supplied when the dream was created.
+  final String? instructions;
+
+  /// ID of the session the dream ran within, if any.
+  final String? sessionId;
+
+  /// Cumulative token usage for the dream across every pipeline stage.
+  final DreamUsage usage;
+
+  /// Creates a [Dream].
+  const Dream({
+    this.type = 'dream',
+    required this.id,
+    required this.inputs,
+    required this.outputs,
+    required this.status,
+    required this.createdAt,
+    this.endedAt,
+    this.archivedAt,
+    this.error,
+    required this.model,
+    this.instructions,
+    this.sessionId,
+    required this.usage,
+  });
+
+  /// Creates a [Dream] from JSON.
+  factory Dream.fromJson(Map<String, dynamic> json) {
+    final rawInputs = json['inputs'] as List? ?? [];
+    final inputs = rawInputs.map((e) {
+      if (e is! Map<String, dynamic>) {
+        throw FormatException(
+          'Dream.inputs: expected Map, got ${e.runtimeType}',
+        );
+      }
+      return DreamInput.fromJson(e);
+    }).toList();
+
+    final rawOutputs = json['outputs'] as List? ?? [];
+    final outputs = rawOutputs.map((e) {
+      if (e is! Map<String, dynamic>) {
+        throw FormatException(
+          'Dream.outputs: expected Map, got ${e.runtimeType}',
+        );
+      }
+      return DreamOutput.fromJson(e);
+    }).toList();
+
+    return Dream(
+      type: json['type'] as String? ?? 'dream',
+      id: json['id'] as String,
+      inputs: inputs,
+      outputs: outputs,
+      status: DreamStatus.fromJson(json['status'] as String),
+      createdAt: DateTime.parse(json['created_at'] as String),
+      endedAt: json['ended_at'] != null
+          ? DateTime.parse(json['ended_at'] as String)
+          : null,
+      archivedAt: json['archived_at'] != null
+          ? DateTime.parse(json['archived_at'] as String)
+          : null,
+      error: json['error'] != null
+          ? DreamError.fromJson(json['error'] as Map<String, dynamic>)
+          : null,
+      model: DreamModelConfig.fromJson(json['model'] as Map<String, dynamic>),
+      instructions: json['instructions'] as String?,
+      sessionId: json['session_id'] as String?,
+      usage: DreamUsage.fromJson(json['usage'] as Map<String, dynamic>),
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'inputs': inputs.map((e) => e.toJson()).toList(),
+    'outputs': outputs.map((e) => e.toJson()).toList(),
+    'status': status.toJson(),
+    'created_at': createdAt.toUtc().toIso8601String(),
+    'ended_at': endedAt?.toUtc().toIso8601String(),
+    'archived_at': archivedAt?.toUtc().toIso8601String(),
+    'error': error?.toJson(),
+    'model': model.toJson(),
+    'instructions': instructions,
+    'session_id': sessionId,
+    'usage': usage.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  ///
+  /// For nullable fields ([endedAt], [archivedAt], [error], [instructions],
+  /// [sessionId]), pass the sentinel value [unsetCopyWithValue] (or omit) to
+  /// keep the original value, or pass `null` explicitly to set the field to
+  /// null.
+  Dream copyWith({
+    String? type,
+    String? id,
+    List<DreamInput>? inputs,
+    List<DreamOutput>? outputs,
+    DreamStatus? status,
+    DateTime? createdAt,
+    Object? endedAt = unsetCopyWithValue,
+    Object? archivedAt = unsetCopyWithValue,
+    Object? error = unsetCopyWithValue,
+    DreamModelConfig? model,
+    Object? instructions = unsetCopyWithValue,
+    Object? sessionId = unsetCopyWithValue,
+    DreamUsage? usage,
+  }) {
+    return Dream(
+      type: type ?? this.type,
+      id: id ?? this.id,
+      inputs: inputs ?? this.inputs,
+      outputs: outputs ?? this.outputs,
+      status: status ?? this.status,
+      createdAt: createdAt ?? this.createdAt,
+      endedAt: endedAt == unsetCopyWithValue
+          ? this.endedAt
+          : endedAt as DateTime?,
+      archivedAt: archivedAt == unsetCopyWithValue
+          ? this.archivedAt
+          : archivedAt as DateTime?,
+      error: error == unsetCopyWithValue ? this.error : error as DreamError?,
+      model: model ?? this.model,
+      instructions: instructions == unsetCopyWithValue
+          ? this.instructions
+          : instructions as String?,
+      sessionId: sessionId == unsetCopyWithValue
+          ? this.sessionId
+          : sessionId as String?,
+      usage: usage ?? this.usage,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Dream &&
+          runtimeType == other.runtimeType &&
+          type == other.type &&
+          id == other.id &&
+          listsEqual(inputs, other.inputs) &&
+          listsEqual(outputs, other.outputs) &&
+          status == other.status &&
+          createdAt == other.createdAt &&
+          endedAt == other.endedAt &&
+          archivedAt == other.archivedAt &&
+          error == other.error &&
+          model == other.model &&
+          instructions == other.instructions &&
+          sessionId == other.sessionId &&
+          usage == other.usage;
+
+  @override
+  int get hashCode => Object.hash(
+    type,
+    id,
+    listHash(inputs),
+    listHash(outputs),
+    status,
+    createdAt,
+    endedAt,
+    archivedAt,
+    error,
+    model,
+    instructions,
+    sessionId,
+    usage,
+  );
+
+  @override
+  String toString() =>
+      'Dream('
+      'type: $type, '
+      'id: $id, '
+      'inputs: ${inputs.length} items, '
+      'outputs: ${outputs.length} items, '
+      'status: $status, '
+      'createdAt: $createdAt, '
+      'endedAt: $endedAt, '
+      'archivedAt: $archivedAt, '
+      'error: $error, '
+      'model: $model, '
+      'instructions: $instructions, '
+      'sessionId: $sessionId, '
+      'usage: $usage)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/dreams/dream_error.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/dreams/dream_error.dart
@@ -1,0 +1,47 @@
+import 'package:meta/meta.dart';
+
+/// Failure detail for a Dream whose `status` is `failed`.
+@immutable
+class DreamError {
+  /// Machine-readable error type.
+  final String type;
+
+  /// Human-readable error message.
+  final String message;
+
+  /// Creates a [DreamError].
+  const DreamError({required this.type, required this.message});
+
+  /// Creates a [DreamError] from JSON.
+  factory DreamError.fromJson(Map<String, dynamic> json) {
+    return DreamError(
+      type: json['type'] as String,
+      message: json['message'] as String,
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {'type': type, 'message': message};
+
+  /// Creates a copy with replaced values.
+  DreamError copyWith({String? type, String? message}) {
+    return DreamError(
+      type: type ?? this.type,
+      message: message ?? this.message,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DreamError &&
+          runtimeType == other.runtimeType &&
+          type == other.type &&
+          message == other.message;
+
+  @override
+  int get hashCode => Object.hash(type, message);
+
+  @override
+  String toString() => 'DreamError(type: $type, message: $message)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/dreams/dream_input.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/dreams/dream_input.dart
@@ -1,0 +1,177 @@
+import 'package:meta/meta.dart';
+
+import '../common/equality_helpers.dart';
+
+/// An input source a Dream reads from.
+///
+/// Variants:
+/// - [DreamMemoryStoreInput] — an input memory store (type: `memory_store`)
+/// - [DreamSessionsInput] — input session transcripts (type: `sessions`)
+/// - [UnknownDreamInput] — unrecognized type (preserves raw JSON)
+sealed class DreamInput {
+  const DreamInput();
+
+  /// Creates a [DreamInput] from JSON.
+  factory DreamInput.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    return switch (type) {
+      'memory_store' => DreamMemoryStoreInput.fromJson(json),
+      'sessions' => DreamSessionsInput.fromJson(json),
+      _ => UnknownDreamInput.fromJson(json),
+    };
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson();
+}
+
+/// An input memory store the dream reads from. The dream never mutates this
+/// store.
+@immutable
+class DreamMemoryStoreInput extends DreamInput {
+  /// Object type. Always `memory_store`.
+  final String type;
+
+  /// The ID of the memory store to read from.
+  final String memoryStoreId;
+
+  /// Creates a [DreamMemoryStoreInput].
+  const DreamMemoryStoreInput({
+    this.type = 'memory_store',
+    required this.memoryStoreId,
+  });
+
+  /// Creates a [DreamMemoryStoreInput] from JSON.
+  factory DreamMemoryStoreInput.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    if (type != 'memory_store') {
+      throw FormatException(
+        'DreamMemoryStoreInput: expected type "memory_store", got "$type"',
+      );
+    }
+    return DreamMemoryStoreInput(
+      type: type!,
+      memoryStoreId: json['memory_store_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'memory_store_id': memoryStoreId,
+  };
+
+  /// Creates a copy with replaced values.
+  DreamMemoryStoreInput copyWith({String? type, String? memoryStoreId}) {
+    return DreamMemoryStoreInput(
+      type: type ?? this.type,
+      memoryStoreId: memoryStoreId ?? this.memoryStoreId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DreamMemoryStoreInput &&
+          runtimeType == other.runtimeType &&
+          type == other.type &&
+          memoryStoreId == other.memoryStoreId;
+
+  @override
+  int get hashCode => Object.hash(type, memoryStoreId);
+
+  @override
+  String toString() =>
+      'DreamMemoryStoreInput(type: $type, memoryStoreId: $memoryStoreId)';
+}
+
+/// Input session transcripts the dream reads.
+@immutable
+class DreamSessionsInput extends DreamInput {
+  /// Object type. Always `sessions`.
+  final String type;
+
+  /// IDs of the sessions to read transcripts from.
+  final List<String> sessionIds;
+
+  /// Creates a [DreamSessionsInput].
+  const DreamSessionsInput({this.type = 'sessions', required this.sessionIds});
+
+  /// Creates a [DreamSessionsInput] from JSON.
+  factory DreamSessionsInput.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    if (type != 'sessions') {
+      throw FormatException(
+        'DreamSessionsInput: expected type "sessions", got "$type"',
+      );
+    }
+    final rawIds = json['session_ids'] as List? ?? [];
+    final sessionIds = rawIds.map((e) {
+      if (e is! String) {
+        throw FormatException(
+          'DreamSessionsInput.session_ids: expected String, got '
+          '${e.runtimeType}',
+        );
+      }
+      return e;
+    }).toList();
+    return DreamSessionsInput(type: type!, sessionIds: sessionIds);
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {'type': type, 'session_ids': sessionIds};
+
+  /// Creates a copy with replaced values.
+  DreamSessionsInput copyWith({String? type, List<String>? sessionIds}) {
+    return DreamSessionsInput(
+      type: type ?? this.type,
+      sessionIds: sessionIds ?? this.sessionIds,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DreamSessionsInput &&
+          runtimeType == other.runtimeType &&
+          type == other.type &&
+          listsEqual(sessionIds, other.sessionIds);
+
+  @override
+  int get hashCode => Object.hash(type, listHash(sessionIds));
+
+  @override
+  String toString() =>
+      'DreamSessionsInput(type: $type, sessionIds: $sessionIds)';
+}
+
+/// Unrecognized [DreamInput] — preserves raw JSON for forward compatibility.
+@immutable
+class UnknownDreamInput extends DreamInput {
+  /// The raw JSON data.
+  final Map<String, dynamic> rawJson;
+
+  /// Creates an [UnknownDreamInput].
+  const UnknownDreamInput({required this.rawJson});
+
+  /// Creates an [UnknownDreamInput] from JSON.
+  factory UnknownDreamInput.fromJson(Map<String, dynamic> json) {
+    return UnknownDreamInput(rawJson: json);
+  }
+
+  @override
+  Map<String, dynamic> toJson() => rawJson;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnknownDreamInput &&
+          runtimeType == other.runtimeType &&
+          mapsDeepEqual(rawJson, other.rawJson);
+
+  @override
+  int get hashCode => mapDeepHashCode(rawJson);
+
+  @override
+  String toString() => 'UnknownDreamInput(rawJson: $rawJson)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/dreams/dream_model_config.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/dreams/dream_model_config.dart
@@ -1,0 +1,163 @@
+import 'package:meta/meta.dart';
+
+import '../common/copy_with_sentinel.dart';
+import '../managed_agents/config/model_config.dart';
+
+/// Model identifier and configuration applied to every pipeline stage of a
+/// Dream, as returned in API responses.
+///
+/// Same wire shape as the Agents API `ModelConfig`.
+@immutable
+class DreamModelConfig {
+  /// Model identifier, e.g. `"claude-opus-4-7"`.
+  final String id;
+
+  /// Inference speed mode. Defaults to `standard`.
+  final AgentSpeed? speed;
+
+  /// Creates a [DreamModelConfig].
+  const DreamModelConfig({required this.id, this.speed});
+
+  /// Creates a [DreamModelConfig] from JSON.
+  factory DreamModelConfig.fromJson(Map<String, dynamic> json) {
+    return DreamModelConfig(
+      id: json['id'] as String,
+      speed: json['speed'] != null
+          ? AgentSpeed.fromJson(json['speed'] as String)
+          : null,
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    if (speed != null) 'speed': speed!.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  DreamModelConfig copyWith({String? id, Object? speed = unsetCopyWithValue}) {
+    return DreamModelConfig(
+      id: id ?? this.id,
+      speed: speed == unsetCopyWithValue ? this.speed : speed as AgentSpeed?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DreamModelConfig &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          speed == other.speed;
+
+  @override
+  int get hashCode => Object.hash(id, speed);
+
+  @override
+  String toString() => 'DreamModelConfig(id: $id, speed: $speed)';
+}
+
+/// Model parameter for creating a Dream — either a plain model ID string or a
+/// [DreamModelConfigParams] object.
+///
+/// Variants:
+/// - [DreamModelParamsId] — a plain model ID string.
+/// - [DreamModelConfigParams] — a model configuration object.
+sealed class DreamModelParams {
+  const DreamModelParams();
+
+  /// Creates a [DreamModelParams] from JSON.
+  ///
+  /// If [json] is a [String], returns [DreamModelParamsId].
+  /// Otherwise expects a [Map] and returns [DreamModelConfigParams].
+  static DreamModelParams fromJson(Object json) {
+    if (json is String) {
+      return DreamModelParamsId(id: json);
+    }
+    return DreamModelConfigParams.fromJson(json as Map<String, dynamic>);
+  }
+
+  /// Converts to JSON.
+  Object toJson();
+}
+
+/// A plain model ID string.
+@immutable
+class DreamModelParamsId extends DreamModelParams {
+  /// The model identifier.
+  final String id;
+
+  /// Creates a [DreamModelParamsId].
+  const DreamModelParamsId({required this.id});
+
+  @override
+  Object toJson() => id;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DreamModelParamsId &&
+          runtimeType == other.runtimeType &&
+          id == other.id;
+
+  @override
+  int get hashCode => id.hashCode;
+
+  @override
+  String toString() => 'DreamModelParamsId(id: $id)';
+}
+
+/// Model identifier and configuration applied to every pipeline stage,
+/// supplied when creating a Dream.
+@immutable
+class DreamModelConfigParams extends DreamModelParams {
+  /// Model identifier, e.g. `"claude-opus-4-7"`.
+  final String id;
+
+  /// Inference speed mode. Defaults to `standard`.
+  final AgentSpeed? speed;
+
+  /// Creates a [DreamModelConfigParams].
+  const DreamModelConfigParams({required this.id, this.speed});
+
+  /// Creates a [DreamModelConfigParams] from JSON.
+  factory DreamModelConfigParams.fromJson(Map<String, dynamic> json) {
+    return DreamModelConfigParams(
+      id: json['id'] as String,
+      speed: json['speed'] != null
+          ? AgentSpeed.fromJson(json['speed'] as String)
+          : null,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    if (speed != null) 'speed': speed!.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  DreamModelConfigParams copyWith({
+    String? id,
+    Object? speed = unsetCopyWithValue,
+  }) {
+    return DreamModelConfigParams(
+      id: id ?? this.id,
+      speed: speed == unsetCopyWithValue ? this.speed : speed as AgentSpeed?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DreamModelConfigParams &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          speed == other.speed;
+
+  @override
+  int get hashCode => Object.hash(id, speed);
+
+  @override
+  String toString() => 'DreamModelConfigParams(id: $id, speed: $speed)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/dreams/dream_output.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/dreams/dream_output.dart
@@ -1,0 +1,114 @@
+import 'package:meta/meta.dart';
+
+import '../common/equality_helpers.dart';
+
+/// An output destination a Dream writes consolidated memories into.
+///
+/// Variants:
+/// - [DreamMemoryStoreOutput] — an output memory store (type: `memory_store`)
+/// - [UnknownDreamOutput] — unrecognized type (preserves raw JSON)
+sealed class DreamOutput {
+  const DreamOutput();
+
+  /// Creates a [DreamOutput] from JSON.
+  factory DreamOutput.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    return switch (type) {
+      'memory_store' => DreamMemoryStoreOutput.fromJson(json),
+      _ => UnknownDreamOutput.fromJson(json),
+    };
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson();
+}
+
+/// An output memory store the dream writes consolidated memories into.
+@immutable
+class DreamMemoryStoreOutput extends DreamOutput {
+  /// Object type. Always `memory_store`.
+  final String type;
+
+  /// The ID of the memory store the dream writes to.
+  final String memoryStoreId;
+
+  /// Creates a [DreamMemoryStoreOutput].
+  const DreamMemoryStoreOutput({
+    this.type = 'memory_store',
+    required this.memoryStoreId,
+  });
+
+  /// Creates a [DreamMemoryStoreOutput] from JSON.
+  factory DreamMemoryStoreOutput.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    if (type != 'memory_store') {
+      throw FormatException(
+        'DreamMemoryStoreOutput: expected type "memory_store", got "$type"',
+      );
+    }
+    return DreamMemoryStoreOutput(
+      type: type!,
+      memoryStoreId: json['memory_store_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'memory_store_id': memoryStoreId,
+  };
+
+  /// Creates a copy with replaced values.
+  DreamMemoryStoreOutput copyWith({String? type, String? memoryStoreId}) {
+    return DreamMemoryStoreOutput(
+      type: type ?? this.type,
+      memoryStoreId: memoryStoreId ?? this.memoryStoreId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DreamMemoryStoreOutput &&
+          runtimeType == other.runtimeType &&
+          type == other.type &&
+          memoryStoreId == other.memoryStoreId;
+
+  @override
+  int get hashCode => Object.hash(type, memoryStoreId);
+
+  @override
+  String toString() =>
+      'DreamMemoryStoreOutput(type: $type, memoryStoreId: $memoryStoreId)';
+}
+
+/// Unrecognized [DreamOutput] — preserves raw JSON for forward compatibility.
+@immutable
+class UnknownDreamOutput extends DreamOutput {
+  /// The raw JSON data.
+  final Map<String, dynamic> rawJson;
+
+  /// Creates an [UnknownDreamOutput].
+  const UnknownDreamOutput({required this.rawJson});
+
+  /// Creates an [UnknownDreamOutput] from JSON.
+  factory UnknownDreamOutput.fromJson(Map<String, dynamic> json) {
+    return UnknownDreamOutput(rawJson: json);
+  }
+
+  @override
+  Map<String, dynamic> toJson() => rawJson;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnknownDreamOutput &&
+          runtimeType == other.runtimeType &&
+          mapsDeepEqual(rawJson, other.rawJson);
+
+  @override
+  int get hashCode => mapDeepHashCode(rawJson);
+
+  @override
+  String toString() => 'UnknownDreamOutput(rawJson: $rawJson)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/dreams/dream_status.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/dreams/dream_status.dart
@@ -1,0 +1,38 @@
+/// Lifecycle status of a Dream.
+enum DreamStatus {
+  /// The dream has not started processing yet.
+  pending('pending'),
+
+  /// The dream is actively processing.
+  running('running'),
+
+  /// The dream finished successfully.
+  completed('completed'),
+
+  /// The dream failed. See the dream's `error` field for details.
+  failed('failed'),
+
+  /// The dream was canceled before completion.
+  canceled('canceled'),
+
+  /// Unknown status — fallback for unrecognized values.
+  unknown('unknown');
+
+  const DreamStatus(this.value);
+
+  /// JSON value for this status.
+  final String value;
+
+  /// Parses a [DreamStatus] from JSON.
+  static DreamStatus fromJson(String value) => switch (value) {
+    'pending' => DreamStatus.pending,
+    'running' => DreamStatus.running,
+    'completed' => DreamStatus.completed,
+    'failed' => DreamStatus.failed,
+    'canceled' => DreamStatus.canceled,
+    _ => DreamStatus.unknown,
+  };
+
+  /// Converts this status to JSON.
+  String toJson() => value;
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/dreams/dream_usage.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/dreams/dream_usage.dart
@@ -1,0 +1,85 @@
+import 'package:meta/meta.dart';
+
+/// Cumulative token usage for a Dream across every pipeline stage.
+@immutable
+class DreamUsage {
+  /// Total uncached input tokens consumed across every pipeline stage.
+  final int inputTokens;
+
+  /// Total output tokens generated across every pipeline stage.
+  final int outputTokens;
+
+  /// Total tokens read from prompt cache.
+  final int cacheReadInputTokens;
+
+  /// Total tokens used to create prompt-cache entries (sum of all TTL tiers).
+  final int cacheCreationInputTokens;
+
+  /// Creates a [DreamUsage].
+  const DreamUsage({
+    required this.inputTokens,
+    required this.outputTokens,
+    required this.cacheReadInputTokens,
+    required this.cacheCreationInputTokens,
+  });
+
+  /// Creates a [DreamUsage] from JSON.
+  factory DreamUsage.fromJson(Map<String, dynamic> json) {
+    return DreamUsage(
+      inputTokens: json['input_tokens'] as int,
+      outputTokens: json['output_tokens'] as int,
+      cacheReadInputTokens: json['cache_read_input_tokens'] as int,
+      cacheCreationInputTokens: json['cache_creation_input_tokens'] as int,
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'input_tokens': inputTokens,
+    'output_tokens': outputTokens,
+    'cache_read_input_tokens': cacheReadInputTokens,
+    'cache_creation_input_tokens': cacheCreationInputTokens,
+  };
+
+  /// Creates a copy with replaced values.
+  DreamUsage copyWith({
+    int? inputTokens,
+    int? outputTokens,
+    int? cacheReadInputTokens,
+    int? cacheCreationInputTokens,
+  }) {
+    return DreamUsage(
+      inputTokens: inputTokens ?? this.inputTokens,
+      outputTokens: outputTokens ?? this.outputTokens,
+      cacheReadInputTokens: cacheReadInputTokens ?? this.cacheReadInputTokens,
+      cacheCreationInputTokens:
+          cacheCreationInputTokens ?? this.cacheCreationInputTokens,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is DreamUsage &&
+          runtimeType == other.runtimeType &&
+          inputTokens == other.inputTokens &&
+          outputTokens == other.outputTokens &&
+          cacheReadInputTokens == other.cacheReadInputTokens &&
+          cacheCreationInputTokens == other.cacheCreationInputTokens;
+
+  @override
+  int get hashCode => Object.hash(
+    inputTokens,
+    outputTokens,
+    cacheReadInputTokens,
+    cacheCreationInputTokens,
+  );
+
+  @override
+  String toString() =>
+      'DreamUsage('
+      'inputTokens: $inputTokens, '
+      'outputTokens: $outputTokens, '
+      'cacheReadInputTokens: $cacheReadInputTokens, '
+      'cacheCreationInputTokens: $cacheCreationInputTokens)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/dreams/list_dreams_response.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/dreams/list_dreams_response.dart
@@ -1,0 +1,70 @@
+import 'package:meta/meta.dart';
+
+import '../common/copy_with_sentinel.dart';
+import '../common/equality_helpers.dart';
+import 'dream.dart';
+
+/// Response containing a paginated list of dreams.
+@immutable
+class ListDreamsResponse {
+  /// List of dreams.
+  final List<Dream> data;
+
+  /// Pagination token for the next page, or null if no more results.
+  final String? nextPage;
+
+  /// Creates a [ListDreamsResponse].
+  const ListDreamsResponse({required this.data, this.nextPage});
+
+  /// Creates a [ListDreamsResponse] from JSON.
+  factory ListDreamsResponse.fromJson(Map<String, dynamic> json) {
+    final rawData = json['data'] as List? ?? [];
+    final data = rawData.map((e) {
+      if (e is! Map<String, dynamic>) {
+        throw FormatException(
+          'ListDreamsResponse.data: expected Map, got ${e.runtimeType}',
+        );
+      }
+      return Dream.fromJson(e);
+    }).toList();
+
+    return ListDreamsResponse(
+      data: data,
+      nextPage: json['next_page'] as String?,
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {
+    'data': data.map((e) => e.toJson()).toList(),
+    'next_page': nextPage,
+  };
+
+  /// Creates a copy with replaced values.
+  ListDreamsResponse copyWith({
+    List<Dream>? data,
+    Object? nextPage = unsetCopyWithValue,
+  }) {
+    return ListDreamsResponse(
+      data: data ?? this.data,
+      nextPage: nextPage == unsetCopyWithValue
+          ? this.nextPage
+          : nextPage as String?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ListDreamsResponse &&
+          runtimeType == other.runtimeType &&
+          listsEqual(data, other.data) &&
+          nextPage == other.nextPage;
+
+  @override
+  int get hashCode => Object.hash(listHash(data), nextPage);
+
+  @override
+  String toString() =>
+      'ListDreamsResponse(data: ${data.length} items, nextPage: $nextPage)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/agents/update_agent_params.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/agents/update_agent_params.dart
@@ -17,8 +17,11 @@ const Object _notSet = Object();
 /// Pass `null` explicitly to clear a clearable field.
 @immutable
 class UpdateAgentParams {
-  /// The agent's current version — for optimistic concurrency.
-  final int version;
+  /// The agent's current version, obtained from create/retrieve.
+  ///
+  /// When supplied, the request fails on a version mismatch (optimistic
+  /// concurrency). Omit to apply the update unconditionally.
+  final int? version;
 
   /// Human-readable name. Omit to preserve.
   String? get name => _name == _notSet ? null : _name as String?;
@@ -72,7 +75,7 @@ class UpdateAgentParams {
   /// Omit a field to preserve its current value on the server.
   /// Pass `null` explicitly to clear a clearable field.
   const UpdateAgentParams({
-    required this.version,
+    this.version,
     Object? name = _notSet,
     Object? description = _notSet,
     Object? system = _notSet,
@@ -95,7 +98,7 @@ class UpdateAgentParams {
   /// Creates an [UpdateAgentParams] from JSON.
   factory UpdateAgentParams.fromJson(Map<String, dynamic> json) {
     return UpdateAgentParams(
-      version: json['version'] as int,
+      version: json['version'] as int?,
       name: json.containsKey('name') ? json['name'] as String? : _notSet,
       description: json.containsKey('description')
           ? json['description'] as String?
@@ -146,7 +149,7 @@ class UpdateAgentParams {
   /// Fields explicitly set to `null` are included as `null` to clear
   /// the value on the server.
   Map<String, dynamic> toJson() => {
-    'version': version,
+    if (version != null) 'version': version,
     if (_name != _notSet) 'name': _name,
     if (_description != _notSet) 'description': _description,
     if (_system != _notSet) 'system': _system,
@@ -173,7 +176,7 @@ class UpdateAgentParams {
 
   /// Creates a copy with replaced values.
   UpdateAgentParams copyWith({
-    int? version,
+    Object? version = unsetCopyWithValue,
     Object? name = unsetCopyWithValue,
     Object? description = unsetCopyWithValue,
     Object? system = unsetCopyWithValue,
@@ -185,7 +188,7 @@ class UpdateAgentParams {
     Object? multiagent = unsetCopyWithValue,
   }) {
     return UpdateAgentParams(
-      version: version ?? this.version,
+      version: version == unsetCopyWithValue ? this.version : version as int?,
       name: name == unsetCopyWithValue ? _name : name,
       description: description == unsetCopyWithValue
           ? _description

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/config/effort_params.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/config/effort_params.dart
@@ -1,0 +1,81 @@
+import 'package:meta/meta.dart';
+
+import '../../beta/config/output_config.dart' show EffortLevel;
+
+/// Effort parameter for a session or agent — either a bare effort-level
+/// string or an object carrying a `type` discriminator.
+///
+/// Variants:
+/// - [EffortParamsLevel] — a bare effort-level string (e.g. `"high"`).
+/// - [EffortParamsObject] — an object with a `type` field (e.g.
+///   `{"type": "high"}`).
+sealed class EffortParams {
+  const EffortParams();
+
+  /// Creates an [EffortParams] from JSON.
+  ///
+  /// If [json] is a [String], returns [EffortParamsLevel]. Otherwise expects
+  /// a [Map] and returns [EffortParamsObject].
+  static EffortParams fromJson(Object json) {
+    if (json is String) {
+      return EffortParamsLevel(EffortLevel.fromJson(json));
+    }
+    final map = json as Map<String, dynamic>;
+    return EffortParamsObject(EffortLevel.fromJson(map['type'] as String));
+  }
+
+  /// Converts to JSON.
+  Object toJson();
+}
+
+/// A bare effort-level string, e.g. `"high"`.
+@immutable
+class EffortParamsLevel extends EffortParams {
+  /// The effort level.
+  final EffortLevel level;
+
+  /// Creates an [EffortParamsLevel].
+  const EffortParamsLevel(this.level);
+
+  @override
+  Object toJson() => level.toJson();
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is EffortParamsLevel &&
+          runtimeType == other.runtimeType &&
+          level == other.level;
+
+  @override
+  int get hashCode => level.hashCode;
+
+  @override
+  String toString() => 'EffortParamsLevel(level: $level)';
+}
+
+/// An effort object with a `type` discriminator, e.g. `{"type": "high"}`.
+@immutable
+class EffortParamsObject extends EffortParams {
+  /// The effort level.
+  final EffortLevel level;
+
+  /// Creates an [EffortParamsObject].
+  const EffortParamsObject(this.level);
+
+  @override
+  Object toJson() => {'type': level.toJson()};
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is EffortParamsObject &&
+          runtimeType == other.runtimeType &&
+          level == other.level;
+
+  @override
+  int get hashCode => level.hashCode;
+
+  @override
+  String toString() => 'EffortParamsObject(level: $level)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/config/model_config.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/config/model_config.dart
@@ -4,9 +4,6 @@ import '../../beta/config/output_config.dart' show EffortLevel;
 import '../../common/copy_with_sentinel.dart';
 import 'effort_params.dart';
 
-/// Private sentinel to distinguish "not provided" from explicit `null`.
-const Object _notSet = Object();
-
 /// Inference speed mode for agents.
 enum AgentSpeed {
   /// Standard throughput mode.
@@ -154,8 +151,9 @@ class ModelParamsId extends ModelParams {
 /// A model configuration object with optional speed setting.
 ///
 /// [effort] distinguishes omission from an explicit `null` on update: omitting
-/// the field leaves the stored effort unchanged, while passing `null`
-/// explicitly resets it to the model's default effort.
+/// the field (and [clearEffort]) leaves the stored effort unchanged, while
+/// passing `clearEffort: true` emits an explicit JSON `null` that resets it to
+/// the model's default effort.
 @immutable
 class ModelParamsConfig extends ModelParams {
   /// The model identifier.
@@ -167,21 +165,27 @@ class ModelParamsConfig extends ModelParams {
   /// Response effort level for model generation — a bare level string or an
   /// object with a `type` field.
   ///
-  /// Omit to preserve the current value on update; pass `null` explicitly to
-  /// reset it to the model's default.
-  EffortParams? get effort =>
-      _effort == _notSet ? null : _effort as EffortParams?;
-  final Object? _effort;
+  /// Leave both this and [clearEffort] at their defaults to preserve the
+  /// current value on update; set this to reset it to a new value; or pass
+  /// `clearEffort: true` (with this left `null`) to reset it to the model's
+  /// default.
+  final EffortParams? effort;
+
+  /// Whether to emit an explicit JSON `null` for `effort`, resetting it to
+  /// the model's default. Ignored — and must be `false` — when [effort] is
+  /// non-null.
+  final bool clearEffort;
 
   /// Creates a [ModelParamsConfig].
-  ///
-  /// Omit [effort] to preserve its current value on update. Pass `null`
-  /// explicitly to reset it to the model's default.
   const ModelParamsConfig({
     required this.id,
     this.speed,
-    Object? effort = _notSet,
-  }) : _effort = effort;
+    this.effort,
+    this.clearEffort = false,
+  }) : assert(
+         effort == null || !clearEffort,
+         'Cannot pass both a non-null effort and clearEffort: true',
+       );
 
   /// Creates a [ModelParamsConfig] from JSON.
   factory ModelParamsConfig.fromJson(Map<String, dynamic> json) {
@@ -190,11 +194,10 @@ class ModelParamsConfig extends ModelParams {
       speed: json['speed'] != null
           ? AgentSpeed.fromJson(json['speed'] as String)
           : null,
-      effort: json.containsKey('effort')
-          ? (json['effort'] != null
-                ? EffortParams.fromJson(json['effort'] as Object)
-                : null)
-          : _notSet,
+      effort: json['effort'] != null
+          ? EffortParams.fromJson(json['effort'] as Object)
+          : null,
+      clearEffort: json.containsKey('effort') && json['effort'] == null,
     );
   }
 
@@ -202,22 +205,28 @@ class ModelParamsConfig extends ModelParams {
   Map<String, dynamic> toJson() => {
     'id': id,
     if (speed != null) 'speed': speed!.toJson(),
-    if (_effort != _notSet) 'effort': effort?.toJson(),
+    if (effort != null)
+      'effort': effort!.toJson()
+    else if (clearEffort)
+      'effort': null,
   };
 
   /// Creates a copy with replaced values.
   ///
-  /// Omit [effort] to preserve its current value. Pass `null` explicitly to
-  /// reset it to the model's default.
+  /// Omit [effort] to preserve its current value (including whether it is
+  /// currently marked for clearing). Pass `null` explicitly to reset it to
+  /// the model's default; pass a value to replace it.
   ModelParamsConfig copyWith({
     String? id,
     Object? speed = unsetCopyWithValue,
     Object? effort = unsetCopyWithValue,
   }) {
+    final effortSet = effort != unsetCopyWithValue;
     return ModelParamsConfig(
       id: id ?? this.id,
       speed: speed == unsetCopyWithValue ? this.speed : speed as AgentSpeed?,
-      effort: effort == unsetCopyWithValue ? _effort : effort,
+      effort: effortSet ? effort as EffortParams? : this.effort,
+      clearEffort: effortSet ? effort == null : clearEffort,
     );
   }
 
@@ -228,12 +237,14 @@ class ModelParamsConfig extends ModelParams {
           runtimeType == other.runtimeType &&
           id == other.id &&
           speed == other.speed &&
-          _effort == other._effort;
+          effort == other.effort &&
+          clearEffort == other.clearEffort;
 
   @override
-  int get hashCode => Object.hash(id, speed, _effort);
+  int get hashCode => Object.hash(id, speed, effort, clearEffort);
 
   @override
   String toString() =>
-      'ModelParamsConfig(id: $id, speed: $speed, effort: $effort)';
+      'ModelParamsConfig(id: $id, speed: $speed, effort: $effort, '
+      'clearEffort: $clearEffort)';
 }

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/config/model_config.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/config/model_config.dart
@@ -172,20 +172,22 @@ class ModelParamsConfig extends ModelParams {
   final EffortParams? effort;
 
   /// Whether to emit an explicit JSON `null` for `effort`, resetting it to
-  /// the model's default. Ignored — and must be `false` — when [effort] is
-  /// non-null.
+  /// the model's default.
+  ///
+  /// A non-null [effort] takes precedence: when one is supplied, this is
+  /// normalized to `false`.
   final bool clearEffort;
 
   /// Creates a [ModelParamsConfig].
+  ///
+  /// A non-null [effort] takes precedence over [clearEffort]; passing both
+  /// stores the effort and normalizes [clearEffort] to `false`.
   const ModelParamsConfig({
     required this.id,
     this.speed,
     this.effort,
-    this.clearEffort = false,
-  }) : assert(
-         effort == null || !clearEffort,
-         'Cannot pass both a non-null effort and clearEffort: true',
-       );
+    bool clearEffort = false,
+  }) : clearEffort = effort == null && clearEffort;
 
   /// Creates a [ModelParamsConfig] from JSON.
   factory ModelParamsConfig.fromJson(Map<String, dynamic> json) {
@@ -216,8 +218,10 @@ class ModelParamsConfig extends ModelParams {
   /// Omit [effort] to preserve its current value (including whether it is
   /// currently marked for clearing). Pass `null` explicitly to reset it to
   /// the model's default; pass a value to replace it. Pass
+  /// `clearEffort: true` to clear the inherited effort, or
   /// `clearEffort: false` to return a cleared instance to the omitted /
-  /// no-change state.
+  /// no-change state. As in the constructor, an explicitly supplied non-null
+  /// [effort] takes precedence over `clearEffort: true`.
   ModelParamsConfig copyWith({
     String? id,
     Object? speed = unsetCopyWithValue,
@@ -225,19 +229,14 @@ class ModelParamsConfig extends ModelParams {
     bool? clearEffort,
   }) {
     final effortSet = effort != unsetCopyWithValue;
-    assert(
-      !(clearEffort ?? false) || !effortSet || effort == null,
-      'Cannot pass both a non-null effort and clearEffort: true',
-    );
-    final clear =
-        clearEffort ?? (effortSet ? effort == null : this.clearEffort);
     return ModelParamsConfig(
       id: id ?? this.id,
       speed: speed == unsetCopyWithValue ? this.speed : speed as AgentSpeed?,
-      effort: clear
-          ? null
-          : (effortSet ? effort as EffortParams? : this.effort),
-      clearEffort: clear,
+      effort: effortSet
+          ? effort as EffortParams?
+          : ((clearEffort ?? false) ? null : this.effort),
+      clearEffort:
+          clearEffort ?? (effortSet ? effort == null : this.clearEffort),
     );
   }
 

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/config/model_config.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/config/model_config.dart
@@ -4,6 +4,9 @@ import '../../beta/config/output_config.dart' show EffortLevel;
 import '../../common/copy_with_sentinel.dart';
 import 'effort_params.dart';
 
+/// Private sentinel to distinguish "not provided" from explicit `null`.
+const Object _notSet = Object();
+
 /// Inference speed mode for agents.
 enum AgentSpeed {
   /// Standard throughput mode.
@@ -149,6 +152,10 @@ class ModelParamsId extends ModelParams {
 }
 
 /// A model configuration object with optional speed setting.
+///
+/// [effort] distinguishes omission from an explicit `null` on update: omitting
+/// the field leaves the stored effort unchanged, while passing `null`
+/// explicitly resets it to the model's default effort.
 @immutable
 class ModelParamsConfig extends ModelParams {
   /// The model identifier.
@@ -159,10 +166,22 @@ class ModelParamsConfig extends ModelParams {
 
   /// Response effort level for model generation — a bare level string or an
   /// object with a `type` field.
-  final EffortParams? effort;
+  ///
+  /// Omit to preserve the current value on update; pass `null` explicitly to
+  /// reset it to the model's default.
+  EffortParams? get effort =>
+      _effort == _notSet ? null : _effort as EffortParams?;
+  final Object? _effort;
 
   /// Creates a [ModelParamsConfig].
-  const ModelParamsConfig({required this.id, this.speed, this.effort});
+  ///
+  /// Omit [effort] to preserve its current value on update. Pass `null`
+  /// explicitly to reset it to the model's default.
+  const ModelParamsConfig({
+    required this.id,
+    this.speed,
+    Object? effort = _notSet,
+  }) : _effort = effort;
 
   /// Creates a [ModelParamsConfig] from JSON.
   factory ModelParamsConfig.fromJson(Map<String, dynamic> json) {
@@ -171,9 +190,11 @@ class ModelParamsConfig extends ModelParams {
       speed: json['speed'] != null
           ? AgentSpeed.fromJson(json['speed'] as String)
           : null,
-      effort: json['effort'] != null
-          ? EffortParams.fromJson(json['effort'] as Object)
-          : null,
+      effort: json.containsKey('effort')
+          ? (json['effort'] != null
+                ? EffortParams.fromJson(json['effort'] as Object)
+                : null)
+          : _notSet,
     );
   }
 
@@ -181,10 +202,13 @@ class ModelParamsConfig extends ModelParams {
   Map<String, dynamic> toJson() => {
     'id': id,
     if (speed != null) 'speed': speed!.toJson(),
-    if (effort != null) 'effort': effort!.toJson(),
+    if (_effort != _notSet) 'effort': effort?.toJson(),
   };
 
   /// Creates a copy with replaced values.
+  ///
+  /// Omit [effort] to preserve its current value. Pass `null` explicitly to
+  /// reset it to the model's default.
   ModelParamsConfig copyWith({
     String? id,
     Object? speed = unsetCopyWithValue,
@@ -193,9 +217,7 @@ class ModelParamsConfig extends ModelParams {
     return ModelParamsConfig(
       id: id ?? this.id,
       speed: speed == unsetCopyWithValue ? this.speed : speed as AgentSpeed?,
-      effort: effort == unsetCopyWithValue
-          ? this.effort
-          : effort as EffortParams?,
+      effort: effort == unsetCopyWithValue ? _effort : effort,
     );
   }
 
@@ -206,10 +228,10 @@ class ModelParamsConfig extends ModelParams {
           runtimeType == other.runtimeType &&
           id == other.id &&
           speed == other.speed &&
-          effort == other.effort;
+          _effort == other._effort;
 
   @override
-  int get hashCode => Object.hash(id, speed, effort);
+  int get hashCode => Object.hash(id, speed, _effort);
 
   @override
   String toString() =>

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/config/model_config.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/config/model_config.dart
@@ -1,6 +1,8 @@
 import 'package:meta/meta.dart';
 
+import '../../beta/config/output_config.dart' show EffortLevel;
 import '../../common/copy_with_sentinel.dart';
+import 'effort_params.dart';
 
 /// Inference speed mode for agents.
 enum AgentSpeed {
@@ -38,8 +40,11 @@ class ModelConfig {
   /// Inference speed mode.
   final AgentSpeed? speed;
 
+  /// Response effort level for model generation, e.g. `{"type": "high"}`.
+  final EffortLevel? effort;
+
   /// Creates a [ModelConfig].
-  const ModelConfig({required this.id, this.speed});
+  const ModelConfig({required this.id, this.speed, this.effort});
 
   /// Creates a [ModelConfig] from JSON.
   factory ModelConfig.fromJson(Map<String, dynamic> json) {
@@ -48,6 +53,11 @@ class ModelConfig {
       speed: json['speed'] != null
           ? AgentSpeed.fromJson(json['speed'] as String)
           : null,
+      effort: json['effort'] != null
+          ? EffortLevel.fromJson(
+              (json['effort'] as Map<String, dynamic>)['type'] as String,
+            )
+          : null,
     );
   }
 
@@ -55,13 +65,21 @@ class ModelConfig {
   Map<String, dynamic> toJson() => {
     'id': id,
     if (speed != null) 'speed': speed!.toJson(),
+    if (effort != null) 'effort': {'type': effort!.toJson()},
   };
 
   /// Creates a copy with replaced values.
-  ModelConfig copyWith({String? id, Object? speed = unsetCopyWithValue}) {
+  ModelConfig copyWith({
+    String? id,
+    Object? speed = unsetCopyWithValue,
+    Object? effort = unsetCopyWithValue,
+  }) {
     return ModelConfig(
       id: id ?? this.id,
       speed: speed == unsetCopyWithValue ? this.speed : speed as AgentSpeed?,
+      effort: effort == unsetCopyWithValue
+          ? this.effort
+          : effort as EffortLevel?,
     );
   }
 
@@ -71,13 +89,14 @@ class ModelConfig {
       other is ModelConfig &&
           runtimeType == other.runtimeType &&
           id == other.id &&
-          speed == other.speed;
+          speed == other.speed &&
+          effort == other.effort;
 
   @override
-  int get hashCode => Object.hash(id, speed);
+  int get hashCode => Object.hash(id, speed, effort);
 
   @override
-  String toString() => 'ModelConfig(id: $id, speed: $speed)';
+  String toString() => 'ModelConfig(id: $id, speed: $speed, effort: $effort)';
 }
 
 /// Model parameter — either a simple model ID string or a [ModelConfig].
@@ -138,8 +157,12 @@ class ModelParamsConfig extends ModelParams {
   /// Inference speed mode.
   final AgentSpeed? speed;
 
+  /// Response effort level for model generation — a bare level string or an
+  /// object with a `type` field.
+  final EffortParams? effort;
+
   /// Creates a [ModelParamsConfig].
-  const ModelParamsConfig({required this.id, this.speed});
+  const ModelParamsConfig({required this.id, this.speed, this.effort});
 
   /// Creates a [ModelParamsConfig] from JSON.
   factory ModelParamsConfig.fromJson(Map<String, dynamic> json) {
@@ -148,6 +171,9 @@ class ModelParamsConfig extends ModelParams {
       speed: json['speed'] != null
           ? AgentSpeed.fromJson(json['speed'] as String)
           : null,
+      effort: json['effort'] != null
+          ? EffortParams.fromJson(json['effort'] as Object)
+          : null,
     );
   }
 
@@ -155,7 +181,23 @@ class ModelParamsConfig extends ModelParams {
   Map<String, dynamic> toJson() => {
     'id': id,
     if (speed != null) 'speed': speed!.toJson(),
+    if (effort != null) 'effort': effort!.toJson(),
   };
+
+  /// Creates a copy with replaced values.
+  ModelParamsConfig copyWith({
+    String? id,
+    Object? speed = unsetCopyWithValue,
+    Object? effort = unsetCopyWithValue,
+  }) {
+    return ModelParamsConfig(
+      id: id ?? this.id,
+      speed: speed == unsetCopyWithValue ? this.speed : speed as AgentSpeed?,
+      effort: effort == unsetCopyWithValue
+          ? this.effort
+          : effort as EffortParams?,
+    );
+  }
 
   @override
   bool operator ==(Object other) =>
@@ -163,11 +205,13 @@ class ModelParamsConfig extends ModelParams {
       other is ModelParamsConfig &&
           runtimeType == other.runtimeType &&
           id == other.id &&
-          speed == other.speed;
+          speed == other.speed &&
+          effort == other.effort;
 
   @override
-  int get hashCode => Object.hash(id, speed);
+  int get hashCode => Object.hash(id, speed, effort);
 
   @override
-  String toString() => 'ModelParamsConfig(id: $id, speed: $speed)';
+  String toString() =>
+      'ModelParamsConfig(id: $id, speed: $speed, effort: $effort)';
 }

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/config/model_config.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/config/model_config.dart
@@ -225,12 +225,19 @@ class ModelParamsConfig extends ModelParams {
     bool? clearEffort,
   }) {
     final effortSet = effort != unsetCopyWithValue;
+    assert(
+      !(clearEffort ?? false) || !effortSet || effort == null,
+      'Cannot pass both a non-null effort and clearEffort: true',
+    );
+    final clear =
+        clearEffort ?? (effortSet ? effort == null : this.clearEffort);
     return ModelParamsConfig(
       id: id ?? this.id,
       speed: speed == unsetCopyWithValue ? this.speed : speed as AgentSpeed?,
-      effort: effortSet ? effort as EffortParams? : this.effort,
-      clearEffort:
-          clearEffort ?? (effortSet ? effort == null : this.clearEffort),
+      effort: clear
+          ? null
+          : (effortSet ? effort as EffortParams? : this.effort),
+      clearEffort: clear,
     );
   }
 

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/config/model_config.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/config/model_config.dart
@@ -215,18 +215,22 @@ class ModelParamsConfig extends ModelParams {
   ///
   /// Omit [effort] to preserve its current value (including whether it is
   /// currently marked for clearing). Pass `null` explicitly to reset it to
-  /// the model's default; pass a value to replace it.
+  /// the model's default; pass a value to replace it. Pass
+  /// `clearEffort: false` to return a cleared instance to the omitted /
+  /// no-change state.
   ModelParamsConfig copyWith({
     String? id,
     Object? speed = unsetCopyWithValue,
     Object? effort = unsetCopyWithValue,
+    bool? clearEffort,
   }) {
     final effortSet = effort != unsetCopyWithValue;
     return ModelParamsConfig(
       id: id ?? this.id,
       speed: speed == unsetCopyWithValue ? this.speed : speed as AgentSpeed?,
       effort: effortSet ? effort as EffortParams? : this.effort,
-      clearEffort: effortSet ? effort == null : clearEffort,
+      clearEffort:
+          clearEffort ?? (effortSet ? effort == null : this.clearEffort),
     );
   }
 

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/create_session_params.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/create_session_params.dart
@@ -7,6 +7,7 @@ import '../config/agent_tool.dart';
 import '../config/mcp_server.dart';
 import '../config/model_config.dart';
 import '../resources/session_resource_params.dart';
+import 'session_initial_event_params.dart';
 
 /// Private sentinel to distinguish "not provided" from explicit `null`.
 const Object _notSet = Object();
@@ -305,6 +306,9 @@ class CreateSessionParams {
   /// Resources to mount into the session's container.
   final List<SessionResourceParams>? resources;
 
+  /// Events sent to the session immediately after it is created.
+  final List<SessionInitialEventParams>? initialEvents;
+
   /// Creates a [CreateSessionParams].
   const CreateSessionParams({
     required this.agent,
@@ -313,6 +317,7 @@ class CreateSessionParams {
     this.metadata,
     this.vaultIds,
     this.resources,
+    this.initialEvents,
   });
 
   /// Creates a [CreateSessionParams] from JSON.
@@ -330,6 +335,12 @@ class CreateSessionParams {
             (e) => SessionResourceParams.fromJson(e as Map<String, dynamic>),
           )
           .toList(),
+      initialEvents: (json['initial_events'] as List?)
+          ?.map(
+            (e) =>
+                SessionInitialEventParams.fromJson(e as Map<String, dynamic>),
+          )
+          .toList(),
     );
   }
 
@@ -342,6 +353,8 @@ class CreateSessionParams {
     if (vaultIds != null) 'vault_ids': vaultIds,
     if (resources != null)
       'resources': resources!.map((e) => e.toJson()).toList(),
+    if (initialEvents != null)
+      'initial_events': initialEvents!.map((e) => e.toJson()).toList(),
   };
 
   /// Creates a copy with replaced values.
@@ -352,6 +365,7 @@ class CreateSessionParams {
     Object? metadata = unsetCopyWithValue,
     Object? vaultIds = unsetCopyWithValue,
     Object? resources = unsetCopyWithValue,
+    Object? initialEvents = unsetCopyWithValue,
   }) {
     return CreateSessionParams(
       agent: agent ?? this.agent,
@@ -366,6 +380,9 @@ class CreateSessionParams {
       resources: resources == unsetCopyWithValue
           ? this.resources
           : resources as List<SessionResourceParams>?,
+      initialEvents: initialEvents == unsetCopyWithValue
+          ? this.initialEvents
+          : initialEvents as List<SessionInitialEventParams>?,
     );
   }
 
@@ -379,7 +396,8 @@ class CreateSessionParams {
           title == other.title &&
           mapsEqual(metadata, other.metadata) &&
           listsEqual(vaultIds, other.vaultIds) &&
-          listsEqual(resources, other.resources);
+          listsEqual(resources, other.resources) &&
+          listsEqual(initialEvents, other.initialEvents);
 
   @override
   int get hashCode => Object.hash(
@@ -389,6 +407,7 @@ class CreateSessionParams {
     mapHash(metadata),
     listHash(vaultIds),
     listHash(resources),
+    listHash(initialEvents),
   );
 
   @override
@@ -399,5 +418,6 @@ class CreateSessionParams {
       'title: $title, '
       'metadata: $metadata, '
       'vaultIds: $vaultIds, '
-      'resources: $resources)';
+      'resources: $resources, '
+      'initialEvents: $initialEvents)';
 }

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/session_initial_event_params.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/sessions/session_initial_event_params.dart
@@ -1,0 +1,147 @@
+import 'package:meta/meta.dart';
+
+import '../../common/equality_helpers.dart';
+import '../events/send_event_params.dart'
+    show UserDefineOutcomeEventParams, UserMessageEventParams;
+
+/// An event sent to a session immediately after it is created (create side).
+///
+/// Supports `user.message` and `user.define_outcome`. This is a narrowed view
+/// of the broader `EventParams` union: the API accepts only these two event
+/// types as session initial events, so the variants below wrap the existing
+/// param classes rather than duplicating them.
+///
+/// Variants:
+/// - [SessionUserMessageEventParams] — wraps [UserMessageEventParams]
+///   (type: "user.message")
+/// - [SessionUserDefineOutcomeEventParams] — wraps
+///   [UserDefineOutcomeEventParams] (type: "user.define_outcome")
+/// - [UnknownSessionInitialEventParams] — Unrecognized type (preserves raw
+///   JSON)
+sealed class SessionInitialEventParams {
+  const SessionInitialEventParams();
+
+  /// Creates a [SessionInitialEventParams] from JSON.
+  factory SessionInitialEventParams.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    return switch (type) {
+      'user.message' => SessionUserMessageEventParams(
+        UserMessageEventParams.fromJson(json),
+      ),
+      'user.define_outcome' => SessionUserDefineOutcomeEventParams(
+        UserDefineOutcomeEventParams.fromJson(json),
+      ),
+      _ => UnknownSessionInitialEventParams(rawJson: json),
+    };
+  }
+
+  /// Wraps a [UserMessageEventParams] as a session initial event.
+  const factory SessionInitialEventParams.userMessage(
+    UserMessageEventParams params,
+  ) = SessionUserMessageEventParams;
+
+  /// Wraps a [UserDefineOutcomeEventParams] as a session initial event.
+  const factory SessionInitialEventParams.userDefineOutcome(
+    UserDefineOutcomeEventParams params,
+  ) = SessionUserDefineOutcomeEventParams;
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson();
+}
+
+/// A `user.message` session initial event, wrapping a
+/// [UserMessageEventParams].
+@immutable
+class SessionUserMessageEventParams extends SessionInitialEventParams {
+  /// The wrapped user message params.
+  final UserMessageEventParams params;
+
+  /// Creates a [SessionUserMessageEventParams].
+  const SessionUserMessageEventParams(this.params);
+
+  @override
+  Map<String, dynamic> toJson() => params.toJson();
+
+  /// Creates a copy with replaced values.
+  SessionUserMessageEventParams copyWith({UserMessageEventParams? params}) {
+    return SessionUserMessageEventParams(params ?? this.params);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SessionUserMessageEventParams &&
+          runtimeType == other.runtimeType &&
+          params == other.params;
+
+  @override
+  int get hashCode => params.hashCode;
+
+  @override
+  String toString() => 'SessionUserMessageEventParams(params: $params)';
+}
+
+/// A `user.define_outcome` session initial event, wrapping a
+/// [UserDefineOutcomeEventParams].
+@immutable
+class SessionUserDefineOutcomeEventParams extends SessionInitialEventParams {
+  /// The wrapped define-outcome params.
+  final UserDefineOutcomeEventParams params;
+
+  /// Creates a [SessionUserDefineOutcomeEventParams].
+  const SessionUserDefineOutcomeEventParams(this.params);
+
+  @override
+  Map<String, dynamic> toJson() => params.toJson();
+
+  /// Creates a copy with replaced values.
+  SessionUserDefineOutcomeEventParams copyWith({
+    UserDefineOutcomeEventParams? params,
+  }) {
+    return SessionUserDefineOutcomeEventParams(params ?? this.params);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SessionUserDefineOutcomeEventParams &&
+          runtimeType == other.runtimeType &&
+          params == other.params;
+
+  @override
+  int get hashCode => params.hashCode;
+
+  @override
+  String toString() => 'SessionUserDefineOutcomeEventParams(params: $params)';
+}
+
+/// Unrecognized session initial event params (preserves raw JSON).
+@immutable
+class UnknownSessionInitialEventParams extends SessionInitialEventParams {
+  /// The raw JSON data.
+  final Map<String, dynamic> rawJson;
+
+  /// Creates an [UnknownSessionInitialEventParams].
+  const UnknownSessionInitialEventParams({required this.rawJson});
+
+  /// Creates an [UnknownSessionInitialEventParams] from JSON.
+  factory UnknownSessionInitialEventParams.fromJson(Map<String, dynamic> json) {
+    return UnknownSessionInitialEventParams(rawJson: json);
+  }
+
+  @override
+  Map<String, dynamic> toJson() => rawJson;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnknownSessionInitialEventParams &&
+          runtimeType == other.runtimeType &&
+          mapsDeepEqual(rawJson, other.rawJson);
+
+  @override
+  int get hashCode => mapDeepHashCode(rawJson);
+
+  @override
+  String toString() => 'UnknownSessionInitialEventParams(rawJson: $rawJson)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/managed_agents/webhooks/webhook_event.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/managed_agents/webhooks/webhook_event.dart
@@ -119,6 +119,13 @@ class WebhookEvent {
 /// - [WebhookDeploymentRunStartedEventData] — `deployment_run.started`.
 /// - [WebhookDeploymentRunSucceededEventData] — `deployment_run.succeeded`.
 /// - [WebhookDeploymentRunFailedEventData] — `deployment_run.failed`.
+/// - [WebhookEnvironmentArchivedEventData] — `environment.archived`.
+/// - [WebhookEnvironmentCreatedEventData] — `environment.created`.
+/// - [WebhookEnvironmentDeletedEventData] — `environment.deleted`.
+/// - [WebhookEnvironmentUpdatedEventData] — `environment.updated`.
+/// - [WebhookMemoryStoreArchivedEventData] — `memory_store.archived`.
+/// - [WebhookMemoryStoreCreatedEventData] — `memory_store.created`.
+/// - [WebhookMemoryStoreDeletedEventData] — `memory_store.deleted`.
 /// - [UnknownWebhookEventData] — unrecognized event-data type, for forward
 ///   compatibility.
 sealed class WebhookEventData {
@@ -190,6 +197,27 @@ sealed class WebhookEventData {
       'deployment_run.succeeded' =>
         WebhookDeploymentRunSucceededEventData.fromJson(json),
       'deployment_run.failed' => WebhookDeploymentRunFailedEventData.fromJson(
+        json,
+      ),
+      'environment.archived' => WebhookEnvironmentArchivedEventData.fromJson(
+        json,
+      ),
+      'environment.created' => WebhookEnvironmentCreatedEventData.fromJson(
+        json,
+      ),
+      'environment.deleted' => WebhookEnvironmentDeletedEventData.fromJson(
+        json,
+      ),
+      'environment.updated' => WebhookEnvironmentUpdatedEventData.fromJson(
+        json,
+      ),
+      'memory_store.archived' => WebhookMemoryStoreArchivedEventData.fromJson(
+        json,
+      ),
+      'memory_store.created' => WebhookMemoryStoreCreatedEventData.fromJson(
+        json,
+      ),
+      'memory_store.deleted' => WebhookMemoryStoreDeletedEventData.fromJson(
         json,
       ),
       _ => UnknownWebhookEventData(rawJson: json),
@@ -2832,6 +2860,510 @@ class WebhookDeploymentRunFailedEventData extends WebhookEventData {
   @override
   String toString() =>
       'WebhookDeploymentRunFailedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling an environment was archived.
+@immutable
+class WebhookEnvironmentArchivedEventData extends WebhookEventData {
+  /// The event-data type, always 'environment.archived'.
+  String get type => 'environment.archived';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookEnvironmentArchivedEventData].
+  const WebhookEnvironmentArchivedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookEnvironmentArchivedEventData] from JSON.
+  factory WebhookEnvironmentArchivedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookEnvironmentArchivedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookEnvironmentArchivedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookEnvironmentArchivedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookEnvironmentArchivedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookEnvironmentArchivedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling an environment was created.
+@immutable
+class WebhookEnvironmentCreatedEventData extends WebhookEventData {
+  /// The event-data type, always 'environment.created'.
+  String get type => 'environment.created';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookEnvironmentCreatedEventData].
+  const WebhookEnvironmentCreatedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookEnvironmentCreatedEventData] from JSON.
+  factory WebhookEnvironmentCreatedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookEnvironmentCreatedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookEnvironmentCreatedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookEnvironmentCreatedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookEnvironmentCreatedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookEnvironmentCreatedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling an environment was deleted.
+@immutable
+class WebhookEnvironmentDeletedEventData extends WebhookEventData {
+  /// The event-data type, always 'environment.deleted'.
+  String get type => 'environment.deleted';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookEnvironmentDeletedEventData].
+  const WebhookEnvironmentDeletedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookEnvironmentDeletedEventData] from JSON.
+  factory WebhookEnvironmentDeletedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookEnvironmentDeletedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookEnvironmentDeletedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookEnvironmentDeletedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookEnvironmentDeletedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookEnvironmentDeletedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling an environment was updated.
+@immutable
+class WebhookEnvironmentUpdatedEventData extends WebhookEventData {
+  /// The event-data type, always 'environment.updated'.
+  String get type => 'environment.updated';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookEnvironmentUpdatedEventData].
+  const WebhookEnvironmentUpdatedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookEnvironmentUpdatedEventData] from JSON.
+  factory WebhookEnvironmentUpdatedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookEnvironmentUpdatedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookEnvironmentUpdatedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookEnvironmentUpdatedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookEnvironmentUpdatedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookEnvironmentUpdatedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a memory store was archived.
+@immutable
+class WebhookMemoryStoreArchivedEventData extends WebhookEventData {
+  /// The event-data type, always 'memory_store.archived'.
+  String get type => 'memory_store.archived';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookMemoryStoreArchivedEventData].
+  const WebhookMemoryStoreArchivedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookMemoryStoreArchivedEventData] from JSON.
+  factory WebhookMemoryStoreArchivedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookMemoryStoreArchivedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookMemoryStoreArchivedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookMemoryStoreArchivedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookMemoryStoreArchivedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookMemoryStoreArchivedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a memory store was created.
+@immutable
+class WebhookMemoryStoreCreatedEventData extends WebhookEventData {
+  /// The event-data type, always 'memory_store.created'.
+  String get type => 'memory_store.created';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookMemoryStoreCreatedEventData].
+  const WebhookMemoryStoreCreatedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookMemoryStoreCreatedEventData] from JSON.
+  factory WebhookMemoryStoreCreatedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookMemoryStoreCreatedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookMemoryStoreCreatedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookMemoryStoreCreatedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookMemoryStoreCreatedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookMemoryStoreCreatedEventData(id: $id, organizationId: $organizationId, '
+      'workspaceId: $workspaceId)';
+}
+
+/// Webhook event data signalling a memory store was deleted.
+@immutable
+class WebhookMemoryStoreDeletedEventData extends WebhookEventData {
+  /// The event-data type, always 'memory_store.deleted'.
+  String get type => 'memory_store.deleted';
+
+  /// ID of the resource this event concerns.
+  final String id;
+
+  /// ID of the organization that owns the resource.
+  final String organizationId;
+
+  /// ID of the workspace that owns the resource.
+  final String workspaceId;
+
+  /// Creates a [WebhookMemoryStoreDeletedEventData].
+  const WebhookMemoryStoreDeletedEventData({
+    required this.id,
+    required this.organizationId,
+    required this.workspaceId,
+  });
+
+  /// Creates a [WebhookMemoryStoreDeletedEventData] from JSON.
+  factory WebhookMemoryStoreDeletedEventData.fromJson(
+    Map<String, dynamic> json,
+  ) {
+    return WebhookMemoryStoreDeletedEventData(
+      id: json['id'] as String,
+      organizationId: json['organization_id'] as String,
+      workspaceId: json['workspace_id'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': type,
+    'id': id,
+    'organization_id': organizationId,
+    'workspace_id': workspaceId,
+  };
+
+  /// Creates a copy with replaced values.
+  WebhookMemoryStoreDeletedEventData copyWith({
+    String? id,
+    String? organizationId,
+    String? workspaceId,
+  }) {
+    return WebhookMemoryStoreDeletedEventData(
+      id: id ?? this.id,
+      organizationId: organizationId ?? this.organizationId,
+      workspaceId: workspaceId ?? this.workspaceId,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is WebhookMemoryStoreDeletedEventData &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          organizationId == other.organizationId &&
+          workspaceId == other.workspaceId;
+
+  @override
+  int get hashCode => Object.hash(id, organizationId, workspaceId);
+
+  @override
+  String toString() =>
+      'WebhookMemoryStoreDeletedEventData(id: $id, organizationId: $organizationId, '
       'workspaceId: $workspaceId)';
 }
 

--- a/packages/anthropic_sdk_dart/lib/src/models/messages/fallback_credit_token_param.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/messages/fallback_credit_token_param.dart
@@ -1,0 +1,159 @@
+import 'package:meta/meta.dart';
+
+import '../common/copy_with_sentinel.dart';
+
+/// How a failing fallback-credit token affects a retry.
+enum FallbackCreditMode {
+  /// The default, and the bare-string behavior: a failing redemption is a 400
+  /// and the retry is not served.
+  strict('strict'),
+
+  /// The retry is served either way — a token-layer failure no longer
+  /// rejects the request; the retry proceeds at normal price and the outcome
+  /// is reported on the response's `usage.fallback_credit`.
+  ///
+  /// Two failures stay hard in both modes: a malformed token, and combining
+  /// `fallback_credit_token` with `fallbacks`.
+  bestEffort('best_effort');
+
+  const FallbackCreditMode(this.value);
+
+  /// JSON value for this mode.
+  final String value;
+
+  /// Parses a [FallbackCreditMode] from JSON.
+  static FallbackCreditMode fromJson(String value) => switch (value) {
+    'strict' => strict,
+    'best_effort' => bestEffort,
+    _ => throw FormatException('Unknown FallbackCreditMode: $value'),
+  };
+
+  /// Converts this mode to JSON.
+  String toJson() => value;
+}
+
+/// `fallback_credit_token` request parameter — either a bare opaque token
+/// string, or a [FallbackCreditTokenParamConfig] object pairing the token
+/// with a redemption [FallbackCreditMode].
+///
+/// The bare string and the mode-less object are equivalent (both select
+/// [FallbackCreditMode.strict]), so wrapping an existing token changes
+/// nothing by itself. The object form requires the
+/// `anthropic-beta: fallback-credit-2026-07-01` header; without that header
+/// the field accepts the bare string only.
+///
+/// Variants:
+/// - [FallbackCreditTokenParamToken] — a plain opaque token string.
+/// - [FallbackCreditTokenParamConfig] — a token plus an optional
+///   [FallbackCreditMode].
+sealed class FallbackCreditTokenParam {
+  const FallbackCreditTokenParam();
+
+  /// Creates a [FallbackCreditTokenParamToken] from a bare token string.
+  const factory FallbackCreditTokenParam.token(String token) =
+      FallbackCreditTokenParamToken;
+
+  /// Creates a [FallbackCreditTokenParamConfig] with an optional redemption
+  /// [mode].
+  const factory FallbackCreditTokenParam.config({
+    required String token,
+    FallbackCreditMode? mode,
+  }) = FallbackCreditTokenParamConfig;
+
+  /// Creates a [FallbackCreditTokenParam] from JSON.
+  ///
+  /// If [json] is a [String], returns [FallbackCreditTokenParamToken].
+  /// Otherwise expects a [Map] and returns [FallbackCreditTokenParamConfig].
+  static FallbackCreditTokenParam fromJson(Object json) {
+    if (json is String) {
+      return FallbackCreditTokenParamToken(json);
+    }
+    return FallbackCreditTokenParamConfig.fromJson(
+      json as Map<String, dynamic>,
+    );
+  }
+
+  /// Converts to JSON.
+  Object toJson();
+}
+
+/// A plain opaque fallback-credit token string.
+@immutable
+class FallbackCreditTokenParamToken extends FallbackCreditTokenParam {
+  /// The opaque `fallback_credit_token` from a prior refusal's
+  /// `stop_details`.
+  final String token;
+
+  /// Creates a [FallbackCreditTokenParamToken].
+  const FallbackCreditTokenParamToken(this.token);
+
+  @override
+  Object toJson() => token;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FallbackCreditTokenParamToken &&
+          runtimeType == other.runtimeType &&
+          token == other.token;
+
+  @override
+  int get hashCode => token.hashCode;
+
+  @override
+  String toString() => 'FallbackCreditTokenParamToken(token: [redacted])';
+}
+
+/// A fallback-credit token paired with a redemption mode.
+@immutable
+class FallbackCreditTokenParamConfig extends FallbackCreditTokenParam {
+  /// The opaque `fallback_credit_token` from a prior refusal's
+  /// `stop_details` — the same string the bare-string form carries.
+  final String token;
+
+  /// How a failing token affects the retry.
+  final FallbackCreditMode? mode;
+
+  /// Creates a [FallbackCreditTokenParamConfig].
+  const FallbackCreditTokenParamConfig({required this.token, this.mode});
+
+  /// Creates a [FallbackCreditTokenParamConfig] from JSON.
+  factory FallbackCreditTokenParamConfig.fromJson(Map<String, dynamic> json) {
+    return FallbackCreditTokenParamConfig(
+      token: json['token'] as String,
+      mode: json['mode'] != null
+          ? FallbackCreditMode.fromJson(json['mode'] as String)
+          : null,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'token': token,
+    if (mode != null) 'mode': mode!.toJson(),
+  };
+
+  /// Creates a copy with replaced values.
+  FallbackCreditTokenParamConfig copyWith({
+    String? token,
+    Object? mode = unsetCopyWithValue,
+  }) => FallbackCreditTokenParamConfig(
+    token: token ?? this.token,
+    mode: mode == unsetCopyWithValue ? this.mode : mode as FallbackCreditMode?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FallbackCreditTokenParamConfig &&
+          runtimeType == other.runtimeType &&
+          token == other.token &&
+          mode == other.mode;
+
+  @override
+  int get hashCode => Object.hash(token, mode);
+
+  @override
+  String toString() =>
+      'FallbackCreditTokenParamConfig(token: [redacted], mode: $mode)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/messages/message_create_request.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/messages/message_create_request.dart
@@ -11,6 +11,7 @@ import '../tools/tool_choice.dart';
 import '../tools/tool_definition.dart';
 import 'diagnostics_param.dart';
 import 'fallback_config.dart';
+import 'fallback_credit_token_param.dart';
 import 'input_message.dart';
 import 'thinking_config.dart';
 
@@ -229,8 +230,13 @@ class MessageCreateRequest {
   ///
   /// Pass the `fallbackCreditToken` from a prior refusal's
   /// [RefusalStopDetails] to refund the cache-miss cost when retrying the
-  /// refused request.
-  final String? fallbackCreditToken;
+  /// refused request. A bare [FallbackCreditTokenParam.token] selects strict
+  /// redemption mode (the default). The object form,
+  /// [FallbackCreditTokenParam.config], additionally lets a caller select
+  /// [FallbackCreditMode.bestEffort] — but requires the
+  /// `anthropic-beta: fallback-credit-2026-07-01` header; without that header
+  /// the field accepts the bare string only.
+  final FallbackCreditTokenParam? fallbackCreditToken;
 
   /// Creates a [MessageCreateRequest].
   const MessageCreateRequest({
@@ -310,7 +316,9 @@ class MessageCreateRequest {
       fallbacks: (json['fallbacks'] as List?)
           ?.map((e) => FallbackConfigV2.fromJson(e as Map<String, dynamic>))
           .toList(),
-      fallbackCreditToken: json['fallback_credit_token'] as String?,
+      fallbackCreditToken: json['fallback_credit_token'] != null
+          ? FallbackCreditTokenParam.fromJson(json['fallback_credit_token'])
+          : null,
     );
   }
 
@@ -339,7 +347,7 @@ class MessageCreateRequest {
     if (fallbacks != null)
       'fallbacks': fallbacks!.map((e) => e.toJson()).toList(),
     if (fallbackCreditToken != null)
-      'fallback_credit_token': fallbackCreditToken,
+      'fallback_credit_token': fallbackCreditToken!.toJson(),
   };
 
   /// Creates a copy with replaced values.
@@ -419,7 +427,7 @@ class MessageCreateRequest {
           : fallbacks as List<FallbackConfigV2>?,
       fallbackCreditToken: fallbackCreditToken == unsetCopyWithValue
           ? this.fallbackCreditToken
-          : fallbackCreditToken as String?,
+          : fallbackCreditToken as FallbackCreditTokenParam?,
     );
   }
 

--- a/packages/anthropic_sdk_dart/lib/src/models/metadata/fallback_credit_usage.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/metadata/fallback_credit_usage.dart
@@ -95,7 +95,7 @@ sealed class FallbackCreditStatus {
   const factory FallbackCreditStatus.redeemed() = FallbackCreditRedeemed;
 
   /// Creates a [FallbackCreditNotApplied] status.
-  const factory FallbackCreditStatus.notApplied({
+  factory FallbackCreditStatus.notApplied({
     required FallbackCreditNotAppliedReason reason,
     List<String>? removeToRedeem,
   }) = FallbackCreditNotApplied;
@@ -154,8 +154,16 @@ class FallbackCreditRedeemed extends FallbackCreditStatus {
 /// No reprice was applied; [reason] says why.
 @immutable
 class FallbackCreditNotApplied extends FallbackCreditStatus {
-  /// Why the reprice was not applied.
-  final FallbackCreditNotAppliedReason reason;
+  /// The raw wire value for [reason], preserved verbatim.
+  ///
+  /// Kept alongside the derived [reason] getter so an unrecognized reason
+  /// round-trips through `fromJson`/`toJson` instead of being collapsed to
+  /// the literal string `"unknown"`.
+  final String rawReason;
+
+  /// Why the reprice was not applied, derived from [rawReason].
+  FallbackCreditNotAppliedReason get reason =>
+      FallbackCreditNotAppliedReason.fromJson(rawReason);
 
   /// Request fields to remove before retrying, so the retry can redeem this
   /// token.
@@ -170,7 +178,17 @@ class FallbackCreditNotApplied extends FallbackCreditStatus {
   final List<String>? removeToRedeem;
 
   /// Creates a [FallbackCreditNotApplied].
-  const FallbackCreditNotApplied({required this.reason, this.removeToRedeem});
+  FallbackCreditNotApplied({
+    required FallbackCreditNotAppliedReason reason,
+    this.removeToRedeem,
+  }) : rawReason = reason.value;
+
+  /// Creates a [FallbackCreditNotApplied], preserving [rawReason] verbatim
+  /// even when it does not match a known [FallbackCreditNotAppliedReason].
+  const FallbackCreditNotApplied.raw({
+    required this.rawReason,
+    this.removeToRedeem,
+  });
 
   /// Creates a [FallbackCreditNotApplied] from JSON.
   factory FallbackCreditNotApplied.fromJson(Map<String, dynamic> json) {
@@ -181,8 +199,8 @@ class FallbackCreditNotApplied extends FallbackCreditStatus {
       );
     }
     final rawRemoveToRedeem = json['remove_to_redeem'] as List?;
-    return FallbackCreditNotApplied(
-      reason: FallbackCreditNotAppliedReason.fromJson(json['reason'] as String),
+    return FallbackCreditNotApplied.raw(
+      rawReason: json['reason'] as String,
       removeToRedeem: rawRemoveToRedeem?.map((e) {
         if (e is! String) {
           throw FormatException(
@@ -197,7 +215,7 @@ class FallbackCreditNotApplied extends FallbackCreditStatus {
   @override
   Map<String, dynamic> toJson() => {
     'type': 'not_applied',
-    'reason': reason.toJson(),
+    'reason': rawReason,
     if (removeToRedeem != null) 'remove_to_redeem': removeToRedeem,
   };
 
@@ -205,8 +223,8 @@ class FallbackCreditNotApplied extends FallbackCreditStatus {
   FallbackCreditNotApplied copyWith({
     FallbackCreditNotAppliedReason? reason,
     Object? removeToRedeem = unsetCopyWithValue,
-  }) => FallbackCreditNotApplied(
-    reason: reason ?? this.reason,
+  }) => FallbackCreditNotApplied.raw(
+    rawReason: reason?.value ?? rawReason,
     removeToRedeem: removeToRedeem == unsetCopyWithValue
         ? this.removeToRedeem
         : removeToRedeem as List<String>?,
@@ -217,11 +235,11 @@ class FallbackCreditNotApplied extends FallbackCreditStatus {
       identical(this, other) ||
       other is FallbackCreditNotApplied &&
           runtimeType == other.runtimeType &&
-          reason == other.reason &&
+          rawReason == other.rawReason &&
           listsEqual(removeToRedeem, other.removeToRedeem);
 
   @override
-  int get hashCode => Object.hash(reason, listHash(removeToRedeem));
+  int get hashCode => Object.hash(rawReason, listHash(removeToRedeem));
 
   @override
   String toString() =>

--- a/packages/anthropic_sdk_dart/lib/src/models/metadata/fallback_credit_usage.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/metadata/fallback_credit_usage.dart
@@ -1,0 +1,302 @@
+import 'package:meta/meta.dart';
+
+import '../common/copy_with_sentinel.dart';
+import '../common/equality_helpers.dart';
+
+/// Why a fallback-credit reprice was not applied to a response's billing.
+///
+/// A closed enum; additions to the redemption-check vocabulary arrive as
+/// deliberate schema updates.
+enum FallbackCreditNotAppliedReason {
+  /// The retry's request body did not match the refused request's body.
+  bodyMismatch('body_mismatch'),
+
+  /// The token was minted mid-server-tool-loop and its partial content was
+  /// continuable, but the retry did not use the appended-assistant form.
+  continuationExcluded('continuation_excluded'),
+
+  /// The token may only be redeemed with the appended-assistant retry form.
+  continuationOnly('continuation_only'),
+
+  /// The token's five-minute redemption window had elapsed.
+  expired('expired'),
+
+  /// The retry model is not an eligible fallback target for this token.
+  invalidTargetModel('invalid_target_model'),
+
+  /// Fallback credit is not enabled for this organization or workspace.
+  notEnabled('not_enabled'),
+
+  /// A reprice could not be computed for this request.
+  repriceUnavailable('reprice_unavailable'),
+
+  /// The redemption check was temporarily unavailable; retrying later may
+  /// succeed.
+  temporarilyUnavailable('temporarily_unavailable'),
+
+  /// The retry body includes fields from a variant sealed hash; see
+  /// [FallbackCreditNotApplied.removeToRedeem] for which fields to remove.
+  variantFieldsPresent('variant_fields_present'),
+
+  /// The token was minted for a different organization.
+  wrongOrganization('wrong_organization'),
+
+  /// The token was minted on a different platform.
+  wrongPlatform('wrong_platform'),
+
+  /// The token was minted for a different workspace.
+  wrongWorkspace('wrong_workspace'),
+
+  /// Unrecognized reason — fallback for unrecognized values.
+  unknown('unknown');
+
+  const FallbackCreditNotAppliedReason(this.value);
+
+  /// JSON value for this reason.
+  final String value;
+
+  /// Parses a [FallbackCreditNotAppliedReason] from JSON.
+  static FallbackCreditNotAppliedReason fromJson(String value) =>
+      switch (value) {
+        'body_mismatch' => bodyMismatch,
+        'continuation_excluded' => continuationExcluded,
+        'continuation_only' => continuationOnly,
+        'expired' => expired,
+        'invalid_target_model' => invalidTargetModel,
+        'not_enabled' => notEnabled,
+        'reprice_unavailable' => repriceUnavailable,
+        'temporarily_unavailable' => temporarilyUnavailable,
+        'variant_fields_present' => variantFieldsPresent,
+        'wrong_organization' => wrongOrganization,
+        'wrong_platform' => wrongPlatform,
+        'wrong_workspace' => wrongWorkspace,
+        _ => unknown,
+      };
+
+  /// Converts this reason to JSON.
+  String toJson() => value;
+}
+
+/// Whether the fallback-credit reprice was applied to a response's billing.
+///
+/// A union discriminated on `type`.
+///
+/// Variants:
+/// - [FallbackCreditRedeemed] — `redeemed`: the retry is billed as if the
+///   conversation had been on the retry model all along.
+/// - [FallbackCreditNotApplied] — `not_applied`: no reprice was applied;
+///   [FallbackCreditNotApplied.reason] says why.
+/// - [UnknownFallbackCreditStatus] — unrecognized `type`, for forward
+///   compatibility.
+sealed class FallbackCreditStatus {
+  const FallbackCreditStatus();
+
+  /// Creates a [FallbackCreditRedeemed] status.
+  const factory FallbackCreditStatus.redeemed() = FallbackCreditRedeemed;
+
+  /// Creates a [FallbackCreditNotApplied] status.
+  const factory FallbackCreditStatus.notApplied({
+    required FallbackCreditNotAppliedReason reason,
+    List<String>? removeToRedeem,
+  }) = FallbackCreditNotApplied;
+
+  /// Creates a [FallbackCreditStatus] from JSON.
+  ///
+  /// Dispatches on the `type` discriminator; unrecognized values fall back to
+  /// [UnknownFallbackCreditStatus].
+  factory FallbackCreditStatus.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    return switch (type) {
+      'redeemed' => FallbackCreditRedeemed.fromJson(json),
+      'not_applied' => FallbackCreditNotApplied.fromJson(json),
+      _ => UnknownFallbackCreditStatus(rawJson: json),
+    };
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson();
+}
+
+/// The reprice was applied: the retry is billed as if the conversation had
+/// been on the retry model all along — including when the resulting shift is
+/// zero because there was nothing to move.
+@immutable
+class FallbackCreditRedeemed extends FallbackCreditStatus {
+  /// Creates a [FallbackCreditRedeemed].
+  const FallbackCreditRedeemed();
+
+  /// Creates a [FallbackCreditRedeemed] from JSON.
+  factory FallbackCreditRedeemed.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'redeemed') {
+      throw FormatException(
+        'FallbackCreditRedeemed: expected type "redeemed", got "$type"',
+      );
+    }
+    return const FallbackCreditRedeemed();
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {'type': 'redeemed'};
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FallbackCreditRedeemed && runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => runtimeType.hashCode;
+
+  @override
+  String toString() => 'FallbackCreditRedeemed()';
+}
+
+/// No reprice was applied; [reason] says why.
+@immutable
+class FallbackCreditNotApplied extends FallbackCreditStatus {
+  /// Why the reprice was not applied.
+  final FallbackCreditNotAppliedReason reason;
+
+  /// Request fields to remove before retrying, so the retry can redeem this
+  /// token.
+  ///
+  /// Present exactly when [reason] is
+  /// [FallbackCreditNotAppliedReason.variantFieldsPresent] — never null, never
+  /// an empty list; absent otherwise. Fields are named only from the caller's
+  /// own request, and only after the sealed variant hash matched. A served
+  /// best-effort retry has already been billed at normal price; nothing
+  /// redeems retroactively, but a corrected re-send inside the token's
+  /// five-minute window can still redeem.
+  final List<String>? removeToRedeem;
+
+  /// Creates a [FallbackCreditNotApplied].
+  const FallbackCreditNotApplied({required this.reason, this.removeToRedeem});
+
+  /// Creates a [FallbackCreditNotApplied] from JSON.
+  factory FallbackCreditNotApplied.fromJson(Map<String, dynamic> json) {
+    final type = json['type'];
+    if (type != 'not_applied') {
+      throw FormatException(
+        'FallbackCreditNotApplied: expected type "not_applied", got "$type"',
+      );
+    }
+    final rawRemoveToRedeem = json['remove_to_redeem'] as List?;
+    return FallbackCreditNotApplied(
+      reason: FallbackCreditNotAppliedReason.fromJson(json['reason'] as String),
+      removeToRedeem: rawRemoveToRedeem?.map((e) {
+        if (e is! String) {
+          throw FormatException(
+            'remove_to_redeem: expected String, got ${e.runtimeType}',
+          );
+        }
+        return e;
+      }).toList(),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'not_applied',
+    'reason': reason.toJson(),
+    if (removeToRedeem != null) 'remove_to_redeem': removeToRedeem,
+  };
+
+  /// Creates a copy with replaced values.
+  FallbackCreditNotApplied copyWith({
+    FallbackCreditNotAppliedReason? reason,
+    Object? removeToRedeem = unsetCopyWithValue,
+  }) => FallbackCreditNotApplied(
+    reason: reason ?? this.reason,
+    removeToRedeem: removeToRedeem == unsetCopyWithValue
+        ? this.removeToRedeem
+        : removeToRedeem as List<String>?,
+  );
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FallbackCreditNotApplied &&
+          runtimeType == other.runtimeType &&
+          reason == other.reason &&
+          listsEqual(removeToRedeem, other.removeToRedeem);
+
+  @override
+  int get hashCode => Object.hash(reason, listHash(removeToRedeem));
+
+  @override
+  String toString() =>
+      'FallbackCreditNotApplied(reason: $reason, '
+      'removeToRedeem: $removeToRedeem)';
+}
+
+/// Unrecognized fallback-credit status type — preserves raw JSON for forward
+/// compatibility.
+@immutable
+class UnknownFallbackCreditStatus extends FallbackCreditStatus {
+  /// The raw JSON.
+  final Map<String, dynamic> rawJson;
+
+  /// Creates an [UnknownFallbackCreditStatus].
+  const UnknownFallbackCreditStatus({required this.rawJson});
+
+  @override
+  Map<String, dynamic> toJson() => rawJson;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnknownFallbackCreditStatus &&
+          runtimeType == other.runtimeType &&
+          mapsDeepEqual(rawJson, other.rawJson);
+
+  @override
+  int get hashCode => mapDeepHashCode(rawJson);
+
+  @override
+  String toString() => 'UnknownFallbackCreditStatus(rawJson: $rawJson)';
+}
+
+/// Outcome of the `fallback_credit_token` presented on a request.
+///
+/// Present on every response to a non-batch request that carried a
+/// `fallback_credit_token`, in either redemption mode; absent otherwise (batch
+/// items accept and ignore the token and carry no outcome object).
+@immutable
+class FallbackCreditUsage {
+  /// Whether the fallback-credit reprice was applied to this response's
+  /// billing.
+  final FallbackCreditStatus status;
+
+  /// Creates a [FallbackCreditUsage].
+  const FallbackCreditUsage({required this.status});
+
+  /// Creates a [FallbackCreditUsage] from JSON.
+  factory FallbackCreditUsage.fromJson(Map<String, dynamic> json) {
+    return FallbackCreditUsage(
+      status: FallbackCreditStatus.fromJson(
+        json['status'] as Map<String, dynamic>,
+      ),
+    );
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson() => {'status': status.toJson()};
+
+  /// Creates a copy with replaced values.
+  FallbackCreditUsage copyWith({FallbackCreditStatus? status}) {
+    return FallbackCreditUsage(status: status ?? this.status);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FallbackCreditUsage &&
+          runtimeType == other.runtimeType &&
+          status == other.status;
+
+  @override
+  int get hashCode => status.hashCode;
+
+  @override
+  String toString() => 'FallbackCreditUsage(status: $status)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/metadata/fallback_credit_usage.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/metadata/fallback_credit_usage.dart
@@ -95,7 +95,7 @@ sealed class FallbackCreditStatus {
   const factory FallbackCreditStatus.redeemed() = FallbackCreditRedeemed;
 
   /// Creates a [FallbackCreditNotApplied] status.
-  factory FallbackCreditStatus.notApplied({
+  const factory FallbackCreditStatus.notApplied({
     required FallbackCreditNotAppliedReason reason,
     List<String>? removeToRedeem,
   }) = FallbackCreditNotApplied;
@@ -154,16 +154,25 @@ class FallbackCreditRedeemed extends FallbackCreditStatus {
 /// No reprice was applied; [reason] says why.
 @immutable
 class FallbackCreditNotApplied extends FallbackCreditStatus {
+  /// Backing field for [reason] when constructed with a typed reason. Null
+  /// when constructed via [FallbackCreditNotApplied.raw].
+  final FallbackCreditNotAppliedReason? _reason;
+
+  /// Backing field for [rawReason] when constructed via
+  /// [FallbackCreditNotApplied.raw]. Null when constructed with a typed
+  /// [reason].
+  final String? _rawReason;
+
+  /// Why the reprice was not applied.
+  FallbackCreditNotAppliedReason get reason =>
+      _reason ?? FallbackCreditNotAppliedReason.fromJson(_rawReason!);
+
   /// The raw wire value for [reason], preserved verbatim.
   ///
   /// Kept alongside the derived [reason] getter so an unrecognized reason
   /// round-trips through `fromJson`/`toJson` instead of being collapsed to
   /// the literal string `"unknown"`.
-  final String rawReason;
-
-  /// Why the reprice was not applied, derived from [rawReason].
-  FallbackCreditNotAppliedReason get reason =>
-      FallbackCreditNotAppliedReason.fromJson(rawReason);
+  String get rawReason => _rawReason ?? _reason!.value;
 
   /// Request fields to remove before retrying, so the retry can redeem this
   /// token.
@@ -178,17 +187,19 @@ class FallbackCreditNotApplied extends FallbackCreditStatus {
   final List<String>? removeToRedeem;
 
   /// Creates a [FallbackCreditNotApplied].
-  FallbackCreditNotApplied({
+  const FallbackCreditNotApplied({
     required FallbackCreditNotAppliedReason reason,
     this.removeToRedeem,
-  }) : rawReason = reason.value;
+  }) : _reason = reason,
+       _rawReason = null;
 
   /// Creates a [FallbackCreditNotApplied], preserving [rawReason] verbatim
   /// even when it does not match a known [FallbackCreditNotAppliedReason].
   const FallbackCreditNotApplied.raw({
-    required this.rawReason,
+    required String rawReason,
     this.removeToRedeem,
-  });
+  }) : _rawReason = rawReason,
+       _reason = null;
 
   /// Creates a [FallbackCreditNotApplied] from JSON.
   factory FallbackCreditNotApplied.fromJson(Map<String, dynamic> json) {

--- a/packages/anthropic_sdk_dart/lib/src/models/metadata/stop_reason.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/metadata/stop_reason.dart
@@ -65,7 +65,10 @@ enum RefusalCategory {
   frontierLlm('frontier_llm'),
 
   /// Reasoning-extraction policy category.
-  reasoningExtraction('reasoning_extraction');
+  reasoningExtraction('reasoning_extraction'),
+
+  /// General-harms policy category.
+  generalHarms('general_harms');
 
   const RefusalCategory(this.value);
 

--- a/packages/anthropic_sdk_dart/lib/src/models/metadata/usage.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/metadata/usage.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../common/copy_with_sentinel.dart';
 import '../common/equality_helpers.dart';
+import 'fallback_credit_usage.dart';
 import 'speed.dart';
 
 /// Token usage breakdown for cache creation.
@@ -415,6 +416,13 @@ class Usage {
   /// Speed mode used for this request.
   final Speed? speed;
 
+  /// Outcome of the `fallback_credit_token` presented on this request.
+  ///
+  /// Present on every response to a non-batch request that carried a
+  /// `fallback_credit_token`, in either redemption mode; absent otherwise
+  /// (batch items accept and ignore the token and carry no outcome object).
+  final FallbackCreditUsage? fallbackCredit;
+
   /// Creates a [Usage].
   const Usage({
     required this.inputTokens,
@@ -429,6 +437,7 @@ class Usage {
     this.inferenceGeo,
     this.iterations,
     this.speed,
+    this.fallbackCredit,
   });
 
   /// Creates a [Usage] from JSON.
@@ -466,6 +475,11 @@ class Usage {
       speed: json['speed'] != null
           ? Speed.fromJson(json['speed'] as String)
           : null,
+      fallbackCredit: json['fallback_credit'] != null
+          ? FallbackCreditUsage.fromJson(
+              json['fallback_credit'] as Map<String, dynamic>,
+            )
+          : null,
     );
   }
 
@@ -487,6 +501,7 @@ class Usage {
     if (iterations != null)
       'iterations': iterations!.map((e) => e.toJson()).toList(),
     if (speed != null) 'speed': speed!.toJson(),
+    if (fallbackCredit != null) 'fallback_credit': fallbackCredit!.toJson(),
   };
 
   /// Creates a copy with replaced values.
@@ -503,6 +518,7 @@ class Usage {
     Object? inferenceGeo = unsetCopyWithValue,
     Object? iterations = unsetCopyWithValue,
     Object? speed = unsetCopyWithValue,
+    Object? fallbackCredit = unsetCopyWithValue,
   }) {
     return Usage(
       inputTokens: inputTokens ?? this.inputTokens,
@@ -535,6 +551,9 @@ class Usage {
           ? this.iterations
           : iterations as List<IterationUsage>?,
       speed: speed == unsetCopyWithValue ? this.speed : speed as Speed?,
+      fallbackCredit: fallbackCredit == unsetCopyWithValue
+          ? this.fallbackCredit
+          : fallbackCredit as FallbackCreditUsage?,
     );
   }
 
@@ -554,7 +573,8 @@ class Usage {
           serviceTier == other.serviceTier &&
           inferenceGeo == other.inferenceGeo &&
           listsEqual(iterations, other.iterations) &&
-          speed == other.speed;
+          speed == other.speed &&
+          fallbackCredit == other.fallbackCredit;
 
   @override
   int get hashCode => Object.hash(
@@ -570,6 +590,7 @@ class Usage {
     inferenceGeo,
     listHash(iterations),
     speed,
+    fallbackCredit,
   );
 
   @override
@@ -580,5 +601,6 @@ class Usage {
       'cacheCreationInputTokens: $cacheCreationInputTokens, '
       'cacheRead: $cacheRead, cacheReadInputTokens: $cacheReadInputTokens, '
       'serverToolUse: $serverToolUse, serviceTier: $serviceTier, '
-      'inferenceGeo: $inferenceGeo, iterations: $iterations, speed: $speed)';
+      'inferenceGeo: $inferenceGeo, iterations: $iterations, speed: $speed, '
+      'fallbackCredit: $fallbackCredit)';
 }

--- a/packages/anthropic_sdk_dart/lib/src/models/streaming/message_delta.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/streaming/message_delta.dart
@@ -3,6 +3,7 @@ import 'package:meta/meta.dart';
 import '../beta/config/container.dart';
 import '../common/copy_with_sentinel.dart';
 import '../common/equality_helpers.dart';
+import '../metadata/fallback_credit_usage.dart';
 import '../metadata/speed.dart';
 import '../metadata/stop_reason.dart';
 import '../metadata/usage.dart';
@@ -128,6 +129,13 @@ class MessageDeltaUsage {
   /// Speed mode used for this response (beta).
   final Speed? speed;
 
+  /// Outcome of the `fallback_credit_token` presented on this request.
+  ///
+  /// Present on every response to a non-batch request that carried a
+  /// `fallback_credit_token`, in either redemption mode; absent otherwise
+  /// (batch items accept and ignore the token and carry no outcome object).
+  final FallbackCreditUsage? fallbackCredit;
+
   /// Creates a [MessageDeltaUsage].
   const MessageDeltaUsage({
     required this.outputTokens,
@@ -138,6 +146,7 @@ class MessageDeltaUsage {
     this.serverToolUse,
     this.iterations,
     this.speed,
+    this.fallbackCredit,
   });
 
   /// Creates a [MessageDeltaUsage] from JSON.
@@ -165,6 +174,11 @@ class MessageDeltaUsage {
       speed: json['speed'] != null
           ? Speed.fromJson(json['speed'] as String)
           : null,
+      fallbackCredit: json['fallback_credit'] != null
+          ? FallbackCreditUsage.fromJson(
+              json['fallback_credit'] as Map<String, dynamic>,
+            )
+          : null,
     );
   }
 
@@ -182,6 +196,7 @@ class MessageDeltaUsage {
     if (iterations != null)
       'iterations': iterations!.map((e) => e.toJson()).toList(),
     if (speed != null) 'speed': speed!.toJson(),
+    if (fallbackCredit != null) 'fallback_credit': fallbackCredit!.toJson(),
   };
 
   /// Creates a copy with replaced values.
@@ -194,6 +209,7 @@ class MessageDeltaUsage {
     Object? serverToolUse = unsetCopyWithValue,
     Object? iterations = unsetCopyWithValue,
     Object? speed = unsetCopyWithValue,
+    Object? fallbackCredit = unsetCopyWithValue,
   }) {
     return MessageDeltaUsage(
       outputTokens: outputTokens ?? this.outputTokens,
@@ -216,6 +232,9 @@ class MessageDeltaUsage {
           ? this.iterations
           : iterations as List<IterationUsage>?,
       speed: speed == unsetCopyWithValue ? this.speed : speed as Speed?,
+      fallbackCredit: fallbackCredit == unsetCopyWithValue
+          ? this.fallbackCredit
+          : fallbackCredit as FallbackCreditUsage?,
     );
   }
 
@@ -231,7 +250,8 @@ class MessageDeltaUsage {
           cacheReadInputTokens == other.cacheReadInputTokens &&
           serverToolUse == other.serverToolUse &&
           listsEqual(iterations, other.iterations) &&
-          speed == other.speed;
+          speed == other.speed &&
+          fallbackCredit == other.fallbackCredit;
 
   @override
   int get hashCode => Object.hash(
@@ -243,6 +263,7 @@ class MessageDeltaUsage {
     serverToolUse,
     listHash(iterations),
     speed,
+    fallbackCredit,
   );
 
   @override
@@ -251,5 +272,6 @@ class MessageDeltaUsage {
       'outputTokensDetails: $outputTokensDetails, inputTokens: $inputTokens, '
       'cacheCreationInputTokens: $cacheCreationInputTokens, '
       'cacheReadInputTokens: $cacheReadInputTokens, '
-      'serverToolUse: $serverToolUse, iterations: $iterations, speed: $speed)';
+      'serverToolUse: $serverToolUse, iterations: $iterations, speed: $speed, '
+      'fallbackCredit: $fallbackCredit)';
 }

--- a/packages/anthropic_sdk_dart/lib/src/models/tools/tool_change_reference.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/tools/tool_change_reference.dart
@@ -1,0 +1,193 @@
+import 'package:meta/meta.dart';
+
+/// Reference to a tool (or MCP toolset) affected by a mid-conversation
+/// tool-change directive.
+///
+/// One of:
+/// - [ToolChangeToolReference] — a tool declared directly in `tools[]`.
+/// - [ToolChangeMCPToolReference] — a single MCP tool by server and name.
+/// - [ToolChangeMCPToolsetReference] — every tool in an MCP server's toolset.
+sealed class ToolChangeReference {
+  const ToolChangeReference();
+
+  /// References a tool declared directly in the request's `tools[]`.
+  factory ToolChangeReference.tool(String name) = ToolChangeToolReference;
+
+  /// References a single MCP tool by its server and remote name.
+  factory ToolChangeReference.mcpTool({
+    required String serverName,
+    required String name,
+  }) = ToolChangeMCPToolReference;
+
+  /// References every tool in the named MCP server's toolset.
+  factory ToolChangeReference.mcpToolset(String serverName) =
+      ToolChangeMCPToolsetReference;
+
+  /// Creates a [ToolChangeReference] from JSON.
+  factory ToolChangeReference.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String;
+    return switch (type) {
+      'tool_reference' => ToolChangeToolReference.fromJson(json),
+      'mcp_tool_reference' => ToolChangeMCPToolReference.fromJson(json),
+      'mcp_toolset_reference' => ToolChangeMCPToolsetReference.fromJson(json),
+      _ => throw FormatException('Unknown ToolChangeReference type: $type'),
+    };
+  }
+
+  /// Converts to JSON.
+  Map<String, dynamic> toJson();
+}
+
+/// Reference to a single tool the caller declared directly in `tools[]`.
+///
+/// Does not accept the composed `{server}_{name}` form the server assigns to
+/// MCP-resolved tools — use [ToolChangeMCPToolReference] or
+/// [ToolChangeMCPToolsetReference] for those.
+@immutable
+class ToolChangeToolReference extends ToolChangeReference {
+  /// The referenced tool's name.
+  final String name;
+
+  /// Creates a [ToolChangeToolReference].
+  const ToolChangeToolReference(this.name);
+
+  /// Creates a [ToolChangeToolReference] from JSON.
+  factory ToolChangeToolReference.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    if (type != 'tool_reference') {
+      throw FormatException(
+        'ToolChangeToolReference: expected type "tool_reference", got "$type"',
+      );
+    }
+    return ToolChangeToolReference(json['name'] as String);
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {'type': 'tool_reference', 'name': name};
+
+  /// Creates a copy with replaced values.
+  ToolChangeToolReference copyWith({String? name}) {
+    return ToolChangeToolReference(name ?? this.name);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ToolChangeToolReference &&
+          runtimeType == other.runtimeType &&
+          name == other.name;
+
+  @override
+  int get hashCode => name.hashCode;
+
+  @override
+  String toString() => 'ToolChangeToolReference(name: $name)';
+}
+
+/// Reference to a single MCP tool by its server and remote name — the same
+/// `server_name`/`name` pair `mcp_tool_use` carries.
+@immutable
+class ToolChangeMCPToolReference extends ToolChangeReference {
+  /// The MCP server name.
+  final String serverName;
+
+  /// The tool's remote name on that server.
+  final String name;
+
+  /// Creates a [ToolChangeMCPToolReference].
+  const ToolChangeMCPToolReference({
+    required this.serverName,
+    required this.name,
+  });
+
+  /// Creates a [ToolChangeMCPToolReference] from JSON.
+  factory ToolChangeMCPToolReference.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    if (type != 'mcp_tool_reference') {
+      throw FormatException(
+        'ToolChangeMCPToolReference: expected type "mcp_tool_reference", '
+        'got "$type"',
+      );
+    }
+    return ToolChangeMCPToolReference(
+      serverName: json['server_name'] as String,
+      name: json['name'] as String,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'mcp_tool_reference',
+    'server_name': serverName,
+    'name': name,
+  };
+
+  /// Creates a copy with replaced values.
+  ToolChangeMCPToolReference copyWith({String? serverName, String? name}) {
+    return ToolChangeMCPToolReference(
+      serverName: serverName ?? this.serverName,
+      name: name ?? this.name,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ToolChangeMCPToolReference &&
+          runtimeType == other.runtimeType &&
+          serverName == other.serverName &&
+          name == other.name;
+
+  @override
+  int get hashCode => Object.hash(serverName, name);
+
+  @override
+  String toString() =>
+      'ToolChangeMCPToolReference(serverName: $serverName, name: $name)';
+}
+
+/// Reference to every tool in the named MCP server's toolset.
+@immutable
+class ToolChangeMCPToolsetReference extends ToolChangeReference {
+  /// The MCP server name.
+  final String serverName;
+
+  /// Creates a [ToolChangeMCPToolsetReference].
+  const ToolChangeMCPToolsetReference(this.serverName);
+
+  /// Creates a [ToolChangeMCPToolsetReference] from JSON.
+  factory ToolChangeMCPToolsetReference.fromJson(Map<String, dynamic> json) {
+    final type = json['type'] as String?;
+    if (type != 'mcp_toolset_reference') {
+      throw FormatException(
+        'ToolChangeMCPToolsetReference: expected type '
+        '"mcp_toolset_reference", got "$type"',
+      );
+    }
+    return ToolChangeMCPToolsetReference(json['server_name'] as String);
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'mcp_toolset_reference',
+    'server_name': serverName,
+  };
+
+  /// Creates a copy with replaced values.
+  ToolChangeMCPToolsetReference copyWith({String? serverName}) {
+    return ToolChangeMCPToolsetReference(serverName ?? this.serverName);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ToolChangeMCPToolsetReference &&
+          runtimeType == other.runtimeType &&
+          serverName == other.serverName;
+
+  @override
+  int get hashCode => serverName.hashCode;
+
+  @override
+  String toString() => 'ToolChangeMCPToolsetReference(serverName: $serverName)';
+}

--- a/packages/anthropic_sdk_dart/lib/src/models/tools/tool_change_reference.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/tools/tool_change_reference.dart
@@ -1,5 +1,7 @@
 import 'package:meta/meta.dart';
 
+import '../common/equality_helpers.dart';
+
 /// Reference to a tool (or MCP toolset) affected by a mid-conversation
 /// tool-change directive.
 ///
@@ -7,6 +9,8 @@ import 'package:meta/meta.dart';
 /// - [ToolChangeToolReference] — a tool declared directly in `tools[]`.
 /// - [ToolChangeMCPToolReference] — a single MCP tool by server and name.
 /// - [ToolChangeMCPToolsetReference] — every tool in an MCP server's toolset.
+/// - [UnknownToolChangeReference] — unrecognized type, for forward
+///   compatibility (preserves raw JSON).
 sealed class ToolChangeReference {
   const ToolChangeReference();
 
@@ -24,13 +28,16 @@ sealed class ToolChangeReference {
       ToolChangeMCPToolsetReference;
 
   /// Creates a [ToolChangeReference] from JSON.
+  ///
+  /// Dispatches on the `type` discriminator; unrecognized values fall back to
+  /// [UnknownToolChangeReference].
   factory ToolChangeReference.fromJson(Map<String, dynamic> json) {
-    final type = json['type'] as String;
+    final type = json['type'] as String?;
     return switch (type) {
       'tool_reference' => ToolChangeToolReference.fromJson(json),
       'mcp_tool_reference' => ToolChangeMCPToolReference.fromJson(json),
       'mcp_toolset_reference' => ToolChangeMCPToolsetReference.fromJson(json),
-      _ => throw FormatException('Unknown ToolChangeReference type: $type'),
+      _ => UnknownToolChangeReference(rawJson: json),
     };
   }
 
@@ -190,4 +197,36 @@ class ToolChangeMCPToolsetReference extends ToolChangeReference {
 
   @override
   String toString() => 'ToolChangeMCPToolsetReference(serverName: $serverName)';
+}
+
+/// Unrecognized [ToolChangeReference] — preserves raw JSON for forward
+/// compatibility.
+@immutable
+class UnknownToolChangeReference extends ToolChangeReference {
+  /// The raw JSON data.
+  final Map<String, dynamic> rawJson;
+
+  /// Creates an [UnknownToolChangeReference].
+  const UnknownToolChangeReference({required this.rawJson});
+
+  /// Creates an [UnknownToolChangeReference] from JSON.
+  factory UnknownToolChangeReference.fromJson(Map<String, dynamic> json) {
+    return UnknownToolChangeReference(rawJson: json);
+  }
+
+  @override
+  Map<String, dynamic> toJson() => rawJson;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is UnknownToolChangeReference &&
+          runtimeType == other.runtimeType &&
+          mapsDeepEqual(rawJson, other.rawJson);
+
+  @override
+  int get hashCode => mapDeepHashCode(rawJson);
+
+  @override
+  String toString() => 'UnknownToolChangeReference(rawJson: $rawJson)';
 }

--- a/packages/anthropic_sdk_dart/lib/src/resources/dreams_resource.dart
+++ b/packages/anthropic_sdk_dart/lib/src/resources/dreams_resource.dart
@@ -1,0 +1,172 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../models/dreams/create_dream_request.dart';
+import '../models/dreams/dream.dart';
+import '../models/dreams/dream_status.dart';
+import '../models/dreams/list_dreams_response.dart';
+import 'base_resource.dart';
+
+/// Beta header for the Dreams API.
+const _betaHeader = 'dreaming-2026-04-21';
+
+/// Resource for the Dreams API (Beta, research preview).
+///
+/// A dream is an asynchronous memory-consolidation job that reads a memory
+/// store plus a set of session transcripts and writes consolidated memories
+/// into a new output memory store. This is a research preview: request and
+/// response shapes are volatile and may change without the deprecation
+/// period that applies to generally-available endpoints. This is a beta
+/// feature and requires the `anthropic-beta` header.
+class DreamsResource extends ResourceBase {
+  /// Creates a [DreamsResource].
+  DreamsResource({
+    required super.config,
+    required super.httpClient,
+    required super.interceptorChain,
+    required super.requestBuilder,
+    super.ensureNotClosed,
+  });
+
+  /// Creates a new dream.
+  ///
+  /// The optional [abortTrigger] allows canceling the request.
+  Future<Dream> create(
+    CreateDreamRequest request, {
+    Future<void>? abortTrigger,
+  }) async {
+    ensureNotClosed?.call();
+    final url = requestBuilder.buildUrl('/v1/dreams');
+    final headers = requestBuilder.buildHeaders(
+      additionalHeaders: {'anthropic-beta': _betaHeader},
+    );
+    final httpRequest = http.Request('POST', url)
+      ..headers.addAll(headers)
+      ..body = jsonEncode(request.toJson());
+
+    final response = await interceptorChain.execute(
+      httpRequest,
+      abortTrigger: abortTrigger,
+    );
+
+    return Dream.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+  }
+
+  /// Lists dreams.
+  ///
+  /// Parameters:
+  /// - [limit]: Maximum number of dreams to return.
+  /// - [page]: Pagination token from a previous response.
+  /// - [includeArchived]: Whether to include archived dreams.
+  /// - [statuses]: Filter dreams by status. Multiple values are OR-ed.
+  /// - [createdAtGt]: Filter dreams created strictly after this ISO 8601
+  ///   timestamp (exclusive lower bound).
+  /// - [createdAtLt]: Filter dreams created strictly before this ISO 8601
+  ///   timestamp (exclusive upper bound).
+  /// - [abortTrigger]: Allows canceling the request.
+  Future<ListDreamsResponse> list({
+    int? limit,
+    String? page,
+    bool? includeArchived,
+    List<DreamStatus>? statuses,
+    String? createdAtGt,
+    String? createdAtLt,
+    Future<void>? abortTrigger,
+  }) async {
+    ensureNotClosed?.call();
+    final queryParams = <String, dynamic>{
+      'limit': ?limit?.toString(),
+      'page': ?page,
+      'include_archived': ?includeArchived?.toString(),
+      'statuses[]': ?statuses?.map((s) => s.toJson()).toList(),
+      'created_at[gt]': ?createdAtGt,
+      'created_at[lt]': ?createdAtLt,
+    };
+
+    final url = requestBuilder.buildUrl(
+      '/v1/dreams',
+      queryParams: queryParams.isEmpty ? null : queryParams,
+    );
+    final headers = requestBuilder.buildHeaders(
+      additionalHeaders: {'anthropic-beta': _betaHeader},
+    );
+    final httpRequest = http.Request('GET', url)..headers.addAll(headers);
+
+    final response = await interceptorChain.execute(
+      httpRequest,
+      abortTrigger: abortTrigger,
+    );
+
+    return ListDreamsResponse.fromJson(
+      jsonDecode(response.body) as Map<String, dynamic>,
+    );
+  }
+
+  /// Retrieves a specific dream.
+  ///
+  /// Parameters:
+  /// - [dreamId]: The ID of the dream to retrieve.
+  /// - [abortTrigger]: Allows canceling the request.
+  Future<Dream> retrieve(String dreamId, {Future<void>? abortTrigger}) async {
+    ensureNotClosed?.call();
+    final url = requestBuilder.buildUrl('/v1/dreams/$dreamId');
+    final headers = requestBuilder.buildHeaders(
+      additionalHeaders: {'anthropic-beta': _betaHeader},
+    );
+    final httpRequest = http.Request('GET', url)..headers.addAll(headers);
+
+    final response = await interceptorChain.execute(
+      httpRequest,
+      abortTrigger: abortTrigger,
+    );
+
+    return Dream.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+  }
+
+  /// Archives a dream.
+  ///
+  /// Parameters:
+  /// - [dreamId]: The ID of the dream to archive.
+  /// - [abortTrigger]: Allows canceling the request.
+  Future<Dream> archive(String dreamId, {Future<void>? abortTrigger}) async {
+    ensureNotClosed?.call();
+    final url = requestBuilder.buildUrl('/v1/dreams/$dreamId/archive');
+    final headers = requestBuilder.buildHeaders(
+      additionalHeaders: {'anthropic-beta': _betaHeader},
+    );
+    final httpRequest = http.Request('POST', url)
+      ..headers.addAll(headers)
+      ..body = jsonEncode(<String, dynamic>{});
+
+    final response = await interceptorChain.execute(
+      httpRequest,
+      abortTrigger: abortTrigger,
+    );
+
+    return Dream.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+  }
+
+  /// Cancels a pending or running dream.
+  ///
+  /// Parameters:
+  /// - [dreamId]: The ID of the dream to cancel.
+  /// - [abortTrigger]: Allows canceling the request.
+  Future<Dream> cancel(String dreamId, {Future<void>? abortTrigger}) async {
+    ensureNotClosed?.call();
+    final url = requestBuilder.buildUrl('/v1/dreams/$dreamId/cancel');
+    final headers = requestBuilder.buildHeaders(
+      additionalHeaders: {'anthropic-beta': _betaHeader},
+    );
+    final httpRequest = http.Request('POST', url)
+      ..headers.addAll(headers)
+      ..body = jsonEncode(<String, dynamic>{});
+
+    final response = await interceptorChain.execute(
+      httpRequest,
+      abortTrigger: abortTrigger,
+    );
+
+    return Dream.fromJson(jsonDecode(response.body) as Map<String, dynamic>);
+  }
+}

--- a/packages/anthropic_sdk_dart/lib/src/resources/session_thread_events_resource.dart
+++ b/packages/anthropic_sdk_dart/lib/src/resources/session_thread_events_resource.dart
@@ -72,23 +72,35 @@ class SessionThreadEventsResource extends ResourceBase with StreamingResource {
   ///
   /// Parameters:
   /// - [lastEventId]: Resume streaming from after this event ID.
+  /// - [eventDeltas]: Event types to preview incrementally via [EventStartEvent]
+  ///   and [EventDeltaEvent] before the complete event arrives. Accepts
+  ///   `agent.message` and `agent.thinking`.
   /// - [abortTrigger]: Allows canceling the stream.
   ///
   /// Uses the eager-guard wrapper pattern so `ensureNotClosed()` runs at call
   /// time rather than on `.listen()`.
   Stream<SessionEvent> stream({
     String? lastEventId,
+    List<String>? eventDeltas,
     Future<void>? abortTrigger,
   }) {
     ensureNotClosed?.call();
-    return _streamImpl(lastEventId: lastEventId, abortTrigger: abortTrigger);
+    return _streamImpl(
+      lastEventId: lastEventId,
+      eventDeltas: eventDeltas,
+      abortTrigger: abortTrigger,
+    );
   }
 
   Stream<SessionEvent> _streamImpl({
     String? lastEventId,
+    List<String>? eventDeltas,
     Future<void>? abortTrigger,
   }) async* {
-    final queryParams = <String, dynamic>{'last_event_id': ?lastEventId};
+    final queryParams = <String, dynamic>{
+      'last_event_id': ?lastEventId,
+      'event_deltas[]': ?eventDeltas,
+    };
 
     final eventStream = getStream(
       '/v1/sessions/$sessionId/threads/$threadId/stream',

--- a/packages/anthropic_sdk_dart/llms.txt
+++ b/packages/anthropic_sdk_dart/llms.txt
@@ -4,7 +4,7 @@
 
 ## Docs
 
-- [README](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/README.md) (~5.3k tokens): Primary package documentation with installation, configuration, and usage examples.
+- [README](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/README.md) (~5.4k tokens): Primary package documentation with installation, configuration, and usage examples.
 - [CHANGELOG](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/CHANGELOG.md) (~11k tokens): Release history and version-by-version changes.
 - [MIGRATION](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/MIGRATION.md) (~7.2k tokens): Upgrade notes and breaking-change guidance.
 
@@ -34,6 +34,7 @@
 - [mcp_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/mcp_example.dart) (~904 tokens): MCP tool integration.
 - [session_threads_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/session_threads_example.dart) (~816 tokens): Session threads: list, retrieve, stream events, archive (beta).
 - [deployments_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/deployments_example.dart) (~609 tokens): Scheduled deployments and deployment runs: cron schedule, pause/resume, run-now (beta).
+- [dreams_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/dreams_example.dart) (~769 tokens): Dreams: memory-consolidation jobs — create, poll, list, archive (beta, research preview).
 - [user_profiles_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/user_profiles_example.dart) (~676 tokens): User profiles and enrollment URLs (beta).
 - [anthropic_sdk_dart_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/anthropic_sdk_dart_example.dart) (~670 tokens): Quick-start overview.
 
@@ -41,4 +42,4 @@
 
 - [Package directory](https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/anthropic_sdk_dart): Source tree, pubspec, and package-local files.
 
-**Total: ~45.8k tokens**
+**Total: ~46.7k tokens**

--- a/packages/anthropic_sdk_dart/specs/openapi.yaml
+++ b/packages/anthropic_sdk_dart/specs/openapi.yaml
@@ -65,9 +65,12 @@
               "advisor-tool-2026-03-01",
               "managed-agents-2026-04-01",
               "cache-diagnosis-2026-04-07",
+              "dreaming-2026-04-21",
               "thinking-token-count-2026-05-13",
               "server-side-fallback-2026-06-01",
+              "server-side-fallback-2026-07-01",
               "fallback-credit-2026-06-01",
+              "fallback-credit-2026-07-01",
               "agent-memory-2026-07-22"
             ],
             "type": "string",
@@ -2051,6 +2054,9 @@
           },
           "id": {
             "description": "Identifier for the container used in this request",
+            "examples": [
+              "container_011CpZohnwH4vuy7gazohgSP"
+            ],
             "title": "Id",
             "type": "string"
           },
@@ -2786,6 +2792,31 @@
         "title": "CountMessageTokensResponse",
         "type": "object"
       },
+      "BetaCreateDreamRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "inputs": {
+            "items": {
+              "$ref": "#/components/schemas/BetaDreamInput"
+            },
+            "type": "array"
+          },
+          "instructions": {
+            "maxLength": 4096,
+            "minLength": 1,
+            "nullable": true,
+            "type": "string"
+          },
+          "model": {
+            "$ref": "#/components/schemas/BetaDreamModelParams"
+          }
+        },
+        "required": [
+          "inputs",
+          "model"
+        ],
+        "type": "object"
+      },
       "BetaCreateMessageBatchParams": {
         "additionalProperties": false,
         "properties": {
@@ -2886,6 +2917,9 @@
                 "type": "string"
               },
               {
+                "$ref": "#/components/schemas/BetaFallbackCreditTokenParam"
+              },
+              {
                 "type": "null"
               }
             ],
@@ -2903,10 +2937,16 @@
                 "type": "array"
               },
               {
+                "const": "default",
+                "title": "FallbacksDefault",
+                "type": "string",
+                "x-stainless-variantName": "Default"
+              },
+              {
                 "type": "null"
               }
             ],
-            "description": "Opt-in server-side retry on one or more substitute models when the requested model declines for policy reasons. Tried in order: if the first entry also declines, the second is tried, and so on.",
+            "description": "Opt-in server-side retry on one or more substitute models when the requested model declines for policy reasons. Tried in order: if the first entry also declines, the second is tried, and so on. The string \"default\" requests the requested model's server-defined default fallback configuration.",
             "title": "Fallbacks"
           },
           "inference_geo": {
@@ -3587,6 +3627,297 @@
         "title": "DirectCaller",
         "type": "object"
       },
+      "BetaDream": {
+        "additionalProperties": false,
+        "description": "An asynchronous memory-consolidation job that reads a memory store plus a set of session transcripts and writes consolidated memories into a new output memory store. The Dreams API is in research preview: the request and response shapes are volatile and may change without the deprecation period that applies to generally-available endpoints.",
+        "properties": {
+          "archived_at": {
+            "$ref": "#/components/schemas/BetaTimestamp",
+            "nullable": true
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/BetaTimestamp"
+          },
+          "ended_at": {
+            "$ref": "#/components/schemas/BetaTimestamp",
+            "nullable": true
+          },
+          "error": {
+            "$ref": "#/components/schemas/BetaDreamError",
+            "nullable": true
+          },
+          "id": {
+            "type": "string"
+          },
+          "inputs": {
+            "items": {
+              "$ref": "#/components/schemas/BetaDreamInput"
+            },
+            "type": "array"
+          },
+          "instructions": {
+            "nullable": true,
+            "type": "string"
+          },
+          "model": {
+            "$ref": "#/components/schemas/BetaDreamModelConfig"
+          },
+          "outputs": {
+            "items": {
+              "$ref": "#/components/schemas/BetaDreamOutput"
+            },
+            "type": "array"
+          },
+          "session_id": {
+            "nullable": true,
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/BetaDreamStatus"
+          },
+          "type": {
+            "enum": [
+              "dream"
+            ],
+            "type": "string"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/BetaDreamUsage"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "inputs",
+          "outputs",
+          "status",
+          "created_at",
+          "ended_at",
+          "archived_at",
+          "error",
+          "model",
+          "instructions",
+          "session_id",
+          "usage"
+        ],
+        "type": "object"
+      },
+      "BetaDreamError": {
+        "additionalProperties": false,
+        "description": "Failure detail for a Dream whose `status` is `failed`.",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "message"
+        ],
+        "type": "object"
+      },
+      "BetaDreamInput": {
+        "discriminator": {
+          "mapping": {
+            "memory_store": "#/components/schemas/BetaDreamMemoryStoreInput",
+            "sessions": "#/components/schemas/BetaDreamSessionsInput"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BetaDreamMemoryStoreInput"
+          },
+          {
+            "$ref": "#/components/schemas/BetaDreamSessionsInput"
+          }
+        ],
+        "type": "object"
+      },
+      "BetaDreamMemoryStoreInput": {
+        "additionalProperties": false,
+        "description": "An input memory store the dream reads from. The dream never mutates this store.",
+        "properties": {
+          "memory_store_id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "memory_store"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "memory_store_id"
+        ],
+        "type": "object"
+      },
+      "BetaDreamMemoryStoreOutput": {
+        "additionalProperties": false,
+        "description": "An output memory store the dream writes consolidated memories into.",
+        "properties": {
+          "memory_store_id": {
+            "type": "string"
+          },
+          "type": {
+            "enum": [
+              "memory_store"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "memory_store_id"
+        ],
+        "type": "object"
+      },
+      "BetaDreamModelConfig": {
+        "additionalProperties": false,
+        "description": "Model identifier and configuration applied to every pipeline stage. Same wire shape as the Agents API ModelConfig.",
+        "properties": {
+          "id": {
+            "description": "Model identifier, e.g. \"claude-opus-4-7\". 1-256 characters.",
+            "maxLength": 256,
+            "minLength": 1,
+            "type": "string"
+          },
+          "speed": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaSpeed"
+              }
+            ],
+            "description": "Inference speed mode. Defaults to `standard`."
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "BetaDreamModelConfigParams": {
+        "additionalProperties": false,
+        "description": "Model identifier and configuration applied to every pipeline stage.",
+        "properties": {
+          "id": {
+            "description": "Model identifier, e.g. \"claude-opus-4-7\". 1-256 characters.",
+            "maxLength": 256,
+            "minLength": 1,
+            "type": "string"
+          },
+          "speed": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaSpeed"
+              }
+            ],
+            "description": "Inference speed mode. Defaults to `standard`.",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "type": "object"
+      },
+      "BetaDreamModelParams": {
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "$ref": "#/components/schemas/BetaDreamModelConfigParams"
+          }
+        ]
+      },
+      "BetaDreamOutput": {
+        "discriminator": {
+          "mapping": {
+            "memory_store": "#/components/schemas/BetaDreamMemoryStoreOutput"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BetaDreamMemoryStoreOutput"
+          }
+        ],
+        "type": "object"
+      },
+      "BetaDreamSessionsInput": {
+        "additionalProperties": false,
+        "description": "Input session transcripts the dream reads.",
+        "properties": {
+          "session_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": {
+            "enum": [
+              "sessions"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "session_ids"
+        ],
+        "type": "object"
+      },
+      "BetaDreamStatus": {
+        "description": "Lifecycle status of a Dream.",
+        "enum": [
+          "pending",
+          "running",
+          "completed",
+          "failed",
+          "canceled"
+        ],
+        "type": "string"
+      },
+      "BetaDreamUsage": {
+        "additionalProperties": false,
+        "description": "Cumulative token usage for the dream across every pipeline stage.",
+        "properties": {
+          "cache_creation_input_tokens": {
+            "description": "Total tokens used to create prompt-cache entries (sum of all TTL tiers).",
+            "format": "int32",
+            "type": "integer"
+          },
+          "cache_read_input_tokens": {
+            "description": "Total tokens read from prompt cache.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "input_tokens": {
+            "description": "Total uncached input tokens consumed across every pipeline stage.",
+            "format": "int32",
+            "type": "integer"
+          },
+          "output_tokens": {
+            "description": "Total output tokens generated across every pipeline stage.",
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "input_tokens",
+          "output_tokens",
+          "cache_read_input_tokens",
+          "cache_creation_input_tokens"
+        ],
+        "type": "object"
+      },
       "BetaEffortCapability": {
         "description": "Effort (reasoning_effort) capability details.",
         "properties": {
@@ -3888,9 +4219,11 @@
             "type": "string"
           },
           "type": {
-            "const": "environment_deleted",
             "default": "environment_deleted",
             "description": "The type of response",
+            "enum": [
+              "environment_deleted"
+            ],
             "examples": [
               "environment_deleted"
             ],
@@ -4072,7 +4405,7 @@
       },
       "BetaFallbackConfigV2": {
         "additionalProperties": true,
-        "description": "One entry in the `fallbacks` chain on a `/v1/messages` request.\n\n`model` is required. The four override fields (`max_tokens`, `thinking`,\n`output_config`, and `speed`) replace the corresponding top-level field\nfor this attempt only and are validated as if the request were made to\n`model`. Any other key is rejected at parse time.",
+        "description": "One entry in the `fallbacks` chain on a `/v1/messages` request.\n\n`model` is required. The override fields (`max_tokens`, `thinking`,\n`output_config`, and `speed`) set the corresponding parameter for this\nattempt only and are validated as if the request were made to `model`.\nAny other key is rejected at parse time.",
         "properties": {
           "max_tokens": {
             "anyOf": [
@@ -4142,6 +4475,130 @@
           "model"
         ],
         "title": "FallbackConfigV2",
+        "type": "object"
+      },
+      "BetaFallbackCreditNotApplied": {
+        "description": "No reprice was applied; ``reason`` says why.",
+        "properties": {
+          "reason": {
+            "description": "Why the reprice was not applied.\n\nA closed enum; additions to the redemption-check vocabulary arrive as\ndeliberate schema updates.",
+            "enum": [
+              "body_mismatch",
+              "continuation_excluded",
+              "continuation_only",
+              "expired",
+              "invalid_target_model",
+              "not_enabled",
+              "reprice_unavailable",
+              "temporarily_unavailable",
+              "variant_fields_present",
+              "wrong_organization",
+              "wrong_platform",
+              "wrong_workspace"
+            ],
+            "title": "Reason",
+            "type": "string"
+          },
+          "remove_to_redeem": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Request fields to remove before retrying, so the retry can redeem this\ntoken.\n\nPresent exactly when `reason` is `variant_fields_present` \u2014 never null,\nnever an empty array; absent otherwise. Fields are named only from your own request, and only after\nthe sealed variant hash matched. A served best-effort retry has already\nbeen billed at normal price; nothing redeems retroactively, but a corrected\nre-send inside the token's five-minute window can still redeem.",
+            "title": "Remove To Redeem"
+          },
+          "type": {
+            "const": "not_applied",
+            "default": "not_applied",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "reason",
+          "type"
+        ],
+        "title": "FallbackCreditNotApplied",
+        "type": "object"
+      },
+      "BetaFallbackCreditRedeemed": {
+        "description": "The reprice was applied: the retry is billed as if the conversation\nhad been on the retry model all along.",
+        "properties": {
+          "type": {
+            "const": "redeemed",
+            "default": "redeemed",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "title": "FallbackCreditRedeemed",
+        "type": "object"
+      },
+      "BetaFallbackCreditTokenParam": {
+        "additionalProperties": false,
+        "description": "Object form of ``fallback_credit_token``: the token plus a redemption\nmode.\n\nRequires ``anthropic-beta: fallback-credit-2026-07-01``; without that\nheader the field accepts the bare string only. The bare string and the\nmode-less object are equivalent (both select ``strict``), so wrapping\nan existing token changes nothing by itself.",
+        "properties": {
+          "mode": {
+            "description": "How a failing token affects the retry. `strict` (the default, and the bare-string behavior): a failing redemption is a 400 and the retry is not served. `best_effort`: the retry is served either way \u2014 a token-layer failure no longer rejects the request; the retry proceeds at normal price and the outcome is reported on the response's `usage.fallback_credit`. Two failures stay hard in both modes: a malformed token, and combining `fallback_credit_token` with `fallbacks`.",
+            "enum": [
+              "strict",
+              "best_effort"
+            ],
+            "title": "Mode",
+            "type": "string"
+          },
+          "token": {
+            "description": "The opaque `fallback_credit_token` from a prior refusal's `stop_details` \u2014 the same string the bare-string form carries.",
+            "maxLength": 2048,
+            "minLength": 1,
+            "title": "Token",
+            "type": "string"
+          }
+        },
+        "required": [
+          "token"
+        ],
+        "title": "FallbackCreditTokenParam",
+        "type": "object"
+      },
+      "BetaFallbackCreditUsage": {
+        "description": "Outcome of the ``fallback_credit_token`` presented on this request.",
+        "properties": {
+          "status": {
+            "description": "Whether the fallback-credit reprice was applied to this response's billing.\n\nA union discriminated on `type`. `redeemed`: the retry is billed as if\nthe conversation had been on the retry model all along \u2014 including when the\nresulting shift is zero because there was nothing to move. `not_applied`:\nno reprice was applied; the arm's `reason` says why.",
+            "discriminator": {
+              "mapping": {
+                "not_applied": "#/components/schemas/BetaFallbackCreditNotApplied",
+                "redeemed": "#/components/schemas/BetaFallbackCreditRedeemed"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/BetaFallbackCreditRedeemed"
+              },
+              {
+                "$ref": "#/components/schemas/BetaFallbackCreditNotApplied"
+              }
+            ],
+            "title": "Status"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "FallbackCreditUsage",
         "type": "object"
       },
       "BetaFallbackMessageIterationUsage": {
@@ -4668,6 +5125,8 @@
             "text": "#/components/schemas/BetaRequestTextBlock",
             "text_editor_code_execution_tool_result": "#/components/schemas/BetaRequestTextEditorCodeExecutionToolResultBlock",
             "thinking": "#/components/schemas/BetaRequestThinkingBlock",
+            "tool_addition": "#/components/schemas/BetaRequestToolAdditionBlock",
+            "tool_removal": "#/components/schemas/BetaRequestToolRemovalBlock",
             "tool_result": "#/components/schemas/BetaRequestToolResultBlock",
             "tool_search_tool_result": "#/components/schemas/BetaRequestToolSearchToolResultBlock",
             "tool_use": "#/components/schemas/BetaRequestToolUseBlock",
@@ -4747,6 +5206,12 @@
           },
           {
             "$ref": "#/components/schemas/BetaRequestMidConvSystemBlock"
+          },
+          {
+            "$ref": "#/components/schemas/BetaRequestToolAdditionBlock"
+          },
+          {
+            "$ref": "#/components/schemas/BetaRequestToolRemovalBlock"
           },
           {
             "$ref": "#/components/schemas/BetaRequestFallbackBlock"
@@ -5087,6 +5552,26 @@
           "type"
         ],
         "title": "LimitedNetworkParams",
+        "type": "object"
+      },
+      "BetaListDreamsResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/BetaDream"
+            },
+            "type": "array"
+          },
+          "next_page": {
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "data",
+          "next_page"
+        ],
         "type": "object"
       },
       "BetaListResponse_MessageBatch_": {
@@ -7488,6 +7973,13 @@
             "minLength": 1,
             "type": "string"
           },
+          "initial_events": {
+            "description": "Initial events to send to the `session` at creation, processed in order. Supports `user.message` and `user.define_outcome` events. Maximum 50 events.",
+            "items": {
+              "$ref": "#/components/schemas/BetaManagedAgentsSessionInitialEventParams"
+            },
+            "type": "array"
+          },
           "metadata": {
             "additionalProperties": {
               "type": "string"
@@ -8227,8 +8719,8 @@
         "description": "A custom tool that is executed by the API client rather than the agent. When the agent calls this tool, an `agent.custom_tool_use` event is emitted and the session goes idle, waiting for the client to provide the result via a `user.custom_tool_result` event.",
         "properties": {
           "description": {
-            "description": "Description of what the tool does, shown to the agent to help it decide when to use the tool. 1-1024 characters.",
-            "maxLength": 1024,
+            "description": "Description of what the tool does, shown to the agent to help it decide when to use the tool. 1-4096 characters.",
+            "maxLength": 4096,
             "minLength": 1,
             "type": "string"
           },
@@ -9043,6 +9535,138 @@
           {
             "$ref": "#/components/schemas/BetaManagedAgentsFileDocumentSource"
           }
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsEffort": {
+        "description": "How hard Claude works on each turn. Sets `output_config.effort` on every Messages call the session makes.",
+        "discriminator": {
+          "mapping": {
+            "high": "#/components/schemas/BetaManagedAgentsEffortHigh",
+            "low": "#/components/schemas/BetaManagedAgentsEffortLow",
+            "max": "#/components/schemas/BetaManagedAgentsEffortMax",
+            "medium": "#/components/schemas/BetaManagedAgentsEffortMedium",
+            "xhigh": "#/components/schemas/BetaManagedAgentsEffortXhigh"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsEffortLow"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsEffortMedium"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsEffortHigh"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsEffortXhigh"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsEffortMax"
+          }
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsEffortHigh": {
+        "additionalProperties": false,
+        "description": "High effort. Favors reasoning depth.",
+        "properties": {
+          "type": {
+            "enum": [
+              "high"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsEffortLevel": {
+        "description": "How hard Claude works on each turn. Higher levels favor reasoning depth over latency. Not all models accept every level; invalid combinations are rejected at create time.",
+        "enum": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ],
+        "type": "string"
+      },
+      "BetaManagedAgentsEffortLow": {
+        "additionalProperties": false,
+        "description": "Low effort. Favors latency over reasoning depth.",
+        "properties": {
+          "type": {
+            "enum": [
+              "low"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsEffortMax": {
+        "additionalProperties": false,
+        "description": "Maximum effort. Favors reasoning depth over latency.",
+        "properties": {
+          "type": {
+            "enum": [
+              "max"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsEffortMedium": {
+        "additionalProperties": false,
+        "description": "Medium effort. Balances latency and reasoning depth.",
+        "properties": {
+          "type": {
+            "enum": [
+              "medium"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object"
+      },
+      "BetaManagedAgentsEffortParams": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsEffortLevel"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsEffort"
+          }
+        ]
+      },
+      "BetaManagedAgentsEffortXhigh": {
+        "additionalProperties": false,
+        "description": "Extra-high effort. Not all models accept this level.",
+        "properties": {
+          "type": {
+            "enum": [
+              "xhigh"
+            ],
+            "type": "string"
+          }
+        },
+        "required": [
+          "type"
         ],
         "type": "object"
       },
@@ -10576,7 +11200,7 @@
         },
         "properties": {
           "data": {
-            "description": "Events for the session, ordered by `created_at`.",
+            "description": "Events for the session, ordered by `processed_at`.",
             "examples": [
               [
                 {
@@ -10710,7 +11334,7 @@
         "description": "Paginated list of events for a single thread within a `session`.",
         "properties": {
           "data": {
-            "description": "Events for the thread, ordered by `created_at`.",
+            "description": "Events for the thread, ordered by `processed_at`.",
             "items": {
               "$ref": "#/components/schemas/BetaManagedAgentsSessionEvent"
             },
@@ -12125,18 +12749,23 @@
             "x-stainless-nominal": false
           },
           {
+            "const": "claude-opus-5",
+            "description": "Powerful intelligence for long-running agents and coding",
+            "x-stainless-nominal": false
+          },
+          {
             "const": "claude-opus-4-8",
-            "description": "Frontier intelligence for long-running agents and coding",
+            "description": "Powerful intelligence for long-running agents and coding",
             "x-stainless-nominal": false
           },
           {
             "const": "claude-opus-4-7",
-            "description": "Frontier intelligence for long-running agents and coding",
+            "description": "Powerful intelligence for long-running agents and coding",
             "x-stainless-nominal": false
           },
           {
             "const": "claude-opus-4-6",
-            "description": "Most intelligent model for building agents and coding",
+            "description": "Powerful intelligence for long-running agents and coding",
             "x-stainless-nominal": false
           },
           {
@@ -12156,12 +12785,12 @@
           },
           {
             "const": "claude-opus-4-5",
-            "description": "Premium model combining maximum intelligence with practical performance",
+            "description": "Powerful intelligence for long-running agents and coding",
             "x-stainless-nominal": false
           },
           {
             "const": "claude-opus-4-5-20251101",
-            "description": "Premium model combining maximum intelligence with practical performance",
+            "description": "Powerful intelligence for long-running agents and coding",
             "x-stainless-nominal": false
           },
           {
@@ -12182,10 +12811,18 @@
         "additionalProperties": false,
         "description": "Model identifier and configuration.",
         "example": {
-          "id": "claude-opus-4-6",
+          "id": "claude-opus-4-8",
           "speed": "standard"
         },
         "properties": {
+          "effort": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsEffort"
+              }
+            ],
+            "description": "How hard Claude works on each inference call. One of `low`, `medium`, `high`, `xhigh`, `max`. Always present; resolved to the per-model default at save time when not supplied."
+          },
           "id": {
             "$ref": "#/components/schemas/BetaManagedAgentsModel"
           },
@@ -12210,9 +12847,18 @@
         "additionalProperties": false,
         "description": "An object that defines additional configuration control over model use",
         "example": {
-          "id": "claude-opus-4-6"
+          "id": "claude-opus-4-8"
         },
         "properties": {
+          "effort": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BetaManagedAgentsEffortParams"
+              }
+            ],
+            "description": "How hard Claude works on each inference call. Accepts a bare level string (`\"high\"`) or `{\"type\": \"high\"}`. On create, omitting it resolves the per-model default; on update, omitting it leaves the stored value unchanged.",
+            "nullable": true
+          },
           "id": {
             "$ref": "#/components/schemas/BetaManagedAgentsModel"
           },
@@ -14013,6 +14659,25 @@
         ],
         "type": "object"
       },
+      "BetaManagedAgentsSessionInitialEventParams": {
+        "description": "An event sent to the `session` immediately after it is created. Supports `user.message` and `user.define_outcome`.",
+        "discriminator": {
+          "mapping": {
+            "user.define_outcome": "#/components/schemas/BetaManagedAgentsUserDefineOutcomeEventParams",
+            "user.message": "#/components/schemas/BetaManagedAgentsUserMessageEventParams"
+          },
+          "propertyName": "type"
+        },
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsUserMessageEventParams"
+          },
+          {
+            "$ref": "#/components/schemas/BetaManagedAgentsUserDefineOutcomeEventParams"
+          }
+        ],
+        "type": "object"
+      },
       "BetaManagedAgentsSessionMultiagent": {
         "description": "Resolved multiagent orchestration configuration as returned on a `session`.",
         "discriminator": {
@@ -14208,7 +14873,7 @@
       },
       "BetaManagedAgentsSessionRetriesExhausted": {
         "additionalProperties": false,
-        "description": "The turn ended because the retry budget was exhausted (`max_iterations` hit or an error escalated to `retry_status: 'exhausted'`).",
+        "description": "The turn ended because repeated errors exhausted the retry budget or an error escalated to `retry_status: 'exhausted'`.",
         "properties": {
           "type": {
             "enum": [
@@ -16653,7 +17318,7 @@
             "type": "array"
           },
           "version": {
-            "description": "The agent's current version, used to prevent concurrent overwrites. Obtain this value from a create or retrieve response. The request fails if this does not match the server's current version.",
+            "description": "The agent's current version, used to prevent concurrent overwrites. Obtain this value from a create or retrieve response. Must be at least 1 if specified. When supplied, the request fails if it does not match the server's current version; omit to apply the update unconditionally.",
             "examples": [
               1
             ],
@@ -16661,9 +17326,6 @@
             "type": "integer"
           }
         },
-        "required": [
-          "version"
-        ],
         "type": "object"
       },
       "BetaManagedAgentsUpdateCredentialRequestBody": {
@@ -18220,7 +18882,7 @@
                 "type": "null"
               }
             ],
-            "description": "The reason that we stopped.\n\nThis may be one the following values:\n* `\"end_turn\"`: the model reached a natural stopping point\n* `\"max_tokens\"`: we exceeded the requested `max_tokens` or the model's maximum\n* `\"stop_sequence\"`: one of your provided custom `stop_sequences` was generated\n* `\"tool_use\"`: the model invoked one or more tools\n* `\"pause_turn\"`: we paused a long-running turn. You may provide the response back as-is in a subsequent request to let the model continue.\n* `\"refusal\"`: when streaming classifiers intervene to handle potential policy violations\n\nIn non-streaming mode this value is always non-null. In streaming mode, it is null in the `message_start` event and non-null otherwise.",
+            "description": "The reason that we stopped.\n\nThis may be one the following values:\n* `\"end_turn\"`: the model reached a natural stopping point\n* `\"max_tokens\"`: we exceeded the requested `max_tokens` or the model's maximum\n* `\"stop_sequence\"`: one of your provided custom `stop_sequences` was generated\n* `\"tool_use\"`: the model invoked one or more tools\n* `\"pause_turn\"`: we paused a long-running turn. You may provide the response back as-is in a subsequent request to let the model continue.\n* `\"refusal\"`: when streaming classifiers intervene to handle potential policy violations\n* `\"model_context_window_exceeded\"`: we exceeded the model's context window\n\nIn non-streaming mode this value is always non-null. In streaming mode, it is null in the `message_start` event and non-null otherwise.",
             "title": "Stop Reason"
           },
           "stop_sequence": {
@@ -18615,6 +19277,18 @@
             ],
             "title": "Cache Read Input Tokens"
           },
+          "fallback_credit": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BetaFallbackCreditUsage"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Outcome of the `fallback_credit_token` presented on this request.\n\nPresent on every response to a non-batch request that carried a\n`fallback_credit_token`, in either redemption mode; absent otherwise (batch\nitems accept and ignore the token and carry no outcome object)."
+          },
           "input_tokens": {
             "anyOf": [
               {
@@ -18671,6 +19345,7 @@
         "required": [
           "cache_creation_input_tokens",
           "cache_read_input_tokens",
+          "fallback_credit",
           "input_tokens",
           "iterations",
           "output_tokens",
@@ -19557,10 +20232,18 @@
           "cyber",
           "bio",
           "frontier_llm",
-          "reasoning_extraction"
+          "reasoning_extraction",
+          "general_harms"
         ],
         "title": "RefusalCategory",
-        "type": "string"
+        "type": "string",
+        "x-enum-descriptions": [
+          "The request could enable cyber harm, such as malware or exploit development. Benign cybersecurity work can also trigger this category.",
+          "The request could enable biological harm, such as dangerous lab methods. Beneficial life sciences work can also trigger this category.",
+          "The request could assist the development of competing AI models, which is restricted under [Anthropic's commercial terms](https://www.anthropic.com/legal/commercial-terms). Benign machine learning work can also trigger this category.",
+          "The request asks the model to reproduce its internal reasoning in the response text. To get reasoning in a structured form instead, use [adaptive thinking](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking).",
+          "The request could be related to an area that was determined as harmful. Benign work might sometimes trigger this category."
+        ]
       },
       "BetaRefusalStopDetails": {
         "description": "Structured information about a refusal.",
@@ -19588,6 +20271,9 @@
             ],
             "default": null,
             "description": "Human-readable explanation of the refusal.\n\nThis text is not guaranteed to be stable. `null` when no explanation is available for the category.",
+            "examples": [
+              "This request was declined because it conflicts with Anthropic's Usage Policy."
+            ],
             "title": "Explanation"
           },
           "fallback_credit_token": {
@@ -19601,6 +20287,9 @@
             ],
             "default": null,
             "description": "Opaque code that refunds the cache-miss cost when retrying this refused\nrequest on the fallback model. Pass it as `fallback_credit_token` on the\nretry request. Expires 5 minutes after the refusal.\n\nThe retry is sent either with the same request body (`system`, `messages`,\n`tools`, and other render-shaping fields), or with the same body plus one\nappended `assistant` message whose content is the partial text (with any\ntrailing whitespace stripped from the final text block) and paired\nserver-tool blocks from this refusal \u2014 which also authorizes that\nappended turn as an assistant-prefill continuation on models that otherwise\ndisallow prefill. A token minted mid-server-tool-loop whose partial content\nwas continuable may only be redeemed the second way \u2014 if a same-body retry\nis rejected with a 400 saying the token must be redeemed by continuing the\npartial response, retry the second way instead. Either way: same workspace,\nsame platform; a mismatch is a 400. Resending a token for an already-warm\nprefix is permitted but yields no additional credit.\n\n`null` when the refused model isn't eligible for a fallback credit.",
+            "examples": [
+              "QW50aHJvcGljL0NsYXVkZQ=="
+            ],
             "title": "Fallback Credit Token"
           },
           "fallback_has_prefill_claim": {
@@ -19627,6 +20316,9 @@
             ],
             "default": null,
             "description": "The server's suggested retry target for this refusal. Populated when a fallback attempt could not be made (the fallback model's rate limit was exhausted, or it was overloaded); names the fallback model the caller can retry directly. Null otherwise.",
+            "examples": [
+              "claude-sonnet-4-6"
+            ],
             "title": "Recommended Model"
           },
           "type": {
@@ -19923,6 +20615,9 @@
         "additionalProperties": false,
         "properties": {
           "cited_text": {
+            "examples": [
+              "The grass is green. The sky is blue."
+            ],
             "title": "Cited Text",
             "type": "string"
           },
@@ -20231,6 +20926,9 @@
         "properties": {
           "cited_text": {
             "description": "The full text of the cited block range, concatenated.\n\nAlways equals the contents of `content[start_block_index:end_block_index]` joined together. The text block is the minimal citable unit; this field is never a substring of a single block. Not counted toward output tokens, and not counted toward input tokens when sent back in subsequent turns.",
+            "examples": [
+              "The grass is green. The sky is blue."
+            ],
             "title": "Cited Text",
             "type": "string"
           },
@@ -20814,13 +21512,21 @@
             "items": {
               "discriminator": {
                 "mapping": {
-                  "text": "#/components/schemas/BetaRequestTextBlock"
+                  "text": "#/components/schemas/BetaRequestTextBlock",
+                  "tool_addition": "#/components/schemas/BetaRequestToolAdditionBlock",
+                  "tool_removal": "#/components/schemas/BetaRequestToolRemovalBlock"
                 },
                 "propertyName": "type"
               },
               "oneOf": [
                 {
                   "$ref": "#/components/schemas/BetaRequestTextBlock"
+                },
+                {
+                  "$ref": "#/components/schemas/BetaRequestToolAdditionBlock"
+                },
+                {
+                  "$ref": "#/components/schemas/BetaRequestToolRemovalBlock"
                 }
               ]
             },
@@ -20844,6 +21550,9 @@
         "additionalProperties": false,
         "properties": {
           "cited_text": {
+            "examples": [
+              "The grass is green. The sky is blue."
+            ],
             "title": "Cited Text",
             "type": "string"
           },
@@ -20974,6 +21683,9 @@
         "properties": {
           "cited_text": {
             "description": "The full text of the cited block range, concatenated.\n\nAlways equals the contents of `content[start_block_index:end_block_index]` joined together. The text block is the minimal citable unit; this field is never a substring of a single block. Not counted toward output tokens, and not counted toward input tokens when sent back in subsequent turns.",
+            "examples": [
+              "The grass is green. The sky is blue."
+            ],
             "title": "Cited Text",
             "type": "string"
           },
@@ -21468,6 +22180,67 @@
         "title": "RequestThinkingBlock",
         "type": "object"
       },
+      "BetaRequestToolAdditionBlock": {
+        "additionalProperties": false,
+        "description": "Mid-conversation directive to surface a declared tool.\n\n``tool`` references a tool (or MCP toolset) by name from the request's\n``tools``; it is offered to the model from this point in the\nconversation onward.",
+        "properties": {
+          "cache_control": {
+            "anyOf": [
+              {
+                "discriminator": {
+                  "mapping": {
+                    "ephemeral": "#/components/schemas/BetaCacheControlEphemeral"
+                  },
+                  "propertyName": "type"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/BetaCacheControlEphemeral"
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Create a cache control breakpoint at this content block.",
+            "title": "Cache Control"
+          },
+          "tool": {
+            "discriminator": {
+              "mapping": {
+                "mcp_tool_reference": "#/components/schemas/BetaToolChangeMCPToolReference",
+                "mcp_toolset_reference": "#/components/schemas/BetaToolChangeMCPToolsetReference",
+                "tool_reference": "#/components/schemas/BetaToolChangeToolReference"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/BetaToolChangeToolReference"
+              },
+              {
+                "$ref": "#/components/schemas/BetaToolChangeMCPToolReference"
+              },
+              {
+                "$ref": "#/components/schemas/BetaToolChangeMCPToolsetReference"
+              }
+            ],
+            "title": "Tool"
+          },
+          "type": {
+            "const": "tool_addition",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tool",
+          "type"
+        ],
+        "title": "RequestToolAdditionBlock",
+        "type": "object"
+      },
       "BetaRequestToolReferenceBlock": {
         "additionalProperties": false,
         "description": "Tool reference block that can be included in tool_result content.",
@@ -21512,6 +22285,67 @@
           "type"
         ],
         "title": "RequestToolReferenceBlock",
+        "type": "object"
+      },
+      "BetaRequestToolRemovalBlock": {
+        "additionalProperties": false,
+        "description": "Mid-conversation directive to withdraw a tool.\n\n``tool`` references a tool (or MCP toolset) by name from the request's\n``tools``; it is no longer offered to the model from this point in the\nconversation onward.",
+        "properties": {
+          "cache_control": {
+            "anyOf": [
+              {
+                "discriminator": {
+                  "mapping": {
+                    "ephemeral": "#/components/schemas/BetaCacheControlEphemeral"
+                  },
+                  "propertyName": "type"
+                },
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/BetaCacheControlEphemeral"
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Create a cache control breakpoint at this content block.",
+            "title": "Cache Control"
+          },
+          "tool": {
+            "discriminator": {
+              "mapping": {
+                "mcp_tool_reference": "#/components/schemas/BetaToolChangeMCPToolReference",
+                "mcp_toolset_reference": "#/components/schemas/BetaToolChangeMCPToolsetReference",
+                "tool_reference": "#/components/schemas/BetaToolChangeToolReference"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/BetaToolChangeToolReference"
+              },
+              {
+                "$ref": "#/components/schemas/BetaToolChangeMCPToolReference"
+              },
+              {
+                "$ref": "#/components/schemas/BetaToolChangeMCPToolsetReference"
+              }
+            ],
+            "title": "Tool"
+          },
+          "type": {
+            "const": "tool_removal",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "tool",
+          "type"
+        ],
+        "title": "RequestToolRemovalBlock",
         "type": "object"
       },
       "BetaRequestToolResultBlock": {
@@ -21981,6 +22815,9 @@
         "additionalProperties": false,
         "properties": {
           "cited_text": {
+            "examples": [
+              "The grass is green. The sky is blue."
+            ],
             "title": "Cited Text",
             "type": "string"
           },
@@ -22365,6 +23202,9 @@
       "BetaResponseCharLocationCitation": {
         "properties": {
           "cited_text": {
+            "examples": [
+              "The grass is green. The sky is blue."
+            ],
             "title": "Cited Text",
             "type": "string"
           },
@@ -22382,6 +23222,9 @@
                 "type": "null"
               }
             ],
+            "examples": [
+              "My Document"
+            ],
             "title": "Document Title"
           },
           "end_char_index": {
@@ -22398,6 +23241,9 @@
               }
             ],
             "default": null,
+            "examples": [
+              "file_011CNha8iCJcU1wXNR6q4V8w"
+            ],
             "title": "File Id"
           },
           "start_char_index": {
@@ -22679,6 +23525,9 @@
         "properties": {
           "cited_text": {
             "description": "The full text of the cited block range, concatenated.\n\nAlways equals the contents of `content[start_block_index:end_block_index]` joined together. The text block is the minimal citable unit; this field is never a substring of a single block. Not counted toward output tokens, and not counted toward input tokens when sent back in subsequent turns.",
+            "examples": [
+              "The grass is green. The sky is blue."
+            ],
             "title": "Cited Text",
             "type": "string"
           },
@@ -22695,6 +23544,9 @@
               {
                 "type": "null"
               }
+            ],
+            "examples": [
+              "My Document"
             ],
             "title": "Document Title"
           },
@@ -22713,6 +23565,9 @@
               }
             ],
             "default": null,
+            "examples": [
+              "file_011CNha8iCJcU1wXNR6q4V8w"
+            ],
             "title": "File Id"
           },
           "start_block_index": {
@@ -23001,6 +23856,9 @@
       "BetaResponsePageLocationCitation": {
         "properties": {
           "cited_text": {
+            "examples": [
+              "The grass is green. The sky is blue."
+            ],
             "title": "Cited Text",
             "type": "string"
           },
@@ -23018,6 +23876,9 @@
                 "type": "null"
               }
             ],
+            "examples": [
+              "My Document"
+            ],
             "title": "Document Title"
           },
           "end_page_number": {
@@ -23034,6 +23895,9 @@
               }
             ],
             "default": null,
+            "examples": [
+              "file_011CNha8iCJcU1wXNR6q4V8w"
+            ],
             "title": "File Id"
           },
           "start_page_number": {
@@ -23084,6 +23948,9 @@
         "properties": {
           "cited_text": {
             "description": "The full text of the cited block range, concatenated.\n\nAlways equals the contents of `content[start_block_index:end_block_index]` joined together. The text block is the minimal citable unit; this field is never a substring of a single block. Not counted toward output tokens, and not counted toward input tokens when sent back in subsequent turns.",
+            "examples": [
+              "The grass is green. The sky is blue."
+            ],
             "title": "Cited Text",
             "type": "string"
           },
@@ -23860,6 +24727,9 @@
       "BetaResponseWebSearchResultLocationCitation": {
         "properties": {
           "cited_text": {
+            "examples": [
+              "The grass is green. The sky is blue."
+            ],
             "title": "Cited Text",
             "type": "string"
           },
@@ -24077,6 +24947,18 @@
             "title": "Metadata",
             "type": "object"
           },
+          "secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Credential payload used by the environment worker to execute this work item. May be populated when polling for work; null on all other retrieval paths.",
+            "title": "Secret"
+          },
           "started_at": {
             "anyOf": [
               {
@@ -24141,6 +25023,7 @@
           "id",
           "latest_heartbeat_at",
           "metadata",
+          "secret",
           "started_at",
           "state",
           "stop_requested_at",
@@ -24611,11 +25494,11 @@
         "type": "object"
       },
       "BetaSpeed": {
+        "description": "Inference speed mode. `fast` provides significantly faster output token generation at premium pricing. Not all models support `fast`; invalid combinations are rejected at create time.",
         "enum": [
           "standard",
           "fast"
         ],
-        "title": "Speed",
         "type": "string"
       },
       "BetaStopReason": {
@@ -25347,6 +26230,75 @@
         "title": "Tool",
         "type": "object"
       },
+      "BetaToolChangeMCPToolReference": {
+        "additionalProperties": false,
+        "description": "Reference to a single MCP tool by its server and remote name \u2014 the\nsame ``server_name``/``name`` pair ``mcp_tool_use`` carries.",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "server_name": {
+            "title": "Server Name",
+            "type": "string"
+          },
+          "type": {
+            "const": "mcp_tool_reference",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "server_name",
+          "type"
+        ],
+        "title": "ToolChangeMCPToolReference",
+        "type": "object"
+      },
+      "BetaToolChangeMCPToolsetReference": {
+        "additionalProperties": false,
+        "description": "Reference to every tool in the named MCP server's toolset.",
+        "properties": {
+          "server_name": {
+            "title": "Server Name",
+            "type": "string"
+          },
+          "type": {
+            "const": "mcp_toolset_reference",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "server_name",
+          "type"
+        ],
+        "title": "ToolChangeMCPToolsetReference",
+        "type": "object"
+      },
+      "BetaToolChangeToolReference": {
+        "additionalProperties": false,
+        "description": "Reference to a single tool the caller declared directly in\n``tools[]``. Does not accept the composed ``{server}_{name}`` form the\nserver assigns to MCP-resolved tools \u2014 use ``mcp_tool_reference`` or\n``mcp_toolset_reference`` for those.",
+        "properties": {
+          "name": {
+            "pattern": "^[a-zA-Z0-9_-]{1,128}$",
+            "title": "Name",
+            "type": "string"
+          },
+          "type": {
+            "const": "tool_reference",
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "type"
+        ],
+        "title": "ToolChangeToolReference",
+        "type": "object"
+      },
       "BetaToolChoice": {
         "description": "How the model should use the provided tools. The model can use a specific tool, any available tool, decide by itself, or not use tools at all.",
         "discriminator": {
@@ -25675,9 +26627,7 @@
             "type": "string"
           },
           "type": {
-            "enum": [
-              "tunnel"
-            ],
+            "const": "tunnel",
             "type": "string"
           }
         },
@@ -25734,9 +26684,7 @@
             "type": "string"
           },
           "type": {
-            "enum": [
-              "tunnel_certificate"
-            ],
+            "const": "tunnel_certificate",
             "type": "string"
           }
         },
@@ -25764,9 +26712,7 @@
             "type": "string"
           },
           "type": {
-            "enum": [
-              "tunnel_token"
-            ],
+            "const": "tunnel_token",
             "type": "string"
           }
         },
@@ -25924,6 +26870,18 @@
             ],
             "title": "Cache Read Input Tokens"
           },
+          "fallback_credit": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BetaFallbackCreditUsage"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Outcome of the `fallback_credit_token` presented on this request.\n\nPresent on every response to a non-batch request that carried a\n`fallback_credit_token`, in either redemption mode; absent otherwise (batch\nitems accept and ignore the token and carry no outcome object)."
+          },
           "inference_geo": {
             "anyOf": [
               {
@@ -25935,6 +26893,9 @@
             ],
             "default": null,
             "description": "The geographic region where inference was performed for this request.",
+            "examples": [
+              "global"
+            ],
             "title": "Inference Geo"
           },
           "input_tokens": {
@@ -26017,6 +26978,7 @@
           "cache_creation",
           "cache_creation_input_tokens",
           "cache_read_input_tokens",
+          "fallback_credit",
           "inference_geo",
           "input_tokens",
           "iterations",
@@ -27532,6 +28494,110 @@
         "title": "BetaWebhookDeploymentUpdatedEventData",
         "type": "object"
       },
+      "BetaWebhookEnvironmentArchivedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the environment that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "environment.archived",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookEnvironmentArchivedEventData",
+        "type": "object"
+      },
+      "BetaWebhookEnvironmentCreatedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the environment that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "environment.created",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookEnvironmentCreatedEventData",
+        "type": "object"
+      },
+      "BetaWebhookEnvironmentDeletedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the environment that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "environment.deleted",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookEnvironmentDeletedEventData",
+        "type": "object"
+      },
+      "BetaWebhookEnvironmentUpdatedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the environment that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "environment.updated",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookEnvironmentUpdatedEventData",
+        "type": "object"
+      },
       "BetaWebhookEvent": {
         "example": {
           "created_at": "2026-03-15T10:00:00Z",
@@ -27541,7 +28607,7 @@
             "type": "session.status_idled",
             "workspace_id": "wrkspc_011CZkZaBF1tNoB5wlCeusgy"
           },
-          "id": "wevt_011CZkZYZd9rLmz3ujAcsqEw",
+          "id": "whe_0f1e2d3c4b5a69788796a5b4c3d2e1f0",
           "type": "event"
         },
         "properties": {
@@ -27567,7 +28633,7 @@
           "id": {
             "description": "Unique event identifier for idempotency.",
             "examples": [
-              "wevt_011CZkZYZd9rLmz3ujAcsqEw"
+              "whe_0f1e2d3c4b5a69788796a5b4c3d2e1f0"
             ],
             "type": "string"
           },
@@ -27605,6 +28671,13 @@
             "deployment_run.failed": "#/components/schemas/BetaWebhookDeploymentRunFailedEventData",
             "deployment_run.started": "#/components/schemas/BetaWebhookDeploymentRunStartedEventData",
             "deployment_run.succeeded": "#/components/schemas/BetaWebhookDeploymentRunSucceededEventData",
+            "environment.archived": "#/components/schemas/BetaWebhookEnvironmentArchivedEventData",
+            "environment.created": "#/components/schemas/BetaWebhookEnvironmentCreatedEventData",
+            "environment.deleted": "#/components/schemas/BetaWebhookEnvironmentDeletedEventData",
+            "environment.updated": "#/components/schemas/BetaWebhookEnvironmentUpdatedEventData",
+            "memory_store.archived": "#/components/schemas/BetaWebhookMemoryStoreArchivedEventData",
+            "memory_store.created": "#/components/schemas/BetaWebhookMemoryStoreCreatedEventData",
+            "memory_store.deleted": "#/components/schemas/BetaWebhookMemoryStoreDeletedEventData",
             "session.archived": "#/components/schemas/BetaWebhookSessionArchivedEventData",
             "session.created": "#/components/schemas/BetaWebhookSessionCreatedEventData",
             "session.deleted": "#/components/schemas/BetaWebhookSessionDeletedEventData",
@@ -27739,9 +28812,108 @@
           },
           {
             "$ref": "#/components/schemas/BetaWebhookDeploymentRunSucceededEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookEnvironmentCreatedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookEnvironmentUpdatedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookEnvironmentArchivedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookEnvironmentDeletedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookMemoryStoreCreatedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookMemoryStoreArchivedEventData"
+          },
+          {
+            "$ref": "#/components/schemas/BetaWebhookMemoryStoreDeletedEventData"
           }
         ],
         "title": "BetaWebhookEventData"
+      },
+      "BetaWebhookMemoryStoreArchivedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the memory store that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "memory_store.archived",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookMemoryStoreArchivedEventData",
+        "type": "object"
+      },
+      "BetaWebhookMemoryStoreCreatedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the memory store that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "memory_store.created",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookMemoryStoreCreatedEventData",
+        "type": "object"
+      },
+      "BetaWebhookMemoryStoreDeletedEventData": {
+        "properties": {
+          "id": {
+            "description": "ID of the memory store that triggered the event.",
+            "type": "string"
+          },
+          "organization_id": {
+            "type": "string"
+          },
+          "type": {
+            "const": "memory_store.deleted",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "id",
+          "organization_id",
+          "workspace_id"
+        ],
+        "title": "BetaWebhookMemoryStoreDeletedEventData",
+        "type": "object"
       },
       "BetaWebhookSessionArchivedEventData": {
         "properties": {
@@ -29062,6 +30234,9 @@
           },
           "id": {
             "description": "Identifier for the container used in this request",
+            "examples": [
+              "container_011CpZohnwH4vuy7gazohgSP"
+            ],
             "title": "Id",
             "type": "string"
           }
@@ -30907,7 +32082,7 @@
                 "type": "null"
               }
             ],
-            "description": "The reason that we stopped.\n\nThis may be one the following values:\n* `\"end_turn\"`: the model reached a natural stopping point\n* `\"max_tokens\"`: we exceeded the requested `max_tokens` or the model's maximum\n* `\"stop_sequence\"`: one of your provided custom `stop_sequences` was generated\n* `\"tool_use\"`: the model invoked one or more tools\n* `\"pause_turn\"`: we paused a long-running turn. You may provide the response back as-is in a subsequent request to let the model continue.\n* `\"refusal\"`: when streaming classifiers intervene to handle potential policy violations\n\nIn non-streaming mode this value is always non-null. In streaming mode, it is null in the `message_start` event and non-null otherwise.",
+            "description": "The reason that we stopped.\n\nThis may be one the following values:\n* `\"end_turn\"`: the model reached a natural stopping point\n* `\"max_tokens\"`: we exceeded the requested `max_tokens` or the model's maximum\n* `\"stop_sequence\"`: one of your provided custom `stop_sequences` was generated\n* `\"tool_use\"`: the model invoked one or more tools\n* `\"pause_turn\"`: we paused a long-running turn. You may provide the response back as-is in a subsequent request to let the model continue.\n* `\"refusal\"`: when streaming classifiers intervene to handle potential policy violations\n* `\"model_context_window_exceeded\"`: we exceeded the model's context window\n\nIn non-streaming mode this value is always non-null. In streaming mode, it is null in the `message_start` event and non-null otherwise.",
             "title": "Stop Reason"
           },
           "stop_sequence": {
@@ -31480,13 +32655,18 @@
             "x-stainless-nominal": false
           },
           {
+            "const": "claude-opus-5",
+            "description": "Powerful intelligence for long-running agents and coding",
+            "x-stainless-nominal": false
+          },
+          {
             "const": "claude-opus-4-8",
-            "description": "Frontier intelligence for long-running agents and coding",
+            "description": "Powerful intelligence for long-running agents and coding",
             "x-stainless-nominal": false
           },
           {
             "const": "claude-opus-4-7",
-            "description": "Frontier intelligence for long-running agents and coding",
+            "description": "Powerful intelligence for long-running agents and coding",
             "x-stainless-nominal": false
           },
           {
@@ -31498,7 +32678,7 @@
           },
           {
             "const": "claude-opus-4-6",
-            "description": "Frontier intelligence for long-running agents and coding",
+            "description": "Powerful intelligence for long-running agents and coding",
             "x-stainless-nominal": false
           },
           {
@@ -31518,12 +32698,12 @@
           },
           {
             "const": "claude-opus-4-5",
-            "description": "Premium model combining maximum intelligence with practical performance",
+            "description": "Powerful intelligence for long-running agents and coding",
             "x-stainless-nominal": false
           },
           {
             "const": "claude-opus-4-5-20251101",
-            "description": "Premium model combining maximum intelligence with practical performance",
+            "description": "Powerful intelligence for long-running agents and coding",
             "x-stainless-nominal": false
           },
           {
@@ -31539,14 +32719,14 @@
           {
             "const": "claude-opus-4-1",
             "deprecated": true,
-            "description": "Exceptional model for specialized complex tasks",
+            "description": "Powerful intelligence for long-running agents and coding",
             "x-stainless-deprecation-message": "Will reach end-of-life on August 5, 2026. Please migrate to a newer model. Visit https://docs.anthropic.com/en/docs/resources/model-deprecations for more information.",
             "x-stainless-nominal": false
           },
           {
             "const": "claude-opus-4-1-20250805",
             "deprecated": true,
-            "description": "Exceptional model for specialized complex tasks",
+            "description": "Powerful intelligence for long-running agents and coding",
             "x-stainless-deprecation-message": "Will reach end-of-life on August 5, 2026. Please migrate to a newer model. Visit https://docs.anthropic.com/en/docs/resources/model-deprecations for more information.",
             "x-stainless-nominal": false
           }
@@ -31851,10 +33031,18 @@
           "cyber",
           "bio",
           "frontier_llm",
-          "reasoning_extraction"
+          "reasoning_extraction",
+          "general_harms"
         ],
         "title": "RefusalCategory",
-        "type": "string"
+        "type": "string",
+        "x-enum-descriptions": [
+          "The request could enable cyber harm, such as malware or exploit development. Benign cybersecurity work can also trigger this category.",
+          "The request could enable biological harm, such as dangerous lab methods. Beneficial life sciences work can also trigger this category.",
+          "The request could assist the development of competing AI models, which is restricted under [Anthropic's commercial terms](https://www.anthropic.com/legal/commercial-terms). Benign machine learning work can also trigger this category.",
+          "The request asks the model to reproduce its internal reasoning in the response text. To get reasoning in a structured form instead, use [adaptive thinking](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking).",
+          "The request could be related to an area that was determined as harmful. Benign work might sometimes trigger this category."
+        ]
       },
       "RefusalStopDetails": {
         "description": "Structured information about a refusal.",
@@ -31882,6 +33070,9 @@
             ],
             "default": null,
             "description": "Human-readable explanation of the refusal.\n\nThis text is not guaranteed to be stable. `null` when no explanation is available for the category.",
+            "examples": [
+              "This request was declined because it conflicts with Anthropic's Usage Policy."
+            ],
             "title": "Explanation"
           },
           "type": {
@@ -32035,6 +33226,9 @@
         "additionalProperties": false,
         "properties": {
           "cited_text": {
+            "examples": [
+              "The grass is green. The sky is blue."
+            ],
             "title": "Cited Text",
             "type": "string"
           },
@@ -32276,6 +33470,9 @@
         "properties": {
           "cited_text": {
             "description": "The full text of the cited block range, concatenated.\n\nAlways equals the contents of `content[start_block_index:end_block_index]` joined together. The text block is the minimal citable unit; this field is never a substring of a single block. Not counted toward output tokens, and not counted toward input tokens when sent back in subsequent turns.",
+            "examples": [
+              "The grass is green. The sky is blue."
+            ],
             "title": "Cited Text",
             "type": "string"
           },
@@ -32638,6 +33835,9 @@
         "additionalProperties": false,
         "properties": {
           "cited_text": {
+            "examples": [
+              "The grass is green. The sky is blue."
+            ],
             "title": "Cited Text",
             "type": "string"
           },
@@ -32768,6 +33968,9 @@
         "properties": {
           "cited_text": {
             "description": "The full text of the cited block range, concatenated.\n\nAlways equals the contents of `content[start_block_index:end_block_index]` joined together. The text block is the minimal citable unit; this field is never a substring of a single block. Not counted toward output tokens, and not counted toward input tokens when sent back in subsequent turns.",
+            "examples": [
+              "The grass is green. The sky is blue."
+            ],
             "title": "Cited Text",
             "type": "string"
           },
@@ -33774,6 +34977,9 @@
         "additionalProperties": false,
         "properties": {
           "cited_text": {
+            "examples": [
+              "The grass is green. The sky is blue."
+            ],
             "title": "Cited Text",
             "type": "string"
           },
@@ -34034,6 +35240,9 @@
       "ResponseCharLocationCitation": {
         "properties": {
           "cited_text": {
+            "examples": [
+              "The grass is green. The sky is blue."
+            ],
             "title": "Cited Text",
             "type": "string"
           },
@@ -34051,6 +35260,9 @@
                 "type": "null"
               }
             ],
+            "examples": [
+              "My Document"
+            ],
             "title": "Document Title"
           },
           "end_char_index": {
@@ -34067,6 +35279,9 @@
               }
             ],
             "default": null,
+            "examples": [
+              "file_011CNha8iCJcU1wXNR6q4V8w"
+            ],
             "title": "File Id"
           },
           "start_char_index": {
@@ -34245,6 +35460,9 @@
         "properties": {
           "cited_text": {
             "description": "The full text of the cited block range, concatenated.\n\nAlways equals the contents of `content[start_block_index:end_block_index]` joined together. The text block is the minimal citable unit; this field is never a substring of a single block. Not counted toward output tokens, and not counted toward input tokens when sent back in subsequent turns.",
+            "examples": [
+              "The grass is green. The sky is blue."
+            ],
             "title": "Cited Text",
             "type": "string"
           },
@@ -34261,6 +35479,9 @@
               {
                 "type": "null"
               }
+            ],
+            "examples": [
+              "My Document"
             ],
             "title": "Document Title"
           },
@@ -34279,6 +35500,9 @@
               }
             ],
             "default": null,
+            "examples": [
+              "file_011CNha8iCJcU1wXNR6q4V8w"
+            ],
             "title": "File Id"
           },
           "start_block_index": {
@@ -34409,6 +35633,9 @@
       "ResponsePageLocationCitation": {
         "properties": {
           "cited_text": {
+            "examples": [
+              "The grass is green. The sky is blue."
+            ],
             "title": "Cited Text",
             "type": "string"
           },
@@ -34426,6 +35653,9 @@
                 "type": "null"
               }
             ],
+            "examples": [
+              "My Document"
+            ],
             "title": "Document Title"
           },
           "end_page_number": {
@@ -34442,6 +35672,9 @@
               }
             ],
             "default": null,
+            "examples": [
+              "file_011CNha8iCJcU1wXNR6q4V8w"
+            ],
             "title": "File Id"
           },
           "start_page_number": {
@@ -34492,6 +35725,9 @@
         "properties": {
           "cited_text": {
             "description": "The full text of the cited block range, concatenated.\n\nAlways equals the contents of `content[start_block_index:end_block_index]` joined together. The text block is the minimal citable unit; this field is never a substring of a single block. Not counted toward output tokens, and not counted toward input tokens when sent back in subsequent turns.",
+            "examples": [
+              "The grass is green. The sky is blue."
+            ],
             "title": "Cited Text",
             "type": "string"
           },
@@ -35279,6 +36515,9 @@
       "ResponseWebSearchResultLocationCitation": {
         "properties": {
           "cited_text": {
+            "examples": [
+              "The grass is green. The sky is blue."
+            ],
             "title": "Cited Text",
             "type": "string"
           },
@@ -35500,7 +36739,8 @@
           "stop_sequence",
           "tool_use",
           "pause_turn",
-          "refusal"
+          "refusal",
+          "model_context_window_exceeded"
         ],
         "type": "string"
       },
@@ -36421,6 +37661,9 @@
             ],
             "default": null,
             "description": "The geographic region where inference was performed for this request.",
+            "examples": [
+              "global"
+            ],
             "title": "Inference Geo"
           },
           "input_tokens": {
@@ -38226,6 +39469,9 @@
         "requestBody": {
           "content": {
             "application/json": {
+              "example": {
+                "description": "updated"
+              },
               "schema": {
                 "$ref": "#/components/schemas/BetaManagedAgentsUpdateAgentParams"
               }
@@ -41182,6 +42428,1110 @@
           }
         },
         "summary": "Create Deployment"
+      }
+    },
+    "/v1/dreams/{dream_id}/archive?beta=true": {
+      "post": {
+        "operationId": "BetaArchiveDream",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Path parameter dream_id",
+            "in": "path",
+            "name": "dream_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-stainless-cli-data-alias": "id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaDream"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "Archive a Dream"
+      }
+    },
+    "/v1/dreams/{dream_id}/cancel?beta=true": {
+      "post": {
+        "operationId": "BetaCancelDream",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Path parameter dream_id",
+            "in": "path",
+            "name": "dream_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-stainless-cli-data-alias": "id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaDream"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "Cancel a Dream"
+      }
+    },
+    "/v1/dreams/{dream_id}?beta=true": {
+      "get": {
+        "operationId": "BetaGetDream",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Path parameter dream_id",
+            "in": "path",
+            "name": "dream_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "x-stainless-cli-data-alias": "id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaDream"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "Get a Dream"
+      }
+    },
+    "/v1/dreams?beta=true": {
+      "get": {
+        "operationId": "BetaListDreams",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "x-api-key",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          },
+          {
+            "description": "Query parameter for limit",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Query parameter for page",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Query parameter for include_archived",
+            "in": "query",
+            "name": "include_archived",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Filter by lifecycle status. Repeat the parameter to match any of multiple statuses. Empty applies no status filter.",
+            "explode": true,
+            "in": "query",
+            "name": "statuses[]",
+            "required": false,
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/BetaDreamStatus"
+              },
+              "type": "array"
+            },
+            "style": "form"
+          },
+          {
+            "description": "Return dreams with `created_at` strictly after this timestamp (exclusive lower bound, RFC 3339). Unset applies no lower bound.",
+            "in": "query",
+            "name": "created_at[gt]",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/BetaTimestamp"
+            }
+          },
+          {
+            "description": "Return dreams with `created_at` strictly before this timestamp (exclusive upper bound, RFC 3339). Unset applies no upper bound.",
+            "in": "query",
+            "name": "created_at[lt]",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/BetaTimestamp"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaListDreamsResponse"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "List Dreams"
+      },
+      "post": {
+        "operationId": "BetaCreateDream",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "anthropic-version",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "anthropic-beta",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "string",
+              "x-stainless-override-schema": {
+                "description": "Optional header to specify the beta version(s) you want to use.",
+                "items": {
+                  "$ref": "#/components/schemas/AnthropicBeta"
+                },
+                "type": "array",
+                "x-stainless-extend-default": true,
+                "x-stainless-param": "betas"
+              }
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaCreateDreamRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaDream"
+                }
+              }
+            },
+            "description": "Successful response (OK)"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid argument - The client specified an invalid argument"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthenticated - The request does not have valid authentication credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Permission denied - The caller does not have permission to execute the specified operation"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Not found - Some requested entity was not found"
+          },
+          "408": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - The deadline expired before the operation could complete"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Aborted - The operation was aborted due to concurrency issue"
+          },
+          "412": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Failed precondition - Operation was rejected because the system is not in required state"
+          },
+          "413": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Out of range - Operation was attempted past the valid range"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Resource exhausted - Some resource has been exhausted (rate limiting)"
+          },
+          "431": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Request header fields too large - Request metadata was too large"
+          },
+          "499": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Cancelled - The operation was cancelled by the client"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Internal - Internal server error"
+          },
+          "501": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unimplemented - The operation is not implemented or supported"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Unavailable - The service is currently unavailable"
+          },
+          "504": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BetaErrorResponse"
+                }
+              }
+            },
+            "description": "Deadline exceeded - Upstream service did not respond in time"
+          }
+        },
+        "summary": "Create a Dream"
       }
     },
     "/v1/environments/{environment_id}/archive?beta=true": {
@@ -48493,7 +50843,7 @@
             }
           },
           {
-            "description": "Sort direction for results, ordered by created_at. Defaults to asc (chronological).",
+            "description": "Sort direction for results, ordered by the event's `processed_at`. Defaults to asc (chronological).",
             "in": "query",
             "name": "order",
             "required": false,
@@ -48516,7 +50866,7 @@
             "style": "form"
           },
           {
-            "description": "Return events created at or after this time (inclusive).",
+            "description": "Return events created at or after this time (inclusive). Compared against the event's `processed_at` value.",
             "in": "query",
             "name": "created_at[gte]",
             "required": false,
@@ -48525,7 +50875,7 @@
             }
           },
           {
-            "description": "Return events created after this time (exclusive).",
+            "description": "Return events created after this time (exclusive). Compared against the event's `processed_at` value.",
             "in": "query",
             "name": "created_at[gt]",
             "required": false,
@@ -48534,7 +50884,7 @@
             }
           },
           {
-            "description": "Return events created at or before this time (inclusive).",
+            "description": "Return events created at or before this time (inclusive). Compared against the event's `processed_at` value.",
             "in": "query",
             "name": "created_at[lte]",
             "required": false,
@@ -48543,7 +50893,7 @@
             }
           },
           {
-            "description": "Return events created before this time (exclusive).",
+            "description": "Return events created before this time (exclusive). Compared against the event's `processed_at` value.",
             "in": "query",
             "name": "created_at[lt]",
             "required": false,
@@ -50583,6 +52933,20 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "When set, this connection also receives streaming deltas (`event_start`, `event_delta`) while an event is being produced, before the event itself arrives. Deltas are best-effort; when the final event is produced it carries the complete content. A model request that ends early (an error or interrupt) produces no final event \u2014 its terminal `span.model_request_end` closes the preview. Accepts one or more event types to preview and may be repeated: `agent.message` streams `content_delta` fragments; `agent.thinking` is start-only \u2014 a signal that the agent has begun extended thinking, concluded by the `agent.thinking` event itself. Only previews of the requested event types are sent.",
+            "explode": true,
+            "in": "query",
+            "name": "event_deltas[]",
+            "required": false,
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/BetaManagedAgentsEventDeltaType"
+              },
+              "type": "array"
+            },
+            "style": "form"
           }
         ],
         "responses": {
@@ -59680,6 +62044,153 @@
           }
         },
         "summary": "deployment_run.succeeded webhook"
+      }
+    },
+    "environment.archived": {
+      "post": {
+        "operationId": "BetaEnvironmentArchivedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "environment.archived webhook"
+      }
+    },
+    "environment.created": {
+      "post": {
+        "operationId": "BetaEnvironmentCreatedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "environment.created webhook"
+      }
+    },
+    "environment.deleted": {
+      "post": {
+        "operationId": "BetaEnvironmentDeletedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "environment.deleted webhook"
+      }
+    },
+    "environment.updated": {
+      "post": {
+        "operationId": "BetaEnvironmentUpdatedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "environment.updated webhook"
+      }
+    },
+    "memory_store.archived": {
+      "post": {
+        "operationId": "BetaMemoryStoreArchivedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "memory_store.archived webhook"
+      }
+    },
+    "memory_store.created": {
+      "post": {
+        "operationId": "BetaMemoryStoreCreatedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "memory_store.created webhook"
+      }
+    },
+    "memory_store.deleted": {
+      "post": {
+        "operationId": "BetaMemoryStoreDeletedWebhook",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BetaWebhookEvent"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Return any 2xx status to acknowledge receipt."
+          }
+        },
+        "summary": "memory_store.deleted webhook"
       }
     },
     "session.archived": {

--- a/packages/anthropic_sdk_dart/specs/spec_metadata.json
+++ b/packages/anthropic_sdk_dart/specs/spec_metadata.json
@@ -2,8 +2,8 @@
   "specs": {
     "main": {
       "current_version": "unknown",
-      "last_fetched": "2026-07-11T06:54:31.075636Z",
-      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-506a5ad71d522b4ae56ac3429380486647af1f92eddde80603480fb592d62b54.yml",
+      "last_fetched": "2026-07-31T21:20:04.243480Z",
+      "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-6d5c96a475b06ff067a4491fc2258181f0426af6c64bcfd4be5d167a8c0d9d16.yml",
       "title": "Anthropic API",
       "version_history": [
         {

--- a/packages/anthropic_sdk_dart/specs/spec_metadata.json
+++ b/packages/anthropic_sdk_dart/specs/spec_metadata.json
@@ -7,6 +7,11 @@
       "title": "Anthropic API",
       "version_history": [
         {
+          "fetched_at": "2026-07-11T06:54:31.075636Z",
+          "source_url": "https://storage.googleapis.com/stainless-sdk-openapi-specs/anthropic/anthropic-506a5ad71d522b4ae56ac3429380486647af1f92eddde80603480fb592d62b54.yml",
+          "version": "unknown"
+        },
+        {
           "fetched_at": "2026-03-20T12:00:00Z",
           "version": "ebeeaa9a9bf7603f0bbcce30389e27ca"
         },

--- a/packages/anthropic_sdk_dart/test/unit/models/agent_multiagent_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/agent_multiagent_test.dart
@@ -223,4 +223,46 @@ void main() {
       expect(set.multiagent, isA<MultiagentCoordinatorParams>());
     });
   });
+
+  group('UpdateAgentParams.version optional', () {
+    test('omitted: no version key in toJson', () {
+      const params = UpdateAgentParams(name: 'Updated');
+      expect(params.version, isNull);
+      expect(params.toJson().containsKey('version'), isFalse);
+    });
+
+    test('provided: version key is emitted', () {
+      const params = UpdateAgentParams(version: 1, name: 'Updated');
+      expect(params.toJson()['version'], 1);
+    });
+
+    test('fromJson without version leaves it null', () {
+      final params = UpdateAgentParams.fromJson(const {'name': 'Updated'});
+      expect(params.version, isNull);
+      expect(params.toJson().containsKey('version'), isFalse);
+    });
+
+    test('copyWith omitted preserves the existing version', () {
+      const params = UpdateAgentParams(version: 1);
+      expect(params.copyWith().version, 1);
+    });
+
+    test('copyWith can set a new version', () {
+      const params = UpdateAgentParams();
+      expect(params.copyWith(version: 2).version, 2);
+    });
+
+    test('copyWith can clear version back to null', () {
+      const params = UpdateAgentParams(version: 1);
+      expect(params.copyWith(version: null).version, isNull);
+    });
+
+    test('toString still includes version when set and when absent', () {
+      expect(
+        const UpdateAgentParams(version: 1).toString(),
+        contains('version: 1'),
+      );
+      expect(const UpdateAgentParams().toString(), contains('version: null'));
+    });
+  });
 }

--- a/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
@@ -1200,11 +1200,13 @@ void main() {
         );
       });
 
-      test('fromJson throws FormatException on unknown type', () {
-        expect(
-          () => ToolChangeReference.fromJson({'type': 'bogus'}),
-          throwsFormatException,
-        );
+      test('fromJson preserves an unrecognized type verbatim', () {
+        final json = {'type': 'bogus', 'name': 'calculator'};
+        final ref = ToolChangeReference.fromJson(json);
+
+        expect(ref, isA<UnknownToolChangeReference>());
+        expect((ref as UnknownToolChangeReference).rawJson, json);
+        expect(ref.toJson(), json);
       });
     });
 

--- a/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
@@ -965,6 +965,249 @@ void main() {
       });
     });
 
+    group('ToolAdditionInputBlock', () {
+      test('round-trips without cacheControl', () {
+        const block = ToolAdditionInputBlock(
+          tool: ToolChangeToolReference('calculator'),
+        );
+        final json = block.toJson();
+
+        expect(json['type'], 'tool_addition');
+        expect(json['tool'], {'type': 'tool_reference', 'name': 'calculator'});
+        expect(json.containsKey('cache_control'), isFalse);
+
+        final parsed = InputContentBlock.fromJson(json);
+        expect(parsed, isA<ToolAdditionInputBlock>());
+        final addition = parsed as ToolAdditionInputBlock;
+        expect(addition.tool, const ToolChangeToolReference('calculator'));
+        expect(addition.cacheControl, isNull);
+      });
+
+      test('round-trips with cacheControl', () {
+        const block = ToolAdditionInputBlock(
+          tool: ToolChangeMCPToolsetReference('my-server'),
+          cacheControl: CacheControlEphemeral(),
+        );
+        final json = block.toJson();
+
+        expect(json['cache_control'], {'type': 'ephemeral'});
+
+        final parsed =
+            InputContentBlock.fromJson(json) as ToolAdditionInputBlock;
+        expect(parsed.tool, const ToolChangeMCPToolsetReference('my-server'));
+        expect(parsed.cacheControl, const CacheControlEphemeral());
+      });
+
+      test('copyWith replaces fields', () {
+        const block = ToolAdditionInputBlock(
+          tool: ToolChangeToolReference('calculator'),
+        );
+        final modified = block.copyWith(
+          tool: const ToolChangeToolReference('other'),
+          cacheControl: const CacheControlEphemeral(),
+        );
+
+        expect(modified.tool, const ToolChangeToolReference('other'));
+        expect(modified.cacheControl, const CacheControlEphemeral());
+      });
+
+      test('toString includes all fields', () {
+        const block = ToolAdditionInputBlock(
+          tool: ToolChangeToolReference('calculator'),
+        );
+
+        expect(block.toString(), contains('tool:'));
+        expect(block.toString(), contains('cacheControl:'));
+      });
+
+      test('supports the InputContentBlock.toolAddition factory', () {
+        final block = InputContentBlock.toolAddition(
+          tool: const ToolChangeToolReference('calculator'),
+        );
+
+        expect(block, isA<ToolAdditionInputBlock>());
+        expect(block.toJson()['type'], 'tool_addition');
+      });
+    });
+
+    group('ToolRemovalInputBlock', () {
+      test('round-trips without cacheControl', () {
+        const block = ToolRemovalInputBlock(
+          tool: ToolChangeMCPToolReference(
+            serverName: 'my-server',
+            name: 'search',
+          ),
+        );
+        final json = block.toJson();
+
+        expect(json['type'], 'tool_removal');
+        expect(json['tool'], {
+          'type': 'mcp_tool_reference',
+          'server_name': 'my-server',
+          'name': 'search',
+        });
+        expect(json.containsKey('cache_control'), isFalse);
+
+        final parsed = InputContentBlock.fromJson(json);
+        expect(parsed, isA<ToolRemovalInputBlock>());
+        final removal = parsed as ToolRemovalInputBlock;
+        expect(
+          removal.tool,
+          const ToolChangeMCPToolReference(
+            serverName: 'my-server',
+            name: 'search',
+          ),
+        );
+        expect(removal.cacheControl, isNull);
+      });
+
+      test('round-trips with cacheControl', () {
+        const block = ToolRemovalInputBlock(
+          tool: ToolChangeToolReference('calculator'),
+          cacheControl: CacheControlEphemeral(),
+        );
+        final json = block.toJson();
+
+        expect(json['cache_control'], {'type': 'ephemeral'});
+
+        final parsed =
+            InputContentBlock.fromJson(json) as ToolRemovalInputBlock;
+        expect(parsed.tool, const ToolChangeToolReference('calculator'));
+        expect(parsed.cacheControl, const CacheControlEphemeral());
+      });
+
+      test('copyWith replaces fields', () {
+        const block = ToolRemovalInputBlock(
+          tool: ToolChangeToolReference('calculator'),
+        );
+        final modified = block.copyWith(
+          tool: const ToolChangeMCPToolsetReference('my-server'),
+        );
+
+        expect(modified.tool, const ToolChangeMCPToolsetReference('my-server'));
+      });
+
+      test('toString includes all fields', () {
+        const block = ToolRemovalInputBlock(
+          tool: ToolChangeToolReference('calculator'),
+        );
+
+        expect(block.toString(), contains('tool:'));
+        expect(block.toString(), contains('cacheControl:'));
+      });
+
+      test('supports the InputContentBlock.toolRemoval factory', () {
+        final block = InputContentBlock.toolRemoval(
+          tool: const ToolChangeToolReference('calculator'),
+        );
+
+        expect(block, isA<ToolRemovalInputBlock>());
+        expect(block.toJson()['type'], 'tool_removal');
+      });
+    });
+
+    group('ToolChangeReference', () {
+      test('round-trips ToolChangeToolReference', () {
+        const ref = ToolChangeToolReference('calculator');
+        final json = ref.toJson();
+
+        expect(json, {'type': 'tool_reference', 'name': 'calculator'});
+        expect(ToolChangeReference.fromJson(json), ref);
+      });
+
+      test('round-trips ToolChangeMCPToolReference', () {
+        const ref = ToolChangeMCPToolReference(
+          serverName: 'my-server',
+          name: 'search',
+        );
+        final json = ref.toJson();
+
+        expect(json, {
+          'type': 'mcp_tool_reference',
+          'server_name': 'my-server',
+          'name': 'search',
+        });
+        expect(ToolChangeReference.fromJson(json), ref);
+      });
+
+      test('round-trips ToolChangeMCPToolsetReference', () {
+        const ref = ToolChangeMCPToolsetReference('my-server');
+        final json = ref.toJson();
+
+        expect(json, {
+          'type': 'mcp_toolset_reference',
+          'server_name': 'my-server',
+        });
+        expect(ToolChangeReference.fromJson(json), ref);
+      });
+
+      test('factory constructors build expected variants', () {
+        expect(
+          ToolChangeReference.tool('calculator'),
+          const ToolChangeToolReference('calculator'),
+        );
+        expect(
+          ToolChangeReference.mcpTool(serverName: 'my-server', name: 'search'),
+          const ToolChangeMCPToolReference(
+            serverName: 'my-server',
+            name: 'search',
+          ),
+        );
+        expect(
+          ToolChangeReference.mcpToolset('my-server'),
+          const ToolChangeMCPToolsetReference('my-server'),
+        );
+      });
+
+      test('copyWith replaces fields on each variant', () {
+        expect(
+          const ToolChangeToolReference('calculator').copyWith(name: 'other'),
+          const ToolChangeToolReference('other'),
+        );
+        expect(
+          const ToolChangeMCPToolReference(
+            serverName: 'my-server',
+            name: 'search',
+          ).copyWith(name: 'other'),
+          const ToolChangeMCPToolReference(
+            serverName: 'my-server',
+            name: 'other',
+          ),
+        );
+        expect(
+          const ToolChangeMCPToolsetReference(
+            'my-server',
+          ).copyWith(serverName: 'other-server'),
+          const ToolChangeMCPToolsetReference('other-server'),
+        );
+      });
+
+      test('toString includes all fields per variant', () {
+        expect(
+          const ToolChangeToolReference('calculator').toString(),
+          contains('name:'),
+        );
+        expect(
+          const ToolChangeMCPToolReference(
+            serverName: 'my-server',
+            name: 'search',
+          ).toString(),
+          allOf(contains('serverName:'), contains('name:')),
+        );
+        expect(
+          const ToolChangeMCPToolsetReference('my-server').toString(),
+          contains('serverName:'),
+        );
+      });
+
+      test('fromJson throws FormatException on unknown type', () {
+        expect(
+          () => ToolChangeReference.fromJson({'type': 'bogus'}),
+          throwsFormatException,
+        );
+      });
+    });
+
     group('MCPToolUseInputBlock', () {
       test('fromJson parses all fields', () {
         final json = {

--- a/packages/anthropic_sdk_dart/test/unit/models/dreams/create_dream_request_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/dreams/create_dream_request_test.dart
@@ -1,0 +1,79 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CreateDreamRequest', () {
+    test('fromJson/toJson round-trip with a bare model-id string', () {
+      const json = {
+        'inputs': [
+          {'type': 'memory_store', 'memory_store_id': 'memstore_in'},
+          {
+            'type': 'sessions',
+            'session_ids': ['s1'],
+          },
+        ],
+        'instructions': 'Focus on preferences.',
+        'model': 'claude-opus-4-7',
+      };
+      final request = CreateDreamRequest.fromJson(json);
+
+      expect(request.inputs, hasLength(2));
+      expect(request.inputs[0], isA<DreamMemoryStoreInput>());
+      expect(request.inputs[1], isA<DreamSessionsInput>());
+      expect(request.instructions, 'Focus on preferences.');
+      expect(request.model, isA<DreamModelParamsId>());
+      expect(request.toJson(), json);
+    });
+
+    test('fromJson/toJson round-trip with a model config object', () {
+      const json = {
+        'inputs': [
+          {'type': 'memory_store', 'memory_store_id': 'memstore_in'},
+        ],
+        'model': {'id': 'claude-opus-4-7', 'speed': 'fast'},
+      };
+      final request = CreateDreamRequest.fromJson(json);
+      expect(request.model, isA<DreamModelConfigParams>());
+      expect(request.instructions, isNull);
+      expect(request.toJson(), json);
+      expect(request.toJson().containsKey('instructions'), isFalse);
+    });
+
+    test('copyWith replaces and clears instructions', () {
+      const request = CreateDreamRequest(
+        inputs: [DreamMemoryStoreInput(memoryStoreId: 'm1')],
+        instructions: 'a',
+        model: DreamModelParamsId(id: 'claude-opus-4-7'),
+      );
+      expect(request.copyWith(instructions: 'b').instructions, 'b');
+      expect(request.copyWith(instructions: null).instructions, isNull);
+      expect(request.copyWith().instructions, 'a');
+    });
+
+    test('equality and hashCode', () {
+      const a = CreateDreamRequest(
+        inputs: [DreamMemoryStoreInput(memoryStoreId: 'm1')],
+        model: DreamModelParamsId(id: 'claude-opus-4-7'),
+      );
+      const b = CreateDreamRequest(
+        inputs: [DreamMemoryStoreInput(memoryStoreId: 'm1')],
+        model: DreamModelParamsId(id: 'claude-opus-4-7'),
+      );
+      const c = CreateDreamRequest(
+        inputs: [DreamMemoryStoreInput(memoryStoreId: 'm2')],
+        model: DreamModelParamsId(id: 'claude-opus-4-7'),
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('toString includes input count and model', () {
+      const request = CreateDreamRequest(
+        inputs: [DreamMemoryStoreInput(memoryStoreId: 'm1')],
+        model: DreamModelParamsId(id: 'claude-opus-4-7'),
+      );
+      expect(request.toString(), contains('inputs: 1 items'));
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/dreams/dream_error_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/dreams/dream_error_test.dart
@@ -1,0 +1,36 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DreamError', () {
+    test('fromJson/toJson round-trip', () {
+      const json = {'type': 'internal_error', 'message': 'boom'};
+      final error = DreamError.fromJson(json);
+      expect(error.type, 'internal_error');
+      expect(error.message, 'boom');
+      expect(error.toJson(), json);
+    });
+
+    test('copyWith replaces values', () {
+      const error = DreamError(type: 'a', message: 'b');
+      final updated = error.copyWith(message: 'c');
+      expect(updated.type, 'a');
+      expect(updated.message, 'c');
+    });
+
+    test('equality and hashCode', () {
+      const a = DreamError(type: 'a', message: 'b');
+      const b = DreamError(type: 'a', message: 'b');
+      const c = DreamError(type: 'a', message: 'different');
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('toString includes all fields', () {
+      const error = DreamError(type: 'a', message: 'b');
+      expect(error.toString(), contains('type: a'));
+      expect(error.toString(), contains('message: b'));
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/dreams/dream_input_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/dreams/dream_input_test.dart
@@ -1,0 +1,102 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DreamInput', () {
+    test('fromJson dispatches memory_store to DreamMemoryStoreInput', () {
+      final input = DreamInput.fromJson(const {
+        'type': 'memory_store',
+        'memory_store_id': 'memstore_1',
+      });
+      expect(input, isA<DreamMemoryStoreInput>());
+      expect((input as DreamMemoryStoreInput).memoryStoreId, 'memstore_1');
+      expect(input.toJson(), {
+        'type': 'memory_store',
+        'memory_store_id': 'memstore_1',
+      });
+    });
+
+    test('fromJson dispatches sessions to DreamSessionsInput', () {
+      final input = DreamInput.fromJson(const {
+        'type': 'sessions',
+        'session_ids': ['s1', 's2'],
+      });
+      expect(input, isA<DreamSessionsInput>());
+      expect((input as DreamSessionsInput).sessionIds, ['s1', 's2']);
+      expect(input.toJson(), {
+        'type': 'sessions',
+        'session_ids': ['s1', 's2'],
+      });
+    });
+
+    test('fromJson falls back to UnknownDreamInput for unrecognized type', () {
+      const json = {'type': 'something_new', 'foo': 'bar'};
+      final input = DreamInput.fromJson(json);
+      expect(input, isA<UnknownDreamInput>());
+      expect((input as UnknownDreamInput).rawJson, json);
+      expect(input.toJson(), json);
+    });
+
+    test(
+      'DreamMemoryStoreInput.fromJson throws on mismatched discriminator',
+      () {
+        expect(
+          () => DreamMemoryStoreInput.fromJson(const {
+            'type': 'sessions',
+            'memory_store_id': 'x',
+          }),
+          throwsFormatException,
+        );
+      },
+    );
+
+    test('DreamSessionsInput.fromJson throws on mismatched discriminator', () {
+      expect(
+        () => DreamSessionsInput.fromJson(const {
+          'type': 'memory_store',
+          'session_ids': <String>[],
+        }),
+        throwsFormatException,
+      );
+    });
+
+    test('DreamMemoryStoreInput copyWith/equality/toString', () {
+      const a = DreamMemoryStoreInput(memoryStoreId: 'm1');
+      const b = DreamMemoryStoreInput(memoryStoreId: 'm1');
+      const c = DreamMemoryStoreInput(memoryStoreId: 'm2');
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+      expect(a.copyWith(memoryStoreId: 'm2').memoryStoreId, 'm2');
+      expect(a.toString(), contains('memoryStoreId: m1'));
+    });
+
+    test('DreamSessionsInput copyWith/equality/toString', () {
+      const a = DreamSessionsInput(sessionIds: ['s1']);
+      const b = DreamSessionsInput(sessionIds: ['s1']);
+      const c = DreamSessionsInput(sessionIds: ['s2']);
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+      expect(a.copyWith(sessionIds: ['s2']).sessionIds, ['s2']);
+      expect(a.toString(), contains('sessionIds: [s1]'));
+    });
+
+    test('UnknownDreamInput uses deep equality for nested payloads', () {
+      const a = UnknownDreamInput(
+        rawJson: {
+          'type': 'x',
+          'nested': {'a': 1},
+        },
+      );
+      const b = UnknownDreamInput(
+        rawJson: {
+          'type': 'x',
+          'nested': {'a': 1},
+        },
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/dreams/dream_model_config_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/dreams/dream_model_config_test.dart
@@ -1,0 +1,101 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DreamModelConfig', () {
+    test('fromJson/toJson round-trip with speed', () {
+      const json = {'id': 'claude-opus-4-7', 'speed': 'fast'};
+      final config = DreamModelConfig.fromJson(json);
+      expect(config.id, 'claude-opus-4-7');
+      expect(config.speed, AgentSpeed.fast);
+      expect(config.toJson(), json);
+    });
+
+    test('speed is null and omitted from toJson when absent', () {
+      final config = DreamModelConfig.fromJson(const {'id': 'claude-opus-4-7'});
+      expect(config.speed, isNull);
+      expect(config.toJson().containsKey('speed'), isFalse);
+    });
+
+    test('copyWith replaces and clears speed', () {
+      const config = DreamModelConfig(
+        id: 'claude-opus-4-7',
+        speed: AgentSpeed.standard,
+      );
+      expect(config.copyWith(speed: AgentSpeed.fast).speed, AgentSpeed.fast);
+      expect(config.copyWith(speed: null).speed, isNull);
+      expect(config.copyWith().speed, AgentSpeed.standard);
+    });
+
+    test('equality and hashCode', () {
+      const a = DreamModelConfig(id: 'x', speed: AgentSpeed.fast);
+      const b = DreamModelConfig(id: 'x', speed: AgentSpeed.fast);
+      const c = DreamModelConfig(id: 'x', speed: AgentSpeed.standard);
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('toString includes all fields', () {
+      const config = DreamModelConfig(id: 'x', speed: AgentSpeed.fast);
+      expect(config.toString(), contains('id: x'));
+      expect(config.toString(), contains('speed: AgentSpeed.fast'));
+    });
+  });
+
+  group('DreamModelParams', () {
+    test('fromJson dispatches a bare string to DreamModelParamsId', () {
+      final params = DreamModelParams.fromJson('claude-opus-4-7');
+      expect(params, isA<DreamModelParamsId>());
+      expect((params as DreamModelParamsId).id, 'claude-opus-4-7');
+      expect(params.toJson(), 'claude-opus-4-7');
+    });
+
+    test('fromJson dispatches a Map to DreamModelConfigParams', () {
+      final params = DreamModelParams.fromJson(const {
+        'id': 'claude-opus-4-7',
+        'speed': 'fast',
+      });
+      expect(params, isA<DreamModelConfigParams>());
+      final config = params as DreamModelConfigParams;
+      expect(config.id, 'claude-opus-4-7');
+      expect(config.speed, AgentSpeed.fast);
+      expect(params.toJson(), {'id': 'claude-opus-4-7', 'speed': 'fast'});
+    });
+
+    test('DreamModelParamsId equality/hashCode/toString', () {
+      const a = DreamModelParamsId(id: 'x');
+      const b = DreamModelParamsId(id: 'x');
+      const c = DreamModelParamsId(id: 'y');
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+      expect(a.toString(), contains('id: x'));
+    });
+
+    test('DreamModelConfigParams speed omitted from toJson when absent', () {
+      const config = DreamModelConfigParams(id: 'x');
+      expect(config.toJson().containsKey('speed'), isFalse);
+    });
+
+    test('DreamModelConfigParams copyWith replaces and clears speed', () {
+      const config = DreamModelConfigParams(id: 'x', speed: AgentSpeed.fast);
+      expect(
+        config.copyWith(speed: AgentSpeed.standard).speed,
+        AgentSpeed.standard,
+      );
+      expect(config.copyWith(speed: null).speed, isNull);
+      expect(config.copyWith().speed, AgentSpeed.fast);
+    });
+
+    test('DreamModelConfigParams equality/hashCode/toString', () {
+      const a = DreamModelConfigParams(id: 'x', speed: AgentSpeed.fast);
+      const b = DreamModelConfigParams(id: 'x', speed: AgentSpeed.fast);
+      const c = DreamModelConfigParams(id: 'x', speed: AgentSpeed.standard);
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+      expect(a.toString(), contains('speed: AgentSpeed.fast'));
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/dreams/dream_output_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/dreams/dream_output_test.dart
@@ -1,0 +1,68 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DreamOutput', () {
+    test('fromJson dispatches memory_store to DreamMemoryStoreOutput', () {
+      final output = DreamOutput.fromJson(const {
+        'type': 'memory_store',
+        'memory_store_id': 'memstore_out1',
+      });
+      expect(output, isA<DreamMemoryStoreOutput>());
+      expect((output as DreamMemoryStoreOutput).memoryStoreId, 'memstore_out1');
+      expect(output.toJson(), {
+        'type': 'memory_store',
+        'memory_store_id': 'memstore_out1',
+      });
+    });
+
+    test('fromJson falls back to UnknownDreamOutput for unrecognized type', () {
+      const json = {'type': 'something_new', 'foo': 'bar'};
+      final output = DreamOutput.fromJson(json);
+      expect(output, isA<UnknownDreamOutput>());
+      expect((output as UnknownDreamOutput).rawJson, json);
+      expect(output.toJson(), json);
+    });
+
+    test(
+      'DreamMemoryStoreOutput.fromJson throws on mismatched discriminator',
+      () {
+        expect(
+          () => DreamMemoryStoreOutput.fromJson(const {
+            'type': 'sessions',
+            'memory_store_id': 'x',
+          }),
+          throwsFormatException,
+        );
+      },
+    );
+
+    test('DreamMemoryStoreOutput copyWith/equality/toString', () {
+      const a = DreamMemoryStoreOutput(memoryStoreId: 'm1');
+      const b = DreamMemoryStoreOutput(memoryStoreId: 'm1');
+      const c = DreamMemoryStoreOutput(memoryStoreId: 'm2');
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+      expect(a.copyWith(memoryStoreId: 'm2').memoryStoreId, 'm2');
+      expect(a.toString(), contains('memoryStoreId: m1'));
+    });
+
+    test('UnknownDreamOutput uses deep equality for nested payloads', () {
+      const a = UnknownDreamOutput(
+        rawJson: {
+          'type': 'x',
+          'nested': {'a': 1},
+        },
+      );
+      const b = UnknownDreamOutput(
+        rawJson: {
+          'type': 'x',
+          'nested': {'a': 1},
+        },
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/dreams/dream_status_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/dreams/dream_status_test.dart
@@ -1,0 +1,26 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DreamStatus', () {
+    test('fromJson parses all known values', () {
+      expect(DreamStatus.fromJson('pending'), DreamStatus.pending);
+      expect(DreamStatus.fromJson('running'), DreamStatus.running);
+      expect(DreamStatus.fromJson('completed'), DreamStatus.completed);
+      expect(DreamStatus.fromJson('failed'), DreamStatus.failed);
+      expect(DreamStatus.fromJson('canceled'), DreamStatus.canceled);
+    });
+
+    test('fromJson falls back to unknown for unrecognized values', () {
+      expect(DreamStatus.fromJson('something_new'), DreamStatus.unknown);
+    });
+
+    test('toJson round-trips known values', () {
+      for (final status in DreamStatus.values.where(
+        (s) => s != DreamStatus.unknown,
+      )) {
+        expect(DreamStatus.fromJson(status.toJson()), status);
+      }
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/dreams/dream_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/dreams/dream_test.dart
@@ -1,0 +1,157 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+Map<String, dynamic> _dreamJson({
+  String status = 'completed',
+  String? endedAt = '2026-04-25T01:00:00.000Z',
+  String? archivedAt,
+  Map<String, dynamic>? error,
+  String? instructions = 'Consolidate notes.',
+  String? sessionId,
+}) {
+  return {
+    'type': 'dream',
+    'id': 'dream_test123',
+    'inputs': [
+      {'type': 'memory_store', 'memory_store_id': 'memstore_in'},
+    ],
+    'outputs': [
+      {'type': 'memory_store', 'memory_store_id': 'memstore_out'},
+    ],
+    'status': status,
+    'created_at': '2026-04-25T00:00:00.000Z',
+    'ended_at': endedAt,
+    'archived_at': archivedAt,
+    'error': error,
+    'model': {'id': 'claude-opus-4-7', 'speed': 'standard'},
+    'instructions': instructions,
+    'session_id': sessionId,
+    'usage': {
+      'input_tokens': 100,
+      'output_tokens': 50,
+      'cache_read_input_tokens': 10,
+      'cache_creation_input_tokens': 5,
+    },
+  };
+}
+
+void main() {
+  group('Dream', () {
+    test('fromJson/toJson round-trip', () {
+      final json = _dreamJson();
+      final dream = Dream.fromJson(json);
+
+      expect(dream.type, 'dream');
+      expect(dream.id, 'dream_test123');
+      expect(dream.inputs, hasLength(1));
+      expect(dream.inputs.single, isA<DreamMemoryStoreInput>());
+      expect(dream.outputs.single, isA<DreamMemoryStoreOutput>());
+      expect(dream.status, DreamStatus.completed);
+      expect(dream.createdAt, DateTime.parse('2026-04-25T00:00:00.000Z'));
+      expect(dream.endedAt, DateTime.parse('2026-04-25T01:00:00.000Z'));
+      expect(dream.archivedAt, isNull);
+      expect(dream.error, isNull);
+      expect(dream.model.id, 'claude-opus-4-7');
+      expect(dream.instructions, 'Consolidate notes.');
+      expect(dream.sessionId, isNull);
+      expect(dream.usage.inputTokens, 100);
+
+      expect(dream.toJson(), json);
+    });
+
+    test('required-nullable fields always emit the key even when null', () {
+      final dream = Dream.fromJson(
+        _dreamJson(
+          status: 'pending',
+          endedAt: null,
+          archivedAt: null,
+          error: null,
+          instructions: null,
+          sessionId: null,
+        ),
+      );
+      final body = dream.toJson();
+      expect(body.containsKey('ended_at'), isTrue);
+      expect(body['ended_at'], isNull);
+      expect(body.containsKey('archived_at'), isTrue);
+      expect(body['archived_at'], isNull);
+      expect(body.containsKey('error'), isTrue);
+      expect(body['error'], isNull);
+      expect(body.containsKey('instructions'), isTrue);
+      expect(body['instructions'], isNull);
+      expect(body.containsKey('session_id'), isTrue);
+      expect(body['session_id'], isNull);
+    });
+
+    test('parses a failed dream with error detail', () {
+      final dream = Dream.fromJson(
+        _dreamJson(
+          status: 'failed',
+          error: const {'type': 'internal_error', 'message': 'boom'},
+        ),
+      );
+      expect(dream.status, DreamStatus.failed);
+      expect(dream.error, isNotNull);
+      expect(dream.error!.type, 'internal_error');
+      expect(dream.error!.message, 'boom');
+      expect(dream.toJson()['error'], {
+        'type': 'internal_error',
+        'message': 'boom',
+      });
+    });
+
+    test('unknown status falls back to DreamStatus.unknown', () {
+      final dream = Dream.fromJson(_dreamJson(status: 'something_new'));
+      expect(dream.status, DreamStatus.unknown);
+    });
+
+    test('unknown input/output types round-trip via unknown fallbacks', () {
+      final json = _dreamJson();
+      json['inputs'] = [
+        {'type': 'something_new', 'foo': 'bar'},
+      ];
+      json['outputs'] = [
+        {'type': 'something_new', 'baz': 'qux'},
+      ];
+      final dream = Dream.fromJson(json);
+      expect(dream.inputs.single, isA<UnknownDreamInput>());
+      expect(dream.outputs.single, isA<UnknownDreamOutput>());
+      expect(dream.toJson()['inputs'], json['inputs']);
+      expect(dream.toJson()['outputs'], json['outputs']);
+    });
+
+    test('copyWith replaces and clears nullable fields', () {
+      final dream = Dream.fromJson(_dreamJson());
+
+      final withArchive = dream.copyWith(archivedAt: DateTime.utc(2026, 5));
+      expect(withArchive.archivedAt, DateTime.utc(2026, 5));
+      expect(withArchive.id, dream.id);
+
+      final cleared = dream.copyWith(instructions: null);
+      expect(cleared.instructions, isNull);
+
+      final unchanged = dream.copyWith();
+      expect(unchanged.instructions, dream.instructions);
+      expect(unchanged.endedAt, dream.endedAt);
+    });
+
+    test('equality and hashCode', () {
+      final a = Dream.fromJson(_dreamJson());
+      final b = Dream.fromJson(_dreamJson());
+      final c = Dream.fromJson(_dreamJson(status: 'failed'));
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('toString includes all fields with list counts', () {
+      final dream = Dream.fromJson(_dreamJson());
+      final str = dream.toString();
+      expect(str, contains('id: dream_test123'));
+      expect(str, contains('inputs: 1 items'));
+      expect(str, contains('outputs: 1 items'));
+      expect(str, contains('status: DreamStatus.completed'));
+      expect(str, contains('usage: '));
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/dreams/dream_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/dreams/dream_test.dart
@@ -105,6 +105,14 @@ void main() {
       expect(dream.status, DreamStatus.unknown);
     });
 
+    test('unknown status round-trips the raw wire value', () {
+      final json = _dreamJson(status: 'something_new');
+      final dream = Dream.fromJson(json);
+      expect(dream.status, DreamStatus.unknown);
+      expect(dream.rawStatus, 'something_new');
+      expect(dream.toJson()['status'], 'something_new');
+    });
+
     test('unknown input/output types round-trip via unknown fallbacks', () {
       final json = _dreamJson();
       json['inputs'] = [

--- a/packages/anthropic_sdk_dart/test/unit/models/dreams/dream_usage_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/dreams/dream_usage_test.dart
@@ -1,0 +1,71 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DreamUsage', () {
+    test('fromJson/toJson round-trip', () {
+      const json = {
+        'input_tokens': 100,
+        'output_tokens': 50,
+        'cache_read_input_tokens': 10,
+        'cache_creation_input_tokens': 5,
+      };
+      final usage = DreamUsage.fromJson(json);
+      expect(usage.inputTokens, 100);
+      expect(usage.outputTokens, 50);
+      expect(usage.cacheReadInputTokens, 10);
+      expect(usage.cacheCreationInputTokens, 5);
+      expect(usage.toJson(), json);
+    });
+
+    test('copyWith replaces values', () {
+      const usage = DreamUsage(
+        inputTokens: 1,
+        outputTokens: 2,
+        cacheReadInputTokens: 3,
+        cacheCreationInputTokens: 4,
+      );
+      final updated = usage.copyWith(outputTokens: 20);
+      expect(updated.inputTokens, 1);
+      expect(updated.outputTokens, 20);
+    });
+
+    test('equality and hashCode', () {
+      const a = DreamUsage(
+        inputTokens: 1,
+        outputTokens: 2,
+        cacheReadInputTokens: 3,
+        cacheCreationInputTokens: 4,
+      );
+      const b = DreamUsage(
+        inputTokens: 1,
+        outputTokens: 2,
+        cacheReadInputTokens: 3,
+        cacheCreationInputTokens: 4,
+      );
+      const c = DreamUsage(
+        inputTokens: 9,
+        outputTokens: 2,
+        cacheReadInputTokens: 3,
+        cacheCreationInputTokens: 4,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('toString includes all fields', () {
+      const usage = DreamUsage(
+        inputTokens: 1,
+        outputTokens: 2,
+        cacheReadInputTokens: 3,
+        cacheCreationInputTokens: 4,
+      );
+      final str = usage.toString();
+      expect(str, contains('inputTokens: 1'));
+      expect(str, contains('outputTokens: 2'));
+      expect(str, contains('cacheReadInputTokens: 3'));
+      expect(str, contains('cacheCreationInputTokens: 4'));
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/dreams/list_dreams_response_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/dreams/list_dreams_response_test.dart
@@ -1,0 +1,87 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+Map<String, dynamic> _dreamJson() {
+  return {
+    'type': 'dream',
+    'id': 'dream_test123',
+    'inputs': <Map<String, dynamic>>[],
+    'outputs': <Map<String, dynamic>>[],
+    'status': 'completed',
+    'created_at': '2026-04-25T00:00:00.000Z',
+    'ended_at': '2026-04-25T01:00:00.000Z',
+    'archived_at': null,
+    'error': null,
+    'model': {'id': 'claude-opus-4-7'},
+    'instructions': null,
+    'session_id': null,
+    'usage': {
+      'input_tokens': 1,
+      'output_tokens': 1,
+      'cache_read_input_tokens': 0,
+      'cache_creation_input_tokens': 0,
+    },
+  };
+}
+
+void main() {
+  group('ListDreamsResponse', () {
+    test('fromJson/toJson round-trip with a next page', () {
+      final json = {
+        'data': [_dreamJson()],
+        'next_page': 'cursor123',
+      };
+      final response = ListDreamsResponse.fromJson(json);
+      expect(response.data, hasLength(1));
+      expect(response.nextPage, 'cursor123');
+      expect(response.toJson(), json);
+    });
+
+    test('next_page key is always emitted, even when null', () {
+      final response = ListDreamsResponse.fromJson(const {
+        'data': <Map<String, dynamic>>[],
+        'next_page': null,
+      });
+      expect(response.nextPage, isNull);
+      final body = response.toJson();
+      expect(body.containsKey('next_page'), isTrue);
+      expect(body['next_page'], isNull);
+    });
+
+    test('copyWith replaces and clears nextPage', () {
+      final response = ListDreamsResponse.fromJson(const {
+        'data': <Map<String, dynamic>>[],
+        'next_page': 'a',
+      });
+      expect(response.copyWith(nextPage: 'b').nextPage, 'b');
+      expect(response.copyWith(nextPage: null).nextPage, isNull);
+      expect(response.copyWith().nextPage, 'a');
+    });
+
+    test('equality and hashCode', () {
+      final a = ListDreamsResponse.fromJson({
+        'data': [_dreamJson()],
+        'next_page': null,
+      });
+      final b = ListDreamsResponse.fromJson({
+        'data': [_dreamJson()],
+        'next_page': null,
+      });
+      final c = ListDreamsResponse.fromJson(const {
+        'data': <Map<String, dynamic>>[],
+        'next_page': null,
+      });
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('toString includes data count', () {
+      final response = ListDreamsResponse.fromJson({
+        'data': [_dreamJson()],
+        'next_page': null,
+      });
+      expect(response.toString(), contains('data: 1 items'));
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/fallback_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/fallback_test.dart
@@ -366,7 +366,9 @@ void main() {
           FallbackConfigV2(model: 'claude-sonnet-4-6', maxTokens: 512),
           FallbackConfigV2(model: 'claude-haiku-4-5-20251001'),
         ],
-        fallbackCreditToken: 'tok_secret_abc123',
+        fallbackCreditToken: FallbackCreditTokenParam.token(
+          'tok_secret_abc123',
+        ),
       );
 
       final json = request.toJson();
@@ -391,7 +393,10 @@ void main() {
       expect(request.fallbacks, hasLength(1));
       expect(request.fallbacks!.first.model, 'claude-sonnet-4-6');
       expect(request.fallbacks!.first.maxTokens, 512);
-      expect(request.fallbackCreditToken, 'tok_secret_abc123');
+      expect(
+        request.fallbackCreditToken,
+        const FallbackCreditTokenParam.token('tok_secret_abc123'),
+      );
     });
 
     test('omits fallback fields when null', () {
@@ -436,7 +441,9 @@ void main() {
           maxTokens: 1024,
           messages: [InputMessage.user('Hi')],
           fallbacks: const [FallbackConfigV2(model: 'claude-sonnet-4-6')],
-          fallbackCreditToken: 'tok_secret_abc123',
+          fallbackCreditToken: const FallbackCreditTokenParam.token(
+            'tok_secret_abc123',
+          ),
         ),
         betas: const [
           'server-side-fallback-2026-06-01',
@@ -466,7 +473,9 @@ void main() {
         model: 'claude-opus-4-8',
         maxTokens: 1024,
         messages: [],
-        fallbackCreditToken: 'tok_super_secret_value',
+        fallbackCreditToken: FallbackCreditTokenParam.token(
+          'tok_super_secret_value',
+        ),
       );
 
       final str = request.toString();
@@ -521,6 +530,14 @@ void main() {
         RefusalCategory.reasoningExtraction.toJson(),
         'reasoning_extraction',
       );
+    });
+
+    test('general_harms round-trips', () {
+      expect(
+        RefusalCategory.fromJson('general_harms'),
+        RefusalCategory.generalHarms,
+      );
+      expect(RefusalCategory.generalHarms.toJson(), 'general_harms');
     });
   });
 

--- a/packages/anthropic_sdk_dart/test/unit/models/managed_agents/create_session_params_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/managed_agents/create_session_params_test.dart
@@ -1,0 +1,126 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CreateSessionParams.initialEvents', () {
+    final userMessageJson = <String, dynamic>{
+      'type': 'user.message',
+      'content': [
+        {'type': 'text', 'text': 'hello'},
+      ],
+    };
+
+    Map<String, dynamic> paramsJson({Object? initialEvents = #absent}) {
+      return {
+        'agent': 'agt_1',
+        'environment_id': 'env_1',
+        if (initialEvents != #absent) 'initial_events': initialEvents,
+      };
+    }
+
+    test('fromJson parses initial_events and round-trips', () {
+      final json = paramsJson(initialEvents: [userMessageJson]);
+      final params = CreateSessionParams.fromJson(json);
+
+      expect(params.initialEvents, hasLength(1));
+      expect(
+        params.initialEvents!.single,
+        isA<SessionUserMessageEventParams>(),
+      );
+      expect(params.toJson(), json);
+    });
+
+    test('is null and omitted from toJson when absent', () {
+      final params = CreateSessionParams.fromJson(paramsJson());
+      expect(params.initialEvents, isNull);
+      expect(params.toJson().containsKey('initial_events'), isFalse);
+    });
+
+    test('copyWith replaces and clears initialEvents', () {
+      const params = CreateSessionParams(
+        agent: AgentParamsId(id: 'agt_1'),
+        environmentId: 'env_1',
+        initialEvents: [
+          SessionInitialEventParams.userMessage(
+            UserMessageEventParams(
+              content: [
+                {'type': 'text', 'text': 'hi'},
+              ],
+            ),
+          ),
+        ],
+      );
+
+      final cleared = params.copyWith(initialEvents: null);
+      expect(cleared.initialEvents, isNull);
+
+      final replaced = params.copyWith(
+        initialEvents: const [
+          SessionInitialEventParams.userDefineOutcome(
+            UserDefineOutcomeEventParams(
+              description: 'd',
+              rubric: TextRubricParams(content: 'r'),
+            ),
+          ),
+        ],
+      );
+      expect(
+        replaced.initialEvents!.single,
+        isA<SessionUserDefineOutcomeEventParams>(),
+      );
+
+      // Omitted preserves the existing value.
+      expect(params.copyWith().initialEvents, params.initialEvents);
+    });
+
+    test('equality and hashCode include initialEvents', () {
+      const a = CreateSessionParams(
+        agent: AgentParamsId(id: 'agt_1'),
+        environmentId: 'env_1',
+        initialEvents: [
+          SessionInitialEventParams.userMessage(
+            UserMessageEventParams(
+              content: [
+                {'type': 'text', 'text': 'hi'},
+              ],
+            ),
+          ),
+        ],
+      );
+      const b = CreateSessionParams(
+        agent: AgentParamsId(id: 'agt_1'),
+        environmentId: 'env_1',
+        initialEvents: [
+          SessionInitialEventParams.userMessage(
+            UserMessageEventParams(
+              content: [
+                {'type': 'text', 'text': 'hi'},
+              ],
+            ),
+          ),
+        ],
+      );
+      const c = CreateSessionParams(
+        agent: AgentParamsId(id: 'agt_1'),
+        environmentId: 'env_1',
+      );
+
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('toString includes initialEvents', () {
+      const params = CreateSessionParams(
+        agent: AgentParamsId(id: 'agt_1'),
+        environmentId: 'env_1',
+        initialEvents: [
+          SessionInitialEventParams.userMessage(
+            UserMessageEventParams(content: []),
+          ),
+        ],
+      );
+      expect(params.toString(), contains('initialEvents:'));
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/managed_agents/model_config_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/managed_agents/model_config_test.dart
@@ -180,6 +180,15 @@ void main() {
         final stillCleared = cleared.copyWith();
         expect(stillCleared.clearEffort, isTrue);
         expect(stillCleared.toJson()['effort'], isNull);
+
+        final unCleared = cleared.copyWith(clearEffort: false);
+        expect(unCleared.clearEffort, isFalse);
+        expect(unCleared.effort, isNull);
+        expect(unCleared.toJson().containsKey('effort'), isFalse);
+
+        final reCleared = unCleared.copyWith(clearEffort: true);
+        expect(reCleared.clearEffort, isTrue);
+        expect(reCleared.toJson()['effort'], isNull);
       },
     );
 

--- a/packages/anthropic_sdk_dart/test/unit/models/managed_agents/model_config_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/managed_agents/model_config_test.dart
@@ -189,6 +189,12 @@ void main() {
         final reCleared = unCleared.copyWith(clearEffort: true);
         expect(reCleared.clearEffort, isTrue);
         expect(reCleared.toJson()['effort'], isNull);
+
+        final clearedFromConfigured = config.copyWith(clearEffort: true);
+        expect(clearedFromConfigured.clearEffort, isTrue);
+        expect(clearedFromConfigured.effort, isNull);
+        expect(clearedFromConfigured.toJson()['effort'], isNull);
+        expect(clearedFromConfigured.toJson().containsKey('effort'), isTrue);
       },
     );
 

--- a/packages/anthropic_sdk_dart/test/unit/models/managed_agents/model_config_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/managed_agents/model_config_test.dart
@@ -92,20 +92,61 @@ void main() {
       expect(config.toJson().containsKey('effort'), isFalse);
     });
 
-    test('copyWith replaces and clears effort', () {
-      const config = ModelParamsConfig(
-        id: 'claude-opus-4-8',
-        effort: EffortParamsLevel(EffortLevel.low),
-      );
-      expect(
-        config
-            .copyWith(effort: const EffortParamsObject(EffortLevel.max))
-            .effort,
-        isA<EffortParamsObject>(),
-      );
-      expect(config.copyWith(effort: null).effort, isNull);
-      expect(config.copyWith().effort, isA<EffortParamsLevel>());
+    test('explicit null is null but present as null in toJson', () {
+      final config = ModelParamsConfig.fromJson(const {
+        'id': 'claude-opus-4-8',
+        'effort': null,
+      });
+      expect(config.effort, isNull);
+      expect(config.toJson().containsKey('effort'), isTrue);
+      expect(config.toJson()['effort'], isNull);
     });
+
+    test('fromJson round-trips omitted, explicit null, and set states', () {
+      final omitted = ModelParamsConfig.fromJson(const {
+        'id': 'claude-opus-4-8',
+      });
+      expect(omitted.toJson(), const {'id': 'claude-opus-4-8'});
+
+      final explicitNull = ModelParamsConfig.fromJson(const {
+        'id': 'claude-opus-4-8',
+        'effort': null,
+      });
+      expect(explicitNull.toJson(), const {
+        'id': 'claude-opus-4-8',
+        'effort': null,
+      });
+
+      final set = ModelParamsConfig.fromJson(const {
+        'id': 'claude-opus-4-8',
+        'effort': 'high',
+      });
+      expect(set.toJson(), const {'id': 'claude-opus-4-8', 'effort': 'high'});
+    });
+
+    test(
+      'copyWith replaces effort, clears to explicit null, and preserves',
+      () {
+        const config = ModelParamsConfig(
+          id: 'claude-opus-4-8',
+          effort: EffortParamsLevel(EffortLevel.low),
+        );
+        expect(
+          config
+              .copyWith(effort: const EffortParamsObject(EffortLevel.max))
+              .effort,
+          isA<EffortParamsObject>(),
+        );
+
+        final cleared = config.copyWith(effort: null);
+        expect(cleared.effort, isNull);
+        expect(cleared.toJson()['effort'], isNull);
+
+        final preserved = config.copyWith();
+        expect(preserved.effort, isA<EffortParamsLevel>());
+        expect(preserved.toJson()['effort'], 'low');
+      },
+    );
 
     test('equality and hashCode include effort', () {
       const a = ModelParamsConfig(

--- a/packages/anthropic_sdk_dart/test/unit/models/managed_agents/model_config_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/managed_agents/model_config_test.dart
@@ -1,0 +1,167 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ModelConfig.effort', () {
+    test('fromJson parses the object wire form', () {
+      final config = ModelConfig.fromJson(const {
+        'id': 'claude-opus-4-8',
+        'effort': {'type': 'high'},
+      });
+      expect(config.effort, EffortLevel.high);
+    });
+
+    test('toJson emits the object wire form', () {
+      const config = ModelConfig(
+        id: 'claude-opus-4-8',
+        effort: EffortLevel.high,
+      );
+      expect(config.toJson()['effort'], {'type': 'high'});
+    });
+
+    test('is null and omitted from toJson when absent', () {
+      final config = ModelConfig.fromJson(const {'id': 'claude-opus-4-8'});
+      expect(config.effort, isNull);
+      expect(config.toJson().containsKey('effort'), isFalse);
+    });
+
+    test('round-trips through fromJson/toJson', () {
+      const json = {
+        'id': 'claude-opus-4-8',
+        'speed': 'fast',
+        'effort': {'type': 'xhigh'},
+      };
+      final config = ModelConfig.fromJson(json);
+      expect(config.toJson(), json);
+    });
+
+    test('copyWith replaces and clears effort', () {
+      const config = ModelConfig(
+        id: 'claude-opus-4-8',
+        effort: EffortLevel.low,
+      );
+      expect(config.copyWith(effort: EffortLevel.max).effort, EffortLevel.max);
+      expect(config.copyWith(effort: null).effort, isNull);
+      expect(config.copyWith().effort, EffortLevel.low);
+    });
+
+    test('equality and hashCode include effort', () {
+      const a = ModelConfig(id: 'claude-opus-4-8', effort: EffortLevel.high);
+      const b = ModelConfig(id: 'claude-opus-4-8', effort: EffortLevel.high);
+      const c = ModelConfig(id: 'claude-opus-4-8', effort: EffortLevel.low);
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('toString includes effort', () {
+      const config = ModelConfig(
+        id: 'claude-opus-4-8',
+        effort: EffortLevel.medium,
+      );
+      expect(config.toString(), contains('effort: EffortLevel.medium'));
+    });
+  });
+
+  group('ModelParamsConfig.effort', () {
+    test('fromJson parses a bare level string via EffortParams', () {
+      final config = ModelParamsConfig.fromJson(const {
+        'id': 'claude-opus-4-8',
+        'effort': 'high',
+      });
+      expect(config.effort, isA<EffortParamsLevel>());
+      expect((config.effort! as EffortParamsLevel).level, EffortLevel.high);
+      expect(config.toJson()['effort'], 'high');
+    });
+
+    test('fromJson parses the object wire form via EffortParams', () {
+      final config = ModelParamsConfig.fromJson(const {
+        'id': 'claude-opus-4-8',
+        'effort': {'type': 'max'},
+      });
+      expect(config.effort, isA<EffortParamsObject>());
+      expect((config.effort! as EffortParamsObject).level, EffortLevel.max);
+      expect(config.toJson()['effort'], {'type': 'max'});
+    });
+
+    test('is null and omitted from toJson when absent', () {
+      final config = ModelParamsConfig.fromJson(const {
+        'id': 'claude-opus-4-8',
+      });
+      expect(config.effort, isNull);
+      expect(config.toJson().containsKey('effort'), isFalse);
+    });
+
+    test('copyWith replaces and clears effort', () {
+      const config = ModelParamsConfig(
+        id: 'claude-opus-4-8',
+        effort: EffortParamsLevel(EffortLevel.low),
+      );
+      expect(
+        config
+            .copyWith(effort: const EffortParamsObject(EffortLevel.max))
+            .effort,
+        isA<EffortParamsObject>(),
+      );
+      expect(config.copyWith(effort: null).effort, isNull);
+      expect(config.copyWith().effort, isA<EffortParamsLevel>());
+    });
+
+    test('equality and hashCode include effort', () {
+      const a = ModelParamsConfig(
+        id: 'claude-opus-4-8',
+        effort: EffortParamsLevel(EffortLevel.high),
+      );
+      const b = ModelParamsConfig(
+        id: 'claude-opus-4-8',
+        effort: EffortParamsLevel(EffortLevel.high),
+      );
+      const c = ModelParamsConfig(
+        id: 'claude-opus-4-8',
+        effort: EffortParamsObject(EffortLevel.high),
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
+  });
+
+  group('EffortParams', () {
+    test('fromJson dispatches String to EffortParamsLevel', () {
+      final params = EffortParams.fromJson('medium');
+      expect(params, isA<EffortParamsLevel>());
+      expect((params as EffortParamsLevel).level, EffortLevel.medium);
+      expect(params.toJson(), 'medium');
+    });
+
+    test('fromJson dispatches Map to EffortParamsObject', () {
+      final params = EffortParams.fromJson(const {'type': 'xhigh'});
+      expect(params, isA<EffortParamsObject>());
+      expect((params as EffortParamsObject).level, EffortLevel.xhigh);
+      expect(params.toJson(), {'type': 'xhigh'});
+    });
+
+    test('equality and hashCode', () {
+      const a = EffortParamsLevel(EffortLevel.high);
+      const b = EffortParamsLevel(EffortLevel.high);
+      const objA = EffortParamsObject(EffortLevel.high);
+      const objB = EffortParamsObject(EffortLevel.high);
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(objA, equals(objB));
+      expect(objA.hashCode, equals(objB.hashCode));
+      expect(a, isNot(equals(objA)));
+    });
+
+    test('toString includes the level', () {
+      expect(
+        const EffortParamsLevel(EffortLevel.high).toString(),
+        contains('EffortLevel.high'),
+      );
+      expect(
+        const EffortParamsObject(EffortLevel.max).toString(),
+        contains('EffortLevel.max'),
+      );
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/managed_agents/model_config_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/managed_agents/model_config_test.dart
@@ -98,20 +98,44 @@ void main() {
         'effort': null,
       });
       expect(config.effort, isNull);
+      expect(config.clearEffort, isTrue);
       expect(config.toJson().containsKey('effort'), isTrue);
       expect(config.toJson()['effort'], isNull);
+    });
+
+    test('clearEffort: true emits an explicit JSON null', () {
+      const config = ModelParamsConfig(
+        id: 'claude-opus-4-8',
+        clearEffort: true,
+      );
+      expect(config.effort, isNull);
+      expect(config.toJson().containsKey('effort'), isTrue);
+      expect(config.toJson()['effort'], isNull);
+    });
+
+    test('passing both effort and clearEffort: true asserts', () {
+      expect(
+        () => ModelParamsConfig(
+          id: 'claude-opus-4-8',
+          effort: const EffortParamsLevel(EffortLevel.high),
+          clearEffort: true,
+        ),
+        throwsA(isA<AssertionError>()),
+      );
     });
 
     test('fromJson round-trips omitted, explicit null, and set states', () {
       final omitted = ModelParamsConfig.fromJson(const {
         'id': 'claude-opus-4-8',
       });
+      expect(omitted.clearEffort, isFalse);
       expect(omitted.toJson(), const {'id': 'claude-opus-4-8'});
 
       final explicitNull = ModelParamsConfig.fromJson(const {
         'id': 'claude-opus-4-8',
         'effort': null,
       });
+      expect(explicitNull.clearEffort, isTrue);
       expect(explicitNull.toJson(), const {
         'id': 'claude-opus-4-8',
         'effort': null,
@@ -121,6 +145,7 @@ void main() {
         'id': 'claude-opus-4-8',
         'effort': 'high',
       });
+      expect(set.clearEffort, isFalse);
       expect(set.toJson(), const {'id': 'claude-opus-4-8', 'effort': 'high'});
     });
 
@@ -145,6 +170,16 @@ void main() {
         final preserved = config.copyWith();
         expect(preserved.effort, isA<EffortParamsLevel>());
         expect(preserved.toJson()['effort'], 'low');
+
+        final reset = cleared.copyWith(
+          effort: const EffortParamsLevel(EffortLevel.medium),
+        );
+        expect(reset.clearEffort, isFalse);
+        expect(reset.toJson()['effort'], 'medium');
+
+        final stillCleared = cleared.copyWith();
+        expect(stillCleared.clearEffort, isTrue);
+        expect(stillCleared.toJson()['effort'], isNull);
       },
     );
 

--- a/packages/anthropic_sdk_dart/test/unit/models/managed_agents/model_config_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/managed_agents/model_config_test.dart
@@ -113,15 +113,22 @@ void main() {
       expect(config.toJson()['effort'], isNull);
     });
 
-    test('passing both effort and clearEffort: true asserts', () {
-      expect(
-        () => ModelParamsConfig(
-          id: 'claude-opus-4-8',
-          effort: const EffortParamsLevel(EffortLevel.high),
-          clearEffort: true,
-        ),
-        throwsA(isA<AssertionError>()),
+    test('non-null effort takes precedence over clearEffort: true', () {
+      const config = ModelParamsConfig(
+        id: 'claude-opus-4-8',
+        effort: EffortParamsLevel(EffortLevel.high),
+        clearEffort: true,
       );
+      expect(config.clearEffort, isFalse);
+      expect(config.toJson()['effort'], 'high');
+
+      final viaCopyWith = const ModelParamsConfig(id: 'claude-opus-4-8')
+          .copyWith(
+            effort: const EffortParamsLevel(EffortLevel.high),
+            clearEffort: true,
+          );
+      expect(viaCopyWith.clearEffort, isFalse);
+      expect(viaCopyWith.toJson()['effort'], 'high');
     });
 
     test('fromJson round-trips omitted, explicit null, and set states', () {

--- a/packages/anthropic_sdk_dart/test/unit/models/managed_agents/session_initial_event_params_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/managed_agents/session_initial_event_params_test.dart
@@ -1,0 +1,119 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SessionInitialEventParams (create wrapper)', () {
+    test('.userMessage factory wraps UserMessageEventParams and toJson '
+        'delegates', () {
+      const params = UserMessageEventParams(
+        content: [
+          {'type': 'text', 'text': 'hello'},
+        ],
+      );
+      const wrapped = SessionInitialEventParams.userMessage(params);
+
+      expect(wrapped, isA<SessionUserMessageEventParams>());
+      expect((wrapped as SessionUserMessageEventParams).params, equals(params));
+      expect(wrapped.toJson(), params.toJson());
+      expect(wrapped.toJson(), {
+        'type': 'user.message',
+        'content': [
+          {'type': 'text', 'text': 'hello'},
+        ],
+      });
+    });
+
+    test('.userDefineOutcome factory wraps UserDefineOutcomeEventParams', () {
+      const params = UserDefineOutcomeEventParams(
+        description: 'Produce a report.',
+        rubric: TextRubricParams(content: 'Grade leniently.'),
+        maxIterations: 5,
+      );
+      const wrapped = SessionInitialEventParams.userDefineOutcome(params);
+
+      expect(wrapped, isA<SessionUserDefineOutcomeEventParams>());
+      expect(wrapped.toJson(), params.toJson());
+      expect(wrapped.toJson()['type'], 'user.define_outcome');
+    });
+
+    test('fromJson dispatches user.message to the right wrapper and '
+        'round-trips', () {
+      final json = <String, dynamic>{
+        'type': 'user.message',
+        'content': [
+          {'type': 'text', 'text': 'hello'},
+        ],
+      };
+
+      final parsed = SessionInitialEventParams.fromJson(json);
+      expect(parsed, isA<SessionUserMessageEventParams>());
+      expect(parsed.toJson(), json);
+    });
+
+    test('fromJson dispatches user.define_outcome to the right wrapper', () {
+      final json = <String, dynamic>{
+        'type': 'user.define_outcome',
+        'description': 'd',
+        'rubric': {'type': 'text', 'content': 'r'},
+        'max_iterations': 3,
+      };
+
+      final parsed = SessionInitialEventParams.fromJson(json);
+      expect(parsed, isA<SessionUserDefineOutcomeEventParams>());
+      expect(parsed.toJson(), json);
+    });
+
+    test('unrecognized type → UnknownSessionInitialEventParams fallback', () {
+      final json = <String, dynamic>{
+        'type': 'system.message',
+        'content': [
+          {'type': 'text', 'text': 'sys'},
+        ],
+      };
+
+      final parsed = SessionInitialEventParams.fromJson(json);
+      expect(parsed, isA<UnknownSessionInitialEventParams>());
+      // Round-trips the raw JSON unchanged.
+      expect(parsed.toJson(), json);
+    });
+
+    test('equality and hashCode', () {
+      const a = SessionInitialEventParams.userMessage(
+        UserMessageEventParams(
+          content: [
+            {'type': 'text', 'text': 'hi'},
+          ],
+        ),
+      );
+      const b = SessionInitialEventParams.userMessage(
+        UserMessageEventParams(
+          content: [
+            {'type': 'text', 'text': 'hi'},
+          ],
+        ),
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('copyWith replaces the wrapped params', () {
+      const wrapped = SessionInitialEventParams.userMessage(
+        UserMessageEventParams(
+          content: [
+            {'type': 'text', 'text': 'hi'},
+          ],
+        ),
+      );
+      final updated = (wrapped as SessionUserMessageEventParams).copyWith(
+        params: const UserMessageEventParams(
+          content: [
+            {'type': 'text', 'text': 'bye'},
+          ],
+        ),
+      );
+      expect(updated.toJson()['content'], [
+        {'type': 'text', 'text': 'bye'},
+      ]);
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/metadata/fallback_credit_usage_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/metadata/fallback_credit_usage_test.dart
@@ -1,0 +1,313 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('FallbackCreditNotAppliedReason', () {
+    test('fromJson maps all twelve known values', () {
+      const expected = {
+        'body_mismatch': FallbackCreditNotAppliedReason.bodyMismatch,
+        'continuation_excluded':
+            FallbackCreditNotAppliedReason.continuationExcluded,
+        'continuation_only': FallbackCreditNotAppliedReason.continuationOnly,
+        'expired': FallbackCreditNotAppliedReason.expired,
+        'invalid_target_model':
+            FallbackCreditNotAppliedReason.invalidTargetModel,
+        'not_enabled': FallbackCreditNotAppliedReason.notEnabled,
+        'reprice_unavailable':
+            FallbackCreditNotAppliedReason.repriceUnavailable,
+        'temporarily_unavailable':
+            FallbackCreditNotAppliedReason.temporarilyUnavailable,
+        'variant_fields_present':
+            FallbackCreditNotAppliedReason.variantFieldsPresent,
+        'wrong_organization': FallbackCreditNotAppliedReason.wrongOrganization,
+        'wrong_platform': FallbackCreditNotAppliedReason.wrongPlatform,
+        'wrong_workspace': FallbackCreditNotAppliedReason.wrongWorkspace,
+      };
+
+      for (final entry in expected.entries) {
+        expect(
+          FallbackCreditNotAppliedReason.fromJson(entry.key),
+          entry.value,
+          reason: entry.key,
+        );
+        expect(entry.value.toJson(), entry.key);
+      }
+    });
+
+    test('fromJson falls back to unknown for unrecognized values', () {
+      expect(
+        FallbackCreditNotAppliedReason.fromJson('some_future_reason'),
+        FallbackCreditNotAppliedReason.unknown,
+      );
+    });
+  });
+
+  group('FallbackCreditStatus', () {
+    test('round-trips redeemed', () {
+      const json = {'type': 'redeemed'};
+      final status = FallbackCreditStatus.fromJson(json);
+      expect(status, isA<FallbackCreditRedeemed>());
+      expect(status.toJson(), json);
+    });
+
+    test('fromJson rejects a mismatched discriminator for redeemed', () {
+      expect(
+        () => FallbackCreditRedeemed.fromJson(const {'type': 'not_applied'}),
+        throwsFormatException,
+      );
+    });
+
+    test('round-trips not_applied without remove_to_redeem', () {
+      final json = {'type': 'not_applied', 'reason': 'expired'};
+      final status = FallbackCreditStatus.fromJson(json);
+      expect(status, isA<FallbackCreditNotApplied>());
+      final notApplied = status as FallbackCreditNotApplied;
+      expect(notApplied.reason, FallbackCreditNotAppliedReason.expired);
+      expect(notApplied.removeToRedeem, isNull);
+      expect(status.toJson(), json);
+    });
+
+    test('round-trips not_applied with remove_to_redeem', () {
+      final json = {
+        'type': 'not_applied',
+        'reason': 'variant_fields_present',
+        'remove_to_redeem': ['top_p', 'top_k'],
+      };
+      final status = FallbackCreditStatus.fromJson(json);
+      final notApplied = status as FallbackCreditNotApplied;
+      expect(
+        notApplied.reason,
+        FallbackCreditNotAppliedReason.variantFieldsPresent,
+      );
+      expect(notApplied.removeToRedeem, ['top_p', 'top_k']);
+      expect(status.toJson(), json);
+    });
+
+    test('fromJson rejects a mismatched discriminator for not_applied', () {
+      expect(
+        () => FallbackCreditNotApplied.fromJson(const {
+          'type': 'redeemed',
+          'reason': 'expired',
+        }),
+        throwsFormatException,
+      );
+    });
+
+    test(
+      'not_applied fromJson rejects a non-string remove_to_redeem entry',
+      () {
+        expect(
+          () => FallbackCreditNotApplied.fromJson(const {
+            'type': 'not_applied',
+            'reason': 'variant_fields_present',
+            'remove_to_redeem': [1, 2],
+          }),
+          throwsFormatException,
+        );
+      },
+    );
+
+    test('preserves an unrecognized status type verbatim', () {
+      final json = {'type': 'some_future_status', 'extra': 'value'};
+      final status = FallbackCreditStatus.fromJson(json);
+      expect(status, isA<UnknownFallbackCreditStatus>());
+      expect(status.toJson(), json);
+    });
+
+    test('not_applied copyWith replaces reason and clears removeToRedeem', () {
+      const original = FallbackCreditNotApplied(
+        reason: FallbackCreditNotAppliedReason.variantFieldsPresent,
+        removeToRedeem: ['top_p'],
+      );
+      final changed = original.copyWith(
+        reason: FallbackCreditNotAppliedReason.expired,
+      );
+      expect(changed.reason, FallbackCreditNotAppliedReason.expired);
+      expect(changed.removeToRedeem, ['top_p']);
+
+      final cleared = original.copyWith(removeToRedeem: null);
+      expect(cleared.removeToRedeem, isNull);
+      expect(cleared.reason, original.reason);
+    });
+
+    test('equality and hashCode for redeemed', () {
+      const a = FallbackCreditRedeemed();
+      const b = FallbackCreditRedeemed();
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a.toString(), 'FallbackCreditRedeemed()');
+    });
+
+    test('equality and hashCode for not_applied', () {
+      const a = FallbackCreditNotApplied(
+        reason: FallbackCreditNotAppliedReason.expired,
+      );
+      const b = FallbackCreditNotApplied(
+        reason: FallbackCreditNotAppliedReason.expired,
+      );
+      const c = FallbackCreditNotApplied(
+        reason: FallbackCreditNotAppliedReason.notEnabled,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+      expect(a.toString(), contains('reason: FallbackCreditNotAppliedReason'));
+    });
+
+    test('equality and hashCode for unknown status', () {
+      const a = UnknownFallbackCreditStatus(
+        rawJson: {
+          'type': 'x',
+          'nested': {'k': 'v'},
+        },
+      );
+      const b = UnknownFallbackCreditStatus(
+        rawJson: {
+          'type': 'x',
+          'nested': {'k': 'v'},
+        },
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a.toString(), contains('rawJson'));
+    });
+  });
+
+  group('FallbackCreditUsage', () {
+    test('round-trips with a redeemed status', () {
+      final json = {
+        'status': {'type': 'redeemed'},
+      };
+      final usage = FallbackCreditUsage.fromJson(json);
+      expect(usage.status, isA<FallbackCreditRedeemed>());
+      expect(usage.toJson(), json);
+    });
+
+    test('round-trips with a not_applied status', () {
+      final json = {
+        'status': {'type': 'not_applied', 'reason': 'wrong_workspace'},
+      };
+      final usage = FallbackCreditUsage.fromJson(json);
+      final status = usage.status as FallbackCreditNotApplied;
+      expect(status.reason, FallbackCreditNotAppliedReason.wrongWorkspace);
+      expect(usage.toJson(), json);
+    });
+
+    test('copyWith replaces status', () {
+      const usage = FallbackCreditUsage(status: FallbackCreditRedeemed());
+      final changed = usage.copyWith(
+        status: const FallbackCreditNotApplied(
+          reason: FallbackCreditNotAppliedReason.expired,
+        ),
+      );
+      expect(changed.status, isA<FallbackCreditNotApplied>());
+    });
+
+    test('equality, hashCode, and toString', () {
+      const a = FallbackCreditUsage(status: FallbackCreditRedeemed());
+      const b = FallbackCreditUsage(status: FallbackCreditRedeemed());
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a.toString(), contains('FallbackCreditRedeemed()'));
+    });
+  });
+
+  group('FallbackCreditMode', () {
+    test('round-trips strict and best_effort', () {
+      expect(FallbackCreditMode.fromJson('strict'), FallbackCreditMode.strict);
+      expect(
+        FallbackCreditMode.fromJson('best_effort'),
+        FallbackCreditMode.bestEffort,
+      );
+      expect(FallbackCreditMode.strict.toJson(), 'strict');
+      expect(FallbackCreditMode.bestEffort.toJson(), 'best_effort');
+    });
+
+    test('fromJson throws for unrecognized values', () {
+      expect(
+        () => FallbackCreditMode.fromJson('lenient'),
+        throwsFormatException,
+      );
+    });
+  });
+
+  group('FallbackCreditTokenParam', () {
+    test('bare token serializes as a plain string', () {
+      const param = FallbackCreditTokenParam.token('tok_abc123');
+      expect(param.toJson(), 'tok_abc123');
+    });
+
+    test('fromJson parses a bare string wire form', () {
+      final param = FallbackCreditTokenParam.fromJson('tok_abc123');
+      expect(param, isA<FallbackCreditTokenParamToken>());
+      expect((param as FallbackCreditTokenParamToken).token, 'tok_abc123');
+    });
+
+    test('config form serializes token and mode', () {
+      const param = FallbackCreditTokenParam.config(
+        token: 'tok_abc123',
+        mode: FallbackCreditMode.bestEffort,
+      );
+      expect(param.toJson(), {'token': 'tok_abc123', 'mode': 'best_effort'});
+    });
+
+    test('config form omits mode when null', () {
+      const param = FallbackCreditTokenParam.config(token: 'tok_abc123');
+      final json = param.toJson() as Map<String, dynamic>;
+      expect(json.containsKey('mode'), isFalse);
+    });
+
+    test('fromJson parses the object wire form', () {
+      final param = FallbackCreditTokenParam.fromJson({
+        'token': 'tok_abc123',
+        'mode': 'strict',
+      });
+      expect(param, isA<FallbackCreditTokenParamConfig>());
+      final config = param as FallbackCreditTokenParamConfig;
+      expect(config.token, 'tok_abc123');
+      expect(config.mode, FallbackCreditMode.strict);
+    });
+
+    test('config copyWith replaces token and clears mode', () {
+      const original = FallbackCreditTokenParamConfig(
+        token: 'tok_abc123',
+        mode: FallbackCreditMode.bestEffort,
+      );
+      final changed = original.copyWith(token: 'tok_new');
+      expect(changed.token, 'tok_new');
+      expect(changed.mode, FallbackCreditMode.bestEffort);
+
+      final cleared = original.copyWith(mode: null);
+      expect(cleared.mode, isNull);
+      expect(cleared.token, 'tok_abc123');
+    });
+
+    test('equality is content-based for both variants', () {
+      const a = FallbackCreditTokenParam.token('tok_abc123');
+      const b = FallbackCreditTokenParam.token('tok_abc123');
+      const c = FallbackCreditTokenParam.token('tok_other');
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+
+      const d = FallbackCreditTokenParam.config(token: 'tok_abc123');
+      const e = FallbackCreditTokenParam.config(token: 'tok_abc123');
+      expect(d, equals(e));
+      expect(d.hashCode, equals(e.hashCode));
+    });
+
+    test('toString masks the token value for both variants', () {
+      const bare = FallbackCreditTokenParam.token('tok_super_secret');
+      expect(bare.toString(), isNot(contains('tok_super_secret')));
+      expect(bare.toString(), contains('[redacted]'));
+
+      const config = FallbackCreditTokenParam.config(
+        token: 'tok_super_secret',
+        mode: FallbackCreditMode.strict,
+      );
+      expect(config.toString(), isNot(contains('tok_super_secret')));
+      expect(config.toString(), contains('[redacted]'));
+      expect(config.toString(), contains('mode: FallbackCreditMode.strict'));
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/metadata/fallback_credit_usage_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/metadata/fallback_credit_usage_test.dart
@@ -83,6 +83,15 @@ void main() {
       expect(status.toJson(), json);
     });
 
+    test('preserves an unrecognized reason verbatim', () {
+      final json = {'type': 'not_applied', 'reason': 'some_future_reason'};
+      final status = FallbackCreditStatus.fromJson(json);
+      final notApplied = status as FallbackCreditNotApplied;
+      expect(notApplied.reason, FallbackCreditNotAppliedReason.unknown);
+      expect(notApplied.rawReason, 'some_future_reason');
+      expect(status.toJson(), json);
+    });
+
     test('fromJson rejects a mismatched discriminator for not_applied', () {
       expect(
         () => FallbackCreditNotApplied.fromJson(const {
@@ -115,9 +124,9 @@ void main() {
     });
 
     test('not_applied copyWith replaces reason and clears removeToRedeem', () {
-      const original = FallbackCreditNotApplied(
+      final original = FallbackCreditNotApplied(
         reason: FallbackCreditNotAppliedReason.variantFieldsPresent,
-        removeToRedeem: ['top_p'],
+        removeToRedeem: const ['top_p'],
       );
       final changed = original.copyWith(
         reason: FallbackCreditNotAppliedReason.expired,
@@ -139,13 +148,13 @@ void main() {
     });
 
     test('equality and hashCode for not_applied', () {
-      const a = FallbackCreditNotApplied(
+      final a = FallbackCreditNotApplied(
         reason: FallbackCreditNotAppliedReason.expired,
       );
-      const b = FallbackCreditNotApplied(
+      final b = FallbackCreditNotApplied(
         reason: FallbackCreditNotAppliedReason.expired,
       );
-      const c = FallbackCreditNotApplied(
+      final c = FallbackCreditNotApplied(
         reason: FallbackCreditNotAppliedReason.notEnabled,
       );
       expect(a, equals(b));
@@ -196,7 +205,7 @@ void main() {
     test('copyWith replaces status', () {
       const usage = FallbackCreditUsage(status: FallbackCreditRedeemed());
       final changed = usage.copyWith(
-        status: const FallbackCreditNotApplied(
+        status: FallbackCreditNotApplied(
           reason: FallbackCreditNotAppliedReason.expired,
         ),
       );

--- a/packages/anthropic_sdk_dart/test/unit/models/metadata/fallback_credit_usage_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/metadata/fallback_credit_usage_test.dart
@@ -124,9 +124,9 @@ void main() {
     });
 
     test('not_applied copyWith replaces reason and clears removeToRedeem', () {
-      final original = FallbackCreditNotApplied(
+      const original = FallbackCreditNotApplied(
         reason: FallbackCreditNotAppliedReason.variantFieldsPresent,
-        removeToRedeem: const ['top_p'],
+        removeToRedeem: ['top_p'],
       );
       final changed = original.copyWith(
         reason: FallbackCreditNotAppliedReason.expired,
@@ -148,13 +148,13 @@ void main() {
     });
 
     test('equality and hashCode for not_applied', () {
-      final a = FallbackCreditNotApplied(
+      const a = FallbackCreditNotApplied(
         reason: FallbackCreditNotAppliedReason.expired,
       );
-      final b = FallbackCreditNotApplied(
+      const b = FallbackCreditNotApplied(
         reason: FallbackCreditNotAppliedReason.expired,
       );
-      final c = FallbackCreditNotApplied(
+      const c = FallbackCreditNotApplied(
         reason: FallbackCreditNotAppliedReason.notEnabled,
       );
       expect(a, equals(b));
@@ -162,6 +162,18 @@ void main() {
       expect(a, isNot(equals(c)));
       expect(a.toString(), contains('reason: FallbackCreditNotAppliedReason'));
     });
+
+    test(
+      'a const typed instance equals an equivalent .raw-parsed instance',
+      () {
+        const typed = FallbackCreditNotApplied(
+          reason: FallbackCreditNotAppliedReason.expired,
+        );
+        const raw = FallbackCreditNotApplied.raw(rawReason: 'expired');
+        expect(typed, equals(raw));
+        expect(typed.hashCode, equals(raw.hashCode));
+      },
+    );
 
     test('equality and hashCode for unknown status', () {
       const a = UnknownFallbackCreditStatus(
@@ -205,7 +217,7 @@ void main() {
     test('copyWith replaces status', () {
       const usage = FallbackCreditUsage(status: FallbackCreditRedeemed());
       final changed = usage.copyWith(
-        status: FallbackCreditNotApplied(
+        status: const FallbackCreditNotApplied(
           reason: FallbackCreditNotAppliedReason.expired,
         ),
       );

--- a/packages/anthropic_sdk_dart/test/unit/models/usage_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/usage_test.dart
@@ -303,7 +303,7 @@ void main() {
         fallbackCredit: FallbackCreditUsage(status: FallbackCreditRedeemed()),
       );
       final updated = usage.copyWith(
-        fallbackCredit: FallbackCreditUsage(
+        fallbackCredit: const FallbackCreditUsage(
           status: FallbackCreditNotApplied(
             reason: FallbackCreditNotAppliedReason.notEnabled,
           ),

--- a/packages/anthropic_sdk_dart/test/unit/models/usage_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/usage_test.dart
@@ -303,7 +303,7 @@ void main() {
         fallbackCredit: FallbackCreditUsage(status: FallbackCreditRedeemed()),
       );
       final updated = usage.copyWith(
-        fallbackCredit: const FallbackCreditUsage(
+        fallbackCredit: FallbackCreditUsage(
           status: FallbackCreditNotApplied(
             reason: FallbackCreditNotAppliedReason.notEnabled,
           ),

--- a/packages/anthropic_sdk_dart/test/unit/models/usage_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/usage_test.dart
@@ -261,4 +261,94 @@ void main() {
       );
     });
   });
+
+  group('Usage.fallbackCredit', () {
+    test('parses and round-trips a redeemed fallbackCredit', () {
+      final json = {
+        'input_tokens': 10,
+        'output_tokens': 20,
+        'fallback_credit': {
+          'status': {'type': 'redeemed'},
+        },
+      };
+      final usage = Usage.fromJson(json);
+      expect(usage.fallbackCredit, isNotNull);
+      expect(usage.fallbackCredit!.status, isA<FallbackCreditRedeemed>());
+      expect(usage.toJson(), json);
+    });
+
+    test('parses and round-trips a not_applied fallbackCredit', () {
+      final json = {
+        'input_tokens': 10,
+        'output_tokens': 20,
+        'fallback_credit': {
+          'status': {'type': 'not_applied', 'reason': 'expired'},
+        },
+      };
+      final usage = Usage.fromJson(json);
+      final status = usage.fallbackCredit!.status as FallbackCreditNotApplied;
+      expect(status.reason, FallbackCreditNotAppliedReason.expired);
+      expect(usage.toJson(), json);
+    });
+
+    test('omits fallback_credit when null', () {
+      const usage = Usage(inputTokens: 10, outputTokens: 20);
+      expect(usage.toJson().containsKey('fallback_credit'), isFalse);
+    });
+
+    test('copyWith updates and clears fallbackCredit', () {
+      const usage = Usage(
+        inputTokens: 10,
+        outputTokens: 20,
+        fallbackCredit: FallbackCreditUsage(status: FallbackCreditRedeemed()),
+      );
+      final updated = usage.copyWith(
+        fallbackCredit: const FallbackCreditUsage(
+          status: FallbackCreditNotApplied(
+            reason: FallbackCreditNotAppliedReason.notEnabled,
+          ),
+        ),
+      );
+      expect(updated.fallbackCredit!.status, isA<FallbackCreditNotApplied>());
+      expect(usage.copyWith(fallbackCredit: null).fallbackCredit, isNull);
+    });
+
+    test('equality and toString include fallbackCredit', () {
+      const a = Usage(
+        inputTokens: 10,
+        outputTokens: 20,
+        fallbackCredit: FallbackCreditUsage(status: FallbackCreditRedeemed()),
+      );
+      const b = Usage(inputTokens: 10, outputTokens: 20);
+      expect(a, isNot(b));
+      expect(a.toString(), contains('fallbackCredit'));
+    });
+  });
+
+  group('MessageDeltaUsage.fallbackCredit', () {
+    test('parses and round-trips fallbackCredit', () {
+      final json = {
+        'output_tokens': 80,
+        'fallback_credit': {
+          'status': {'type': 'redeemed'},
+        },
+      };
+      final usage = MessageDeltaUsage.fromJson(json);
+      expect(usage.fallbackCredit!.status, isA<FallbackCreditRedeemed>());
+      expect(usage.toJson(), json);
+    });
+
+    test('omits fallback_credit when null', () {
+      const usage = MessageDeltaUsage(outputTokens: 80);
+      expect(usage.toJson().containsKey('fallback_credit'), isFalse);
+    });
+
+    test('copyWith clears fallbackCredit', () {
+      const usage = MessageDeltaUsage(
+        outputTokens: 80,
+        fallbackCredit: FallbackCreditUsage(status: FallbackCreditRedeemed()),
+      );
+      expect(usage.copyWith(fallbackCredit: null).fallbackCredit, isNull);
+    });
+  });
 }

--- a/packages/anthropic_sdk_dart/test/unit/models/webhook_event_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/webhook_event_test.dart
@@ -96,6 +96,17 @@ void main() {
       false,
       isA<WebhookDeploymentRunFailedEventData>(),
     ),
+    ('environment.archived', false, isA<WebhookEnvironmentArchivedEventData>()),
+    ('environment.created', false, isA<WebhookEnvironmentCreatedEventData>()),
+    ('environment.deleted', false, isA<WebhookEnvironmentDeletedEventData>()),
+    ('environment.updated', false, isA<WebhookEnvironmentUpdatedEventData>()),
+    (
+      'memory_store.archived',
+      false,
+      isA<WebhookMemoryStoreArchivedEventData>(),
+    ),
+    ('memory_store.created', false, isA<WebhookMemoryStoreCreatedEventData>()),
+    ('memory_store.deleted', false, isA<WebhookMemoryStoreDeletedEventData>()),
   ];
 
   Map<String, dynamic> dataJson(String type, {required bool withVault}) {
@@ -112,8 +123,8 @@ void main() {
   }
 
   group('WebhookEventData dispatch', () {
-    test('covers all 36 spec variants', () {
-      expect(variants, hasLength(36));
+    test('covers all 43 spec variants', () {
+      expect(variants, hasLength(43));
     });
 
     for (final (type, withVault, matcher) in variants) {

--- a/packages/anthropic_sdk_dart/test/unit/resources/dreams_resource_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/resources/dreams_resource_test.dart
@@ -1,0 +1,243 @@
+import 'dart:convert';
+
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+import '../../mocks/mock_http_client.dart';
+
+/// Fixture helpers for dream responses.
+class _DreamFixtures {
+  _DreamFixtures._();
+
+  static Map<String, dynamic> dream({
+    String id = 'dream_test123',
+    String status = 'completed',
+    String? endedAt = '2026-04-25T01:00:00Z',
+    String? archivedAt,
+    Map<String, dynamic>? error,
+  }) {
+    return {
+      'type': 'dream',
+      'id': id,
+      'inputs': [
+        {'type': 'memory_store', 'memory_store_id': 'memstore_in123'},
+        {
+          'type': 'sessions',
+          'session_ids': ['session_a', 'session_b'],
+        },
+      ],
+      'outputs': [
+        {'type': 'memory_store', 'memory_store_id': 'memstore_out123'},
+      ],
+      'status': status,
+      'created_at': '2026-04-25T00:00:00Z',
+      'ended_at': endedAt,
+      'archived_at': archivedAt,
+      'error': error,
+      'model': {'id': 'claude-opus-4-7', 'speed': 'standard'},
+      'instructions': 'Consolidate notes about user preferences.',
+      'session_id': null,
+      'usage': {
+        'input_tokens': 100,
+        'output_tokens': 50,
+        'cache_read_input_tokens': 10,
+        'cache_creation_input_tokens': 5,
+      },
+    };
+  }
+}
+
+void main() {
+  late MockHttpClient mockHttpClient;
+  late AnthropicClient client;
+
+  setUp(() {
+    mockHttpClient = MockHttpClient();
+    client = AnthropicClient(
+      config: const AnthropicConfig(
+        authProvider: ApiKeyProvider('test-api-key'),
+        retryPolicy: RetryPolicy(maxRetries: 0),
+      ),
+      httpClient: mockHttpClient,
+    );
+  });
+
+  tearDown(() {
+    client.close();
+  });
+
+  group('DreamsResource', () {
+    test('create sends correct request and parses response', () async {
+      mockHttpClient.queueJsonResponse(_DreamFixtures.dream());
+
+      final dream = await client.dreams.create(
+        const CreateDreamRequest(
+          inputs: [
+            DreamMemoryStoreInput(memoryStoreId: 'memstore_in123'),
+            DreamSessionsInput(sessionIds: ['session_a', 'session_b']),
+          ],
+          instructions: 'Consolidate notes about user preferences.',
+          model: DreamModelParamsId(id: 'claude-opus-4-7'),
+        ),
+      );
+
+      expect(dream.id, 'dream_test123');
+      expect(dream.status, DreamStatus.completed);
+      expect(dream.inputs, hasLength(2));
+      expect(dream.inputs[0], isA<DreamMemoryStoreInput>());
+      expect(dream.inputs[1], isA<DreamSessionsInput>());
+      expect(dream.outputs.single, isA<DreamMemoryStoreOutput>());
+      expect(dream.model.id, 'claude-opus-4-7');
+      expect(dream.model.speed, AgentSpeed.standard);
+      expect(dream.usage.inputTokens, 100);
+
+      final request = mockHttpClient.lastRequest!;
+      expect(request.url.path, '/v1/dreams');
+      expect(request.method, 'POST');
+      expect(request.headers['anthropic-beta'], 'dreaming-2026-04-21');
+      expect(request.headers['x-api-key'], 'test-api-key');
+
+      final body =
+          jsonDecode((request as dynamic).body) as Map<String, dynamic>;
+      final inputs = body['inputs'] as List;
+      expect(inputs, hasLength(2));
+      expect(inputs[0], {
+        'type': 'memory_store',
+        'memory_store_id': 'memstore_in123',
+      });
+      expect(inputs[1], {
+        'type': 'sessions',
+        'session_ids': ['session_a', 'session_b'],
+      });
+      expect(body['model'], 'claude-opus-4-7');
+      expect(body['instructions'], 'Consolidate notes about user preferences.');
+    });
+
+    test('create with a model config object sends the object body', () async {
+      mockHttpClient.queueJsonResponse(_DreamFixtures.dream());
+
+      await client.dreams.create(
+        const CreateDreamRequest(
+          inputs: [DreamMemoryStoreInput(memoryStoreId: 'memstore_in123')],
+          model: DreamModelConfigParams(
+            id: 'claude-opus-4-7',
+            speed: AgentSpeed.fast,
+          ),
+        ),
+      );
+
+      final request = mockHttpClient.lastRequest!;
+      expect(request.headers['anthropic-beta'], 'dreaming-2026-04-21');
+
+      final body =
+          jsonDecode((request as dynamic).body) as Map<String, dynamic>;
+      expect(body['model'], {'id': 'claude-opus-4-7', 'speed': 'fast'});
+      expect(body.containsKey('instructions'), isFalse);
+    });
+
+    test('list sends correct request with all query params', () async {
+      mockHttpClient.queueJsonResponse({
+        'data': [_DreamFixtures.dream()],
+        'next_page': 'cursor123',
+      });
+
+      final response = await client.dreams.list(
+        limit: 25,
+        page: 'prev_cursor',
+        includeArchived: true,
+        statuses: [DreamStatus.completed, DreamStatus.failed],
+        createdAtGt: '2026-04-01T00:00:00Z',
+        createdAtLt: '2026-04-30T00:00:00Z',
+      );
+
+      expect(response.data, hasLength(1));
+      expect(response.data.first.id, 'dream_test123');
+      expect(response.nextPage, 'cursor123');
+
+      final request = mockHttpClient.lastRequest!;
+      expect(request.url.path, '/v1/dreams');
+      expect(request.method, 'GET');
+      expect(request.url.queryParameters['limit'], '25');
+      expect(request.url.queryParameters['page'], 'prev_cursor');
+      expect(request.url.queryParameters['include_archived'], 'true');
+      expect(request.url.queryParametersAll['statuses[]'], [
+        'completed',
+        'failed',
+      ]);
+      expect(
+        request.url.queryParameters['created_at[gt]'],
+        '2026-04-01T00:00:00Z',
+      );
+      expect(
+        request.url.queryParameters['created_at[lt]'],
+        '2026-04-30T00:00:00Z',
+      );
+      expect(request.headers['anthropic-beta'], 'dreaming-2026-04-21');
+    });
+
+    test('list parses an unknown status as a fallback', () async {
+      mockHttpClient.queueJsonResponse({
+        'data': [_DreamFixtures.dream(status: 'something_new')],
+        'next_page': null,
+      });
+
+      final response = await client.dreams.list();
+
+      expect(response.data.single.status, DreamStatus.unknown);
+      expect(
+        mockHttpClient.lastRequest!.headers['anthropic-beta'],
+        'dreaming-2026-04-21',
+      );
+    });
+
+    test('retrieve sends correct request and parses response', () async {
+      mockHttpClient.queueJsonResponse(_DreamFixtures.dream());
+
+      final dream = await client.dreams.retrieve('dream_test123');
+
+      expect(dream.id, 'dream_test123');
+
+      final req = mockHttpClient.lastRequest!;
+      expect(req.url.path, '/v1/dreams/dream_test123');
+      expect(req.method, 'GET');
+      expect(req.headers['anthropic-beta'], 'dreaming-2026-04-21');
+    });
+
+    test('archive sends empty-body POST and parses response', () async {
+      mockHttpClient.queueJsonResponse(
+        _DreamFixtures.dream(archivedAt: '2026-04-25T12:00:00Z'),
+      );
+
+      final dream = await client.dreams.archive('dream_test123');
+
+      expect(dream.archivedAt, isNotNull);
+
+      final req = mockHttpClient.lastRequest!;
+      expect(req.url.path, '/v1/dreams/dream_test123/archive');
+      expect(req.method, 'POST');
+      expect(req.headers['anthropic-beta'], 'dreaming-2026-04-21');
+
+      final body = jsonDecode((req as dynamic).body) as Map<String, dynamic>;
+      expect(body, isEmpty);
+    });
+
+    test('cancel sends empty-body POST and parses response', () async {
+      mockHttpClient.queueJsonResponse(
+        _DreamFixtures.dream(status: 'canceled', endedAt: null),
+      );
+
+      final dream = await client.dreams.cancel('dream_test123');
+
+      expect(dream.status, DreamStatus.canceled);
+      expect(dream.endedAt, isNull);
+
+      final req = mockHttpClient.lastRequest!;
+      expect(req.url.path, '/v1/dreams/dream_test123/cancel');
+      expect(req.method, 'POST');
+      expect(req.headers['anthropic-beta'], 'dreaming-2026-04-21');
+
+      final body = jsonDecode((req as dynamic).body) as Map<String, dynamic>;
+      expect(body, isEmpty);
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/resources/managed_agents_resource_test.dart
@@ -712,6 +712,46 @@ void main() {
       );
       expect(request.headers['anthropic-beta'], 'managed-agents-2026-04-01');
     });
+
+    test('stream sends event_deltas[] and parses preview events', () async {
+      mockHttpClient.queueStreamingResponse([
+        {
+          'type': 'event_start',
+          'event': {'type': 'agent.message', 'id': 'event_010'},
+        },
+        {
+          'type': 'event_delta',
+          'event_id': 'event_010',
+          'delta': {
+            'type': 'content_delta',
+            'content': {'type': 'text', 'text': 'Hi'},
+            'index': 0,
+          },
+        },
+      ]);
+
+      final events = await client.sessions
+          .threads('session_test123')
+          .events('sthr_test123')
+          .stream(eventDeltas: ['agent.message', 'agent.thinking'])
+          .toList();
+
+      expect(events, hasLength(2));
+      expect(events[0], isA<EventStartEvent>());
+      expect(events[1], isA<EventDeltaEvent>());
+      expect((events[1] as EventDeltaEvent).eventId, 'event_010');
+
+      final request = mockHttpClient.lastRequest!;
+      expect(
+        request.url.path,
+        '/v1/sessions/session_test123/threads/sthr_test123/stream',
+      );
+      expect(request.url.queryParametersAll['event_deltas[]'], [
+        'agent.message',
+        'agent.thinking',
+      ]);
+      expect(request.headers['anthropic-beta'], 'managed-agents-2026-04-01');
+    });
   });
 
   group('SessionResourcesResource', () {


### PR DESCRIPTION
## Summary
- **Dreams API (beta, research preview)**: new `client.dreams` resource covering all five endpoints — `create`, `list` (with `statuses[]`, `created_at[gt|lt]`, `include_archived`, cursor pagination), `retrieve`, `archive`, and `cancel` — plus the full model tree (`Dream`, `DreamStatus`, `DreamInput`/`DreamOutput` unions, `DreamModelParams` string-or-object union, `DreamUsage`, `DreamError`). All requests send the `dreaming-2026-04-21` beta header.
- **Mid-conversation tool changes (beta)**: new `tool_addition` / `tool_removal` input content blocks (`InputContentBlock.toolAddition(...)` / `.toolRemoval(...)`) with a `ToolChangeReference` union to target a declared tool, a single MCP tool, or an entire MCP toolset — add or remove tools between turns while preserving the prompt cache.
- **Fallback credits**: `Usage` and `MessageDeltaUsage` now expose `fallbackCredit`, reporting the redemption outcome of a `fallback_credit_token` (`redeemed`, or `not_applied` with a 12-value reason enum and `removeToRedeem` hints). `MessageCreateRequest.fallbackCreditToken` accepts the new object form with `strict`/`best_effort` redemption mode (breaking, see below).
- **Managed agents**: `effort` level on agent model config (params accept a bare level string or `{type: ...}` object; reuses the existing `EffortLevel` enum), `initialEvents` on session creation (seed up to 50 `user.message`/`user.define_outcome` events), seven new webhook event types (`environment.{created,updated,archived,deleted}`, `memory_store.{created,archived,deleted}`), `event_deltas[]` support on session *thread* event streams, and `UpdateAgentParams.version` is now optional (omit to update unconditionally).
- **Enums**: `RefusalCategory` gains `general_harms`; the stable `StopReason` schema (now including `model_context_window_exceeded`) is tracked in the toolkit manifest.
- Spec promoted to hash `6d5c96a4` with the api-toolkit manifest fully reconciled (verify `--checks all --scope all` and review both clean).

## Details

Create and poll a dream:

```dart
final dream = await client.dreams.create(
  const CreateDreamRequest(
    inputs: [
      DreamMemoryStoreInput(memoryStoreId: 'mem_store_...'),
      DreamSessionsInput(sessionIds: ['session_...']),
    ],
    model: DreamModelParamsId(id: 'claude-sonnet-5'),
  ),
);
final done = await client.dreams.retrieve(dream.id);
```

Change tools mid-conversation:

```dart
InputMessage.userBlocks([
  InputContentBlock.toolRemoval(
    tool: ToolChangeReference.tool('legacy_search'),
  ),
  InputContentBlock.toolAddition(
    tool: ToolChangeReference.mcpToolset('db-tools'),
  ),
  InputContentBlock.text('Now query the database instead.'),
])
```

Redeem a fallback credit token in best-effort mode (requires the `fallback-credit-2026-07-01` beta header; a bare token or mode-less object is equivalent to `strict`):

```dart
MessageCreateRequest(
  // ...
  fallbackCreditToken: FallbackCreditTokenParam.config(
    token: refusal.fallbackCreditToken!,
    mode: FallbackCreditMode.bestEffort,
  ),
)
// Outcome is reported on the response:
final status = response.usage.fallbackCredit?.status; // redeemed / notApplied
```

Design notes:
- The managed-agents effort object union (`BetaManagedAgentsEffort` + five `{type}` variants) is collapsed onto the existing `EffortLevel` enum rather than generating five empty wrapper classes; the params-side `EffortParams` union preserves both wire forms.
- `SessionInitialEventParams` mirrors the existing `DeploymentInitialEventParams` thin-wrapper pattern (narrowed to `user.message`/`user.define_outcome`, with an unknown-type fallback).
- No dedicated beta header exists for mid-conversation tool changes in the spec or official SDKs, so none is hardcoded.
- `BetaSelfHostedWork.secret` is acknowledged in the manifest only — the `environments` resource remains excluded.

## Breaking Changes

- `MessageCreateRequest.fallbackCreditToken` changed from `String?` to `FallbackCreditTokenParam?` to support the new object wire form with a redemption `mode` (matching the spec's `anyOf[string, object]` and the package's sealed-union convention for such fields).

  ```dart
  // Before
  MessageCreateRequest(fallbackCreditToken: 'fct_...')

  // After
  MessageCreateRequest(
    fallbackCreditToken: FallbackCreditTokenParam.token('fct_...'),
  )
  ```

## References

- [Anthropic API changelog — July 24, 2026](https://platform.claude.com/docs/en/release-notes/api) — Opus 5 launch, mid-conversation tool changes beta, fallbacks `"default"` mode
- [Refusals and fallback](https://platform.claude.com/docs/en/build-with-claude/refusals-and-fallback) — fallback credit token semantics
- [Dreams (research preview)](https://platform.claude.com/docs/en/managed-agents/dreams) — supported models and limits
- [Effort levels](https://platform.claude.com/docs/en/build-with-claude/effort#effort-levels) — managed-agents effort configuration

## Test Plan

- [x] Unit tests pass for affected packages (1471 passed)
- [x] New tests added for new functionality (Dreams resource asserts the `dreaming-2026-04-21` header on all 5 endpoints; both `fallback_credit_token` wire forms; 7 webhook round-trips; effort/initial_events/event_deltas coverage)
- [x] Sealed class/enum changes include variant, round-trip, and error tests (unknown fallbacks for DreamInput/DreamOutput/DreamStatus/FallbackCreditStatus/SessionInitialEventParams)
- [x] `fromJson`/`toJson` round-trip serialization verified
- [x] `==`/`hashCode` contract verified (same fields in both)
- [x] api-toolkit `verify --checks all --scope all` and `review` clean; `dart analyze --fatal-infos` and `dart format` clean
