### PR TITLE
feat(ollama_dart): CreateRequest renderer/parser and files/adapters

### DIFF
--- a/packages/ollama_dart/.agents/skills/openapi-ollama/config/manifest.json
+++ b/packages/ollama_dart/.agents/skills/openapi-ollama/config/manifest.json
@@ -242,6 +242,15 @@
       "schema": "ChatResponse",
       "tags": []
     },
+    "CreateRequest": {
+      "spec": "main",
+      "kind": "object",
+      "dart_class": "CreateRequest",
+      "file": "lib/src/models/models/create_request.dart",
+      "schema": "CreateRequest",
+      "note": "Dart class adds client-ahead fields (files, adapters, draft_quantize, draft_files, remote_host, requires, info) sourced from Ollama api/types.go + docs/api.md; upstream docs/openapi.yaml omits them.",
+      "tags": []
+    },
     "GenerateRequest": {
       "spec": "main",
       "kind": "object",

--- a/packages/ollama_dart/lib/src/models/models/create_request.dart
+++ b/packages/ollama_dart/lib/src/models/models/create_request.dart
@@ -2,6 +2,7 @@ import 'package:meta/meta.dart';
 
 import '../chat/chat_message.dart';
 import '../common/copy_with_sentinel.dart';
+import '../common/equality_helpers.dart';
 
 /// Request to create a model.
 @immutable
@@ -32,6 +33,57 @@ class CreateRequest {
   /// Quantization level to apply (e.g., `q4_K_M`, `q8_0`).
   final String? quantize;
 
+  /// Name of the renderer for the model (e.g., `qwen3.5`). Selects the
+  /// tool-calling prompt renderer.
+  final String? renderer;
+
+  /// Name of the parser for the model (e.g., `harmony`). Selects the
+  /// tool-calling/thinking output parser.
+  final String? parser;
+
+  /// Map of file names to SHA256 digests of blobs to create the model from.
+  ///
+  /// Sourced from Ollama `api/types.go` + `docs/api.md`; not yet in the
+  /// upstream OpenAPI spec.
+  final Map<String, String>? files;
+
+  /// Map of LoRA adapter file names to SHA256 digests of blobs.
+  ///
+  /// Sourced from Ollama `api/types.go` + `docs/api.md`; not yet in the
+  /// upstream OpenAPI spec.
+  final Map<String, String>? adapters;
+
+  /// Quantization format for the draft model (speculative decoding).
+  ///
+  /// Sourced from Ollama `api/types.go` + `docs/api.md`; not yet in the
+  /// upstream OpenAPI spec.
+  final String? draftQuantize;
+
+  /// Map of file names to SHA256 digests for the draft model (speculative
+  /// decoding).
+  ///
+  /// Sourced from Ollama `api/types.go` + `docs/api.md`; not yet in the
+  /// upstream OpenAPI spec.
+  final Map<String, String>? draftFiles;
+
+  /// URL of the upstream Ollama API for the model, if any.
+  ///
+  /// Sourced from Ollama `api/types.go` + `docs/api.md`; not yet in the
+  /// upstream OpenAPI spec.
+  final String? remoteHost;
+
+  /// Minimum version of Ollama required by the model.
+  ///
+  /// Sourced from Ollama `api/types.go` + `docs/api.md`; not yet in the
+  /// upstream OpenAPI spec.
+  final String? requires;
+
+  /// Additional information for the model.
+  ///
+  /// Sourced from Ollama `api/types.go` + `docs/api.md`; not yet in the
+  /// upstream OpenAPI spec.
+  final Map<String, dynamic>? info;
+
   /// Stream status updates.
   final bool? stream;
 
@@ -45,6 +97,15 @@ class CreateRequest {
     this.parameters,
     this.messages,
     this.quantize,
+    this.renderer,
+    this.parser,
+    this.files,
+    this.adapters,
+    this.draftQuantize,
+    this.draftFiles,
+    this.remoteHost,
+    this.requires,
+    this.info,
     this.stream,
   });
 
@@ -60,6 +121,15 @@ class CreateRequest {
         ?.map((e) => ChatMessage.fromJson(e as Map<String, dynamic>))
         .toList(),
     quantize: json['quantize'] as String?,
+    renderer: json['renderer'] as String?,
+    parser: json['parser'] as String?,
+    files: (json['files'] as Map?)?.cast<String, String>(),
+    adapters: (json['adapters'] as Map?)?.cast<String, String>(),
+    draftQuantize: json['draft_quantize'] as String?,
+    draftFiles: (json['draft_files'] as Map?)?.cast<String, String>(),
+    remoteHost: json['remote_host'] as String?,
+    requires: json['requires'] as String?,
+    info: json['info'] as Map<String, dynamic>?,
     stream: json['stream'] as bool?,
   );
 
@@ -73,6 +143,15 @@ class CreateRequest {
     if (parameters != null) 'parameters': parameters,
     if (messages != null) 'messages': messages!.map((e) => e.toJson()).toList(),
     if (quantize != null) 'quantize': quantize,
+    if (renderer != null) 'renderer': renderer,
+    if (parser != null) 'parser': parser,
+    if (files != null) 'files': files,
+    if (adapters != null) 'adapters': adapters,
+    if (draftQuantize != null) 'draft_quantize': draftQuantize,
+    if (draftFiles != null) 'draft_files': draftFiles,
+    if (remoteHost != null) 'remote_host': remoteHost,
+    if (requires != null) 'requires': requires,
+    if (info != null) 'info': info,
     if (stream != null) 'stream': stream,
   };
 
@@ -86,6 +165,15 @@ class CreateRequest {
     Object? parameters = unsetCopyWithValue,
     Object? messages = unsetCopyWithValue,
     Object? quantize = unsetCopyWithValue,
+    Object? renderer = unsetCopyWithValue,
+    Object? parser = unsetCopyWithValue,
+    Object? files = unsetCopyWithValue,
+    Object? adapters = unsetCopyWithValue,
+    Object? draftQuantize = unsetCopyWithValue,
+    Object? draftFiles = unsetCopyWithValue,
+    Object? remoteHost = unsetCopyWithValue,
+    Object? requires = unsetCopyWithValue,
+    Object? info = unsetCopyWithValue,
     Object? stream = unsetCopyWithValue,
   }) {
     return CreateRequest(
@@ -105,20 +193,106 @@ class CreateRequest {
       quantize: quantize == unsetCopyWithValue
           ? this.quantize
           : quantize as String?,
+      renderer: renderer == unsetCopyWithValue
+          ? this.renderer
+          : renderer as String?,
+      parser: parser == unsetCopyWithValue ? this.parser : parser as String?,
+      files: files == unsetCopyWithValue
+          ? this.files
+          : files as Map<String, String>?,
+      adapters: adapters == unsetCopyWithValue
+          ? this.adapters
+          : adapters as Map<String, String>?,
+      draftQuantize: draftQuantize == unsetCopyWithValue
+          ? this.draftQuantize
+          : draftQuantize as String?,
+      draftFiles: draftFiles == unsetCopyWithValue
+          ? this.draftFiles
+          : draftFiles as Map<String, String>?,
+      remoteHost: remoteHost == unsetCopyWithValue
+          ? this.remoteHost
+          : remoteHost as String?,
+      requires: requires == unsetCopyWithValue
+          ? this.requires
+          : requires as String?,
+      info: info == unsetCopyWithValue
+          ? this.info
+          : info as Map<String, dynamic>?,
       stream: stream == unsetCopyWithValue ? this.stream : stream as bool?,
     );
   }
+
+  static bool _licenseEqual(Object? a, Object? b) =>
+      (a is List && b is List) ? listsEqual(a as List?, b as List?) : a == b;
+
+  static int _licenseHash(Object? license) =>
+      license is List ? listHash(license as List?) : license.hashCode;
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is CreateRequest &&
           runtimeType == other.runtimeType &&
-          model == other.model;
+          model == other.model &&
+          from == other.from &&
+          template == other.template &&
+          _licenseEqual(license, other.license) &&
+          system == other.system &&
+          mapsDeepEqual(parameters, other.parameters) &&
+          listsEqual(messages, other.messages) &&
+          quantize == other.quantize &&
+          renderer == other.renderer &&
+          parser == other.parser &&
+          mapsEqual(files, other.files) &&
+          mapsEqual(adapters, other.adapters) &&
+          draftQuantize == other.draftQuantize &&
+          mapsEqual(draftFiles, other.draftFiles) &&
+          remoteHost == other.remoteHost &&
+          requires == other.requires &&
+          mapsDeepEqual(info, other.info) &&
+          stream == other.stream;
 
   @override
-  int get hashCode => model.hashCode;
+  int get hashCode => Object.hashAll([
+    model,
+    from,
+    template,
+    _licenseHash(license),
+    system,
+    mapDeepHashCode(parameters),
+    listHash(messages),
+    quantize,
+    renderer,
+    parser,
+    mapHash(files),
+    mapHash(adapters),
+    draftQuantize,
+    mapHash(draftFiles),
+    remoteHost,
+    requires,
+    mapDeepHashCode(info),
+    stream,
+  ]);
 
   @override
-  String toString() => 'CreateRequest(model: $model, from: $from)';
+  String toString() =>
+      'CreateRequest('
+      'model: $model, '
+      'from: $from, '
+      'template: $template, '
+      'license: $license, '
+      'system: $system, '
+      'parameters: $parameters, '
+      'messages: $messages, '
+      'quantize: $quantize, '
+      'renderer: $renderer, '
+      'parser: $parser, '
+      'files: $files, '
+      'adapters: $adapters, '
+      'draftQuantize: $draftQuantize, '
+      'draftFiles: $draftFiles, '
+      'remoteHost: $remoteHost, '
+      'requires: $requires, '
+      'info: $info, '
+      'stream: $stream)';
 }

--- a/packages/ollama_dart/specs/openapi.json
+++ b/packages/ollama_dart/specs/openapi.json
@@ -322,8 +322,16 @@
             "description": "Key-value parameters for the model",
             "type": "object"
           },
+          "parser": {
+            "description": "Name of the parser for the model",
+            "type": "string"
+          },
           "quantize": {
             "description": "Quantization level to apply (e.g. `q4_K_M`, `q8_0`)",
+            "type": "string"
+          },
+          "renderer": {
+            "description": "Name of the renderer for the model",
             "type": "string"
           },
           "stream": {

--- a/packages/ollama_dart/specs/spec_metadata.json
+++ b/packages/ollama_dart/specs/spec_metadata.json
@@ -2,7 +2,7 @@
   "specs": {
     "main": {
       "current_version": "0.1.0",
-      "last_fetched": "2026-07-04T11:08:16.594466Z",
+      "last_fetched": "2026-08-02T05:59:42.284937Z",
       "source_url": "https://raw.githubusercontent.com/ollama/ollama/refs/heads/main/docs/openapi.yaml",
       "title": "Ollama API",
       "version_history": []

--- a/packages/ollama_dart/test/unit/models/create_request_test.dart
+++ b/packages/ollama_dart/test/unit/models/create_request_test.dart
@@ -1,0 +1,217 @@
+import 'package:ollama_dart/ollama_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('CreateRequest', () {
+    test('fromJson creates request correctly', () {
+      final json = {
+        'model': 'llama3.2',
+        'from': 'llama3.1',
+        'template': '{{ .Prompt }}',
+        'license': 'MIT',
+        'system': 'You are a helpful assistant.',
+        'parameters': {'temperature': 0.7},
+        'messages': [
+          {'role': 'user', 'content': 'Hello'},
+        ],
+        'quantize': 'q4_K_M',
+        'renderer': 'qwen3.5',
+        'parser': 'harmony',
+        'files': {'model.gguf': 'sha256:abc123'},
+        'adapters': {'adapter.gguf': 'sha256:def456'},
+        'draft_quantize': 'q8_0',
+        'draft_files': {'draft.gguf': 'sha256:ghi789'},
+        'remote_host': 'https://example.com',
+        'requires': '0.5.0',
+        'info': {'author': 'someone'},
+        'stream': false,
+      };
+
+      final request = CreateRequest.fromJson(json);
+
+      expect(request.model, 'llama3.2');
+      expect(request.from, 'llama3.1');
+      expect(request.template, '{{ .Prompt }}');
+      expect(request.license, 'MIT');
+      expect(request.system, 'You are a helpful assistant.');
+      expect(request.parameters, {'temperature': 0.7});
+      expect(request.messages?.length, 1);
+      expect(request.messages?.first.content, 'Hello');
+      expect(request.quantize, 'q4_K_M');
+      expect(request.renderer, 'qwen3.5');
+      expect(request.parser, 'harmony');
+      expect(request.files, {'model.gguf': 'sha256:abc123'});
+      expect(request.adapters, {'adapter.gguf': 'sha256:def456'});
+      expect(request.draftQuantize, 'q8_0');
+      expect(request.draftFiles, {'draft.gguf': 'sha256:ghi789'});
+      expect(request.remoteHost, 'https://example.com');
+      expect(request.requires, '0.5.0');
+      expect(request.info, {'author': 'someone'});
+      expect(request.stream, false);
+    });
+
+    test('toJson converts request correctly', () {
+      const request = CreateRequest(
+        model: 'llama3.2',
+        from: 'llama3.1',
+        template: '{{ .Prompt }}',
+        license: 'MIT',
+        system: 'You are a helpful assistant.',
+        parameters: {'temperature': 0.7},
+        messages: [ChatMessage.user('Hi')],
+        quantize: 'q4_K_M',
+        renderer: 'qwen3.5',
+        parser: 'harmony',
+        files: {'model.gguf': 'sha256:abc123'},
+        adapters: {'adapter.gguf': 'sha256:def456'},
+        draftQuantize: 'q8_0',
+        draftFiles: {'draft.gguf': 'sha256:ghi789'},
+        remoteHost: 'https://example.com',
+        requires: '0.5.0',
+        info: {'author': 'someone'},
+        stream: true,
+      );
+
+      final json = request.toJson();
+
+      expect(json['model'], 'llama3.2');
+      expect(json['from'], 'llama3.1');
+      expect(json['template'], '{{ .Prompt }}');
+      expect(json['license'], 'MIT');
+      expect(json['system'], 'You are a helpful assistant.');
+      expect(json['parameters'], {'temperature': 0.7});
+      expect(json['messages'], isA<List<dynamic>>());
+      expect(json['quantize'], 'q4_K_M');
+      expect(json['renderer'], 'qwen3.5');
+      expect(json['parser'], 'harmony');
+      expect(json['files'], {'model.gguf': 'sha256:abc123'});
+      expect(json['adapters'], {'adapter.gguf': 'sha256:def456'});
+      expect(json['draft_quantize'], 'q8_0');
+      expect(json['draft_files'], {'draft.gguf': 'sha256:ghi789'});
+      expect(json['remote_host'], 'https://example.com');
+      expect(json['requires'], '0.5.0');
+      expect(json['info'], {'author': 'someone'});
+      expect(json['stream'], true);
+    });
+
+    test('toJson of minimal request omits optional fields', () {
+      const request = CreateRequest(model: 'x');
+
+      final json = request.toJson();
+
+      expect(json, {'model': 'x'});
+    });
+
+    test('fromJson/toJson round-trip preserves all new fields', () {
+      final json = {
+        'model': 'llama3.2',
+        'renderer': 'qwen3.5',
+        'parser': 'harmony',
+        'files': {'model.gguf': 'sha256:abc123'},
+        'adapters': {'adapter.gguf': 'sha256:def456'},
+        'draft_quantize': 'q8_0',
+        'draft_files': {'draft.gguf': 'sha256:ghi789'},
+        'remote_host': 'https://example.com',
+        'requires': '0.5.0',
+        'info': {'author': 'someone'},
+      };
+
+      final restored = CreateRequest.fromJson(json).toJson();
+
+      expect(restored, json);
+    });
+
+    test('copyWith works correctly', () {
+      const original = CreateRequest(
+        model: 'llama3.2',
+        renderer: 'qwen3.5',
+        files: {'model.gguf': 'sha256:abc123'},
+      );
+
+      final copied = original.copyWith(
+        renderer: 'other-renderer',
+        files: {'other.gguf': 'sha256:xyz'},
+      );
+
+      expect(copied.model, 'llama3.2');
+      expect(copied.renderer, 'other-renderer');
+      expect(copied.files, {'other.gguf': 'sha256:xyz'});
+
+      // Omitting a param keeps the original value.
+      final unchanged = original.copyWith(model: 'mistral');
+      expect(unchanged.renderer, 'qwen3.5');
+      expect(unchanged.files, {'model.gguf': 'sha256:abc123'});
+
+      // Passing null explicitly clears the value.
+      final cleared = original.copyWith(renderer: null, files: null);
+      expect(cleared.renderer, isNull);
+      expect(cleared.files, isNull);
+    });
+
+    test('equality works correctly', () {
+      const request1 = CreateRequest(
+        model: 'llama3.2',
+        renderer: 'qwen3.5',
+        files: {'model.gguf': 'sha256:abc123'},
+        adapters: {'adapter.gguf': 'sha256:def456'},
+        info: {
+          'author': 'someone',
+          'nested': {'a': 1},
+        },
+        messages: [ChatMessage.user('Hello')],
+      );
+      const request2 = CreateRequest(
+        model: 'llama3.2',
+        renderer: 'qwen3.5',
+        files: {'model.gguf': 'sha256:abc123'},
+        adapters: {'adapter.gguf': 'sha256:def456'},
+        info: {
+          'author': 'someone',
+          'nested': {'a': 1},
+        },
+        messages: [ChatMessage.user('Hello')],
+      );
+
+      expect(request1, equals(request2));
+      expect(request1.hashCode, equals(request2.hashCode));
+
+      final differentRenderer = request1.copyWith(renderer: 'other');
+      expect(request1, isNot(equals(differentRenderer)));
+
+      final differentFiles = request1.copyWith(
+        files: {'other.gguf': 'sha256:xyz'},
+      );
+      expect(request1, isNot(equals(differentFiles)));
+
+      final differentInfo = request1.copyWith(info: {'author': 'someone-else'});
+      expect(request1, isNot(equals(differentInfo)));
+    });
+
+    test('toString includes new fields', () {
+      const request = CreateRequest(
+        model: 'llama3.2',
+        renderer: 'qwen3.5',
+        parser: 'harmony',
+        files: {'model.gguf': 'sha256:abc123'},
+        adapters: {'adapter.gguf': 'sha256:def456'},
+        draftQuantize: 'q8_0',
+        draftFiles: {'draft.gguf': 'sha256:ghi789'},
+        remoteHost: 'https://example.com',
+        requires: '0.5.0',
+        info: {'author': 'someone'},
+      );
+
+      final str = request.toString();
+
+      expect(str, contains('renderer: qwen3.5'));
+      expect(str, contains('parser: harmony'));
+      expect(str, contains('files: {model.gguf: sha256:abc123}'));
+      expect(str, contains('adapters: {adapter.gguf: sha256:def456}'));
+      expect(str, contains('draftQuantize: q8_0'));
+      expect(str, contains('draftFiles: {draft.gguf: sha256:ghi789}'));
+      expect(str, contains('remoteHost: https://example.com'));
+      expect(str, contains('requires: 0.5.0'));
+      expect(str, contains('info: {author: someone}'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- `CreateRequest` gains the two fields added to the upstream OpenAPI spec: `renderer` (tool-calling prompt renderer, e.g. `qwen3.5`) and `parser` (tool-calling/thinking output parser, e.g. `harmony`).
- Adds client-ahead fields for full `api/types.go` parity that the upstream spec still omits: `files` and `adapters` (filename → SHA256 blob digest maps for creating models from GGUF/Safetensors and LoRA adapters), `draftQuantize`/`draftFiles` (speculative-decoding draft model), `remoteHost`, `requires` (minimum Ollama version), and `info`.
- Fixes the previously partial `==`/`hashCode`/`toString` contract on `CreateRequest` (it only compared `model`) to cover all 18 fields with content-based map/list equality.
- Registers `CreateRequest` in the api-toolkit manifest (it was untracked) and promotes the refreshed spec.

## Details

The upstream `docs/openapi.yaml` only added `renderer`/`parser`, but cross-checking `api/types.go`, `docs/api.md`, and ollama-python showed 7 more real request fields with no spec representation. `files`/`adapters` are documented in `api.md` with examples and already shipped in ollama-python; the remainder come from `api/types.go`. Each client-ahead field's doc comment notes its sourcing, and the manifest entry carries a `note` so future spec syncs keep tracking them. The deprecated `name`/`quantization` legacy aliases were intentionally skipped.

Creating a model from pushed blobs:

```dart
await client.models.create(
  request: CreateRequest(
    model: 'my-model',
    files: {'model.gguf': 'sha256:432f310a77f4650a88d0fd59ecdd7cebed8d684bafea53cbff0473542964f0c3'},
    renderer: 'qwen3.5',
    parser: 'harmony',
  ),
);
```

No resource-layer changes were needed: `create()`/`createStream()` serialize the whole request, so the new fields flow through automatically.

Note on behavior: `CreateRequest` equality previously considered two requests equal if their `model` matched; it now compares all fields (content-based for maps/lists). This corrects the `==`/`hashCode` contract rather than extending the broken one.

## References

- [Ollama API docs — Create a Model](https://github.com/ollama/ollama/blob/main/docs/api.md#create-a-model) — documents `files`, `adapters`, `renderer`, `parser`
- [Ollama `api/types.go` `CreateRequest`](https://github.com/ollama/ollama/blob/main/api/types.go) — source of the client-ahead fields

## Test Plan

- [x] Unit tests pass for affected packages (`dart test test/unit/` — 262 passed)
- [x] New tests added for new functionality (`test/unit/models/create_request_test.dart`)
- [x] `fromJson`/`toJson` round-trip serialization verified (incl. optional-omit for minimal request)
- [x] `==`/`hashCode` contract verified (same 18 fields in both; equal-but-not-identical maps/lists compare equal)
- [x] `api_toolkit verify --checks all --scope all` passes (0 errors); `review` clean (0 changed types, 0 missing manifest entries)
- [x] `dart analyze --fatal-infos` and `dart format` clean