### PR TITLE
fix(anthropic_sdk_dart): decode JSON responses as UTF-8

### DIFF
--- a/packages/anthropic_sdk_dart/lib/src/client/anthropic_client.dart
+++ b/packages/anthropic_sdk_dart/lib/src/client/anthropic_client.dart
@@ -22,6 +22,7 @@ import 'config.dart';
 import 'interceptor_chain.dart';
 import 'request_builder.dart';
 import 'retry_wrapper.dart';
+import 'utf8_response_client.dart';
 
 /// Dart client for the Anthropic API.
 ///
@@ -116,7 +117,7 @@ class AnthropicClient {
   /// [close] is called. If provided, you are responsible for closing it.
   AnthropicClient({AnthropicConfig? config, http.Client? httpClient})
     : config = config ?? const AnthropicConfig(),
-      _httpClient = httpClient ?? http.Client(),
+      _httpClient = Utf8ResponseClient(httpClient ?? http.Client()),
       _ownsHttpClient = httpClient == null {
     _initialize();
   }

--- a/packages/anthropic_sdk_dart/lib/src/client/utf8_response_client.dart
+++ b/packages/anthropic_sdk_dart/lib/src/client/utf8_response_client.dart
@@ -1,0 +1,49 @@
+import 'package:http/http.dart' as http;
+
+/// An [http.Client] wrapper that labels JSON responses as UTF-8.
+///
+/// The API returns `content-type: application/json` without a charset
+/// parameter. When the charset is absent, `package:http` falls back to
+/// latin-1 in [http.Response.body], so any non-ASCII character in a
+/// response is mangled before it reaches `jsonDecode`: `Barœul` is read as
+/// `BarÅul`, `Müller` as `MÃ¼ller`.
+///
+/// JSON is always UTF-8 (RFC 8259 §8.1), so labelling the response is safe
+/// and does not alter the bytes. Only the `content-type` header is
+/// rewritten, and only when it announces JSON without a charset.
+///
+/// Streaming responses are unaffected: the SSE parser already decodes bytes
+/// with `utf8.decoder`.
+class Utf8ResponseClient extends http.BaseClient {
+  /// Creates a client that delegates to [_inner].
+  Utf8ResponseClient(this._inner);
+
+  final http.Client _inner;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) async {
+    final response = await _inner.send(request);
+    final contentType = response.headers['content-type'];
+    if (contentType == null ||
+        !contentType.contains('json') ||
+        contentType.contains('charset')) {
+      return response;
+    }
+    return http.StreamedResponse(
+      response.stream,
+      response.statusCode,
+      contentLength: response.contentLength,
+      request: response.request,
+      headers: {
+        ...response.headers,
+        'content-type': '$contentType; charset=utf-8',
+      },
+      isRedirect: response.isRedirect,
+      persistentConnection: response.persistentConnection,
+      reasonPhrase: response.reasonPhrase,
+    );
+  }
+
+  @override
+  void close() => _inner.close();
+}

--- a/packages/anthropic_sdk_dart/test/unit/client/utf8_response_client_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/client/utf8_response_client_test.dart
@@ -1,0 +1,103 @@
+import 'dart:convert';
+
+import 'package:anthropic_sdk_dart/src/client/utf8_response_client.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:test/test.dart';
+
+/// Builds a client that always replies with [body], labelled [contentType].
+Utf8ResponseClient clientReplying(List<int> body, String? contentType) {
+  return Utf8ResponseClient(
+    MockClient(
+      (_) async => http.Response.bytes(
+        body,
+        200,
+        headers: {'content-type': ?contentType},
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('Utf8ResponseClient', () {
+    // The API replies `application/json` with no charset. Without a charset,
+    // package:http decodes Response.body as latin-1, which mangles every
+    // non-ASCII character before jsonDecode ever sees it.
+    test('decodes JSON responses without a charset as UTF-8', () async {
+      final client = clientReplying(
+        utf8.encode('{"city":"Marcq-en-Barœul"}'),
+        'application/json',
+      );
+
+      final response = await client.get(Uri.parse('https://example.com'));
+
+      expect(jsonDecode(response.body), {'city': 'Marcq-en-Barœul'});
+    });
+
+    test('leaves an explicit charset untouched', () async {
+      final client = clientReplying(
+        utf8.encode('{"city":"Marcq-en-Barœul"}'),
+        'application/json; charset=utf-8',
+      );
+
+      final response = await client.get(Uri.parse('https://example.com'));
+
+      expect(response.headers['content-type'], 'application/json; charset=utf-8');
+      expect(jsonDecode(response.body), {'city': 'Marcq-en-Barœul'});
+    });
+
+    test('leaves non-JSON responses untouched', () async {
+      final client = clientReplying(utf8.encode('plain'), 'text/plain');
+
+      final response = await client.get(Uri.parse('https://example.com'));
+
+      expect(response.headers['content-type'], 'text/plain');
+    });
+
+    test('leaves responses without a content-type untouched', () async {
+      final client = clientReplying(utf8.encode('{}'), null);
+
+      final response = await client.get(Uri.parse('https://example.com'));
+
+      expect(response.headers.containsKey('content-type'), isFalse);
+    });
+
+    test('preserves status code and reason phrase', () async {
+      final client = Utf8ResponseClient(
+        MockClient(
+          (_) async => http.Response(
+            '{"error":"nope"}',
+            429,
+            headers: {'content-type': 'application/json'},
+            reasonPhrase: 'Too Many Requests',
+          ),
+        ),
+      );
+
+      final response = await client.get(Uri.parse('https://example.com'));
+
+      expect(response.statusCode, 429);
+      expect(response.reasonPhrase, 'Too Many Requests');
+    });
+
+    test('closes the inner client', () {
+      var closed = false;
+      Utf8ResponseClient(_ClosableClient(() => closed = true)).close();
+
+      expect(closed, isTrue);
+    });
+  });
+}
+
+class _ClosableClient extends http.BaseClient {
+  _ClosableClient(this.onClose);
+
+  final void Function() onClose;
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) =>
+      throw UnimplementedError();
+
+  @override
+  void close() => onClose();
+}


### PR DESCRIPTION
## Problem

The API returns `content-type: application/json` with no charset parameter:

```console
$ curl -sD - -o /dev/null https://api.anthropic.com/v1/messages \
    -H "x-api-key: …" -H "anthropic-version: 2023-06-01" \
    -H "content-type: application/json" -d '{…}' | grep -i content-type
content-type: application/json
```

When the charset is absent, `package:http` falls back to latin-1 in `Response.body`. Every non-ASCII character is therefore mangled before `jsonDecode` sees it:

| Sent by the API | Read by the SDK |
|---|---|
| `Barœul` | `BarÅul` |
| `Müller` | `MÃ¼ller` |
| `São Paulo` | `SÃ£o Paulo` |

This affects **all non-streaming responses** — resources decode with `jsonDecode(response.body)` in 91 places across 23 files. I hit it extracting names and addresses from scanned documents, where the mangled value is then stored downstream.

Streaming is not affected: `streaming_parser.dart` already decodes bytes with `utf8.decoder`.

## Fix

Wrap the HTTP client so JSON responses are labelled `charset=utf-8`. JSON is always UTF-8 ([RFC 8259 §8.1](https://datatracker.ietf.org/doc/html/rfc8259#section-8.1)), so the label is safe and the bytes are left untouched.

Wrapping the client fixes all 91 call sites at once — including any added later — rather than replacing each `response.body` with a manual `utf8.decode(response.bodyBytes)`.

Responses that already declare a charset, and those that are not JSON, pass through unchanged. A user-supplied `httpClient` is still not closed by the SDK: the wrapper only forwards `close()`, and `_ownsHttpClient` keeps its meaning.

I considered making this opt-in via `AnthropicConfig`, but decoding a JSON body as latin-1 is never correct, so an option would only preserve the broken behaviour by default.

## Tests

Six unit tests in `test/unit/client/utf8_response_client_test.dart`: a JSON response with no charset round-trips a non-ASCII string, an explicit charset is left alone, non-JSON and header-less responses are untouched, status code and reason phrase are preserved, and `close()` reaches the inner client.

The existing unit suite passes unchanged (1485 tests).

## Note

The same pattern appears in the sibling packages of this repository (`openai_dart`, `mistralai_dart`, `googleai_dart`, …), which decode with `response.body` as well. I have kept this PR to `anthropic_sdk_dart`; happy to extend it if you would rather fix them together.
