### PR TITLE
fix(googleai_dart): preserve embedding config in Vertex requests

### DIFF
--- a/packages/googleai_dart/lib/src/resources/models_resource.dart
+++ b/packages/googleai_dart/lib/src/resources/models_resource.dart
@@ -356,19 +356,28 @@ class ModelsResource extends ResourceBase with StreamingResource {
       throw ArgumentError('Content must contain at least one text part');
     }
     final text = textParts.first.text;
+    final embedConfig = request.embedContentConfig;
+    final taskType = embedConfig?.taskType ?? request.taskType;
+    final title = embedConfig?.title ?? request.title;
+    final outputDimensionality =
+        embedConfig?.outputDimensionality ?? request.outputDimensionality;
 
     // Build instance in Vertex AI format
     final instance = <String, dynamic>{
       'content': text,
-      if (request.taskType != null)
-        'task_type': taskTypeToString(request.taskType!),
-      if (request.title != null) 'title': request.title,
+      if (taskType != null) 'task_type': taskTypeToString(taskType),
+      'title': ?title,
     };
 
     // Build parameters
     final parameters = <String, dynamic>{
-      if (request.outputDimensionality != null)
-        'outputDimensionality': request.outputDimensionality,
+      'outputDimensionality': ?outputDimensionality,
+      if (embedConfig?.autoTruncate != null)
+        'autoTruncate': embedConfig!.autoTruncate,
+      if (embedConfig?.documentOcr != null)
+        'documentOcr': embedConfig!.documentOcr,
+      if (embedConfig?.audioTrackExtraction != null)
+        'audioTrackExtraction': embedConfig!.audioTrackExtraction,
     };
 
     // Call predict endpoint

--- a/packages/googleai_dart/test/unit/resources/models_resource_embeddings_test.dart
+++ b/packages/googleai_dart/test/unit/resources/models_resource_embeddings_test.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:googleai_dart/googleai_dart.dart';
+import 'package:googleai_dart/src/client/interceptor_chain.dart';
+import 'package:googleai_dart/src/client/request_builder.dart';
+import 'package:googleai_dart/src/resources/models_resource.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class _MockHttpClient extends Mock implements http.Client {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(
+      http.Request('POST', Uri.parse('https://example.com')),
+    );
+  });
+
+  test('Vertex embeddings map EmbedContentConfig to predict fields', () async {
+    final mockHttpClient = _MockHttpClient();
+    late http.Request capturedRequest;
+    when(() => mockHttpClient.send(any())).thenAnswer((invocation) async {
+      capturedRequest = invocation.positionalArguments.single as http.Request;
+      final body = utf8.encode(
+        jsonEncode({
+          'predictions': [
+            {
+              'embeddings': {
+                'values': [0.1, 0.2],
+              },
+            },
+          ],
+        }),
+      );
+      return http.StreamedResponse(
+        Stream.value(body),
+        200,
+        headers: {'content-type': 'application/json'},
+      );
+    });
+
+    final config = GoogleAIConfig.vertexAI(
+      projectId: 'test-project',
+      authProvider: const ApiKeyProvider('test-key'),
+    );
+    final resource = ModelsResource(
+      config: config,
+      httpClient: mockHttpClient,
+      interceptorChain: InterceptorChain(
+        interceptors: const [],
+        httpClient: mockHttpClient,
+      ),
+      requestBuilder: RequestBuilder(config: config),
+    );
+
+    final response = await resource.embedContent(
+      model: 'text-embedding-005',
+      request: const EmbedContentRequest(
+        content: Content(parts: [TextPart('document')]),
+        embedContentConfig: EmbedContentConfig(
+          taskType: TaskType.retrievalDocument,
+          title: 'Document title',
+          outputDimensionality: 64,
+          autoTruncate: true,
+          documentOcr: true,
+          audioTrackExtraction: false,
+        ),
+      ),
+    );
+
+    expect(response.embedding.values, [0.1, 0.2]);
+    expect(jsonDecode(capturedRequest.body), {
+      'instances': [
+        {
+          'content': 'document',
+          'task_type': 'RETRIEVAL_DOCUMENT',
+          'title': 'Document title',
+        },
+      ],
+      'parameters': {
+        'outputDimensionality': 64,
+        'autoTruncate': true,
+        'documentOcr': true,
+        'audioTrackExtraction': false,
+      },
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- map `EmbedContentConfig` into Vertex AI `predict` instances and parameters
- preserve task type, title, output dimensionality, auto-truncation, document OCR, and audio extraction settings
- retain the deprecated top-level embedding fields as compatibility fallbacks

## Details

`EmbedContentRequest` now recommends the typed `EmbedContentConfig`, but the Vertex AI adapter still read only the deprecated top-level fields. Consumers following the new API therefore lost their embedding configuration when the client translated `embedContent` into a Vertex `predict` request.

The adapter now gives the typed configuration precedence and falls back to the legacy fields when it is absent. A wire-level unit test verifies the complete Vertex request body and parsed embedding response.

## Test Plan

- [x] repository-wide Dart 3.13.2 formatting check
- [x] repository-wide `dart analyze --fatal-infos`
- [x] all `googleai_dart` unit tests (1,704 passed; 7 environment-dependent skips)
- [x] targeted Vertex embedding request test
- [ ] live integration tests (not run)
