### PR TITLE
fix(mistralai_dart): retain streamed tool-call indexes

### DIFF
--- a/packages/mistralai_dart/lib/src/models/tools/tool_call.dart
+++ b/packages/mistralai_dart/lib/src/models/tools/tool_call.dart
@@ -14,11 +14,17 @@ class ToolCall {
   /// The function call details.
   final FunctionCall function;
 
+  /// The index of this tool call in a streaming response.
+  ///
+  /// Mistral uses this value to correlate deltas for parallel tool calls.
+  final int? index;
+
   /// Creates a [ToolCall].
   const ToolCall({
     required this.id,
     this.type = 'function',
     required this.function,
+    this.index,
   });
 
   /// Creates a [ToolCall] from JSON.
@@ -28,6 +34,7 @@ class ToolCall {
     function: FunctionCall.fromJson(
       json['function'] as Map<String, dynamic>? ?? {},
     ),
+    index: json['index'] as int?,
   );
 
   /// Converts to JSON.
@@ -35,6 +42,7 @@ class ToolCall {
     'id': id,
     'type': type,
     'function': function.toJson(),
+    if (index != null) 'index': index,
   };
 
   @override
@@ -44,11 +52,13 @@ class ToolCall {
           runtimeType == other.runtimeType &&
           id == other.id &&
           type == other.type &&
-          function == other.function;
+          function == other.function &&
+          index == other.index;
 
   @override
-  int get hashCode => Object.hash(id, type, function);
+  int get hashCode => Object.hash(id, type, function, index);
 
   @override
-  String toString() => 'ToolCall(id: $id, type: $type, function: $function)';
+  String toString() =>
+      'ToolCall(id: $id, type: $type, function: $function, index: $index)';
 }

--- a/packages/mistralai_dart/test/unit/models/tools/tool_call_test.dart
+++ b/packages/mistralai_dart/test/unit/models/tools/tool_call_test.dart
@@ -6,6 +6,7 @@ void main() {
     test('creates with required fields', () {
       const toolCall = ToolCall(
         id: 'call_123',
+        index: 2,
         function: FunctionCall(
           name: 'get_weather',
           arguments: '{"location": "Paris"}',
@@ -14,6 +15,7 @@ void main() {
 
       expect(toolCall.id, 'call_123');
       expect(toolCall.type, 'function');
+      expect(toolCall.index, 2);
       expect(toolCall.function.name, 'get_weather');
       expect(toolCall.function.arguments, '{"location": "Paris"}');
     });
@@ -22,6 +24,7 @@ void main() {
       final json = {
         'id': 'call_123',
         'type': 'function',
+        'index': 2,
         'function': {
           'name': 'get_weather',
           'arguments': '{"location": "Paris"}',
@@ -31,6 +34,7 @@ void main() {
 
       expect(toolCall.id, 'call_123');
       expect(toolCall.type, 'function');
+      expect(toolCall.index, 2);
       expect(toolCall.function.name, 'get_weather');
       expect(toolCall.function.arguments, '{"location": "Paris"}');
     });
@@ -76,6 +80,7 @@ void main() {
       const toolCall = ToolCall(
         id: 'call_123',
         type: 'function',
+        index: 2,
         function: FunctionCall(
           name: 'get_weather',
           arguments: '{"location": "Paris"}',
@@ -85,6 +90,7 @@ void main() {
 
       expect(json['id'], 'call_123');
       expect(json['type'], 'function');
+      expect(json['index'], 2);
       final functionJson = json['function'] as Map<String, dynamic>;
       expect(functionJson['name'], 'get_weather');
       expect(functionJson['arguments'], '{"location": "Paris"}');


### PR DESCRIPTION
## Summary

- expose the official Mistral `ToolCall.index` field
- retain it through JSON serialization, equality, and hashing
- add model-level regression coverage

This is required to correlate deltas from parallel same-name tool calls without conflating their arguments.

## Verification

- `dart analyze packages/mistralai_dart`
- `dart test packages/mistralai_dart/test/unit/models/tools/tool_call_test.dart`