### PR TITLE
fix(ollama_dart): support assistant thinking replay

### DIFF
--- a/packages/ollama_dart/lib/src/models/chat/chat_message.dart
+++ b/packages/ollama_dart/lib/src/models/chat/chat_message.dart
@@ -64,6 +64,9 @@ class ChatMessage {
   /// Message text content.
   final String content;
 
+  /// Deliberate thinking trace to replay for an assistant message.
+  final String? thinking;
+
   /// Optional list of inline images for multimodal models.
   ///
   /// Images should be base64-encoded.
@@ -76,6 +79,7 @@ class ChatMessage {
   const ChatMessage({
     required this.role,
     required this.content,
+    this.thinking,
     this.images,
     this.toolCalls,
   });
@@ -89,8 +93,16 @@ class ChatMessage {
     : this(role: MessageRole.system, content: content);
 
   /// Creates an assistant message.
-  const ChatMessage.assistant(String content, {List<ToolCall>? toolCalls})
-    : this(role: MessageRole.assistant, content: content, toolCalls: toolCalls);
+  const ChatMessage.assistant(
+    String content, {
+    String? thinking,
+    List<ToolCall>? toolCalls,
+  }) : this(
+         role: MessageRole.assistant,
+         content: content,
+         thinking: thinking,
+         toolCalls: toolCalls,
+       );
 
   /// Creates a tool result message.
   const ChatMessage.tool(String content)
@@ -100,6 +112,7 @@ class ChatMessage {
   factory ChatMessage.fromJson(Map<String, dynamic> json) => ChatMessage(
     role: messageRoleFromString(json['role'] as String?),
     content: json['content'] as String? ?? '',
+    thinking: json['thinking'] as String?,
     images: (json['images'] as List?)?.cast<String>(),
     toolCalls: (json['tool_calls'] as List?)
         ?.map((e) => ToolCall.fromJson(e as Map<String, dynamic>))
@@ -110,6 +123,7 @@ class ChatMessage {
   Map<String, dynamic> toJson() => {
     'role': messageRoleToString(role),
     'content': content,
+    if (thinking != null) 'thinking': thinking,
     if (images != null) 'images': images,
     if (toolCalls != null)
       'tool_calls': toolCalls!.map((e) => e.toJson()).toList(),
@@ -119,12 +133,16 @@ class ChatMessage {
   ChatMessage copyWith({
     MessageRole? role,
     String? content,
+    Object? thinking = unsetCopyWithValue,
     Object? images = unsetCopyWithValue,
     Object? toolCalls = unsetCopyWithValue,
   }) {
     return ChatMessage(
       role: role ?? this.role,
       content: content ?? this.content,
+      thinking: thinking == unsetCopyWithValue
+          ? this.thinking
+          : thinking as String?,
       images: images == unsetCopyWithValue
           ? this.images
           : images as List<String>?,
@@ -141,18 +159,25 @@ class ChatMessage {
           runtimeType == other.runtimeType &&
           role == other.role &&
           content == other.content &&
+          thinking == other.thinking &&
           listsEqual(images, other.images) &&
           listsEqual(toolCalls, other.toolCalls);
 
   @override
-  int get hashCode =>
-      Object.hash(role, content, listHash(images), listHash(toolCalls));
+  int get hashCode => Object.hash(
+    role,
+    content,
+    thinking,
+    listHash(images),
+    listHash(toolCalls),
+  );
 
   @override
   String toString() =>
       'ChatMessage('
       'role: $role, '
       'content: $content, '
+      'thinking: $thinking, '
       'images: $images, '
       'toolCalls: $toolCalls)';
 }

--- a/packages/ollama_dart/test/unit/models/chat_message_test.dart
+++ b/packages/ollama_dart/test/unit/models/chat_message_test.dart
@@ -42,12 +42,17 @@ void main() {
 
   group('ChatMessage', () {
     test('fromJson creates message correctly', () {
-      final json = {'role': 'user', 'content': 'Hello, world!'};
+      final json = {
+        'role': 'assistant',
+        'content': 'Hello, world!',
+        'thinking': 'I should greet the user.',
+      };
 
       final message = ChatMessage.fromJson(json);
 
-      expect(message.role, MessageRole.user);
+      expect(message.role, MessageRole.assistant);
       expect(message.content, 'Hello, world!');
+      expect(message.thinking, 'I should greet the user.');
       expect(message.images, isNull);
       expect(message.toolCalls, isNull);
     });
@@ -56,12 +61,14 @@ void main() {
       const message = ChatMessage(
         role: MessageRole.assistant,
         content: 'Hello!',
+        thinking: 'A short greeting is enough.',
       );
 
       final json = message.toJson();
 
       expect(json['role'], 'assistant');
       expect(json['content'], 'Hello!');
+      expect(json['thinking'], 'A short greeting is enough.');
       expect(json.containsKey('images'), isFalse);
     });
 
@@ -74,9 +81,13 @@ void main() {
       expect(user.role, MessageRole.user);
       expect(user.content, 'Hi');
 
-      const assistant = ChatMessage.assistant('Hello');
+      const assistant = ChatMessage.assistant(
+        'Hello',
+        thinking: 'I should greet the user.',
+      );
       expect(assistant.role, MessageRole.assistant);
       expect(assistant.content, 'Hello');
+      expect(assistant.thinking, 'I should greet the user.');
 
       const tool = ChatMessage.tool('{"result": 42}');
       expect(tool.role, MessageRole.tool);


### PR DESCRIPTION
## Summary

- add the official `thinking` field to chat history messages
- support it in the assistant constructor, JSON, copies, equality, and hashing
- add unit coverage for parsing and replay

Ollama’s tool-calling guidance requires accumulated thinking, content, and tool calls to be sent together in the follow-up assistant message.

## Verification

- `dart analyze packages/ollama_dart`
- `dart test packages/ollama_dart/test/unit/models/chat_message_test.dart`