### PR TITLE
style: format integration tests

### DIFF
--- a/packages/chromadb/test/integration/auth_test.dart
+++ b/packages/chromadb/test/integration/auth_test.dart
@@ -20,11 +20,15 @@ void main() {
   });
 
   group('AuthResource', () {
-    test('identity returns user info when authenticated', () async {
-      final response = await client.auth.identity();
+    test(
+      'identity returns user info when authenticated',
+      () async {
+        final response = await client.auth.identity();
 
-      expect(response, isNotNull);
-      // The response may have null fields for unauthenticated servers
-    }, skip: 'Requires authentication to be enabled on the server');
+        expect(response, isNotNull);
+        // The response may have null fields for unauthenticated servers
+      },
+      skip: 'Requires authentication to be enabled on the server',
+    );
   });
 }

--- a/packages/chromadb/test/integration/tenants_test.dart
+++ b/packages/chromadb/test/integration/tenants_test.dart
@@ -26,13 +26,18 @@ void main() {
       expect(tenant.name, equals('default_tenant'));
     });
 
-    test('create creates a new tenant', () async {
-      final tenantName = 'test_tenant_${DateTime.now().millisecondsSinceEpoch}';
+    test(
+      'create creates a new tenant',
+      () async {
+        final tenantName =
+            'test_tenant_${DateTime.now().millisecondsSinceEpoch}';
 
-      final tenant = await client.tenants.create(name: tenantName);
+        final tenant = await client.tenants.create(name: tenantName);
 
-      expect(tenant.name, equals(tenantName));
-    }, skip: 'Destructive test - creates a tenant that cannot be deleted');
+        expect(tenant.name, equals(tenantName));
+      },
+      skip: 'Destructive test - creates a tenant that cannot be deleted',
+    );
 
     test('update modifies tenant name', () async {
       // Note: Update may not work on all ChromaDB versions

--- a/packages/googleai_dart/test/integration/interactions_test.dart
+++ b/packages/googleai_dart/test/integration/interactions_test.dart
@@ -431,25 +431,29 @@ void main() {
   });
 
   group('Interactions - URL Context', () {
-    test('fetches and analyzes content from a URL', () async {
-      if (apiKey == null) {
-        markTestSkipped('API key not available');
-        return;
-      }
+    test(
+      'fetches and analyzes content from a URL',
+      () async {
+        if (apiKey == null) {
+          markTestSkipped('API key not available');
+          return;
+        }
 
-      final interaction = await client!.interactions.create(
-        model: defaultInteractionsModel,
-        input: const InteractionInput.text(
-          'What is Dart according to https://dart.dev/overview ?',
-        ),
-        tools: const [UrlContextTool()],
-      );
+        final interaction = await client!.interactions.create(
+          model: defaultInteractionsModel,
+          input: const InteractionInput.text(
+            'What is Dart according to https://dart.dev/overview ?',
+          ),
+          tools: const [UrlContextTool()],
+        );
 
-      expect(interaction.status, InteractionStatus.completed);
-      expect(interaction.text, isNotNull);
-      // Should reference Dart programming language
-      expect(interaction.text!.toLowerCase(), contains('dart'));
-    }, timeout: const Timeout(Duration(seconds: 120)));
+        expect(interaction.status, InteractionStatus.completed);
+        expect(interaction.text, isNotNull);
+        // Should reference Dart programming language
+        expect(interaction.text!.toLowerCase(), contains('dart'));
+      },
+      timeout: const Timeout(Duration(seconds: 120)),
+    );
   });
 
   group('Interactions - Streaming', () {

--- a/packages/googleai_dart/test/integration/live_test.dart
+++ b/packages/googleai_dart/test/integration/live_test.dart
@@ -39,151 +39,171 @@ void main() {
   });
 
   group('Connection & Setup', () {
-    test('connects to Live API and receives setup complete', () async {
-      if (apiKey == null) {
-        markTestSkipped('API key not available');
-        return;
-      }
-
-      final session = await liveClient!.connect(
-        model: defaultLiveModel,
-        liveConfig: LiveConfig(
-          generationConfig: LiveGenerationConfig.audioOnly(),
-        ),
-      );
-
-      expect(session, isNotNull);
-      expect(session.isConnected, isTrue);
-
-      await session.close();
-    }, timeout: const Timeout(Duration(seconds: 30)));
-
-    test('establishes connection and can receive messages', () async {
-      if (apiKey == null) {
-        markTestSkipped('API key not available');
-        return;
-      }
-
-      final session = await liveClient!.connect(
-        model: defaultLiveModel,
-        liveConfig: LiveConfig(
-          generationConfig: LiveGenerationConfig.audioOnly(),
-        ),
-      );
-
-      // Connection is established after setup completes
-      expect(session.isConnected, isTrue);
-
-      // Send a text message and verify we can receive a response
-      session.sendText('Hi');
-
-      // Wait for at least one message (content or turn complete)
-      var receivedMessage = false;
-      await for (final message in session.messages) {
-        receivedMessage = true;
-        if (message is BidiGenerateContentServerContent) {
-          if (message.turnComplete ?? false) break;
+    test(
+      'connects to Live API and receives setup complete',
+      () async {
+        if (apiKey == null) {
+          markTestSkipped('API key not available');
+          return;
         }
-      }
 
-      expect(receivedMessage, isTrue);
+        final session = await liveClient!.connect(
+          model: defaultLiveModel,
+          liveConfig: LiveConfig(
+            generationConfig: LiveGenerationConfig.audioOnly(),
+          ),
+        );
 
-      await session.close();
-    }, timeout: const Timeout(Duration(seconds: 60)));
+        expect(session, isNotNull);
+        expect(session.isConnected, isTrue);
+
+        await session.close();
+      },
+      timeout: const Timeout(Duration(seconds: 30)),
+    );
+
+    test(
+      'establishes connection and can receive messages',
+      () async {
+        if (apiKey == null) {
+          markTestSkipped('API key not available');
+          return;
+        }
+
+        final session = await liveClient!.connect(
+          model: defaultLiveModel,
+          liveConfig: LiveConfig(
+            generationConfig: LiveGenerationConfig.audioOnly(),
+          ),
+        );
+
+        // Connection is established after setup completes
+        expect(session.isConnected, isTrue);
+
+        // Send a text message and verify we can receive a response
+        session.sendText('Hi');
+
+        // Wait for at least one message (content or turn complete)
+        var receivedMessage = false;
+        await for (final message in session.messages) {
+          receivedMessage = true;
+          if (message is BidiGenerateContentServerContent) {
+            if (message.turnComplete ?? false) break;
+          }
+        }
+
+        expect(receivedMessage, isTrue);
+
+        await session.close();
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
   });
 
   group('Text Exchange', () {
-    test('sends text and receives response', () async {
-      if (apiKey == null) {
-        markTestSkipped('API key not available');
-        return;
-      }
-
-      final session = await liveClient!.connect(
-        model: defaultLiveModel,
-        liveConfig: LiveConfig(
-          generationConfig: LiveGenerationConfig.audioOnly(),
-        ),
-      );
-
-      // Send text
-      session.sendText('Say hello');
-
-      // Wait for turn complete
-      var receivedResponse = false;
-      messageLoop:
-      await for (final message in session.messages) {
-        switch (message) {
-          case BidiGenerateContentServerContent(:final turnComplete):
-            receivedResponse = true;
-            if (turnComplete ?? false) {
-              break messageLoop;
-            }
-          default:
-            // Ignore other message types
-            break;
+    test(
+      'sends text and receives response',
+      () async {
+        if (apiKey == null) {
+          markTestSkipped('API key not available');
+          return;
         }
-      }
 
-      expect(receivedResponse, isTrue);
+        final session = await liveClient!.connect(
+          model: defaultLiveModel,
+          liveConfig: LiveConfig(
+            generationConfig: LiveGenerationConfig.audioOnly(),
+          ),
+        );
 
-      await session.close();
-    }, timeout: const Timeout(Duration(seconds: 60)));
+        // Send text
+        session.sendText('Say hello');
 
-    test('receives turn complete signal', () async {
-      if (apiKey == null) {
-        markTestSkipped('API key not available');
-        return;
-      }
-
-      final session = await liveClient!.connect(
-        model: defaultLiveModel,
-        liveConfig: LiveConfig(
-          generationConfig: LiveGenerationConfig.audioOnly(),
-        ),
-      );
-
-      session.sendText('Hi');
-
-      var turnCompleted = false;
-      await for (final message in session.messages) {
-        if (message is BidiGenerateContentServerContent) {
-          if (message.turnComplete ?? false) {
-            turnCompleted = true;
-            break;
+        // Wait for turn complete
+        var receivedResponse = false;
+        messageLoop:
+        await for (final message in session.messages) {
+          switch (message) {
+            case BidiGenerateContentServerContent(:final turnComplete):
+              receivedResponse = true;
+              if (turnComplete ?? false) {
+                break messageLoop;
+              }
+            default:
+              // Ignore other message types
+              break;
           }
         }
-      }
 
-      expect(turnCompleted, isTrue);
+        expect(receivedResponse, isTrue);
 
-      await session.close();
-    }, timeout: const Timeout(Duration(seconds: 60)));
+        await session.close();
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
+
+    test(
+      'receives turn complete signal',
+      () async {
+        if (apiKey == null) {
+          markTestSkipped('API key not available');
+          return;
+        }
+
+        final session = await liveClient!.connect(
+          model: defaultLiveModel,
+          liveConfig: LiveConfig(
+            generationConfig: LiveGenerationConfig.audioOnly(),
+          ),
+        );
+
+        session.sendText('Hi');
+
+        var turnCompleted = false;
+        await for (final message in session.messages) {
+          if (message is BidiGenerateContentServerContent) {
+            if (message.turnComplete ?? false) {
+              turnCompleted = true;
+              break;
+            }
+          }
+        }
+
+        expect(turnCompleted, isTrue);
+
+        await session.close();
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
   });
 
   group('VAD Modes', () {
-    test('automatic VAD mode configuration works', () async {
-      if (apiKey == null) {
-        markTestSkipped('API key not available');
-        return;
-      }
+    test(
+      'automatic VAD mode configuration works',
+      () async {
+        if (apiKey == null) {
+          markTestSkipped('API key not available');
+          return;
+        }
 
-      final session = await liveClient!.connect(
-        model: defaultLiveModel,
-        liveConfig: LiveConfig(
-          generationConfig: LiveGenerationConfig.audioOnly(),
-          realtimeInputConfig: RealtimeInputConfig.withVAD(
-            silenceDurationMs: 500,
-            activityHandling: ActivityHandling.startOfActivityInterrupts,
+        final session = await liveClient!.connect(
+          model: defaultLiveModel,
+          liveConfig: LiveConfig(
+            generationConfig: LiveGenerationConfig.audioOnly(),
+            realtimeInputConfig: RealtimeInputConfig.withVAD(
+              silenceDurationMs: 500,
+              activityHandling: ActivityHandling.startOfActivityInterrupts,
+            ),
           ),
-        ),
-      );
+        );
 
-      // If we got here without exception, VAD config was accepted
-      expect(session.isConnected, isTrue);
+        // If we got here without exception, VAD config was accepted
+        expect(session.isConnected, isTrue);
 
-      await session.close();
-    }, timeout: const Timeout(Duration(seconds: 30)));
+        await session.close();
+      },
+      timeout: const Timeout(Duration(seconds: 30)),
+    );
 
     test('manual VAD signals work', () async {
       if (apiKey == null) {
@@ -229,103 +249,111 @@ void main() {
   });
 
   group('Tool Calling', () {
-    test('can configure tools in session', () async {
-      if (apiKey == null) {
-        markTestSkipped('API key not available');
-        return;
-      }
-
-      // Define a simple tool
-      const tools = [
-        Tool(
-          functionDeclarations: [
-            FunctionDeclaration(
-              name: 'get_current_time',
-              description: 'Gets the current time in a specific timezone',
-              parameters: Schema(
-                type: SchemaType.object,
-                properties: {
-                  'timezone': Schema(
-                    type: SchemaType.string,
-                    description: 'The timezone to get time for',
-                  ),
-                },
-              ),
-            ),
-          ],
-        ),
-      ];
-
-      // Verify we can create a session with tools configured
-      final session = await liveClient!.connect(
-        model: defaultLiveModel,
-        liveConfig: LiveConfig(
-          generationConfig: LiveGenerationConfig.audioOnly(),
-          tools: tools,
-        ),
-      );
-
-      expect(session.isConnected, isTrue);
-
-      // Send a message and get a response
-      session.sendText('Hello');
-
-      var receivedResponse = false;
-      messageLoop:
-      await for (final message in session.messages) {
-        switch (message) {
-          case BidiGenerateContentServerContent(:final turnComplete):
-            receivedResponse = true;
-            if (turnComplete ?? false) break messageLoop;
-          case BidiGenerateContentToolCall():
-            receivedResponse = true;
-            break messageLoop;
-          default:
-            break;
+    test(
+      'can configure tools in session',
+      () async {
+        if (apiKey == null) {
+          markTestSkipped('API key not available');
+          return;
         }
-      }
 
-      expect(receivedResponse, isTrue);
+        // Define a simple tool
+        const tools = [
+          Tool(
+            functionDeclarations: [
+              FunctionDeclaration(
+                name: 'get_current_time',
+                description: 'Gets the current time in a specific timezone',
+                parameters: Schema(
+                  type: SchemaType.object,
+                  properties: {
+                    'timezone': Schema(
+                      type: SchemaType.string,
+                      description: 'The timezone to get time for',
+                    ),
+                  },
+                ),
+              ),
+            ],
+          ),
+        ];
 
-      await session.close();
-    }, timeout: const Timeout(Duration(seconds: 60)));
+        // Verify we can create a session with tools configured
+        final session = await liveClient!.connect(
+          model: defaultLiveModel,
+          liveConfig: LiveConfig(
+            generationConfig: LiveGenerationConfig.audioOnly(),
+            tools: tools,
+          ),
+        );
+
+        expect(session.isConnected, isTrue);
+
+        // Send a message and get a response
+        session.sendText('Hello');
+
+        var receivedResponse = false;
+        messageLoop:
+        await for (final message in session.messages) {
+          switch (message) {
+            case BidiGenerateContentServerContent(:final turnComplete):
+              receivedResponse = true;
+              if (turnComplete ?? false) break messageLoop;
+            case BidiGenerateContentToolCall():
+              receivedResponse = true;
+              break messageLoop;
+            default:
+              break;
+          }
+        }
+
+        expect(receivedResponse, isTrue);
+
+        await session.close();
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
   });
 
   group('Session Resumption', () {
-    test('can enable session resumption', () async {
-      if (apiKey == null) {
-        markTestSkipped('API key not available');
-        return;
-      }
-
-      // Verify we can create a session with resumption enabled
-      final session = await liveClient!.connect(
-        model: defaultLiveModel,
-        liveConfig: LiveConfig(
-          generationConfig: LiveGenerationConfig.audioOnly(),
-          sessionResumption: const SessionResumptionConfig.enabled(),
-        ),
-      );
-
-      expect(session.isConnected, isTrue);
-
-      session.sendText('Hello');
-
-      // Wait for turn complete
-      messageLoop:
-      await for (final message in session.messages) {
-        switch (message) {
-          case BidiGenerateContentServerContent(:final turnComplete):
-            if (turnComplete ?? false) break messageLoop;
-          default:
-            break;
+    test(
+      'can enable session resumption',
+      () async {
+        if (apiKey == null) {
+          markTestSkipped('API key not available');
+          return;
         }
-      }
 
-      // The resumption token may or may not be provided depending on the model
-      // We just verify the session worked with resumption enabled
-      await session.close();
-    }, timeout: const Timeout(Duration(seconds: 60)));
+        // Verify we can create a session with resumption enabled
+        final session = await liveClient!.connect(
+          model: defaultLiveModel,
+          liveConfig: LiveConfig(
+            generationConfig: LiveGenerationConfig.audioOnly(),
+            sessionResumption: const SessionResumptionConfig.enabled(),
+          ),
+        );
+
+        expect(session.isConnected, isTrue);
+
+        session.sendText('Hello');
+
+        // Wait for turn complete
+        messageLoop:
+        await for (final message in session.messages) {
+          switch (message) {
+            case BidiGenerateContentServerContent(:final turnComplete):
+              if (turnComplete ?? false) break messageLoop;
+            default:
+              break;
+          }
+        }
+
+        // The resumption token may or may not be provided depending on the model
+        // We just verify the session worked with resumption enabled
+        await session.close();
+      },
+      timeout: const Timeout(Duration(seconds: 60)),
+    );
 
     test('resumes session with token', () async {
       if (apiKey == null) {

--- a/packages/ollama_dart/test/integration/chat_test.dart
+++ b/packages/ollama_dart/test/integration/chat_test.dart
@@ -211,30 +211,34 @@ void main() {
       expect(response.evalCount, lessThanOrEqualTo(2));
     });
 
-    test('image input works with vision model', () async {
-      final visionModel =
-          Platform.environment['OLLAMA_VISION_MODEL'] ?? 'llava';
+    test(
+      'image input works with vision model',
+      () async {
+        final visionModel =
+            Platform.environment['OLLAMA_VISION_MODEL'] ?? 'llava';
 
-      final response = await client.chat.create(
-        request: ChatRequest(
-          model: visionModel,
-          messages: const [
-            ChatMessage.system('You are a helpful assistant.'),
-            ChatMessage(
-              role: MessageRole.user,
-              content: 'Describe the contents of the image.',
-              images: [
-                // Small base64 encoded star image
-                'iVBORw0KGgoAAAANSUhEUgAAAAkAAAANCAIAAAD0YtNRAAAABnRSTlMA/AD+APzoM1ogAAAAWklEQVR4AWP48+8PLkR7uUdzcMvtU8EhdykHKAciEXL3pvw5FQIURaBDJkARoDhY3zEXiCgCHbNBmAlUiyaBkENoxZSDWnOtBmoAQu7TnT+3WuDOA7KBIkAGAGwiNeqjusp/AAAAAElFTkSuQmCC',
-              ],
-            ),
-          ],
-        ),
-      );
+        final response = await client.chat.create(
+          request: ChatRequest(
+            model: visionModel,
+            messages: const [
+              ChatMessage.system('You are a helpful assistant.'),
+              ChatMessage(
+                role: MessageRole.user,
+                content: 'Describe the contents of the image.',
+                images: [
+                  // Small base64 encoded star image
+                  'iVBORw0KGgoAAAANSUhEUgAAAAkAAAANCAIAAAD0YtNRAAAABnRSTlMA/AD+APzoM1ogAAAAWklEQVR4AWP48+8PLkR7uUdzcMvtU8EhdykHKAciEXL3pvw5FQIURaBDJkARoDhY3zEXiCgCHbNBmAlUiyaBkENoxZSDWnOtBmoAQu7TnT+3WuDOA7KBIkAGAGwiNeqjusp/AAAAAElFTkSuQmCC',
+                ],
+              ),
+            ],
+          ),
+        );
 
-      expect(response.message, isNotNull);
-      final content = response.message!.content?.toLowerCase() ?? '';
-      expect(content, contains('star'));
-    }, skip: 'Requires a vision model (e.g., llava) to be available');
+        expect(response.message, isNotNull);
+        final content = response.message!.content?.toLowerCase() ?? '';
+        expect(content, contains('star'));
+      },
+      skip: 'Requires a vision model (e.g., llava) to be available',
+    );
   });
 }

--- a/packages/ollama_dart/test/integration/completions_test.dart
+++ b/packages/ollama_dart/test/integration/completions_test.dart
@@ -64,19 +64,24 @@ void main() {
       expect(response.response!.toLowerCase(), contains('robo'));
     });
 
-    test('JSON format works', () async {
-      final response = await client.completions.generate(
-        request: GenerateRequest(
-          model: model,
-          prompt: 'Return a JSON object with key "greeting" and value "hello"',
-          format: const JsonFormat(),
-        ),
-      );
+    test(
+      'JSON format works',
+      () async {
+        final response = await client.completions.generate(
+          request: GenerateRequest(
+            model: model,
+            prompt:
+                'Return a JSON object with key "greeting" and value "hello"',
+            format: const JsonFormat(),
+          ),
+        );
 
-      expect(response.response, isNotNull);
-      expect(response.response, contains('{'));
-      expect(response.response, contains('hello'));
-    }, skip: 'Requires a model with JSON format support (e.g., llama3.2)');
+        expect(response.response, isNotNull);
+        expect(response.response, contains('{'));
+        expect(response.response, contains('hello'));
+      },
+      skip: 'Requires a model with JSON format support (e.g., llama3.2)',
+    );
 
     test('includes timing statistics', () async {
       final response = await client.completions.generate(
@@ -123,24 +128,28 @@ void main() {
       expect(output, isNot(contains('456789')));
     });
 
-    test('image input works with vision model', () async {
-      final visionModel =
-          Platform.environment['OLLAMA_VISION_MODEL'] ?? 'llava';
+    test(
+      'image input works with vision model',
+      () async {
+        final visionModel =
+            Platform.environment['OLLAMA_VISION_MODEL'] ?? 'llava';
 
-      final response = await client.completions.generate(
-        request: GenerateRequest(
-          model: visionModel,
-          prompt: 'What is in the image?',
-          images: const [
-            // Small base64 encoded star image
-            'iVBORw0KGgoAAAANSUhEUgAAAAkAAAANCAIAAAD0YtNRAAAABnRSTlMA/AD+APzoM1ogAAAAWklEQVR4AWP48+8PLkR7uUdzcMvtU8EhdykHKAciEXL3pvw5FQIURaBDJkARoDhY3zEXiCgCHbNBmAlUiyaBkENoxZSDWnOtBmoAQu7TnT+3WuDOA7KBIkAGAGwiNeqjusp/AAAAAElFTkSuQmCC',
-          ],
-        ),
-      );
+        final response = await client.completions.generate(
+          request: GenerateRequest(
+            model: visionModel,
+            prompt: 'What is in the image?',
+            images: const [
+              // Small base64 encoded star image
+              'iVBORw0KGgoAAAANSUhEUgAAAAkAAAANCAIAAAD0YtNRAAAABnRSTlMA/AD+APzoM1ogAAAAWklEQVR4AWP48+8PLkR7uUdzcMvtU8EhdykHKAciEXL3pvw5FQIURaBDJkARoDhY3zEXiCgCHbNBmAlUiyaBkENoxZSDWnOtBmoAQu7TnT+3WuDOA7KBIkAGAGwiNeqjusp/AAAAAElFTkSuQmCC',
+            ],
+          ),
+        );
 
-      expect(response.response, isNotNull);
-      final content = response.response!.toLowerCase();
-      expect(content, contains('star'));
-    }, skip: 'Requires a vision model (e.g., llava) to be available');
+        expect(response.response, isNotNull);
+        final content = response.response!.toLowerCase();
+        expect(content, contains('star'));
+      },
+      skip: 'Requires a vision model (e.g., llava) to be available',
+    );
   });
 }

--- a/packages/ollama_dart/test/integration/models_test.dart
+++ b/packages/ollama_dart/test/integration/models_test.dart
@@ -68,47 +68,55 @@ void main() {
       expect(response.parameters, isNotNull);
     });
 
-    test('create model from base model', () async {
-      const modelName = 'test-model-create';
+    test(
+      'create model from base model',
+      () async {
+        const modelName = 'test-model-create';
 
-      final response = await client.models.create(
-        request: CreateRequest(
-          model: modelName,
-          from: model,
-          system: 'You are a helpful assistant.',
-        ),
-      );
+        final response = await client.models.create(
+          request: CreateRequest(
+            model: modelName,
+            from: model,
+            system: 'You are a helpful assistant.',
+          ),
+        );
 
-      expect(response.status, equals('success'));
+        expect(response.status, equals('success'));
 
-      // Cleanup
-      await client.models.delete(
-        request: const DeleteRequest(model: modelName),
-      );
-    }, skip: 'Destructive test - creates a new model');
+        // Cleanup
+        await client.models.delete(
+          request: const DeleteRequest(model: modelName),
+        );
+      },
+      skip: 'Destructive test - creates a new model',
+    );
 
-    test('createStream yields progress updates', () async {
-      const modelName = 'test-model-stream';
+    test(
+      'createStream yields progress updates',
+      () async {
+        const modelName = 'test-model-stream';
 
-      final events = <StatusEvent>[];
-      await client.models
-          .createStream(
-            request: CreateRequest(
-              model: modelName,
-              from: model,
-              system: 'You are a helpful assistant.',
-            ),
-          )
-          .forEach(events.add);
+        final events = <StatusEvent>[];
+        await client.models
+            .createStream(
+              request: CreateRequest(
+                model: modelName,
+                from: model,
+                system: 'You are a helpful assistant.',
+              ),
+            )
+            .forEach(events.add);
 
-      expect(events, isNotEmpty);
-      expect(events.last.status, equals('success'));
+        expect(events, isNotEmpty);
+        expect(events.last.status, equals('success'));
 
-      // Cleanup
-      await client.models.delete(
-        request: const DeleteRequest(model: modelName),
-      );
-    }, skip: 'Destructive test - creates a new model');
+        // Cleanup
+        await client.models.delete(
+          request: const DeleteRequest(model: modelName),
+        );
+      },
+      skip: 'Destructive test - creates a new model',
+    );
 
     test('copy creates a duplicate model', () async {
       const newName = 'test-model-copy';
@@ -124,48 +132,62 @@ void main() {
       await client.models.delete(request: const DeleteRequest(model: newName));
     }, skip: 'Destructive test - copies a model');
 
-    test('delete removes a model', () async {
-      const copyName = 'test-model-delete';
+    test(
+      'delete removes a model',
+      () async {
+        const copyName = 'test-model-delete';
 
-      // First create a copy to delete
-      await client.models.copy(
-        request: CopyRequest(source: model, destination: copyName),
-      );
+        // First create a copy to delete
+        await client.models.copy(
+          request: CopyRequest(source: model, destination: copyName),
+        );
 
-      // Verify it exists
-      final before = await client.models.list();
-      expect(before.models?.any((m) => m.name == '$copyName:latest'), isTrue);
+        // Verify it exists
+        final before = await client.models.list();
+        expect(before.models?.any((m) => m.name == '$copyName:latest'), isTrue);
 
-      // Delete it
-      await client.models.delete(request: const DeleteRequest(model: copyName));
+        // Delete it
+        await client.models.delete(
+          request: const DeleteRequest(model: copyName),
+        );
 
-      // Verify it's gone
-      final after = await client.models.list();
-      expect(after.models?.any((m) => m.name == '$copyName:latest'), isFalse);
-    }, skip: 'Destructive test - creates and deletes a model');
+        // Verify it's gone
+        final after = await client.models.list();
+        expect(after.models?.any((m) => m.name == '$copyName:latest'), isFalse);
+      },
+      skip: 'Destructive test - creates and deletes a model',
+    );
 
-    test('pull downloads a model', () async {
-      final response = await client.models.pull(
-        request: const PullRequest(model: 'nomic-embed-text:latest'),
-      );
+    test(
+      'pull downloads a model',
+      () async {
+        final response = await client.models.pull(
+          request: const PullRequest(model: 'nomic-embed-text:latest'),
+        );
 
-      expect(response.status, isNotNull);
-    }, skip: 'Long running test - downloads a model from registry');
+        expect(response.status, isNotNull);
+      },
+      skip: 'Long running test - downloads a model from registry',
+    );
 
-    test('pullStream yields download progress', () async {
-      final events = <StatusEvent>[];
+    test(
+      'pullStream yields download progress',
+      () async {
+        final events = <StatusEvent>[];
 
-      await client.models
-          .pullStream(
-            request: const PullRequest(model: 'nomic-embed-text:latest'),
-          )
-          .forEach(events.add);
+        await client.models
+            .pullStream(
+              request: const PullRequest(model: 'nomic-embed-text:latest'),
+            )
+            .forEach(events.add);
 
-      expect(events, isNotEmpty);
-      // Check that we got progress updates
-      final hasProgress = events.any((e) => e.total != null && e.total! > 0);
-      expect(hasProgress, isTrue);
-    }, skip: 'Long running test - downloads a model from registry');
+        expect(events, isNotEmpty);
+        // Check that we got progress updates
+        final hasProgress = events.any((e) => e.total != null && e.total! > 0);
+        expect(hasProgress, isTrue);
+      },
+      skip: 'Long running test - downloads a model from registry',
+    );
   });
 
   group('VersionResource', () {


### PR DESCRIPTION
## Summary
- Applies canonical Dart formatting to integration tests in `chromadb`, `googleai_dart`, and `ollama_dart`.
- Keeps the workspace formatter-clean without changing test behavior.

## Test Plan
- [x] `dart format --show=none --summary=line .` reports 0 changes on a second pass
- [x] `dart analyze .`
- [x] `git diff --check`
