### PR TITLE
fix(openai_dart): preserve reasoning detail fidelity

### DIFF
--- a/packages/openai_dart/lib/src/models/chat/chat_message.dart
+++ b/packages/openai_dart/lib/src/models/chat/chat_message.dart
@@ -395,9 +395,7 @@ class AssistantMessage extends ChatMessage {
 
   /// Whether this message contains reasoning content.
   bool get hasReasoningContent =>
-      reasoningContent != null ||
-      reasoning != null ||
-      (reasoningDetails != null && reasoningDetails!.isNotEmpty);
+      reasoningContent != null || reasoning != null || reasoningDetails != null;
 
   @override
   String get role => 'assistant';

--- a/packages/openai_dart/lib/src/models/chat/reasoning_detail.dart
+++ b/packages/openai_dart/lib/src/models/chat/reasoning_detail.dart
@@ -1,11 +1,24 @@
 import 'package:meta/meta.dart';
 
+import '../common/equality_helpers.dart';
+
+const _reservedReasoningDetailKeys = {
+  'type',
+  'id',
+  'format',
+  'index',
+  'summary',
+  'text',
+  'data',
+  'signature',
+};
+
 /// Details about model reasoning, returned by some providers.
 ///
 /// **OpenRouter only.** Not part of the official OpenAI API.
 ///
-/// This is returned by OpenRouter when using models that support reasoning
-/// (e.g., DeepSeek R1). Different types indicate different content:
+/// This is returned by OpenRouter when using models that support reasoning.
+/// Different types indicate different content:
 ///
 /// - `reasoning.summary`: A summary of the reasoning process
 /// - `reasoning.text`: The full reasoning text
@@ -17,8 +30,8 @@ import 'package:meta/meta.dart';
 /// final message = response.firstChoice?.message;
 /// if (message?.reasoningDetails != null) {
 ///   for (final detail in message!.reasoningDetails!) {
-///     if (detail.type == 'reasoning.summary') {
-///       print('Summary: ${detail.text}');
+///     if (detail.isSummary) {
+///       print('Summary: ${detail.summary}');
 ///     }
 ///   }
 /// }
@@ -26,14 +39,90 @@ import 'package:meta/meta.dart';
 @immutable
 class ReasoningDetail {
   /// Creates a [ReasoningDetail].
-  const ReasoningDetail({required this.type, this.text, this.data});
+  const ReasoningDetail({
+    required this.type,
+    this.id,
+    this.format,
+    this.index,
+    this.summary,
+    this.text,
+    this.data,
+    this.signature,
+  }) : _additionalProperties = const {},
+       _rawJson = null;
+
+  const ReasoningDetail._({
+    required this.type,
+    required this.id,
+    required this.format,
+    required this.index,
+    required this.summary,
+    required this.text,
+    required this.data,
+    required this.signature,
+    required Map<String, dynamic> additionalProperties,
+    required Map<String, dynamic>? rawJson,
+  }) : _additionalProperties = additionalProperties,
+       _rawJson = rawJson;
+
+  /// Creates a programmatic [ReasoningDetail] with future provider fields.
+  ///
+  /// Recognized fields must be passed through their typed parameters. A
+  /// reserved-key collision in [additionalProperties] throws an
+  /// [ArgumentError].
+  factory ReasoningDetail.withAdditionalProperties({
+    required String type,
+    String? id,
+    String? format,
+    int? index,
+    String? summary,
+    String? text,
+    String? data,
+    String? signature,
+    required Map<String, dynamic> additionalProperties,
+  }) {
+    final collisions = additionalProperties.keys
+        .where(_reservedReasoningDetailKeys.contains)
+        .toList(growable: false);
+    if (collisions.isNotEmpty) {
+      throw ArgumentError.value(
+        additionalProperties,
+        'additionalProperties',
+        'Contains reserved keys: ${collisions.join(', ')}',
+      );
+    }
+    return ReasoningDetail._(
+      type: type,
+      id: id,
+      format: format,
+      index: index,
+      summary: summary,
+      text: text,
+      data: data,
+      signature: signature,
+      additionalProperties: _freezeJsonMap(additionalProperties),
+      rawJson: null,
+    );
+  }
 
   /// Creates a [ReasoningDetail] from JSON.
   factory ReasoningDetail.fromJson(Map<String, dynamic> json) {
-    return ReasoningDetail(
+    final additionalProperties = {
+      for (final entry in json.entries)
+        if (!_reservedReasoningDetailKeys.contains(entry.key))
+          entry.key: entry.value,
+    };
+    return ReasoningDetail._(
       type: json['type'] as String,
+      id: json['id'] as String?,
+      format: json['format'] as String?,
+      index: json['index'] as int?,
+      summary: json['summary'] as String?,
       text: json['text'] as String?,
       data: json['data'] as String?,
+      signature: json['signature'] as String?,
+      additionalProperties: _freezeJsonMap(additionalProperties),
+      rawJson: _freezeJsonMap(json),
     );
   }
 
@@ -45,11 +134,34 @@ class ReasoningDetail {
   /// - `reasoning.encrypted`: Encrypted reasoning data (base64 encoded)
   final String type;
 
-  /// The text content (for summary and text types).
+  /// Unique provider identifier for this reasoning detail.
+  final String? id;
+
+  /// Provider-specific reasoning format.
+  final String? format;
+
+  /// Sequential position of this detail in the reasoning sequence.
+  final int? index;
+
+  /// Summary content for `reasoning.summary` details.
+  final String? summary;
+
+  /// Text content for `reasoning.text` details.
   final String? text;
 
-  /// Encrypted data (for encrypted type, base64 encoded).
+  /// Encrypted data for `reasoning.encrypted` details.
   final String? data;
+
+  /// Optional verification signature for text reasoning.
+  final String? signature;
+
+  final Map<String, dynamic> _additionalProperties;
+  final Map<String, dynamic>? _rawJson;
+
+  /// Future provider fields not currently modeled by this client.
+  ///
+  /// The returned map and its nested collections are immutable.
+  Map<String, dynamic> get additionalProperties => _additionalProperties;
 
   /// Whether this is a summary detail.
   bool get isSummary => type == 'reasoning.summary';
@@ -61,29 +173,65 @@ class ReasoningDetail {
   bool get isEncrypted => type == 'reasoning.encrypted';
 
   /// Converts to JSON.
-  Map<String, dynamic> toJson() => {
-    'type': type,
-    if (text != null) 'text': text,
-    if (data != null) 'data': data,
-  };
+  ///
+  /// Parsed instances reproduce the original payload exactly, including
+  /// explicit nulls and future fields.
+  Map<String, dynamic> toJson() {
+    final rawJson = _rawJson;
+    if (rawJson != null) return _copyJsonMap(rawJson);
+    return {
+      ..._copyJsonMap(_additionalProperties),
+      'type': type,
+      if (id != null) 'id': id,
+      if (format != null) 'format': format,
+      if (index != null) 'index': index,
+      if (summary != null) 'summary': summary,
+      if (text != null) 'text': text,
+      if (data != null) 'data': data,
+      if (signature != null) 'signature': signature,
+    };
+  }
 
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is ReasoningDetail &&
           runtimeType == other.runtimeType &&
-          type == other.type &&
-          text == other.text &&
-          data == other.data;
+          mapsDeepEqual(toJson(), other.toJson());
 
   @override
-  int get hashCode => Object.hash(type, text, data);
+  int get hashCode => mapDeepHashCode(toJson());
 
   @override
   String toString() {
-    if (isSummary || isText) {
+    if (isSummary) {
+      return 'ReasoningDetail(type: $type, summary: ${summary?.length ?? text?.length ?? 0} chars)';
+    }
+    if (isText) {
       return 'ReasoningDetail(type: $type, text: ${text?.length ?? 0} chars)';
     }
     return 'ReasoningDetail(type: $type)';
   }
 }
+
+Map<String, dynamic> _freezeJsonMap(Map<String, dynamic> value) =>
+    Map.unmodifiable(
+      value.map((key, nested) => MapEntry(key, _freezeJsonValue(nested))),
+    );
+
+Object? _freezeJsonValue(Object? value) => switch (value) {
+  final Map<String, dynamic> map => _freezeJsonMap(map),
+  final List<dynamic> list => List<Object?>.unmodifiable(
+    list.map(_freezeJsonValue),
+  ),
+  _ => value,
+};
+
+Map<String, dynamic> _copyJsonMap(Map<String, dynamic> value) =>
+    value.map((key, nested) => MapEntry(key, _copyJsonValue(nested)));
+
+Object? _copyJsonValue(Object? value) => switch (value) {
+  final Map<String, dynamic> map => _copyJsonMap(map),
+  final List<dynamic> list => list.map(_copyJsonValue).toList(),
+  _ => value,
+};

--- a/packages/openai_dart/lib/src/models/streaming/chat_stream_event.dart
+++ b/packages/openai_dart/lib/src/models/streaming/chat_stream_event.dart
@@ -7,6 +7,7 @@ import '../chat/chat_completion_moderation.dart';
 import '../chat/chat_message.dart';
 import '../chat/reasoning_detail.dart';
 import '../chat/tool_call.dart';
+import '../common/equality_helpers.dart';
 import '../common/finish_reason.dart';
 import '../common/logprobs.dart';
 import '../common/usage.dart';
@@ -301,8 +302,7 @@ class ChatDelta {
 
   /// Whether this delta has reasoning content.
   bool get hasReasoningContent =>
-      (reasoningContent != null && reasoningContent!.isNotEmpty) ||
-      (reasoning != null && reasoning!.isNotEmpty);
+      reasoningContent != null || reasoning != null || reasoningDetails != null;
 
   /// Converts to JSON.
   Map<String, dynamic> toJson() => {
@@ -325,12 +325,21 @@ class ChatDelta {
           role == other.role &&
           content == other.content &&
           refusal == other.refusal &&
+          listsEqual(toolCalls, other.toolCalls) &&
           reasoningContent == other.reasoningContent &&
-          reasoning == other.reasoning;
+          reasoning == other.reasoning &&
+          listsEqual(reasoningDetails, other.reasoningDetails);
 
   @override
-  int get hashCode =>
-      Object.hash(role, content, refusal, reasoningContent, reasoning);
+  int get hashCode => Object.hash(
+    role,
+    content,
+    refusal,
+    toolCalls != null ? Object.hashAll(toolCalls!) : null,
+    reasoningContent,
+    reasoning,
+    reasoningDetails != null ? Object.hashAll(reasoningDetails!) : null,
+  );
 
   @override
   String toString() {
@@ -474,6 +483,7 @@ class AccumulatedChoice {
     required this.reasoningContent,
     required this.reasoning,
     required this.reasoningDetails,
+    required this.reasoningDetailsPresent,
     required this.logprobs,
   });
 
@@ -504,6 +514,11 @@ class AccumulatedChoice {
   /// **OpenRouter only.** The accumulated reasoning details.
   final List<ReasoningDetail> reasoningDetails;
 
+  /// Whether at least one delta contained the `reasoning_details` field.
+  ///
+  /// This distinguishes an explicitly empty array from an absent field.
+  final bool reasoningDetailsPresent;
+
   /// Log probability information.
   final Logprobs? logprobs;
 
@@ -512,7 +527,9 @@ class AccumulatedChoice {
 
   /// Whether there is any reasoning content.
   bool get hasReasoningContent =>
-      reasoningContent.isNotEmpty || reasoning.isNotEmpty;
+      reasoningContent.isNotEmpty ||
+      reasoning.isNotEmpty ||
+      reasoningDetailsPresent;
 }
 
 /// Helper class for accumulating streaming chunks into a complete response.
@@ -601,6 +618,7 @@ class ChatStreamAccumulator {
       }
 
       if (delta.reasoningDetails != null) {
+        accumulated.reasoningDetailsPresent = true;
         accumulated.reasoningDetails.addAll(delta.reasoningDetails!);
       }
 
@@ -711,7 +729,8 @@ class ChatStreamAccumulator {
   bool get hasReasoningContent =>
       _choices.isNotEmpty &&
       (_choices[0].reasoningContent.isNotEmpty ||
-          _choices[0].reasoning.isNotEmpty);
+          _choices[0].reasoning.isNotEmpty ||
+          _choices[0].reasoningDetailsPresent);
 
   /// The message role.
   ///
@@ -765,6 +784,7 @@ class ChatStreamAccumulator {
         reasoningContent: _choices[i].reasoningContent.toString(),
         reasoning: _choices[i].reasoning.toString(),
         reasoningDetails: List.unmodifiable(_choices[i].reasoningDetails),
+        reasoningDetailsPresent: _choices[i].reasoningDetailsPresent,
         logprobs: _buildLogprobs(_choices[i]),
       ),
   ];
@@ -820,7 +840,9 @@ class ChatStreamAccumulator {
             ? reasoningContentStr
             : null,
         reasoning: reasoningStr.isNotEmpty ? reasoningStr : null,
-        reasoningDetails: rds.isNotEmpty ? List.unmodifiable(rds) : null,
+        reasoningDetails: choice.reasoningDetailsPresent
+            ? List.unmodifiable(rds)
+            : null,
       ),
     );
   }
@@ -848,6 +870,7 @@ class _AccumulatedChoice {
   final StringBuffer reasoningContent = StringBuffer();
   final StringBuffer reasoning = StringBuffer();
   final List<ReasoningDetail> reasoningDetails = [];
+  bool reasoningDetailsPresent = false;
   final List<_AccumulatedToolCall> toolCalls = [];
   final List<TokenLogprob> logprobsContent = [];
   final List<TokenLogprob> logprobsRefusal = [];

--- a/packages/openai_dart/test/unit/models/reasoning_detail_test.dart
+++ b/packages/openai_dart/test/unit/models/reasoning_detail_test.dart
@@ -3,123 +3,188 @@ import 'package:test/test.dart';
 
 void main() {
   group('ReasoningDetail', () {
-    test('fromJson parses summary type', () {
-      final json = {
+    test('round-trips every documented field and future properties', () {
+      final json = <String, dynamic>{
+        'type': 'reasoning.text',
+        'id': 'reasoning-text-1',
+        'format': 'anthropic-claude-v1',
+        'index': 2,
+        'text': 'Let me think.',
+        'signature': null,
+        'future': {
+          'nested': [
+            1,
+            {'keep': true},
+          ],
+        },
+      };
+
+      final detail = ReasoningDetail.fromJson(json);
+
+      expect(detail.id, 'reasoning-text-1');
+      expect(detail.format, 'anthropic-claude-v1');
+      expect(detail.index, 2);
+      expect(detail.text, 'Let me think.');
+      expect(detail.signature, isNull);
+      expect(detail.additionalProperties, contains('future'));
+      expect(detail.toJson(), equals(json));
+      expect(detail.toJson(), containsPair('signature', null));
+    });
+
+    test('round-trips summary and encrypted shapes', () {
+      final summary = ReasoningDetail.fromJson(const {
         'type': 'reasoning.summary',
-        'text': 'This is a summary of the reasoning.',
-      };
-
-      final detail = ReasoningDetail.fromJson(json);
-
-      expect(detail.type, 'reasoning.summary');
-      expect(detail.text, 'This is a summary of the reasoning.');
-      expect(detail.data, isNull);
-      expect(detail.isSummary, true);
-      expect(detail.isText, false);
-      expect(detail.isEncrypted, false);
-    });
-
-    test('fromJson parses text type', () {
-      final json = {
-        'type': 'reasoning.text',
-        'text': 'Full reasoning text here.',
-      };
-
-      final detail = ReasoningDetail.fromJson(json);
-
-      expect(detail.type, 'reasoning.text');
-      expect(detail.text, 'Full reasoning text here.');
-      expect(detail.isSummary, false);
-      expect(detail.isText, true);
-      expect(detail.isEncrypted, false);
-    });
-
-    test('fromJson parses encrypted type', () {
-      final json = {
+        'summary': 'Checked the constraints.',
+        'id': 'summary-1',
+        'format': 'openai-responses-v1',
+        'index': 0,
+      });
+      final encrypted = ReasoningDetail.fromJson(const {
         'type': 'reasoning.encrypted',
-        'data': 'YmFzZTY0ZW5jb2RlZGRhdGE=',
-      };
+        'data': 'ZW5jcnlwdGVk',
+        'id': 'encrypted-1',
+        'format': 'anthropic-claude-v1',
+        'index': 1,
+      });
 
-      final detail = ReasoningDetail.fromJson(json);
-
-      expect(detail.type, 'reasoning.encrypted');
-      expect(detail.text, isNull);
-      expect(detail.data, 'YmFzZTY0ZW5jb2RlZGRhdGE=');
-      expect(detail.isSummary, false);
-      expect(detail.isText, false);
-      expect(detail.isEncrypted, true);
+      expect(summary.summary, 'Checked the constraints.');
+      expect(summary.toJson()['summary'], 'Checked the constraints.');
+      expect(encrypted.data, 'ZW5jcnlwdGVk');
+      expect(encrypted.toJson()['data'], 'ZW5jcnlwdGVk');
     });
 
-    test('toJson produces correct output', () {
+    test('keeps the existing const constructor source compatible', () {
+      const first = ReasoningDetail(
+        type: 'reasoning.summary',
+        text: 'Legacy summary text',
+      );
+      const same = ReasoningDetail(
+        type: 'reasoning.summary',
+        text: 'Legacy summary text',
+      );
+
+      expect(first.isSummary, isTrue);
+      expect(first.isText, isFalse);
+      expect(first.isEncrypted, isFalse);
+      expect(first.toJson(), {
+        'type': 'reasoning.summary',
+        'text': 'Legacy summary text',
+      });
+      expect(first, same);
+      expect(first.hashCode, same.hashCode);
+      expect(first.toString(), contains('19 chars'));
+    });
+
+    test('programmatic constructor serializes all typed fields', () {
       const detail = ReasoningDetail(
-        type: 'reasoning.summary',
-        text: 'Summary text',
+        type: 'reasoning.text',
+        id: 'detail-1',
+        format: 'anthropic-claude-v1',
+        index: 3,
+        text: 'Thinking',
+        signature: 'sig-1',
       );
 
-      final json = detail.toJson();
-
-      expect(json['type'], 'reasoning.summary');
-      expect(json['text'], 'Summary text');
-      expect(json.containsKey('data'), false); // null fields excluded
-    });
-
-    test('toJson round-trip', () {
-      final original = {
+      expect(detail.toJson(), {
         'type': 'reasoning.text',
-        'text': 'Some reasoning content',
+        'id': 'detail-1',
+        'format': 'anthropic-claude-v1',
+        'index': 3,
+        'text': 'Thinking',
+        'signature': 'sig-1',
+      });
+    });
+
+    test('parsed payload is isolated from source and returned JSON', () {
+      final source = <String, dynamic>{
+        'type': 'reasoning.text',
+        'future': {
+          'items': [1, 2],
+        },
       };
+      final detail = ReasoningDetail.fromJson(source);
 
-      final detail = ReasoningDetail.fromJson(original);
-      final json = detail.toJson();
+      (source['future'] as Map<String, dynamic>)['items'] = [3];
+      final serialized = detail.toJson();
+      ((serialized['future'] as Map<String, dynamic>)['items'] as List).add(4);
 
-      expect(json['type'], original['type']);
-      expect(json['text'], original['text']);
+      expect(detail.toJson()['future'], {
+        'items': [1, 2],
+      });
+      expect(
+        () => detail.additionalProperties['future'] = false,
+        throwsUnsupportedError,
+      );
     });
 
-    test('equality works correctly', () {
-      const detail1 = ReasoningDetail(
-        type: 'reasoning.summary',
-        text: 'Same text',
+    test('rejects reserved additional-property collisions', () {
+      expect(
+        () => ReasoningDetail.withAdditionalProperties(
+          type: 'reasoning.text',
+          additionalProperties: const {'signature': 'duplicate'},
+        ),
+        throwsArgumentError,
       );
-      const detail2 = ReasoningDetail(
-        type: 'reasoning.summary',
-        text: 'Same text',
-      );
-      const detail3 = ReasoningDetail(
-        type: 'reasoning.summary',
-        text: 'Different text',
-      );
-
-      expect(detail1, equals(detail2));
-      expect(detail1, isNot(equals(detail3)));
     });
 
-    test('hashCode is consistent', () {
-      const detail1 = ReasoningDetail(
-        type: 'reasoning.summary',
-        text: 'Test text',
-      );
-      const detail2 = ReasoningDetail(
-        type: 'reasoning.summary',
-        text: 'Test text',
-      );
+    test('equality and hash include complete serialized payload', () {
+      final first = ReasoningDetail.fromJson(const {
+        'type': 'reasoning.text',
+        'signature': null,
+        'future': {'value': 1},
+      });
+      final same = ReasoningDetail.fromJson(const {
+        'future': {'value': 1},
+        'signature': null,
+        'type': 'reasoning.text',
+      });
+      final missingNull = ReasoningDetail.fromJson(const {
+        'type': 'reasoning.text',
+        'future': {'value': 1},
+      });
 
-      expect(detail1.hashCode, equals(detail2.hashCode));
+      expect(first, same);
+      expect(first.hashCode, same.hashCode);
+      expect(first, isNot(missingNull));
     });
 
-    test('toString produces readable output', () {
-      const summaryDetail = ReasoningDetail(
-        type: 'reasoning.summary',
-        text: 'Short',
-      );
-      const encryptedDetail = ReasoningDetail(
-        type: 'reasoning.encrypted',
-        data: 'base64data',
+    test('chat request preserves reasoning details exactly', () {
+      final details = [
+        ReasoningDetail.fromJson(const {
+          'type': 'reasoning.text',
+          'text': '',
+          'signature': 'sig-1',
+          'id': 'detail-1',
+          'format': 'anthropic-claude-v1',
+          'index': 0,
+          'future': {'opaque': true},
+        }),
+      ];
+      final request = ChatCompletionCreateRequest(
+        model: 'provider/model',
+        messages: [
+          AssistantMessage(toolCalls: const [], reasoningDetails: details),
+        ],
       );
 
-      expect(summaryDetail.toString(), contains('reasoning.summary'));
-      expect(summaryDetail.toString(), contains('5 chars'));
-      expect(encryptedDetail.toString(), contains('reasoning.encrypted'));
+      final message =
+          (request.toJson()['messages'] as List).single as Map<String, dynamic>;
+      expect(
+        message['reasoning_details'],
+        equals(details.map((detail) => detail.toJson()).toList()),
+      );
+    });
+
+    test('assistant retains an explicitly empty reasoning array', () {
+      final message = AssistantMessage.fromJson(const {
+        'role': 'assistant',
+        'content': null,
+        'reasoning_details': <dynamic>[],
+      });
+
+      expect(message.hasReasoningContent, isTrue);
+      expect(message.reasoningDetails, isEmpty);
+      expect(message.toJson(), containsPair('reasoning_details', <dynamic>[]));
     });
   });
 }

--- a/packages/openai_dart/test/unit/models/streaming_test.dart
+++ b/packages/openai_dart/test/unit/models/streaming_test.dart
@@ -146,6 +146,74 @@ void main() {
       expect(delta.toolCalls!.first.id, 'call_abc123');
       expect(delta.toolCalls!.first.function!.name, 'get_weather');
     });
+
+    test('equality and hash include tool calls and reasoning details', () {
+      final json = jsonDecode_(r'''
+        {
+          "tool_calls": [
+            {
+              "index": 0,
+              "id": "call_1",
+              "type": "function",
+              "function": {"name": "lookup", "arguments": "{}"}
+            }
+          ],
+          "reasoning_details": [
+            {
+              "type": "reasoning.text",
+              "text": "thinking",
+              "signature": "sig-1"
+            }
+          ]
+        }
+      ''');
+      final sameJson = jsonDecode_(r'''
+        {
+          "tool_calls": [
+            {
+              "index": 0,
+              "id": "call_1",
+              "type": "function",
+              "function": {"name": "lookup", "arguments": "{}"}
+            }
+          ],
+          "reasoning_details": [
+            {
+              "type": "reasoning.text",
+              "text": "thinking",
+              "signature": "sig-1"
+            }
+          ]
+        }
+      ''');
+      final differentJson = jsonDecode_(r'''
+        {
+          "tool_calls": [
+            {
+              "index": 0,
+              "id": "call_2",
+              "type": "function",
+              "function": {"name": "lookup", "arguments": "{}"}
+            }
+          ],
+          "reasoning_details": [
+            {
+              "type": "reasoning.text",
+              "text": "thinking",
+              "signature": "sig-2"
+            }
+          ]
+        }
+      ''');
+
+      final first = ChatDelta.fromJson(json);
+      final same = ChatDelta.fromJson(sameJson);
+      final different = ChatDelta.fromJson(differentJson);
+
+      expect(first, same);
+      expect(first.hashCode, same.hashCode);
+      expect(first, isNot(different));
+    });
   });
 
   group('ChatStreamAccumulator', () {
@@ -940,6 +1008,125 @@ void main() {
         expect(choices[0].reasoningDetails[0].text, equals('Step 1'));
         expect(choices[0].reasoningDetails[1].type, equals('reasoning.text'));
         expect(choices[0].reasoningDetails[1].text, equals('Step 2 details'));
+        expect(choices[0].reasoningDetailsPresent, isTrue);
+        expect(choices[0].hasReasoningContent, isTrue);
+      });
+
+      test('empty reasoningDetails remains present after accumulation', () {
+        final accumulator = ChatStreamAccumulator()
+          ..add(
+            ChatStreamEvent.fromJson(
+              jsonDecode_('''
+              {
+                "id": "chatcmpl-empty-rd",
+                "model": "provider/model",
+                "choices": [
+                  {
+                    "index": 0,
+                    "delta": {"reasoning_details": []},
+                    "finish_reason": "tool_calls"
+                  }
+                ]
+              }
+            '''),
+            ),
+          );
+
+        expect(accumulator.hasReasoningContent, isTrue);
+        expect(accumulator.choices.single.reasoningDetailsPresent, isTrue);
+        expect(accumulator.choices.single.reasoningDetails, isEmpty);
+        final message = accumulator.toChatCompletion().choices.single.message;
+        expect(message.reasoningDetails, isNotNull);
+        expect(message.reasoningDetails, isEmpty);
+        expect(
+          message.toJson(),
+          containsPair('reasoning_details', <dynamic>[]),
+        );
+      });
+
+      test('reasoning detail chunks retain exact order and fields', () {
+        final accumulator = ChatStreamAccumulator()
+          ..add(
+            ChatStreamEvent.fromJson(
+              jsonDecode_('''
+              {
+                "id": "chatcmpl-ordered-rd",
+                "model": "provider/model",
+                "choices": [
+                  {
+                    "index": 0,
+                    "delta": {
+                      "reasoning_details": [
+                        {
+                          "type": "reasoning.text",
+                          "text": "first",
+                          "signature": null,
+                          "id": "r-1",
+                          "format": "anthropic-claude-v1",
+                          "index": 0
+                        }
+                      ]
+                    },
+                    "finish_reason": null
+                  }
+                ]
+              }
+            '''),
+            ),
+          )
+          ..add(
+            ChatStreamEvent.fromJson(
+              jsonDecode_('''
+              {
+                "id": "chatcmpl-ordered-rd",
+                "model": "provider/model",
+                "choices": [
+                  {
+                    "index": 0,
+                    "delta": {
+                      "reasoning_details": [
+                        {
+                          "type": "reasoning.encrypted",
+                          "data": "opaque",
+                          "id": "r-2",
+                          "format": "anthropic-claude-v1",
+                          "index": 1,
+                          "future": {"keep": true}
+                        }
+                      ]
+                    },
+                    "finish_reason": "tool_calls"
+                  }
+                ]
+              }
+            '''),
+            ),
+          );
+
+        final json = accumulator
+            .toChatCompletion()
+            .choices
+            .single
+            .message
+            .toJson();
+        expect(json['reasoning_details'], [
+          {
+            'type': 'reasoning.text',
+            'text': 'first',
+            'signature': null,
+            'id': 'r-1',
+            'format': 'anthropic-claude-v1',
+            'index': 0,
+          },
+          {
+            'type': 'reasoning.encrypted',
+            'data': 'opaque',
+            'id': 'r-2',
+            'format': 'anthropic-claude-v1',
+            'index': 1,
+            'future': {'keep': true},
+          },
+        ]);
       });
 
       test('logprobs and reasoningDetails in toChatCompletion()', () {


### PR DESCRIPTION
## Summary

- Preserve every documented and future OpenRouter `reasoning_details` field, including explicit `null` values and nested unknown data.
- Retain explicitly empty reasoning arrays and ordered detail chunks through stream accumulation.
- Include tool calls and reasoning details in `ChatDelta` equality and hashing.

## Details

The existing `ReasoningDetail` constructor remains source-compatible and now exposes typed `id`, `format`, `index`, `summary`, and `signature` fields. Parsed instances serialize back to their exact original JSON payload; programmatic callers can use `ReasoningDetail.withAdditionalProperties` for future non-reserved fields.

This is the upstream fidelity prerequisite for davidmigloz/langchain_dart#945 and exact agent-loop reasoning replay. It follows OpenRouter's requirement to preserve reasoning detail sequences unchanged between requests.

## References

- https://openrouter.ai/docs/guides/best-practices/reasoning-tokens
- davidmigloz/langchain_dart#945

## Test plan

- [x] Run `dart analyze` for the complete repository
- [x] Run all `openai_dart` unit tests (1,676 passed; 2 skipped)
- [x] Verify exact JSON round trips, request serialization, signature-only details, explicit nulls, unknown nested fields, and immutable additional properties
- [x] Verify empty arrays, detail ordering, and equality/hash behavior through streaming accumulation
- [x] Run `git diff --check`