### PR TITLE
feat(anthropic_sdk_dart)!: thinking input blocks and replay helper

### DIFF
--- a/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
+++ b/packages/anthropic_sdk_dart/.agents/skills/openapi-anthropic/config/manifest.json
@@ -1113,6 +1113,8 @@
           "ImageBlockParam": "image",
           "DocumentBlockParam": "document",
           "SearchResultBlockParam": "search_result",
+          "ThinkingBlockParam": "thinking",
+          "RedactedThinkingBlockParam": "redacted_thinking",
           "ToolUseBlockParam": "tool_use",
           "ToolResultBlockParam": "tool_result",
           "ServerToolUseBlockParam": "server_tool_use",
@@ -1223,6 +1225,46 @@
       "file": "lib/src/models/content/input_content_block.dart",
       "schema": "RequestSearchResultBlock",
       "parent": "InputContentBlock"
+    },
+    "ThinkingBlockParam": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "ThinkingInputBlock",
+      "file": "lib/src/models/content/input_content_block.dart",
+      "schema": "RequestThinkingBlock",
+      "parent": "InputContentBlock"
+    },
+    "BetaRequestThinkingBlock": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "ThinkingInputBlock",
+      "file": "lib/src/models/content/input_content_block.dart",
+      "schema": "BetaRequestThinkingBlock",
+      "parent": "InputContentBlock",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Beta variant maps to same Dart class as GA RequestThinkingBlock."
+    },
+    "RedactedThinkingBlockParam": {
+      "spec": "main",
+      "kind": "sealed_variant",
+      "dart_class": "RedactedThinkingInputBlock",
+      "file": "lib/src/models/content/input_content_block.dart",
+      "schema": "RequestRedactedThinkingBlock",
+      "parent": "InputContentBlock"
+    },
+    "BetaRequestRedactedThinkingBlock": {
+      "spec": "main",
+      "kind": "skip",
+      "dart_class": "RedactedThinkingInputBlock",
+      "file": "lib/src/models/content/input_content_block.dart",
+      "schema": "BetaRequestRedactedThinkingBlock",
+      "parent": "InputContentBlock",
+      "tags": [
+        "acknowledged"
+      ],
+      "note": "Beta variant maps to same Dart class as GA RequestRedactedThinkingBlock."
     },
     "ToolUseBlockParam": {
       "spec": "main",

--- a/packages/anthropic_sdk_dart/README.md
+++ b/packages/anthropic_sdk_dart/README.md
@@ -34,7 +34,7 @@ Dart client for the **[Anthropic API](https://docs.anthropic.com/en/api)** to bu
 - Messages with typed inputs, system prompts, and multi-turn history
 - Mid-conversation system messages: update instructions inside the messages array, no user turn required (Opus 4.8)
 - SSE streaming with cancelation and token counting
-- Extended thinking and adaptive thinking controls, with `outputTokensDetails` reasoning-token breakdown
+- Extended thinking and adaptive thinking controls, with `outputTokensDetails` reasoning-token breakdown, typed `thinking`/`redacted_thinking` input blocks, and `Message.toInputMessage()` for multi-turn replay
 - Prompt-cache diagnostics: report why the cache prefix diverged between turns (beta)
 - Server-side fallback: automatically re-run refused requests on another model via the `fallbacks` chain, or retry manually with the refusal `fallback_credit_token` — including best-effort redemption mode and per-response `fallback_credit` usage outcomes (beta)
 
@@ -293,6 +293,24 @@ Future<void> main() async {
     client.close();
   }
 }
+```
+
+For a multi-turn conversation (e.g. tool use) that keeps thinking enabled, replay the assistant turn with `response.toInputMessage()` instead of hand-picking blocks — thinking blocks must be passed back unmodified and in their original order, or the API returns a 400 error.
+
+```dart
+final messages = [
+  userMessage,
+  response.toInputMessage(), // preserves thinking blocks + order
+  InputMessage(
+    role: MessageRole.user,
+    content: MessageContent.blocks([
+      InputContentBlock.toolResult(
+        toolUseId: toolUse.id,
+        content: [ToolResultContent.text(toolResult)],
+      ),
+    ]),
+  ),
+];
 ```
 
 → [Full example](example/thinking_example.dart)
@@ -671,7 +689,7 @@ See the [example/](example/) directory for complete examples:
 | [`web_search_example.dart`](example/web_search_example.dart) | Web search tool |
 | [`advisor_example.dart`](example/advisor_example.dart) | Advisor tool (beta) |
 | [`computer_use_example.dart`](example/computer_use_example.dart) | Computer use tool |
-| [`thinking_example.dart`](example/thinking_example.dart) | Extended thinking |
+| [`thinking_example.dart`](example/thinking_example.dart) | Extended thinking and multi-turn thinking replay |
 | [`diagnostics_example.dart`](example/diagnostics_example.dart) | Prompt-cache diagnostics: why the cache prefix diverged (beta) |
 | [`fallback_example.dart`](example/fallback_example.dart) | Server-side fallback chain and refusal credit-token retry (beta) |
 | [`vision_example.dart`](example/vision_example.dart) | Image and document inputs |

--- a/packages/anthropic_sdk_dart/README.md
+++ b/packages/anthropic_sdk_dart/README.md
@@ -301,15 +301,14 @@ For a multi-turn conversation (e.g. tool use) that keeps thinking enabled, repla
 final messages = [
   userMessage,
   response.toInputMessage(), // preserves thinking blocks + order
-  InputMessage(
-    role: MessageRole.user,
-    content: MessageContent.blocks([
+  // One tool_result per replayed tool_use block, or the API rejects the turn.
+  InputMessage.userBlocks([
+    for (final toolUse in response.toolUseBlocks)
       InputContentBlock.toolResult(
         toolUseId: toolUse.id,
         content: [ToolResultContent.text(toolResult)],
       ),
-    ]),
-  ),
+  ]),
 ];
 ```
 

--- a/packages/anthropic_sdk_dart/example/advisor_example.dart
+++ b/packages/anthropic_sdk_dart/example/advisor_example.dart
@@ -103,12 +103,7 @@ final response1 = await client.messages.create(request, betas: [...]);
 // Build next turn — include full assistant content (with advisor blocks)
 final messages = [
   InputMessage.user('Build a Go worker pool.'),
-  InputMessage(
-    role: MessageRole.assistant,
-    content: response1.content
-        .map((b) => InputContentBlock.fromJson(b.toJson()))
-        .toList(),
-  ),
+  response1.toInputMessage(),
   InputMessage.user('Now add a max-in-flight limit of 10.'),
 ];
 

--- a/packages/anthropic_sdk_dart/example/thinking_example.dart
+++ b/packages/anthropic_sdk_dart/example/thinking_example.dart
@@ -1,4 +1,6 @@
 // ignore_for_file: avoid_print
+import 'dart:convert';
+
 import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
 
 /// Extended thinking example.
@@ -8,6 +10,7 @@ import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
 /// - Accessing thinking blocks from responses
 /// - Streaming with thinking blocks
 /// - Budget tokens configuration
+/// - Multi-turn conversation with thinking replay (tool use)
 ///
 /// Note: Extended thinking requires compatible models like claude-sonnet-4.
 void main() async {
@@ -133,6 +136,94 @@ void main() async {
     if (textBlocks.isNotEmpty) {
       print('\nFinal answer:');
       print(textBlocks.map((b) => b.text).join('\n'));
+    }
+
+    // Example 4: Multi-turn conversation with thinking replay
+    print('\n=== Multi-Turn Conversation with Thinking Replay ===');
+
+    // Define a simple client tool
+    const exchangeRateTool = Tool(
+      name: 'get_exchange_rate',
+      description: 'Get the current exchange rate between two currencies.',
+      inputSchema: InputSchema(
+        properties: {
+          'from': {
+            'type': 'string',
+            'description': 'Source currency code, e.g. "USD"',
+          },
+          'to': {
+            'type': 'string',
+            'description': 'Target currency code, e.g. "EUR"',
+          },
+        },
+        required: ['from', 'to'],
+        extra: {'additionalProperties': false},
+      ),
+    );
+
+    final userMessage = InputMessage.user(
+      'Convert 250 USD to EUR and tell me if that is enough to buy a '
+      '€200 item.',
+    );
+
+    final toolResponse = await client.messages.create(
+      MessageCreateRequest(
+        model: 'claude-sonnet-4-6',
+        maxTokens: 16000,
+        thinking: const ThinkingEnabled(budgetTokens: 10000),
+        tools: [ToolDefinition.custom(exchangeRateTool)],
+        messages: [userMessage],
+      ),
+    );
+
+    for (final block in toolResponse.content) {
+      switch (block) {
+        case ThinkingBlock(:final thinking):
+          print('Thinking process:');
+          print(thinking);
+          print('');
+        case ToolUseBlock(:final name, :final input):
+          print('Claude wants to use tool: $name');
+          print('With input: ${jsonEncode(input)}');
+        default:
+          break;
+      }
+    }
+
+    if (toolResponse.hasToolUse) {
+      final toolUse = toolResponse.toolUseBlocks.first;
+
+      // Simulate tool execution
+      final toolResult = jsonEncode({'rate': 0.92});
+
+      final finalResponse = await client.messages.create(
+        MessageCreateRequest(
+          model: 'claude-sonnet-4-6',
+          maxTokens: 16000,
+          thinking: const ThinkingEnabled(budgetTokens: 10000),
+          tools: [ToolDefinition.custom(exchangeRateTool)],
+          messages: [
+            userMessage,
+            // Preserves block order, which is load-bearing here: the API
+            // requires thinking blocks to be replayed unmodified and in
+            // their original position when continuing a turn that used
+            // extended thinking together with tool use.
+            toolResponse.toInputMessage(),
+            InputMessage(
+              role: MessageRole.user,
+              content: MessageContent.blocks([
+                InputContentBlock.toolResult(
+                  toolUseId: toolUse.id,
+                  content: [ToolResultContent.text(toolResult)],
+                ),
+              ]),
+            ),
+          ],
+        ),
+      );
+
+      print('\nFinal answer:');
+      print(finalResponse.text);
     }
   } finally {
     client.close();

--- a/packages/anthropic_sdk_dart/example/thinking_example.dart
+++ b/packages/anthropic_sdk_dart/example/thinking_example.dart
@@ -190,11 +190,21 @@ void main() async {
       }
     }
 
-    if (toolResponse.hasToolUse) {
-      final toolUse = toolResponse.toolUseBlocks.first;
-
-      // Simulate tool execution
-      final toolResult = jsonEncode({'rate': 0.92});
+    final toolUses = toolResponse.toolUseBlocks;
+    if (toolUses.isNotEmpty) {
+      // Every replayed tool_use block needs its own tool_result in the next
+      // message — Claude can request several tools in a single turn, and the
+      // API rejects the request if any of them goes unanswered.
+      final toolResults = [
+        for (final toolUse in toolUses)
+          InputContentBlock.toolResult(
+            toolUseId: toolUse.id,
+            // Simulate tool execution
+            content: [
+              ToolResultContent.text(jsonEncode({'rate': 0.92})),
+            ],
+          ),
+      ];
 
       final finalResponse = await client.messages.create(
         MessageCreateRequest(
@@ -209,15 +219,7 @@ void main() async {
             // their original position when continuing a turn that used
             // extended thinking together with tool use.
             toolResponse.toInputMessage(),
-            InputMessage(
-              role: MessageRole.user,
-              content: MessageContent.blocks([
-                InputContentBlock.toolResult(
-                  toolUseId: toolUse.id,
-                  content: [ToolResultContent.text(toolResult)],
-                ),
-              ]),
-            ),
+            InputMessage.userBlocks(toolResults),
           ],
         ),
       );

--- a/packages/anthropic_sdk_dart/example/tool_calling_example.dart
+++ b/packages/anthropic_sdk_dart/example/tool_calling_example.dart
@@ -64,18 +64,7 @@ void main() async {
             tools: [ToolDefinition.custom(weatherTool)],
             messages: [
               InputMessage.user('What is the weather in San Francisco?'),
-              InputMessage.assistantBlocks(
-                response.content
-                    .map(
-                      (b) => switch (b) {
-                        TextBlock(:final text) => TextInputBlock(text),
-                        ToolUseBlock(:final id, :final name, :final input) =>
-                          ToolUseInputBlock(id: id, name: name, input: input),
-                        _ => throw StateError('Unexpected block type'),
-                      },
-                    )
-                    .toList(),
-              ),
+              response.toInputMessage(),
               InputMessage(
                 role: MessageRole.user,
                 content: MessageContent.blocks([

--- a/packages/anthropic_sdk_dart/lib/anthropic_sdk_dart.dart
+++ b/packages/anthropic_sdk_dart/lib/anthropic_sdk_dart.dart
@@ -55,6 +55,7 @@ export 'src/errors/exceptions.dart'
         ValidationException;
 
 // Extensions
+export 'src/extensions/content_block_extensions.dart';
 export 'src/extensions/message_extensions.dart';
 export 'src/extensions/stream_extensions.dart';
 

--- a/packages/anthropic_sdk_dart/lib/src/extensions/content_block_extensions.dart
+++ b/packages/anthropic_sdk_dart/lib/src/extensions/content_block_extensions.dart
@@ -7,10 +7,18 @@ extension ContentBlockConversion on ContentBlock {
   /// assistant turn in a follow-up request (e.g. multi-turn tool use or
   /// extended thinking).
   ///
-  /// Round-trips through JSON, so every block type is handled: types without a
-  /// typed input counterpart become [UnknownInputContentBlock], preserving the
-  /// raw payload verbatim. Thinking blocks must be replayed unmodified and in
-  /// their original order; a modified block results in a 400
-  /// `invalid_request_error`.
+  /// Round-trips through JSON: an *unrecognized* block type becomes an
+  /// [UnknownInputContentBlock] that preserves the raw payload verbatim, so
+  /// new server-side block types replay without an SDK update.
+  ///
+  /// A *malformed* block is not silently degraded. Throws [FormatException]
+  /// when a response block omits a field the request schema requires — the
+  /// response models are deliberately lenient about fields that
+  /// Anthropic-compatible third-party servers may drop, and failing here
+  /// names the offending field instead of sending a request the API rejects
+  /// with an opaque 400.
+  ///
+  /// Thinking blocks must be replayed unmodified and in their original order;
+  /// a modified block results in a 400 `invalid_request_error`.
   InputContentBlock toInputBlock() => InputContentBlock.fromJson(toJson());
 }

--- a/packages/anthropic_sdk_dart/lib/src/extensions/content_block_extensions.dart
+++ b/packages/anthropic_sdk_dart/lib/src/extensions/content_block_extensions.dart
@@ -1,0 +1,16 @@
+import '../models/content/content_block.dart';
+import '../models/content/input_content_block.dart';
+
+/// Conversion from response [ContentBlock]s to request [InputContentBlock]s.
+extension ContentBlockConversion on ContentBlock {
+  /// Converts this response block into its input counterpart for replaying an
+  /// assistant turn in a follow-up request (e.g. multi-turn tool use or
+  /// extended thinking).
+  ///
+  /// Round-trips through JSON, so every block type is handled: types without a
+  /// typed input counterpart become [UnknownInputContentBlock], preserving the
+  /// raw payload verbatim. Thinking blocks must be replayed unmodified and in
+  /// their original order; a modified block results in a 400
+  /// `invalid_request_error`.
+  InputContentBlock toInputBlock() => InputContentBlock.fromJson(toJson());
+}

--- a/packages/anthropic_sdk_dart/lib/src/extensions/message_extensions.dart
+++ b/packages/anthropic_sdk_dart/lib/src/extensions/message_extensions.dart
@@ -1,6 +1,8 @@
 import '../models/content/content_block.dart';
+import '../models/messages/input_message.dart';
 import '../models/messages/message.dart';
 import '../models/metadata/stop_reason.dart';
+import 'content_block_extensions.dart';
 
 /// Extensions on [Message] for convenient access to content.
 extension MessageExtensions on Message {
@@ -60,4 +62,13 @@ extension MessageExtensions on Message {
 
   /// Returns true if the message stopped due to a refusal.
   bool get isRefusal => stopReason == StopReason.refusal;
+
+  /// Converts this response into an assistant [InputMessage] for replay in a
+  /// follow-up request (e.g. multi-turn tool use or extended thinking).
+  ///
+  /// Preserves block order, which is load-bearing: thinking blocks must be
+  /// passed back unmodified and in their original position.
+  InputMessage toInputMessage() => InputMessage.assistantBlocks(
+    content.map((block) => block.toInputBlock()).toList(),
+  );
 }

--- a/packages/anthropic_sdk_dart/lib/src/extensions/message_extensions.dart
+++ b/packages/anthropic_sdk_dart/lib/src/extensions/message_extensions.dart
@@ -63,12 +63,17 @@ extension MessageExtensions on Message {
   /// Returns true if the message stopped due to a refusal.
   bool get isRefusal => stopReason == StopReason.refusal;
 
-  /// Converts this response into an assistant [InputMessage] for replay in a
-  /// follow-up request (e.g. multi-turn tool use or extended thinking).
+  /// Converts this response into an [InputMessage] for replay in a follow-up
+  /// request (e.g. multi-turn tool use or extended thinking).
   ///
-  /// Preserves block order, which is load-bearing: thinking blocks must be
-  /// passed back unmodified and in their original position.
-  InputMessage toInputMessage() => InputMessage.assistantBlocks(
-    content.map((block) => block.toInputBlock()).toList(),
+  /// Carries over this message's [role] — [MessageRole.assistant] for every
+  /// API response — and preserves block order, which is load-bearing:
+  /// thinking blocks must be passed back unmodified and in their original
+  /// position.
+  InputMessage toInputMessage() => InputMessage(
+    role: role,
+    content: MessageContent.blocks(
+      content.map((block) => block.toInputBlock()).toList(),
+    ),
   );
 }

--- a/packages/anthropic_sdk_dart/lib/src/models/content/input_content_block.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/input_content_block.dart
@@ -23,6 +23,25 @@ sealed class InputContentBlock {
     CacheControlEphemeral? cacheControl,
   }) = TextInputBlock;
 
+  /// Creates a thinking content block.
+  ///
+  /// Used to replay an assistant turn's extended thinking in a follow-up
+  /// request (e.g. multi-turn tool use). Thinking blocks must be passed back
+  /// unmodified and in their original order; a modified block results in a
+  /// 400 `invalid_request_error`.
+  factory InputContentBlock.thinking({
+    required String thinking,
+    required String signature,
+  }) = ThinkingInputBlock;
+
+  /// Creates a redacted thinking content block.
+  ///
+  /// Used to replay an assistant turn's redacted thinking in a follow-up
+  /// request. The [data] payload is opaque and encrypted; pass it back
+  /// unchanged.
+  factory InputContentBlock.redactedThinking({required String data}) =
+      RedactedThinkingInputBlock;
+
   /// Creates an image content block.
   factory InputContentBlock.image(
     ImageSource source, {
@@ -188,6 +207,8 @@ sealed class InputContentBlock {
     final type = json['type'] as String;
     return switch (type) {
       'text' => TextInputBlock.fromJson(json),
+      'thinking' => ThinkingInputBlock.fromJson(json),
+      'redacted_thinking' => RedactedThinkingInputBlock.fromJson(json),
       'image' => ImageInputBlock.fromJson(json),
       'document' => DocumentInputBlock.fromJson(json),
       'search_result' => SearchResultInputBlock.fromJson(json),
@@ -299,6 +320,108 @@ class TextInputBlock extends InputContentBlock {
   String toString() =>
       'TextInputBlock(text: [${text.length} chars], citations: $citations, '
       'cacheControl: $cacheControl)';
+}
+
+/// Thinking (reasoning) content block for input.
+///
+/// Replays an assistant turn's extended thinking in a follow-up request
+/// (e.g. multi-turn tool use). Thinking blocks must be passed back unmodified
+/// and in their original order; a modified block results in a 400
+/// `invalid_request_error`. Unlike most input blocks, thinking blocks do not
+/// support `cache_control`.
+@immutable
+class ThinkingInputBlock extends InputContentBlock {
+  /// The `thinking` text of this block, exactly as returned by the API.
+  final String thinking;
+
+  /// The `signature` value of this thinking block, exactly as returned by the
+  /// API in a previous response. Used to verify that the block was generated
+  /// by Claude.
+  final String signature;
+
+  /// Creates a [ThinkingInputBlock].
+  const ThinkingInputBlock({required this.thinking, required this.signature});
+
+  /// Creates a [ThinkingInputBlock] from JSON.
+  factory ThinkingInputBlock.fromJson(Map<String, dynamic> json) {
+    return ThinkingInputBlock(
+      thinking: json['thinking'] as String? ?? '',
+      signature: json['signature'] as String? ?? '',
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {
+    'type': 'thinking',
+    'thinking': thinking,
+    'signature': signature,
+  };
+
+  /// Creates a copy with replaced values.
+  ThinkingInputBlock copyWith({String? thinking, String? signature}) {
+    return ThinkingInputBlock(
+      thinking: thinking ?? this.thinking,
+      signature: signature ?? this.signature,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ThinkingInputBlock &&
+          runtimeType == other.runtimeType &&
+          thinking == other.thinking &&
+          signature == other.signature;
+
+  @override
+  int get hashCode => Object.hash(thinking, signature);
+
+  @override
+  String toString() =>
+      'ThinkingInputBlock(thinking: [${thinking.length} chars], '
+      'signature: [${signature.length} chars])';
+}
+
+/// Redacted thinking content block for input.
+///
+/// Replays an assistant turn's redacted thinking in a follow-up request. The
+/// [data] payload is opaque and encrypted; pass it back unchanged. Unlike most
+/// input blocks, redacted thinking blocks do not support `cache_control`.
+@immutable
+class RedactedThinkingInputBlock extends InputContentBlock {
+  /// The `data` value of this redacted thinking block, exactly as returned by
+  /// the API in a previous response. Opaque and encrypted.
+  final String data;
+
+  /// Creates a [RedactedThinkingInputBlock].
+  const RedactedThinkingInputBlock({required this.data});
+
+  /// Creates a [RedactedThinkingInputBlock] from JSON.
+  factory RedactedThinkingInputBlock.fromJson(Map<String, dynamic> json) {
+    return RedactedThinkingInputBlock(data: json['data'] as String? ?? '');
+  }
+
+  @override
+  Map<String, dynamic> toJson() => {'type': 'redacted_thinking', 'data': data};
+
+  /// Creates a copy with replaced values.
+  RedactedThinkingInputBlock copyWith({String? data}) {
+    return RedactedThinkingInputBlock(data: data ?? this.data);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RedactedThinkingInputBlock &&
+          runtimeType == other.runtimeType &&
+          data == other.data;
+
+  @override
+  int get hashCode => data.hashCode;
+
+  @override
+  String toString() =>
+      'RedactedThinkingInputBlock(data: [${data.length} chars])';
 }
 
 /// Image content block for input.

--- a/packages/anthropic_sdk_dart/lib/src/models/content/input_content_block.dart
+++ b/packages/anthropic_sdk_dart/lib/src/models/content/input_content_block.dart
@@ -343,11 +343,28 @@ class ThinkingInputBlock extends InputContentBlock {
   const ThinkingInputBlock({required this.thinking, required this.signature});
 
   /// Creates a [ThinkingInputBlock] from JSON.
+  ///
+  /// Both fields are `required` on the request schema, so a missing key throws
+  /// [FormatException]. Unlike the response-side [ThinkingBlock] — which
+  /// tolerates absent fields because a streaming `content_block_start` carries
+  /// a partial block whose `signature` arrives later in a `signature_delta` —
+  /// there is no partial form on the request side, and silently substituting
+  /// an empty `signature` would send a block the API rejects with an opaque
+  /// 400. An empty-but-present value still parses.
   factory ThinkingInputBlock.fromJson(Map<String, dynamic> json) {
-    return ThinkingInputBlock(
-      thinking: json['thinking'] as String? ?? '',
-      signature: json['signature'] as String? ?? '',
-    );
+    final thinking = json['thinking'] as String?;
+    if (thinking == null) {
+      throw const FormatException(
+        'ThinkingInputBlock: missing required "thinking"',
+      );
+    }
+    final signature = json['signature'] as String?;
+    if (signature == null) {
+      throw const FormatException(
+        'ThinkingInputBlock: missing required "signature"',
+      );
+    }
+    return ThinkingInputBlock(thinking: thinking, signature: signature);
   }
 
   @override
@@ -397,8 +414,18 @@ class RedactedThinkingInputBlock extends InputContentBlock {
   const RedactedThinkingInputBlock({required this.data});
 
   /// Creates a [RedactedThinkingInputBlock] from JSON.
+  ///
+  /// [data] is `required` on the request schema, so a missing key throws
+  /// [FormatException] rather than silently substituting an empty payload the
+  /// API would reject. An empty-but-present value still parses.
   factory RedactedThinkingInputBlock.fromJson(Map<String, dynamic> json) {
-    return RedactedThinkingInputBlock(data: json['data'] as String? ?? '');
+    final data = json['data'] as String?;
+    if (data == null) {
+      throw const FormatException(
+        'RedactedThinkingInputBlock: missing required "data"',
+      );
+    }
+    return RedactedThinkingInputBlock(data: data);
   }
 
   @override
@@ -2341,11 +2368,16 @@ class MidConversationSystemInputBlock extends InputContentBlock {
 @immutable
 class UnknownInputContentBlock extends InputContentBlock {
   /// The raw JSON for this unknown input content block.
+  ///
+  /// Stored deeply unmodifiable (nested maps and lists are frozen too), so a
+  /// block converted from a response via `ContentBlock.toInputBlock()` cannot
+  /// be mutated through the map it was decoded from — which would otherwise
+  /// change this block's [hashCode] and serialized output after construction.
   final Map<String, dynamic> raw;
 
   /// Creates an [UnknownInputContentBlock].
   UnknownInputContentBlock({required Map<String, dynamic> raw})
-    : raw = Map.unmodifiable(raw);
+    : raw = deepUnmodifiableMap(raw);
 
   /// Creates an [UnknownInputContentBlock] from JSON.
   factory UnknownInputContentBlock.fromJson(Map<String, dynamic> json) {
@@ -2717,6 +2749,13 @@ class WebSearchResultLocationInputCitation extends InputCitation {
   final String? title;
 
   /// URL of the source.
+  ///
+  /// Required and non-nullable per the request schema. The response-side
+  /// `WebSearchResultLocationCitation.url` is deliberately more lenient
+  /// (nullable, for Anthropic-compatible third-party servers that omit it),
+  /// so echoing such a citation back via `ContentBlock.toInputBlock()` throws
+  /// a [FormatException] rather than silently building a request the API
+  /// would reject.
   final String url;
 
   /// Creates a [WebSearchResultLocationInputCitation].
@@ -2731,11 +2770,17 @@ class WebSearchResultLocationInputCitation extends InputCitation {
   factory WebSearchResultLocationInputCitation.fromJson(
     Map<String, dynamic> json,
   ) {
+    final url = json['url'] as String?;
+    if (url == null) {
+      throw const FormatException(
+        'WebSearchResultLocationInputCitation: missing required "url"',
+      );
+    }
     return WebSearchResultLocationInputCitation(
       citedText: json['cited_text'] as String,
       encryptedIndex: json['encrypted_index'] as String,
       title: json['title'] as String?,
-      url: json['url'] as String,
+      url: url,
     );
   }
 

--- a/packages/anthropic_sdk_dart/llms.txt
+++ b/packages/anthropic_sdk_dart/llms.txt
@@ -4,16 +4,16 @@
 
 ## Docs
 
-- [README](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/README.md) (~5.4k tokens): Primary package documentation with installation, configuration, and usage examples.
-- [CHANGELOG](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/CHANGELOG.md) (~11k tokens): Release history and version-by-version changes.
-- [MIGRATION](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/MIGRATION.md) (~7.2k tokens): Upgrade notes and breaking-change guidance.
+- [README](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/README.md) (~5.6k tokens): Primary package documentation with installation, configuration, and usage examples.
+- [CHANGELOG](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/CHANGELOG.md) (~11.5k tokens): Release history and version-by-version changes.
+- [MIGRATION](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/MIGRATION.md) (~7.6k tokens): Upgrade notes and breaking-change guidance.
 
 ## Examples
 
 - [messages_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/messages_example.dart) (~821 tokens): Basic message creation.
 - [streaming_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/streaming_example.dart) (~1.3k tokens): Streaming responses.
-- [tool_calling_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/tool_calling_example.dart) (~777 tokens): Tool calling with schemas.
-- [thinking_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/thinking_example.dart) (~937 tokens): Extended thinking.
+- [tool_calling_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/tool_calling_example.dart) (~689 tokens): Tool calling with schemas.
+- [thinking_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/thinking_example.dart) (~1.6k tokens): Extended thinking and multi-turn thinking replay.
 - [vision_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/vision_example.dart) (~1.2k tokens): Image and document inputs.
 - [token_counting_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/token_counting_example.dart) (~1.1k tokens): Token counting.
 - [message_batches_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/message_batches_example.dart) (~859 tokens): Batch processing.
@@ -25,10 +25,10 @@
 - [error_handling_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/error_handling_example.dart) (~632 tokens): Exception handling patterns.
 - [mid_conversation_system_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/mid_conversation_system_example.dart) (~458 tokens): Mid-conversation system messages (Opus 4.8).
 - [web_search_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/web_search_example.dart) (~793 tokens): Web search tool.
-- [advisor_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/advisor_example.dart) (~967 tokens): Advisor tool (beta).
+- [advisor_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/advisor_example.dart) (~932 tokens): Advisor tool (beta).
 - [computer_use_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/computer_use_example.dart) (~866 tokens): Computer use tool.
 - [diagnostics_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/diagnostics_example.dart) (~660 tokens): Prompt-cache diagnostics: why the cache prefix diverged (beta).
-- [fallback_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/fallback_example.dart) (~784 tokens): Server-side fallback chain and refusal credit-token retry (beta).
+- [fallback_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/fallback_example.dart) (~896 tokens): Server-side fallback chain and refusal credit-token retry (beta).
 - [document_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/document_example.dart) (~937 tokens): Document inputs with citations.
 - [search_result_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/search_result_example.dart) (~710 tokens): Supplying your own cited `search_result` blocks (RAG).
 - [mcp_example.dart](https://github.com/davidmigloz/ai_clients_dart/blob/main/packages/anthropic_sdk_dart/example/mcp_example.dart) (~904 tokens): MCP tool integration.
@@ -42,4 +42,4 @@
 
 - [Package directory](https://github.com/davidmigloz/ai_clients_dart/tree/main/packages/anthropic_sdk_dart): Source tree, pubspec, and package-local files.
 
-**Total: ~46.7k tokens**
+**Total: ~48.3k tokens**

--- a/packages/anthropic_sdk_dart/test/integration/tools_integration_test.dart
+++ b/packages/anthropic_sdk_dart/test/integration/tools_integration_test.dart
@@ -115,11 +115,6 @@ void main() {
         final toolUse = response1.toolUseBlocks.first;
         expect(toolUse.name, 'get_weather');
 
-        // Convert ContentBlocks to InputContentBlocks via JSON roundtrip
-        final assistantBlocks = response1.content
-            .map((block) => InputContentBlock.fromJson(block.toJson()))
-            .toList();
-
         // Second turn - provide tool result
         final response2 = await client!.messages.create(
           MessageCreateRequest(
@@ -128,7 +123,7 @@ void main() {
             tools: [ToolDefinition.custom(weatherTool)],
             messages: [
               InputMessage.user('What is the weather in Paris?'),
-              InputMessage.assistantBlocks(assistantBlocks),
+              response1.toInputMessage(),
               InputMessage.userBlocks([
                 InputContentBlock.toolResult(
                   toolUseId: toolUse.id,

--- a/packages/anthropic_sdk_dart/test/unit/extensions/message_extensions_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/extensions/message_extensions_test.dart
@@ -1,6 +1,19 @@
 import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
 import 'package:test/test.dart';
 
+Message buildMessage() => const Message(
+  id: 'msg_1',
+  role: MessageRole.assistant,
+  content: [
+    ThinkingBlock(thinking: 'Let me think...', signature: 'sig123'),
+    TextBlock(text: 'Here is my answer.'),
+    ToolUseBlock(id: 'tu_1', name: 'get_weather', input: {'city': 'NYC'}),
+  ],
+  model: 'claude-sonnet-4-6',
+  stopReason: StopReason.toolUse,
+  usage: Usage(inputTokens: 10, outputTokens: 20),
+);
+
 void main() {
   group('ContentBlockConversion', () {
     test('TextBlock converts to TextInputBlock preserving text', () {
@@ -120,22 +133,41 @@ void main() {
       expect(input, isA<UnknownInputContentBlock>());
       expect(input.toJson(), json);
     });
+
+    test('TextBlock with a url-less web search citation throws a diagnostic '
+        'FormatException', () {
+      // The response citation is lenient about `url` (third-party
+      // Anthropic-compatible servers may omit it) while the request schema
+      // marks it required, so conversion must fail loudly and name the field
+      // rather than raise an opaque TypeError or build a request the API
+      // rejects with a 400.
+      const block = TextBlock(
+        text: 'Dart 3.10 shipped.',
+        citations: [
+          WebSearchResultLocationCitation(
+            citedText: 'Dart 3.10 shipped.',
+            encryptedIndex: 'enc_idx',
+          ),
+        ],
+      );
+
+      expect(
+        block.toInputBlock,
+        throwsA(
+          isA<FormatException>().having(
+            (e) => e.message,
+            'message',
+            allOf(
+              contains('WebSearchResultLocationInputCitation'),
+              contains('url'),
+            ),
+          ),
+        ),
+      );
+    });
   });
 
   group('MessageExtensions.toInputMessage', () {
-    Message buildMessage() => const Message(
-      id: 'msg_1',
-      role: MessageRole.assistant,
-      content: [
-        ThinkingBlock(thinking: 'Let me think...', signature: 'sig123'),
-        TextBlock(text: 'Here is my answer.'),
-        ToolUseBlock(id: 'tu_1', name: 'get_weather', input: {'city': 'NYC'}),
-      ],
-      model: 'claude-sonnet-4-6',
-      stopReason: StopReason.toolUse,
-      usage: Usage(inputTokens: 10, outputTokens: 20),
-    );
-
     test('returns an assistant InputMessage', () {
       final inputMessage = buildMessage().toInputMessage();
 
@@ -163,36 +195,17 @@ void main() {
       expect(firstBlock['thinking'], 'Let me think...');
       expect(firstBlock['signature'], 'sig123');
     });
-  });
 
-  group('MessageExtensions getters', () {
-    Message buildMessage() => const Message(
-      id: 'msg_1',
-      role: MessageRole.assistant,
-      content: [
-        ThinkingBlock(thinking: 'Let me think...', signature: 'sig123'),
-        TextBlock(text: 'Here is my answer.'),
-        ToolUseBlock(id: 'tu_1', name: 'get_weather', input: {'city': 'NYC'}),
-      ],
-      model: 'claude-sonnet-4-6',
-      stopReason: StopReason.toolUse,
-      usage: Usage(inputTokens: 10, outputTokens: 20),
-    );
+    test('preserves a non-assistant role', () {
+      const message = Message(
+        id: 'msg_1',
+        role: MessageRole.user,
+        content: [TextBlock(text: 'Echoed back.')],
+        model: 'claude-sonnet-4-6',
+        usage: Usage(inputTokens: 1, outputTokens: 1),
+      );
 
-    test('text concatenates text blocks', () {
-      expect(buildMessage().text, 'Here is my answer.');
-    });
-
-    test('thinkingBlocks and hasThinking', () {
-      final message = buildMessage();
-      expect(message.thinkingBlocks, hasLength(1));
-      expect(message.hasThinking, isTrue);
-    });
-
-    test('toolUseBlocks and hasToolUse', () {
-      final message = buildMessage();
-      expect(message.toolUseBlocks, hasLength(1));
-      expect(message.hasToolUse, isTrue);
+      expect(message.toInputMessage().role, MessageRole.user);
     });
   });
 }

--- a/packages/anthropic_sdk_dart/test/unit/extensions/message_extensions_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/extensions/message_extensions_test.dart
@@ -1,0 +1,198 @@
+import 'package:anthropic_sdk_dart/anthropic_sdk_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ContentBlockConversion', () {
+    test('TextBlock converts to TextInputBlock preserving text', () {
+      const block = TextBlock(text: 'Hello, Claude!');
+
+      final input = block.toInputBlock();
+
+      expect(input, isA<TextInputBlock>());
+      expect((input as TextInputBlock).text, 'Hello, Claude!');
+    });
+
+    test('TextBlock with citations converts preserving citations', () {
+      const block = TextBlock(
+        text: 'Earth orbits the Sun.',
+        citations: [
+          CharLocationCitation(
+            citedText: 'Earth orbits the Sun.',
+            documentIndex: 0,
+            documentTitle: 'Astronomy',
+            startCharIndex: 0,
+            endCharIndex: 22,
+          ),
+        ],
+      );
+
+      final input = block.toInputBlock();
+
+      expect(input, isA<TextInputBlock>());
+      final textInput = input as TextInputBlock;
+      expect(textInput.text, 'Earth orbits the Sun.');
+      expect(textInput.citations, isNotNull);
+      expect(textInput.citations, hasLength(1));
+    });
+
+    test('ThinkingBlock converts to ThinkingInputBlock verbatim', () {
+      const block = ThinkingBlock(
+        thinking: 'reasoning...',
+        signature: 'sig123',
+      );
+
+      final input = block.toInputBlock();
+
+      expect(input, isA<ThinkingInputBlock>());
+      final thinkingInput = input as ThinkingInputBlock;
+      expect(thinkingInput.thinking, 'reasoning...');
+      expect(thinkingInput.signature, 'sig123');
+    });
+
+    test(
+      'RedactedThinkingBlock converts to RedactedThinkingInputBlock verbatim',
+      () {
+        const block = RedactedThinkingBlock(data: 'opaque');
+
+        final input = block.toInputBlock();
+
+        expect(input, isA<RedactedThinkingInputBlock>());
+        expect((input as RedactedThinkingInputBlock).data, 'opaque');
+      },
+    );
+
+    test('ToolUseBlock converts to ToolUseInputBlock preserving fields', () {
+      const block = ToolUseBlock(
+        id: 'tu_1',
+        name: 'get_weather',
+        input: {'city': 'San Francisco'},
+      );
+
+      final input = block.toInputBlock();
+
+      expect(input, isA<ToolUseInputBlock>());
+      final toolUseInput = input as ToolUseInputBlock;
+      expect(toolUseInput.id, 'tu_1');
+      expect(toolUseInput.name, 'get_weather');
+      expect(toolUseInput.input, {'city': 'San Francisco'});
+    });
+
+    test('ServerToolUseBlock converts to ServerToolUseInputBlock preserving '
+        'fields', () {
+      const block = ServerToolUseBlock(
+        id: 'stu_1',
+        name: 'web_search',
+        input: {'query': 'dart sdk'},
+      );
+
+      final input = block.toInputBlock();
+
+      expect(input, isA<ServerToolUseInputBlock>());
+      final serverToolUseInput = input as ServerToolUseInputBlock;
+      expect(serverToolUseInput.id, 'stu_1');
+      expect(serverToolUseInput.name, 'web_search');
+      expect(serverToolUseInput.input, {'query': 'dart sdk'});
+    });
+
+    test('CompactionBlock converts to CompactionInputBlock preserving '
+        'encryptedContent', () {
+      const block = CompactionBlock(
+        content: 'Conversation summary',
+        encryptedContent: 'enc_payload_xyz',
+      );
+
+      final input = block.toInputBlock();
+
+      expect(input, isA<CompactionInputBlock>());
+      final compactionInput = input as CompactionInputBlock;
+      expect(compactionInput.content, 'Conversation summary');
+      expect(compactionInput.encryptedContent, 'enc_payload_xyz');
+    });
+
+    test('unknown response block converts to UnknownInputContentBlock '
+        'preserving raw payload', () {
+      final json = {'type': 'made_up_block', 'foo': 'bar'};
+      final block = ContentBlock.fromJson(json);
+      expect(block, isA<UnknownContentBlock>());
+
+      final input = block.toInputBlock();
+
+      expect(input, isA<UnknownInputContentBlock>());
+      expect(input.toJson(), json);
+    });
+  });
+
+  group('MessageExtensions.toInputMessage', () {
+    Message buildMessage() => const Message(
+      id: 'msg_1',
+      role: MessageRole.assistant,
+      content: [
+        ThinkingBlock(thinking: 'Let me think...', signature: 'sig123'),
+        TextBlock(text: 'Here is my answer.'),
+        ToolUseBlock(id: 'tu_1', name: 'get_weather', input: {'city': 'NYC'}),
+      ],
+      model: 'claude-sonnet-4-6',
+      stopReason: StopReason.toolUse,
+      usage: Usage(inputTokens: 10, outputTokens: 20),
+    );
+
+    test('returns an assistant InputMessage', () {
+      final inputMessage = buildMessage().toInputMessage();
+
+      expect(inputMessage.role, MessageRole.assistant);
+      expect(inputMessage.content, isA<BlocksMessageContent>());
+    });
+
+    test('preserves block order: thinking, text, tool use', () {
+      final inputMessage = buildMessage().toInputMessage();
+      final blocks = (inputMessage.content as BlocksMessageContent).blocks;
+
+      expect(blocks, hasLength(3));
+      expect(blocks[0], isA<ThinkingInputBlock>());
+      expect(blocks[1], isA<TextInputBlock>());
+      expect(blocks[2], isA<ToolUseInputBlock>());
+    });
+
+    test('serialized request JSON has thinking block first with signature', () {
+      final inputMessage = buildMessage().toInputMessage();
+      final json = inputMessage.toJson();
+      final content = json['content'] as List;
+
+      final firstBlock = content.first as Map<String, dynamic>;
+      expect(firstBlock['type'], 'thinking');
+      expect(firstBlock['thinking'], 'Let me think...');
+      expect(firstBlock['signature'], 'sig123');
+    });
+  });
+
+  group('MessageExtensions getters', () {
+    Message buildMessage() => const Message(
+      id: 'msg_1',
+      role: MessageRole.assistant,
+      content: [
+        ThinkingBlock(thinking: 'Let me think...', signature: 'sig123'),
+        TextBlock(text: 'Here is my answer.'),
+        ToolUseBlock(id: 'tu_1', name: 'get_weather', input: {'city': 'NYC'}),
+      ],
+      model: 'claude-sonnet-4-6',
+      stopReason: StopReason.toolUse,
+      usage: Usage(inputTokens: 10, outputTokens: 20),
+    );
+
+    test('text concatenates text blocks', () {
+      expect(buildMessage().text, 'Here is my answer.');
+    });
+
+    test('thinkingBlocks and hasThinking', () {
+      final message = buildMessage();
+      expect(message.thinkingBlocks, hasLength(1));
+      expect(message.hasThinking, isTrue);
+    });
+
+    test('toolUseBlocks and hasToolUse', () {
+      final message = buildMessage();
+      expect(message.toolUseBlocks, hasLength(1));
+      expect(message.hasToolUse, isTrue);
+    });
+  });
+}

--- a/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
@@ -636,9 +636,27 @@ void main() {
         expect(block, isNot(isA<UnknownInputContentBlock>()));
       });
 
-      test('fromJson tolerates missing fields', () {
+      test('fromJson throws on missing required fields', () {
+        expect(
+          () => InputContentBlock.fromJson({'type': 'thinking'}),
+          throwsFormatException,
+        );
+        expect(
+          () => InputContentBlock.fromJson({
+            'type': 'thinking',
+            'thinking': 'Reasoning...',
+          }),
+          throwsFormatException,
+        );
+      });
+
+      test('fromJson accepts empty-but-present fields', () {
         final block =
-            InputContentBlock.fromJson({'type': 'thinking'})
+            InputContentBlock.fromJson({
+                  'type': 'thinking',
+                  'thinking': '',
+                  'signature': '',
+                })
                 as ThinkingInputBlock;
 
         expect(block.thinking, '');
@@ -723,9 +741,19 @@ void main() {
         expect(block, isNot(isA<UnknownInputContentBlock>()));
       });
 
-      test('fromJson tolerates missing fields', () {
+      test('fromJson throws on missing required data', () {
+        expect(
+          () => InputContentBlock.fromJson({'type': 'redacted_thinking'}),
+          throwsFormatException,
+        );
+      });
+
+      test('fromJson accepts an empty-but-present data', () {
         final block =
-            InputContentBlock.fromJson({'type': 'redacted_thinking'})
+            InputContentBlock.fromJson({
+                  'type': 'redacted_thinking',
+                  'data': '',
+                })
                 as RedactedThinkingInputBlock;
 
         expect(block.data, '');

--- a/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
+++ b/packages/anthropic_sdk_dart/test/unit/models/content_block_test.dart
@@ -605,6 +605,163 @@ void main() {
       });
     });
 
+    group('ThinkingInputBlock', () {
+      test('round-trips thinking block', () {
+        const block = ThinkingInputBlock(
+          thinking: 'Let me think about this...',
+          signature: 'sig123',
+        );
+        final json = block.toJson();
+
+        expect(json['type'], 'thinking');
+        expect(json['thinking'], 'Let me think about this...');
+        expect(json['signature'], 'sig123');
+        expect(json.containsKey('cache_control'), isFalse);
+        expect(json, hasLength(3));
+
+        final parsed = InputContentBlock.fromJson(json);
+        expect(parsed, isA<ThinkingInputBlock>());
+        expect(parsed, equals(block));
+      });
+
+      test('fromJson parses thinking block as typed variant '
+          '(not UnknownInputContentBlock)', () {
+        final block = InputContentBlock.fromJson({
+          'type': 'thinking',
+          'thinking': 'Reasoning...',
+          'signature': 'sig456',
+        });
+
+        expect(block, isA<ThinkingInputBlock>());
+        expect(block, isNot(isA<UnknownInputContentBlock>()));
+      });
+
+      test('fromJson tolerates missing fields', () {
+        final block =
+            InputContentBlock.fromJson({'type': 'thinking'})
+                as ThinkingInputBlock;
+
+        expect(block.thinking, '');
+        expect(block.signature, '');
+      });
+
+      test('factory creates ThinkingInputBlock', () {
+        final block = InputContentBlock.thinking(
+          thinking: 'Some reasoning',
+          signature: 'sig789',
+        );
+
+        expect(block, isA<ThinkingInputBlock>());
+        final thinkingBlock = block as ThinkingInputBlock;
+        expect(thinkingBlock.thinking, 'Some reasoning');
+        expect(thinkingBlock.signature, 'sig789');
+      });
+
+      test('copyWith replaces fields independently', () {
+        const block = ThinkingInputBlock(
+          thinking: 'Original thinking',
+          signature: 'original_sig',
+        );
+
+        final withNewThinking = block.copyWith(thinking: 'New thinking');
+        expect(withNewThinking.thinking, 'New thinking');
+        expect(withNewThinking.signature, 'original_sig');
+
+        final withNewSignature = block.copyWith(signature: 'new_sig');
+        expect(withNewSignature.thinking, 'Original thinking');
+        expect(withNewSignature.signature, 'new_sig');
+      });
+
+      test('equality and hashCode', () {
+        const a = ThinkingInputBlock(thinking: 'Same', signature: 'sig');
+        const b = ThinkingInputBlock(thinking: 'Same', signature: 'sig');
+        const differentThinking = ThinkingInputBlock(
+          thinking: 'Different',
+          signature: 'sig',
+        );
+        const differentSignature = ThinkingInputBlock(
+          thinking: 'Same',
+          signature: 'other',
+        );
+
+        expect(a, equals(b));
+        expect(a.hashCode, b.hashCode);
+        expect(a, isNot(equals(differentThinking)));
+        expect(a, isNot(equals(differentSignature)));
+      });
+
+      test('toString does not leak content', () {
+        const block = ThinkingInputBlock(thinking: 'abcde', signature: 'sig');
+        expect(block.toString(), contains('[5 chars]'));
+        expect(block.toString(), isNot(contains('abcde')));
+      });
+    });
+
+    group('RedactedThinkingInputBlock', () {
+      test('round-trips redacted thinking block', () {
+        const block = RedactedThinkingInputBlock(data: 'opaque_payload');
+        final json = block.toJson();
+
+        expect(json['type'], 'redacted_thinking');
+        expect(json['data'], 'opaque_payload');
+        expect(json.containsKey('cache_control'), isFalse);
+        expect(json, hasLength(2));
+
+        final parsed = InputContentBlock.fromJson(json);
+        expect(parsed, isA<RedactedThinkingInputBlock>());
+        expect(parsed, equals(block));
+      });
+
+      test('fromJson parses redacted thinking block as typed variant '
+          '(not UnknownInputContentBlock)', () {
+        final block = InputContentBlock.fromJson({
+          'type': 'redacted_thinking',
+          'data': 'encrypted_data',
+        });
+
+        expect(block, isA<RedactedThinkingInputBlock>());
+        expect(block, isNot(isA<UnknownInputContentBlock>()));
+      });
+
+      test('fromJson tolerates missing fields', () {
+        final block =
+            InputContentBlock.fromJson({'type': 'redacted_thinking'})
+                as RedactedThinkingInputBlock;
+
+        expect(block.data, '');
+      });
+
+      test('factory creates RedactedThinkingInputBlock', () {
+        final block = InputContentBlock.redactedThinking(data: 'opaque');
+
+        expect(block, isA<RedactedThinkingInputBlock>());
+        expect((block as RedactedThinkingInputBlock).data, 'opaque');
+      });
+
+      test('copyWith replaces data', () {
+        const block = RedactedThinkingInputBlock(data: 'original');
+        final copy = block.copyWith(data: 'updated');
+
+        expect(copy.data, 'updated');
+      });
+
+      test('equality and hashCode', () {
+        const a = RedactedThinkingInputBlock(data: 'same');
+        const b = RedactedThinkingInputBlock(data: 'same');
+        const c = RedactedThinkingInputBlock(data: 'different');
+
+        expect(a, equals(b));
+        expect(a.hashCode, b.hashCode);
+        expect(a, isNot(equals(c)));
+      });
+
+      test('toString does not leak content', () {
+        const block = RedactedThinkingInputBlock(data: 'abcde');
+        expect(block.toString(), contains('[5 chars]'));
+        expect(block.toString(), isNot(contains('abcde')));
+      });
+    });
+
     group('SearchResultInputBlock', () {
       Map<String, dynamic> sampleJson() => {
         'type': 'search_result',


### PR DESCRIPTION
## Summary
- Adds typed `ThinkingInputBlock` and `RedactedThinkingInputBlock` variants to the `InputContentBlock` sealed union, with `InputContentBlock.thinking(...)` / `.redactedThinking(...)` factories — the request-side counterparts of the response `ThinkingBlock`/`RedactedThinkingBlock` that were missing from the union despite being in the pinned spec (`RequestThinkingBlock` / `RequestRedactedThinkingBlock`).
- Adds `ContentBlock.toInputBlock()` and `Message.toInputMessage()` extension helpers to replay a full assistant turn (thinking blocks included, order preserved) in follow-up requests — the API multi-turn tool loops with extended thinking need.
- `InputContentBlock.fromJson` now parses `thinking`/`redacted_thinking` JSON as typed variants instead of falling through to `UnknownInputContentBlock`.
- Registers the GA schema names in the toolkit manifest and updates examples/README. See **Why `verify` never caught this** below — the manifest entries are correct and give the new classes field-level verification, but they do *not* close the detection gap.

## Details

Motivated by [genkit-ai/genkit-dart#400](https://github.com/genkit-ai/genkit-dart/pull/400), where the genkit Anthropic plugin had to rebuild thinking blocks through the raw-JSON `InputContentBlock.fromJson` escape hatch because the SDK had no thinking input variant, and multi-turn thinking + tool loops failed on the second turn.

Replaying an assistant turn is now one call:

```dart
final response = await client.messages.create(
  MessageCreateRequest(
    model: 'claude-sonnet-4-6',
    maxTokens: 16000,
    thinking: const ThinkingEnabled(budgetTokens: 10000),
    tools: [ToolDefinition.custom(myTool)],
    messages: [userMessage],
  ),
);

final followUp = [
  userMessage,
  response.toInputMessage(), // preserves thinking blocks + order
  InputMessage(
    role: MessageRole.user,
  InputMessage.userBlocks([
    for (final toolUse in response.toolUseBlocks)
      InputContentBlock.toolResult(
        toolUseId: toolUse.id,
        content: [ToolResultContent.text(result)],
      ),
  ]),
];
```

Note the loop: `toInputMessage()` replays *every* `tool_use` block, and the API rejects the follow-up if any one of them goes unanswered — so parallel tool calls need one `tool_result` each.

Design notes:
- Per the spec, both request schemas are `additionalProperties: false` — so unlike almost every other input block, the new variants intentionally have **no `cacheControl`** field.
- Doc comments carry the official-SDK semantics: `signature` must be passed back exactly as returned; thinking blocks must be replayed unmodified and in their original order or the API returns a 400 `invalid_request_error`; redacted `data` is opaque/encrypted.
- `toInputBlock()` round-trips through JSON rather than a ~20-arm typed switch: it cannot drift from the canonical `fromJson` parsers as new variants land, and an *unrecognized* block type degrades to `UnknownInputContentBlock` with its payload verbatim. A *malformed* block is not degraded — see below.
- **Required fields fail fast.** The new variants throw `FormatException` naming the missing field rather than substituting `''`. The response-side blocks are deliberately lenient (a streaming `content_block_start` carries a partial block whose `signature` arrives in a later `signature_delta`, and Anthropic-compatible third-party servers may omit fields), but there is no partial form on the request side, so silently defaulting would trade a local error for an opaque remote 400. Empty-but-present values still parse, so the `MessageStreamAccumulator` path is unaffected.
- The same reasoning fixes a latent crash this PR would otherwise have promoted: a `web_search_result_location` citation with no `url` used to throw a bare `TypeError` through the replay path, because the response model allows a null `url` while the request model force-cast it. `url` stays required per the request schema (it is required on *both* schemas in the spec) and the error now names the field.
- `example/tool_calling_example.dart`'s hand-rolled conversion switch — which threw `StateError` on thinking blocks — is replaced with `toInputMessage()`, as is the last hand-rolled conversion in `tools_integration_test.dart`.

## Breaking Changes

- Two new variants on the exported sealed union `InputContentBlock` break `switch` statements that match it exhaustively without a wildcard/`default` branch (same breaking surface as the `mid_conv_system` addition in v4.0.0). Pure-deserialization consumers are unaffected.

  ```dart
  // Before — compiled, thinking blocks fell into UnknownInputContentBlock
  switch (block) {
    case TextInputBlock(): ...
    // ...
    case UnknownInputContentBlock(): ...
  }

  // After — add the new cases (or a default/wildcard branch)
  switch (block) {
    case TextInputBlock(): ...
    case ThinkingInputBlock(): ...
    case RedactedThinkingInputBlock(): ...
    // ...
    case UnknownInputContentBlock(): ...
  }
  ```

- Behavioral: `InputContentBlock.fromJson({'type': 'thinking', ...})` now returns `ThinkingInputBlock` (previously `UnknownInputContentBlock`). Code that special-cased `UnknownInputContentBlock` for thinking payloads should switch to the typed variants; the wire-level JSON output is unchanged.

## References

- [genkit-ai/genkit-dart#400](https://github.com/genkit-ai/genkit-dart/pull/400) — consumer PR that surfaced the gap
- [Extended thinking docs](https://platform.claude.com/docs/en/build-with-claude/extended-thinking) — thinking block replay requirements for multi-turn tool use

## Test Plan

- [x] Unit tests pass for affected packages (1507 passed)
- [x] New tests added for new functionality (round-trip, typed-parse regression, `FormatException` on missing required fields, copyWith/equality/toString; `toInputBlock()` per-variant typed mapping incl. unknown fallback and the null-`url` citation; `toInputMessage()` role + order preservation)
- [x] Sealed class changes include variant, round-trip, and error tests
- [x] `fromJson`/`toJson` round-trip serialization verified
- [x] `==`/`hashCode` contract verified (same fields in both)
- [x] `dart analyze --fatal-infos`, `dart format --set-exit-if-changed .` clean
- [x] `api_toolkit.py verify --checks all --scope all` — no failing or warning checks
- [ ] **Not covered:** no integration test exercises thinking replay against the live API. `tools_integration_test.dart` now round-trips `toInputMessage()` for real, but without `thinking:` enabled, so the thinking-block wire shape is verified only by unit tests. Worth adding when someone next runs the live suite.
